### PR TITLE
feat: Restrict interactive exercises tab to admins only

### DIFF
--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/LessonContent.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/LessonContent.tsx
@@ -37,9 +37,8 @@ export function LessonContent({
   const hasContent = validFiles.length > 0
   const hasExercises = exercises.length > 0
 
-  // For admins: always show exercises option, default to interactive if no content
-  // For others: only show if has exercises
-  const showExercisesToggle = isAdmin || hasExercises
+  // Only show exercises toggle to admins
+  const showExercisesToggle = isAdmin
   const initialViewMode: ViewMode =
     !hasContent && showExercisesToggle ? 'interactive' : 'non-interactive'
   const [viewMode, setViewMode] = useState<ViewMode>(initialViewMode)


### PR DESCRIPTION
Change exercise tab visibility to admin-only access. Previously shown to all users when exercises existed, now hidden from non-admins regardless of exercise availability.