### PR TITLE
Lesson view media parity

### DIFF
--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ChatInterface/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ChatInterface/index.tsx
@@ -10,10 +10,11 @@ import { useNotebookChat } from '../NotebookChat/useNotebookChat'
 import { ChatMessageRole } from '@/lib/ai/chat-message-role'
 
 interface ChatInterfaceProps {
-  exerciseId: string
+  exerciseId?: string
+  lessonId?: string
 }
 
-export function ChatInterface({ exerciseId }: ChatInterfaceProps) {
+export function ChatInterface({ exerciseId, lessonId }: ChatInterfaceProps) {
   const t = useTranslations('courses')
   const {
     messages,
@@ -33,6 +34,7 @@ export function ChatInterface({ exerciseId }: ChatInterfaceProps) {
     fullSolutionPrompt: t('chatFullSolutionPrompt'),
     acknowledgment: t('chatAIAcknowledgment'),
     exerciseId,
+    lessonId,
   })
 
   const [isMathPaletteOpen, setIsMathPaletteOpen] = useState(false)

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/NotebookChat/useNotebookChat.ts
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/NotebookChat/useNotebookChat.ts
@@ -16,7 +16,8 @@ interface UseNotebookChatProps {
   solutionPrompt: string
   fullSolutionPrompt: string
   acknowledgment: string
-  exerciseId: string
+  exerciseId?: string
+  lessonId?: string
 }
 
 export function useNotebookChat({
@@ -28,6 +29,7 @@ export function useNotebookChat({
   fullSolutionPrompt,
   acknowledgment,
   exerciseId,
+  lessonId,
 }: UseNotebookChatProps) {
   const messagesContainerRef = useRef<HTMLDivElement>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
@@ -59,7 +61,7 @@ export function useNotebookChat({
   useEffect(() => {
     async function loadConversationHistory() {
       try {
-        const result = await apiService.getConversation(exerciseId)
+        const result = await apiService.getConversation(exerciseId, lessonId)
 
         if (result.success && result.exists && result.messages.length > 0) {
           // Map API messages to chat messages
@@ -79,7 +81,7 @@ export function useNotebookChat({
     }
 
     loadConversationHistory()
-  }, [exerciseId, initialMessage])
+  }, [exerciseId, lessonId, initialMessage])
 
   const sendMessage = async (message: string) => {
     if (!message.trim() || isLoading) return
@@ -90,7 +92,7 @@ export function useNotebookChat({
     setIsLoading(true)
 
     try {
-      const result = await apiService.chat(message, acknowledgment, exerciseId)
+      const result = await apiService.chat(message, acknowledgment, exerciseId, lessonId)
 
       if (!result.success) {
         if (result.authRequired) {

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/page.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/page.tsx
@@ -1,8 +1,4 @@
 import { notFound } from 'next/navigation'
-import { headers as getHeaders } from 'next/headers'
-import { getPayload } from 'payload'
-import configPromise from '@payload-config'
-
 import { queryCourseBySlug } from '@/lib/queries/courses'
 import { queryLessonBySlug } from '@/lib/queries/lessons'
 import { queryExercisesByLesson } from '@/lib/queries/exercises'
@@ -23,16 +19,10 @@ interface LessonPageProps {
 export default async function LessonPage({ params }: LessonPageProps) {
   const { courseSlug, chapterSlug, lessonSlug } = await params
 
-  const [course, lesson, payload] = await Promise.all([
+  const [course, lesson] = await Promise.all([
     queryCourseBySlug({ slug: courseSlug }),
     queryLessonBySlug({ slug: lessonSlug }),
-    getPayload({ config: configPromise }),
   ])
-
-  // Get current user
-  const headers = await getHeaders()
-  const { user } = await payload.auth({ headers })
-  const isAdmin = user?.role === 'admin'
 
   if (!course || !lesson) {
     notFound()

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/page.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/page.tsx
@@ -1,14 +1,16 @@
 import { notFound } from 'next/navigation'
+import { headers as getHeaders } from 'next/headers'
+import { getPayload } from 'payload'
+import configPromise from '@payload-config'
+
 import { queryCourseBySlug } from '@/lib/queries/courses'
 import { queryLessonBySlug } from '@/lib/queries/lessons'
 import { queryExercisesByLesson } from '@/lib/queries/exercises'
-import { Breadcrumb } from '../../../../../_components/Breadcrumb'
-import { LessonHeader } from '../../../../../_components/LessonHeader'
-import { LessonContent } from './_components/LessonContent'
-import { getPayload } from 'payload'
-import configPromise from '@payload-config'
-import { headers as getHeaders } from 'next/headers'
-import type { Media } from '@/payload-types'
+import type { Exercise, Media } from '@/payload-types'
+import { Media as MediaComponent } from '@/components/Media'
+import { EmptyState } from '../../../../../_components/EmptyState'
+import { ExerciseWorkspace } from './exercises/[exerciseId]/_components/ExerciseWorkspace'
+import { ChatInterface } from './exercises/[exerciseId]/_components/ChatInterface'
 
 interface LessonPageProps {
   params: Promise<{
@@ -49,39 +51,55 @@ export default async function LessonPage({ params }: LessonPageProps) {
     notFound()
   }
 
-  // Fetch exercises for this lesson
+  // Fetch exercises for this lesson (used for chat context)
   const exercises = await queryExercisesByLesson({ lessonId: lesson.id })
 
-  const breadcrumbItems = [
-    { label: 'Courses', href: '/courses' },
-    { label: course.title, href: `/courses/${courseSlug}` },
-    { label: lessonChapter.title, href: `/courses/${courseSlug}/chapters/${chapterSlug}` },
-    { label: lesson.title },
-  ]
+  // Use the first exercise as the primary chat context when available,
+  // otherwise use the lesson ID for lesson-scoped conversation.
+  const primaryExercise = exercises[0] as Exercise | undefined
+  const chatExerciseId = primaryExercise?.id
+  const chatLessonId = primaryExercise ? undefined : lesson.id
+
+  const validFiles =
+    lesson.contentFiles
+      ?.map((file) => (typeof file === 'string' ? null : file))
+      .filter((file): file is Media => file !== null && Boolean(file.url)) || []
+
+  const hasContent = validFiles.length > 0
+
+  const pdfContent = hasContent ? (
+    <div className="w-full max-w-[920px] max-h-full bg-card border border-border rounded-[10px] p-12 text-foreground shadow-[0_10px_30px_hsl(var(--border))] overflow-auto">
+      <div className="flex flex-col gap-0">
+        {validFiles.map((file, index) => (
+          <div key={file.id} className="w-full min-h-[841px] flex-shrink-0">
+            {index > 0 && (
+              <div className="h-0.5 my-8 flex-shrink-0 bg-gradient-to-r from-transparent via-border to-transparent" />
+            )}
+            <div className="border rounded-lg overflow-hidden bg-gray-50">
+              <MediaComponent resource={file} className="w-full" htmlElement={null} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  ) : (
+    <div className="w-full max-w-[920px] max-h-full flex items-center justify-center">
+      <EmptyState type="noPDF" />
+    </div>
+  )
 
   return (
-    <div className="container mx-auto px-4 py-8">
-      <Breadcrumb items={breadcrumbItems} />
-
-      <LessonHeader order={lesson.order} title={lesson.title} description={lesson.description} />
-
-      <LessonContent
-        contentFiles={
-          lesson.contentFiles
-            ? lesson.contentFiles
-                .map((file) => (typeof file === 'string' ? null : file))
-                .filter((file): file is Media => file !== null)
-            : null
-        }
-        lessonTitle={lesson.title}
-        exercises={exercises}
-        courseSlug={courseSlug}
-        chapterSlug={chapterSlug}
-        lessonSlug={lessonSlug}
-        lessonId={lesson.id}
-        isAdmin={isAdmin}
-      />
-    </div>
+    <ExerciseWorkspace
+      exerciseTitle={lesson.title}
+      backUrl={`/courses/${courseSlug}/chapters/${chapterSlug}`}
+      pdfContent={pdfContent}
+      chatContent={
+        <ChatInterface
+          exerciseId={chatExerciseId}
+          lessonId={chatLessonId}
+        />
+      }
+    />
   )
 }
 

--- a/src/collections/Conversations.ts
+++ b/src/collections/Conversations.ts
@@ -173,6 +173,7 @@ export const Conversations: CollectionConfig = {
     beforeValidate: [
       async ({ data }) => {
         // Ensure either exercise or lesson is provided, but not both
+        if (!data) return data
         if (!data.exercise && !data.lesson) {
           throw new Error('Either exercise or lesson must be provided')
         }

--- a/src/collections/Conversations.ts
+++ b/src/collections/Conversations.ts
@@ -1,6 +1,6 @@
 /**
  * Conversations Collection
- * Stores chat conversations between users and AI tutor for exercises
+ * Stores chat conversations between users and AI tutor for exercises and lessons
  *
  * @fileType collection-config
  * @domain chat
@@ -13,7 +13,8 @@
  *
  * Relationships:
  * - user: The student who owns this conversation
- * - exercise: The exercise this conversation is about
+ * - exercise: The exercise this conversation is about (optional, for exercise-specific chats)
+ * - lesson: The lesson this conversation is about (optional, for lesson-specific chats)
  */
 import type { User } from '@/payload-types'
 import type { Access, CollectionConfig } from 'payload'
@@ -36,7 +37,7 @@ export const Conversations: CollectionConfig = {
   slug: 'conversations',
   admin: {
     useAsTitle: 'id',
-    defaultColumns: ['user', 'exercise', 'lastMessageAt', 'createdAt'],
+    defaultColumns: ['user', 'exercise', 'lesson', 'lastMessageAt', 'createdAt'],
     description: 'Chat conversations between users and AI tutor',
   },
   access: {
@@ -60,10 +61,22 @@ export const Conversations: CollectionConfig = {
       name: 'exercise',
       type: 'relationship',
       relationTo: 'exercises',
-      required: true,
+      required: false,
       index: true,
       admin: {
-        description: 'Exercise this conversation is about',
+        description: 'Exercise this conversation is about (for exercise-specific chats)',
+        condition: (data) => !data.lesson, // Only show if lesson is not set
+      },
+    },
+    {
+      name: 'lesson',
+      type: 'relationship',
+      relationTo: 'lessons',
+      required: false,
+      index: true,
+      admin: {
+        description: 'Lesson this conversation is about (for lesson-specific chats)',
+        condition: (data) => !data.exercise, // Only show if exercise is not set
       },
     },
     {
@@ -157,6 +170,18 @@ export const Conversations: CollectionConfig = {
     },
   ],
   hooks: {
+    beforeValidate: [
+      async ({ data }) => {
+        // Ensure either exercise or lesson is provided, but not both
+        if (!data.exercise && !data.lesson) {
+          throw new Error('Either exercise or lesson must be provided')
+        }
+        if (data.exercise && data.lesson) {
+          throw new Error('Cannot have both exercise and lesson')
+        }
+        return data
+      },
+    ],
     beforeChange: [
       async ({ data }) => {
         // Auto-update lastMessageAt when messages are added

--- a/src/endpoints/agent/chat.ts
+++ b/src/endpoints/agent/chat.ts
@@ -36,7 +36,10 @@ import { z } from 'zod'
 const requestSchema = z.object({
   message: z.string().min(1).max(1000),
   acknowledgment: z.string().min(1),
-  exerciseId: z.string().min(1),
+  exerciseId: z.string().min(1).optional(),
+  lessonId: z.string().min(1).optional(),
+}).refine((data) => data.exerciseId || data.lessonId, {
+  message: 'Either exerciseId or lessonId must be provided',
 })
 
 export async function agentChat(req: PayloadRequest & { json?: () => Promise<unknown> }) {
@@ -57,16 +60,23 @@ export async function agentChat(req: PayloadRequest & { json?: () => Promise<unk
     const body = await req.json()
     const validated = requestSchema.parse(body)
 
+    const contextId = validated.exerciseId || validated.lessonId
+    const contextType = validated.exerciseId ? 'exercise' : 'lesson'
+    const contextField = validated.exerciseId ? 'exercise' : 'lesson'
+
     reqLogger.info(
-      { userId: req.user.id, exerciseId: validated.exerciseId },
+      { userId: req.user.id, contextType, contextId },
       'Processing chat request',
     )
 
     // 3) Find or create conversation
+    const whereClause: any = { user: { equals: req.user.id } }
+    whereClause[contextField] = { equals: contextId }
+
     const existingConv = await req.payload.find({
       collection: 'conversations',
       where: {
-        and: [{ user: { equals: req.user.id } }, { exercise: { equals: validated.exerciseId } }],
+        and: [whereClause],
       },
       limit: 1,
       user: req.user, // Explicitly pass user for access control
@@ -83,22 +93,28 @@ export async function agentChat(req: PayloadRequest & { json?: () => Promise<unk
       reqLogger.info({ conversationId }, 'Using existing conversation')
     } else {
       // Create new conversation
+      const conversationData: any = {
+        user: req.user.id,
+        messages: [],
+        lastMessageAt: new Date().toISOString(),
+        contextPolicyVersion: 'v1',
+      }
+      if (validated.exerciseId) {
+        conversationData.exercise = validated.exerciseId
+      } else if (validated.lessonId) {
+        conversationData.lesson = validated.lessonId
+      }
+
       const newConv = await req.payload.create({
         collection: 'conversations',
-        data: {
-          user: req.user.id,
-          exercise: validated.exerciseId,
-          messages: [],
-          lastMessageAt: new Date().toISOString(),
-          contextPolicyVersion: 'v1',
-        },
+        data: conversationData,
         draft: false,
         user: req.user, // Explicitly pass user for access control
         overrideAccess: false, // Enforce user's access control
       })
       conversationId = newConv.id
       conversation = newConv
-      reqLogger.info({ conversationId }, 'Created new conversation')
+      reqLogger.info({ conversationId, contextType }, 'Created new conversation')
     }
 
     // 4) Persist user message FIRST

--- a/src/services/api/api-service.ts
+++ b/src/services/api/api-service.ts
@@ -33,19 +33,28 @@ export const apiService = {
    *
    * @param message - The user's message
    * @param acknowledgment - The AI's acknowledgment message (from locale)
-   * @param exerciseId - The ID of the exercise being discussed
+   * @param exerciseId - The ID of the exercise being discussed (optional)
+   * @param lessonId - The ID of the lesson being discussed (optional)
    * @returns Response with success status and either message or error
    */
   async chat(
     message: string,
     acknowledgment: string,
-    exerciseId: string,
+    exerciseId?: string,
+    lessonId?: string,
   ): Promise<ChatApiResponse> {
     try {
+      const body: any = { message, acknowledgment }
+      if (exerciseId) {
+        body.exerciseId = exerciseId
+      } else if (lessonId) {
+        body.lessonId = lessonId
+      }
+
       const response = await fetch('/api/agent/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message, acknowledgment, exerciseId }),
+        body: JSON.stringify(body),
       })
 
       const data = await response.json()
@@ -74,18 +83,26 @@ export const apiService = {
   },
 
   /**
-   * Fetch existing conversation history for an exercise using Payload's REST API
+   * Fetch existing conversation history for an exercise or lesson using Payload's REST API
    *
-   * @param exerciseId - The ID of the exercise
+   * @param exerciseId - The ID of the exercise (optional)
+   * @param lessonId - The ID of the lesson (optional)
    * @returns Conversation history with messages
    */
-  async getConversation(exerciseId: string): Promise<ConversationApiResponse> {
+  async getConversation(
+    exerciseId?: string,
+    lessonId?: string,
+  ): Promise<ConversationApiResponse> {
     try {
       // Use Payload's auto-generated REST API with query filters
       // Access control is automatically enforced by Payload
-      const whereQuery = JSON.stringify({
-        exercise: { equals: exerciseId },
-      })
+      const whereClause: any = {}
+      if (exerciseId) {
+        whereClause.exercise = { equals: exerciseId }
+      } else if (lessonId) {
+        whereClause.lesson = { equals: lessonId }
+      }
+      const whereQuery = JSON.stringify(whereClause)
 
       const response = await fetch(
         `/api/conversations?where=${encodeURIComponent(whereQuery)}&limit=1`,


### PR DESCRIPTION
Refactor lesson media view to match exercise notebook layout with a working chat sidebar, by extending the chat system to support lessons.

The existing chat system was tightly coupled to exercises. This PR generalizes the chat backend (Payload collection, API endpoint, and service) and frontend components to accept either an `exerciseId` or a `lessonId`, allowing lessons to have their own chat context. The lesson page now leverages the `ExerciseWorkspace` component, which provides the desired layout including the resizable chat sidebar and PDF viewer.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d0c41b9-abd4-4552-a436-e1b980c5ca4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7d0c41b9-abd4-4552-a436-e1b980c5ca4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

