### PR TITLE
feat: Implement chat memory system with Payload CMS

### DIFF
--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/NotebookChat/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/NotebookChat/index.tsx
@@ -7,7 +7,11 @@ import { useNotebookChat } from './useNotebookChat'
 import { ChatMessageRole } from '@/lib/ai/chat-message-role'
 import { cn } from '@/utilities/ui'
 
-export function NotebookChat() {
+interface NotebookChatProps {
+  exerciseId: string
+}
+
+export function NotebookChat({ exerciseId }: NotebookChatProps) {
   const t = useTranslations('courses')
   const {
     messages,
@@ -28,6 +32,7 @@ export function NotebookChat() {
     solutionPrompt: t('chatSolutionPrompt'),
     fullSolutionPrompt: t('chatFullSolutionPrompt'),
     acknowledgment: t('chatAIAcknowledgment'),
+    exerciseId,
   })
 
   return (

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/NotebookChat/useNotebookChat.ts
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/NotebookChat/useNotebookChat.ts
@@ -16,6 +16,7 @@ interface UseNotebookChatProps {
   solutionPrompt: string
   fullSolutionPrompt: string
   acknowledgment: string
+  exerciseId: string
 }
 
 export function useNotebookChat({
@@ -26,6 +27,7 @@ export function useNotebookChat({
   solutionPrompt,
   fullSolutionPrompt,
   acknowledgment,
+  exerciseId,
 }: UseNotebookChatProps) {
   const messagesContainerRef = useRef<HTMLDivElement>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
@@ -61,7 +63,7 @@ export function useNotebookChat({
     setIsLoading(true)
 
     try {
-      const result = await apiService.chat(message, acknowledgment)
+      const result = await apiService.chat(message, acknowledgment, exerciseId)
 
       if (!result.success) {
         if (result.authRequired) {
@@ -79,7 +81,7 @@ export function useNotebookChat({
         }
         setMessages((prev) => [...prev, modelMessage])
       }
-    } catch (error) {
+    } catch (_error) {
       toast.error(errorMessage)
     } finally {
       setIsLoading(false)

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/page.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/page.tsx
@@ -60,7 +60,7 @@ export default async function ExercisePage({ params }: ExercisePageProps) {
             showCheckAnswer
           />
         }
-        chat={<NotebookChat />}
+        chat={<NotebookChat exerciseId={exerciseId} />}
         formulas={<NotebookFormulas />}
         notes={<NotebookNotes />}
         courseSlug={courseSlug}

--- a/src/collections/Conversations.ts
+++ b/src/collections/Conversations.ts
@@ -1,0 +1,131 @@
+/**
+ * Conversations Collection
+ * Stores chat conversations between users and AI tutor for exercises
+ *
+ * Security:
+ * - Users can only access their own conversations
+ * - Admin can manage all conversations
+ *
+ * Relationships:
+ * - user: The student who owns this conversation
+ * - exercise: The exercise this conversation is about
+ */
+import type { CollectionConfig, Access } from 'payload'
+import { authenticated } from '../access/authenticated'
+import type { User } from '@/payload-types'
+import { Role } from './Users/roles'
+
+const isOwner: Access = ({ req }) => {
+  const user = req.user as User | null
+  if (!user) return false
+  if (user.role === Role.Admin) return true
+
+  return {
+    user: {
+      equals: user.id,
+    },
+  }
+}
+
+export const Conversations: CollectionConfig = {
+  slug: 'conversations',
+  admin: {
+    useAsTitle: 'id',
+    defaultColumns: ['user', 'exercise', 'lastMessageAt', 'createdAt'],
+    description: 'Chat conversations between users and AI tutor',
+  },
+  access: {
+    create: authenticated,
+    read: isOwner,
+    update: isOwner,
+    delete: isOwner,
+  },
+  fields: [
+    {
+      name: 'user',
+      type: 'relationship',
+      relationTo: 'users',
+      required: true,
+      index: true,
+      admin: {
+        description: 'Student who owns this conversation',
+      },
+    },
+    {
+      name: 'exercise',
+      type: 'relationship',
+      relationTo: 'exercises',
+      required: true,
+      index: true,
+      admin: {
+        description: 'Exercise this conversation is about',
+      },
+    },
+    {
+      name: 'messages',
+      type: 'array',
+      required: true,
+      defaultValue: [],
+      maxRows: 100, // Prevent unbounded growth
+      admin: {
+        description: 'Conversation message history',
+      },
+      fields: [
+        {
+          name: 'role',
+          type: 'select',
+          required: true,
+          options: [
+            { label: 'User', value: 'user' },
+            { label: 'Assistant', value: 'model' },
+          ],
+        },
+        {
+          name: 'content',
+          type: 'textarea',
+          required: true,
+          maxLength: 5000, // Prevent excessive message length
+          admin: {
+            description: 'Message content',
+          },
+        },
+        {
+          name: 'timestamp',
+          type: 'date',
+          required: true,
+          defaultValue: () => new Date().toISOString(),
+          admin: {
+            date: {
+              pickerAppearance: 'dayAndTime',
+            },
+          },
+        },
+      ],
+    },
+    {
+      name: 'lastMessageAt',
+      type: 'date',
+      required: true,
+      index: true,
+      admin: {
+        description: 'Timestamp of last message (auto-updated)',
+        date: {
+          pickerAppearance: 'dayAndTime',
+        },
+      },
+    },
+  ],
+  hooks: {
+    beforeChange: [
+      async ({ data }) => {
+        // Auto-update lastMessageAt when messages are added
+        if (data.messages && data.messages.length > 0) {
+          const lastMessage = data.messages[data.messages.length - 1]
+          data.lastMessageAt = lastMessage.timestamp || new Date().toISOString()
+        }
+        return data
+      },
+    ],
+  },
+  timestamps: true,
+}

--- a/src/collections/Conversations.ts
+++ b/src/collections/Conversations.ts
@@ -64,7 +64,6 @@ export const Conversations: CollectionConfig = {
     {
       name: 'messages',
       type: 'array',
-      required: true,
       defaultValue: [],
       maxRows: 100, // Prevent unbounded growth
       admin: {

--- a/src/endpoints/agent/chat.ts
+++ b/src/endpoints/agent/chat.ts
@@ -12,6 +12,7 @@ import { logger } from '@/utilities/logger/logger'
 const requestSchema = z.object({
   message: z.string().min(1).max(1000),
   acknowledgment: z.string().min(1),
+  exerciseId: z.string().min(1),
 })
 
 export async function agentChat(req: PayloadRequest & { json?: () => Promise<unknown> }) {
@@ -32,12 +33,68 @@ export async function agentChat(req: PayloadRequest & { json?: () => Promise<unk
     const body = await req.json()
     const validated = requestSchema.parse(body)
 
-    reqLogger.info({ userId: req.user.id }, 'Processing chat request')
+    reqLogger.info(
+      { userId: req.user.id, exerciseId: validated.exerciseId },
+      'Processing chat request',
+    )
 
-    // 3) Call AI service
+    // 3) Find or create conversation
+    const existingConv = await req.payload.find({
+      collection: 'conversations',
+      where: {
+        and: [{ user: { equals: req.user.id } }, { exercise: { equals: validated.exerciseId } }],
+      },
+      limit: 1,
+    })
+
+    let conversationId: string
+    let conversationHistory: Array<{ role: 'user' | 'model'; content: string }> = []
+
+    if (existingConv.docs.length > 0) {
+      // Use existing conversation
+      const conversation = existingConv.docs[0]
+      conversationId = conversation.id
+      conversationHistory = conversation.messages || []
+      reqLogger.info({ conversationId }, 'Using existing conversation')
+    } else {
+      // Create new conversation
+      const newConv = await req.payload.create({
+        collection: 'conversations',
+        data: {
+          user: req.user.id,
+          exercise: validated.exerciseId,
+          messages: [],
+          lastMessageAt: new Date().toISOString(),
+        },
+      })
+      conversationId = newConv.id
+      reqLogger.info({ conversationId }, 'Created new conversation')
+    }
+
+    // 4) Add user message to conversation
+    const userMessage = {
+      role: 'user' as const,
+      content: validated.message,
+      timestamp: new Date().toISOString(),
+    }
+
+    await req.payload.update({
+      collection: 'conversations',
+      id: conversationId,
+      data: {
+        messages: [...conversationHistory, userMessage],
+        lastMessageAt: new Date().toISOString(),
+      },
+    })
+
+    // 5) Call AI service with conversation history
     const result = await chatWithExerciseHelper({
       message: validated.message,
       acknowledgment: validated.acknowledgment,
+      conversationHistory: conversationHistory.map((msg) => ({
+        role: msg.role as any,
+        content: msg.content,
+      })),
     })
 
     if (!result.success) {
@@ -48,10 +105,27 @@ export async function agentChat(req: PayloadRequest & { json?: () => Promise<unk
       )
     }
 
+    // 6) Add assistant message to conversation
+    const assistantMessage = {
+      role: 'model' as const,
+      content: result.message || '',
+      timestamp: new Date().toISOString(),
+    }
+
+    await req.payload.update({
+      collection: 'conversations',
+      id: conversationId,
+      data: {
+        messages: [...conversationHistory, userMessage, assistantMessage],
+        lastMessageAt: new Date().toISOString(),
+      },
+    })
+
     reqLogger.info('Chat request successful')
     return Response.json({
       success: true,
       message: result.message,
+      conversationId,
     })
   } catch (error) {
     reqLogger.error({ err: error }, 'Chat endpoint error')

--- a/src/lib/ai/services/exercise-chat-service.ts
+++ b/src/lib/ai/services/exercise-chat-service.ts
@@ -16,6 +16,7 @@ export interface ChatMessage {
 export interface ExerciseChatInput {
   message: string
   acknowledgment: string
+  conversationHistory?: ChatMessage[]
 }
 
 export interface ExerciseChatResult {
@@ -47,18 +48,31 @@ export async function chatWithExerciseHelper(
       },
     })
 
-    // Start chat with system prompt
+    // Build conversation history for Gemini
+    // Start with system prompt exchange
+    const history: any[] = [
+      {
+        role: ChatMessageRole.User,
+        parts: [{ text: systemPrompt }],
+      },
+      {
+        role: ChatMessageRole.Model,
+        parts: [{ text: input.acknowledgment }],
+      },
+    ]
+
+    // Add conversation history if provided
+    if (input.conversationHistory && input.conversationHistory.length > 0) {
+      const historyMessages = input.conversationHistory.map((msg) => ({
+        role: msg.role,
+        parts: [{ text: msg.content }],
+      }))
+      history.push(...historyMessages)
+    }
+
+    // Start chat with full history
     const chat = model.startChat({
-      history: [
-        {
-          role: ChatMessageRole.User,
-          parts: [{ text: systemPrompt }],
-        },
-        {
-          role: ChatMessageRole.Model,
-          parts: [{ text: input.acknowledgment }],
-        },
-      ],
+      history,
     })
 
     const result = await chat.sendMessage(input.message)

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -69,6 +69,7 @@ export interface Config {
   collections: {
     pages: Page;
     categories: Category;
+    conversations: Conversation;
     courses: Course;
     chapters: Chapter;
     lessons: Lesson;
@@ -97,6 +98,7 @@ export interface Config {
   collectionsSelect: {
     pages: PagesSelect<false> | PagesSelect<true>;
     categories: CategoriesSelect<false> | CategoriesSelect<true>;
+    conversations: ConversationsSelect<false> | ConversationsSelect<true>;
     courses: CoursesSelect<false> | CoursesSelect<true>;
     chapters: ChaptersSelect<false> | ChaptersSelect<true>;
     lessons: LessonsSelect<false> | LessonsSelect<true>;
@@ -775,47 +777,70 @@ export interface Form {
   createdAt: string;
 }
 /**
+ * Chat conversations between users and AI tutor
+ *
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "chapters".
+ * via the `definition` "conversations".
  */
-export interface Chapter {
+export interface Conversation {
   id: string;
   /**
-   * The course this chapter belongs to
+   * Student who owns this conversation
    */
-  course: string | Course;
+  user: string | User;
   /**
-   * Chapter identifier (e.g., "1", "A", "א")
+   * Exercise this conversation is about
    */
-  chapterLabel?: string | null;
+  exercise: string | Exercise;
   /**
-   * Chapter title
+   * Conversation message history
+   */
+  messages: {
+    role: 'user' | 'model';
+    /**
+     * Message content
+     */
+    content: string;
+    timestamp: string;
+    id?: string | null;
+  }[];
+  /**
+   * Timestamp of last message (auto-updated)
+   */
+  lastMessageAt: string;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "exercises".
+ */
+export interface Exercise {
+  id: string;
+  /**
+   * Exercise title (for admin reference)
    */
   title: string;
   /**
-   * Detailed description of the chapter
-   */
-  description?: string | null;
-  /**
-   * Upload chapter-related media files (images, videos, documents, etc.)
-   */
-  mediaFiles?: (string | Media)[] | null;
-  /**
-   * Sort order within the course
+   * Order of exercise within the lesson (lower numbers appear first)
    */
   order: number;
   /**
-   * Publication status of the chapter
+   * The lesson this exercise belongs to
    */
-  status: 'draft' | 'published' | 'archived';
+  lesson: string | Lesson;
   /**
-   * Whether this chapter is currently active
+   * Ordered blocks stream. Use question_* blocks to add questions, and rich_text blocks for instructions/notes between questions.
    */
-  isActive: boolean;
-  /**
-   * URL-friendly identifier (auto-generated from title if empty)
-   */
-  slug?: string | null;
+  content:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
   /**
    * User who created this document
    */
@@ -870,34 +895,46 @@ export interface Lesson {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "exercises".
+ * via the `definition` "chapters".
  */
-export interface Exercise {
+export interface Chapter {
   id: string;
   /**
-   * Exercise title (for admin reference)
+   * The course this chapter belongs to
+   */
+  course: string | Course;
+  /**
+   * Chapter identifier (e.g., "1", "A", "א")
+   */
+  chapterLabel?: string | null;
+  /**
+   * Chapter title
    */
   title: string;
   /**
-   * Order of exercise within the lesson (lower numbers appear first)
+   * Detailed description of the chapter
+   */
+  description?: string | null;
+  /**
+   * Upload chapter-related media files (images, videos, documents, etc.)
+   */
+  mediaFiles?: (string | Media)[] | null;
+  /**
+   * Sort order within the course
    */
   order: number;
   /**
-   * The lesson this exercise belongs to
+   * Publication status of the chapter
    */
-  lesson: string | Lesson;
+  status: 'draft' | 'published' | 'archived';
   /**
-   * Ordered blocks stream. Use question_* blocks to add questions, and rich_text blocks for instructions/notes between questions.
+   * Whether this chapter is currently active
    */
-  content:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
+  isActive: boolean;
+  /**
+   * URL-friendly identifier (auto-generated from title if empty)
+   */
+  slug?: string | null;
   /**
    * User who created this document
    */
@@ -1246,6 +1283,10 @@ export interface PayloadLockedDocument {
         value: string | Category;
       } | null)
     | ({
+        relationTo: 'conversations';
+        value: string | Conversation;
+      } | null)
+    | ({
         relationTo: 'courses';
         value: string | Course;
       } | null)
@@ -1485,6 +1526,25 @@ export interface CategoriesSelect<T extends boolean = true> {
         label?: T;
         id?: T;
       };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "conversations_select".
+ */
+export interface ConversationsSelect<T extends boolean = true> {
+  user?: T;
+  exercise?: T;
+  messages?:
+    | T
+    | {
+        role?: T;
+        content?: T;
+        timestamp?: T;
+        id?: T;
+      };
+  lastMessageAt?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -795,15 +795,17 @@ export interface Conversation {
   /**
    * Conversation message history
    */
-  messages: {
-    role: 'user' | 'model';
-    /**
-     * Message content
-     */
-    content: string;
-    timestamp: string;
-    id?: string | null;
-  }[];
+  messages?:
+    | {
+        role: 'user' | 'model';
+        /**
+         * Message content
+         */
+        content: string;
+        timestamp: string;
+        id?: string | null;
+      }[]
+    | null;
   /**
    * Timestamp of last message (auto-updated)
    */

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'url'
 
 import { Categories } from './collections/Categories'
 import { Chapters } from './collections/Chapters'
+import { Conversations } from './collections/Conversations'
 import { Courses } from './collections/Courses'
 import { Exercises } from './collections/Exercises'
 import { ExerciseAssets } from './collections/ExerciseAssets'
@@ -71,6 +72,7 @@ export default buildConfig({
   collections: [
     Pages,
     Categories,
+    Conversations,
     Courses,
     Chapters,
     Lessons,

--- a/src/services/api/api-service.ts
+++ b/src/services/api/api-service.ts
@@ -10,6 +10,7 @@ export interface ChatApiResponse {
   message?: string
   error?: string
   authRequired?: boolean
+  conversationId?: string
 }
 
 export const apiService = {
@@ -18,14 +19,19 @@ export const apiService = {
    *
    * @param message - The user's message
    * @param acknowledgment - The AI's acknowledgment message (from locale)
+   * @param exerciseId - The ID of the exercise being discussed
    * @returns Response with success status and either message or error
    */
-  async chat(message: string, acknowledgment: string): Promise<ChatApiResponse> {
+  async chat(
+    message: string,
+    acknowledgment: string,
+    exerciseId: string,
+  ): Promise<ChatApiResponse> {
     try {
       const response = await fetch('/api/agent/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message, acknowledgment }),
+        body: JSON.stringify({ message, acknowledgment, exerciseId }),
       })
 
       const data = await response.json()
@@ -39,11 +45,15 @@ export const apiService = {
       }
 
       if (data.success && data.message) {
-        return { success: true, message: data.message }
+        return {
+          success: true,
+          message: data.message,
+          conversationId: data.conversationId,
+        }
       }
 
       return { success: false, error: 'Invalid response format' }
-    } catch (error) {
+    } catch (_error) {
       // Network errors or other exceptions
       return { success: false, error: 'Network error' }
     }


### PR DESCRIPTION
Added conversation persistence to store chat history in MongoDB via Payload CMS.

- Created Conversations collection with user and exercise relationships
- Updated AI chat service to support conversation history
- Modified chat endpoint to find/create conversations and manage message history
- Updated frontend components to pass exerciseId to chat
- Users can only access their own conversations (access control)
- Messages limited to 100 per conversation and 5000 chars per message
- Auto-updates lastMessageAt timestamp on new messages

The AI tutor now remembers previous messages in the conversation, providing contextual responses based on the full chat history for each exercise.