### PR TITLE
chore: enforce commit body requirement in commitlint

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -18,5 +18,7 @@ export default {
         'revert', // Reverts a previous commit
       ],
     ],
+    'body-min-length': [2, 'always', 20], // Require at least 20 characters in commit body
+    'body-empty': [2, 'never'], // Body must not be empty
   },
 }


### PR DESCRIPTION
Added two rules to ensure all commits have meaningful descriptions:
- body-empty: body must not be empty (error level)
- body-min-length: body must be at least 20 characters (error level)

This prevents commits without proper descriptions from being accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)