### PR TITLE
Agent chat prompt file

### DIFF
--- a/src/lib/ai/memory-extraction.ts
+++ b/src/lib/ai/memory-extraction.ts
@@ -41,11 +41,66 @@ function getOpenAIClient(): OpenAI {
   return openai
 }
 
-// Load prompt from external file
-const MEMORY_EXTRACTION_PROMPT = readFileSync(
-  join(__dirname, 'prompts/memory-extraction-system-prompt.md'),
-  'utf-8',
-)
+// Load prompt from external file with a safe fallback so that missing files
+// do not crash the agent chat endpoint at module load time (e.g. in serverless environments).
+// First tries to load the main prompt file, then falls back to the default file, then to inline default.
+let MEMORY_EXTRACTION_PROMPT: string = ''
+
+try {
+  const promptPath = join(__dirname, 'prompts/memory-extraction-system-prompt.md')
+  MEMORY_EXTRACTION_PROMPT = readFileSync(promptPath, 'utf-8')
+} catch (error: unknown) {
+  logger.warn(
+    { err: error, path: join(__dirname, 'prompts/memory-extraction-system-prompt.md') },
+    '[MemoryExtraction] Failed to load memory extraction prompt from markdown file, trying default fallback',
+  )
+
+  // Try to load the default fallback file
+  try {
+    const defaultPath = join(__dirname, 'prompts/memory-extraction-system-prompt.default.md')
+    MEMORY_EXTRACTION_PROMPT = readFileSync(defaultPath, 'utf-8')
+    logger.info('[MemoryExtraction] Loaded default memory extraction prompt from fallback file')
+  } catch (fallbackError: unknown) {
+    logger.warn(
+      { err: fallbackError },
+      '[MemoryExtraction] Failed to load default fallback file, using inline default',
+    )
+    // Final fallback: inline default (matches memory-extraction-system-prompt.default.md)
+    MEMORY_EXTRACTION_PROMPT = [
+      'You are a memory extraction assistant for an educational platform.',
+      '',
+      'Analyze the conversation and extract important information worth remembering long-term.',
+      '',
+      'Focus on:',
+      '',
+      '- User preferences (learning style, pace, topics of interest)',
+      '- Decisions made (chose X over Y, wants to focus on Z)',
+      '- Important facts (user\'s background, goals, constraints)',
+      '- Open loops (questions to follow up on later)',
+      '- Profile information (skill level, prior knowledge)',
+      '',
+      'Output format (JSON):',
+      '{',
+      '"memories": [',
+      '{',
+      '"type": "preference|decision|fact|open_loop|profile|constraint|other",',
+      '"text": "Concise statement (max 200 chars)",',
+      '"importance": 1-5,',
+      '"scope": "user|conversation",',
+      '"reason": "Why this is worth remembering"',
+      '}',
+      ']',
+      '}',
+      '',
+      'Filtering rules:',
+      '',
+      '- Omit greetings, acknowledgments, small talk',
+      '- Omit temporary/ephemeral content',
+      '- Be selective: quality over quantity (max 3-5 items per extraction)',
+      '- Each item must be actionable or informative',
+    ].join('\n')
+  }
+}
 
 interface MemoryCandidate {
   type: 'preference' | 'decision' | 'fact' | 'open_loop' | 'profile' | 'constraint' | 'other'

--- a/src/lib/ai/memory-extraction.ts
+++ b/src/lib/ai/memory-extraction.ts
@@ -75,7 +75,7 @@ try {
       '',
       '- User preferences (learning style, pace, topics of interest)',
       '- Decisions made (chose X over Y, wants to focus on Z)',
-      '- Important facts (user\'s background, goals, constraints)',
+      "- Important facts (user's background, goals, constraints)",
       '- Open loops (questions to follow up on later)',
       '- Profile information (skill level, prior knowledge)',
       '',

--- a/src/lib/ai/prompts/memory-extraction-system-prompt.default.md
+++ b/src/lib/ai/prompts/memory-extraction-system-prompt.default.md
@@ -1,0 +1,31 @@
+You are a memory extraction assistant for an educational platform.
+
+Analyze the conversation and extract important information worth remembering long-term.
+
+Focus on:
+
+- User preferences (learning style, pace, topics of interest)
+- Decisions made (chose X over Y, wants to focus on Z)
+- Important facts (user's background, goals, constraints)
+- Open loops (questions to follow up on later)
+- Profile information (skill level, prior knowledge)
+
+Output format (JSON):
+{
+"memories": [
+{
+"type": "preference|decision|fact|open_loop|profile|constraint|other",
+"text": "Concise statement (max 200 chars)",
+"importance": 1-5,
+"scope": "user|conversation",
+"reason": "Why this is worth remembering"
+}
+]
+}
+
+Filtering rules:
+
+- Omit greetings, acknowledgments, small talk
+- Omit temporary/ephemeral content
+- Be selective: quality over quantity (max 3-5 items per extraction)
+- Each item must be actionable or informative

--- a/src/lib/ai/prompts/summary-system-prompt.default.md
+++ b/src/lib/ai/prompts/summary-system-prompt.default.md
@@ -1,0 +1,13 @@
+You are a conversation summarizer for an educational chat system.
+
+Your task is to create a concise, factual summary that preserves:
+
+- Key decisions made
+- User preferences and constraints
+- Important facts and context
+- Open loops (unresolved questions)
+- Learning progress and goals
+
+Keep the summary under 500 words. Use clear, structured format.
+Omit greetings, small talk, and ephemeral content.
+Focus on information that will help continue the conversation later.

--- a/src/lib/ai/summary.ts
+++ b/src/lib/ai/summary.ts
@@ -41,11 +41,37 @@ export interface SummaryResult {
   tokensUsed: number
 }
 
-// Load prompt from external file
-const SUMMARY_SYSTEM_PROMPT = readFileSync(
-  join(__dirname, 'prompts/summary-system-prompt.md'),
-  'utf-8',
-)
+// Default summary system prompt used if the markdown file cannot be read at runtime.
+// This matches the content of `src/lib/ai/prompts/summary-system-prompt.md`.
+const DEFAULT_SUMMARY_SYSTEM_PROMPT = [
+  'You are a conversation summarizer for an educational chat system.',
+  '',
+  'Your task is to create a concise, factual summary that preserves:',
+  '',
+  '- Key decisions made',
+  '- User preferences and constraints',
+  '- Important facts and context',
+  '- Open loops (unresolved questions)',
+  '- Learning progress and goals',
+  '',
+  'Keep the summary under 500 words. Use clear, structured format.',
+  'Omit greetings, small talk, and ephemeral content.',
+  'Focus on information that will help continue the conversation later.',
+].join('\n')
+
+// Load prompt from external file with a safe fallback so that missing files
+// do not crash the agent chat endpoint at module load time (e.g. in serverless environments).
+let SUMMARY_SYSTEM_PROMPT: string = DEFAULT_SUMMARY_SYSTEM_PROMPT
+
+try {
+  const promptPath = join(__dirname, 'prompts/summary-system-prompt.md')
+  SUMMARY_SYSTEM_PROMPT = readFileSync(promptPath, 'utf-8')
+} catch (error: unknown) {
+  logger.warn(
+    { err: error },
+    '[Summary] Failed to load summary system prompt from markdown file, falling back to default inline prompt',
+  )
+}
 
 /**
  * Generate or update conversation summary

--- a/src/lib/ai/summary.ts
+++ b/src/lib/ai/summary.ts
@@ -41,36 +41,47 @@ export interface SummaryResult {
   tokensUsed: number
 }
 
-// Default summary system prompt used if the markdown file cannot be read at runtime.
-// This matches the content of `src/lib/ai/prompts/summary-system-prompt.md`.
-const DEFAULT_SUMMARY_SYSTEM_PROMPT = [
-  'You are a conversation summarizer for an educational chat system.',
-  '',
-  'Your task is to create a concise, factual summary that preserves:',
-  '',
-  '- Key decisions made',
-  '- User preferences and constraints',
-  '- Important facts and context',
-  '- Open loops (unresolved questions)',
-  '- Learning progress and goals',
-  '',
-  'Keep the summary under 500 words. Use clear, structured format.',
-  'Omit greetings, small talk, and ephemeral content.',
-  'Focus on information that will help continue the conversation later.',
-].join('\n')
-
 // Load prompt from external file with a safe fallback so that missing files
 // do not crash the agent chat endpoint at module load time (e.g. in serverless environments).
-let SUMMARY_SYSTEM_PROMPT: string = DEFAULT_SUMMARY_SYSTEM_PROMPT
+// First tries to load the main prompt file, then falls back to the default file, then to inline default.
+let SUMMARY_SYSTEM_PROMPT: string = ''
 
 try {
   const promptPath = join(__dirname, 'prompts/summary-system-prompt.md')
   SUMMARY_SYSTEM_PROMPT = readFileSync(promptPath, 'utf-8')
 } catch (error: unknown) {
   logger.warn(
-    { err: error },
-    '[Summary] Failed to load summary system prompt from markdown file, falling back to default inline prompt',
+    { err: error, path: join(__dirname, 'prompts/summary-system-prompt.md') },
+    '[Summary] Failed to load summary system prompt from markdown file, trying default fallback',
   )
+
+  // Try to load the default fallback file
+  try {
+    const defaultPath = join(__dirname, 'prompts/summary-system-prompt.default.md')
+    SUMMARY_SYSTEM_PROMPT = readFileSync(defaultPath, 'utf-8')
+    logger.info('[Summary] Loaded default summary prompt from fallback file')
+  } catch (fallbackError: unknown) {
+    logger.warn(
+      { err: fallbackError },
+      '[Summary] Failed to load default fallback file, using inline default',
+    )
+    // Final fallback: inline default (matches summary-system-prompt.default.md)
+    SUMMARY_SYSTEM_PROMPT = [
+      'You are a conversation summarizer for an educational chat system.',
+      '',
+      'Your task is to create a concise, factual summary that preserves:',
+      '',
+      '- Key decisions made',
+      '- User preferences and constraints',
+      '- Important facts and context',
+      '- Open loops (unresolved questions)',
+      '- Learning progress and goals',
+      '',
+      'Keep the summary under 500 words. Use clear, structured format.',
+      'Omit greetings, small talk, and ephemeral content.',
+      'Focus on information that will help continue the conversation later.',
+    ].join('\n')
+  }
 }
 
 /**

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -804,9 +804,13 @@ export interface Conversation {
    */
   user: string | User;
   /**
-   * Exercise this conversation is about
+   * Exercise this conversation is about (for exercise-specific chats)
    */
-  exercise: string | Exercise;
+  exercise?: (string | null) | Exercise;
+  /**
+   * Lesson this conversation is about (for lesson-specific chats)
+   */
+  lesson?: (string | null) | Lesson;
   /**
    * Conversation message history
    */
@@ -1689,6 +1693,7 @@ export interface CategoriesSelect<T extends boolean = true> {
 export interface ConversationsSelect<T extends boolean = true> {
   user?: T;
   exercise?: T;
+  lesson?: T;
   messages?:
     | T
     | {

--- a/tests/int/agent-chat.int.spec.ts
+++ b/tests/int/agent-chat.int.spec.ts
@@ -50,13 +50,17 @@ vi.mock('@/lib/ai/maintenance', () => ({
   })),
 }))
 
-vi.mock('@/lib/feature-flags', () => ({
-  featureFlags: {
-    SUMMARY_MAINTENANCE_ENABLED: true,
-    MEMORY_EXTRACTION_ENABLED: true,
-    MEMORY_RETRIEVAL_ENABLED: true,
-  },
-}))
+vi.mock('@/lib/feature-flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/feature-flags')>()
+  return {
+    ...actual,
+    featureFlags: {
+      SUMMARY_MAINTENANCE_ENABLED: true,
+      MEMORY_EXTRACTION_ENABLED: true,
+      MEMORY_RETRIEVAL_ENABLED: true,
+    },
+  }
+})
 
 let payload: Payload
 let testUserId: string

--- a/tests/int/agent-chat.int.spec.ts
+++ b/tests/int/agent-chat.int.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * Integration tests for the /api/agent/chat endpoint logic (agentChat).
+ *
+ * These tests focus on:
+ * - Authentication behavior (401 when unauthenticated)
+ * - Happy-path chat flow with a real Payload instance
+ *   (AI calls and vector search are mocked to avoid external dependencies).
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import config from '@payload-config'
+import type { Payload } from 'payload'
+import { getPayload } from 'payload'
+import type { PayloadRequest } from 'payload'
+import { agentChat } from '@/endpoints/agent/chat'
+
+// Mock AI and vector-related services to keep tests deterministic and offline.
+vi.mock('@/lib/ai/services/exercise-chat-service', () => ({
+  chatWithExerciseHelper: vi.fn(async () => ({
+    success: true,
+    message: 'Mock assistant response',
+  })),
+  getSystemPrompt: vi.fn(() => 'You are a helpful assistant.'),
+}))
+
+vi.mock('@/lib/ai/vector-index-check', () => ({
+  isVectorIndexAvailable: vi.fn(async () => false),
+}))
+
+vi.mock('@/lib/ai/vector-search', () => ({
+  retrieveMemoryItems: vi.fn(async () => ({
+    items: [],
+    latencyMs: 0,
+    localCount: 0,
+    globalCount: 0,
+  })),
+}))
+
+vi.mock('@/lib/ai/memory-extraction', () => ({
+  extractMemoryCandidates: vi.fn(async () => []),
+  persistMemoryItems: vi.fn(async () => 0),
+}))
+
+vi.mock('@/lib/ai/maintenance', () => ({
+  runSummaryMaintenance: vi.fn(async () => ({
+    summaryUpdated: false,
+    messagesTrimmed: 0,
+  })),
+}))
+
+vi.mock('@/lib/feature-flags', () => ({
+  featureFlags: {
+    SUMMARY_MAINTENANCE_ENABLED: true,
+    MEMORY_EXTRACTION_ENABLED: true,
+    MEMORY_RETRIEVAL_ENABLED: true,
+  },
+}))
+
+let payload: Payload
+let testUserId: string
+let testExerciseId: string | undefined
+
+beforeAll(async () => {
+  payload = await getPayload({ config })
+
+  const user = await payload.create({
+    collection: 'users',
+    data: {
+      email: `agent-chat-int-${Date.now()}@example.com`,
+      password: 'test123456',
+      role: 'student',
+    },
+  })
+  testUserId = user.id
+
+  // Reuse an existing exercise if available; otherwise create a minimal one.
+  const existingExercises = await payload.find({
+    collection: 'exercises',
+    limit: 1,
+  })
+
+  if (existingExercises.docs.length > 0) {
+    testExerciseId = existingExercises.docs[0].id
+  } else {
+    const exercise = await payload.create({
+      collection: 'exercises',
+      data: {
+        title: 'Agent Chat Integration Test Exercise',
+        slug: `agent-chat-int-${Date.now()}`,
+        _status: 'published',
+      } as any,
+    })
+    testExerciseId = exercise.id
+  }
+}, 30000)
+
+afterAll(async () => {
+  if (!payload) return
+
+  if (testUserId) {
+    await payload.delete({
+      collection: 'users',
+      id: testUserId,
+    })
+  }
+}, 30000)
+
+describe('agentChat endpoint', () => {
+  it('returns 401 when user is not authenticated', async () => {
+    const req = {
+      payload,
+      json: async () => ({
+        message: 'Hello',
+        acknowledgment: 'ack-1',
+        exerciseId: testExerciseId,
+      }),
+    } as unknown as PayloadRequest & { json: () => Promise<unknown> }
+
+    const res = await agentChat(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('processes chat request successfully for authenticated user', async () => {
+    if (!testExerciseId) {
+      throw new Error('testExerciseId was not initialized')
+    }
+
+    const req = {
+      payload,
+      user: { id: testUserId } as any,
+      json: async () => ({
+        message: 'Hello, can you help me with this exercise?',
+        acknowledgment: 'ack-1',
+        exerciseId: testExerciseId,
+      }),
+    } as unknown as PayloadRequest & { json: () => Promise<unknown> }
+
+    const res = await agentChat(req)
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body.success).toBe(true)
+    expect(typeof body.message).toBe('string')
+    expect(body.message).toBe('Mock assistant response')
+    expect(body.conversationId).toBeDefined()
+
+    // Verify conversation was created and contains both user and assistant messages.
+    const conversation = await payload.findByID({
+      collection: 'conversations',
+      id: body.conversationId,
+    })
+
+    expect(conversation).toBeDefined()
+    expect(Array.isArray(conversation.messages)).toBe(true)
+    expect(conversation.messages!.length).toBeGreaterThanOrEqual(2)
+  }, 60000)
+})
+

--- a/tests/int/agent-chat.int.spec.ts
+++ b/tests/int/agent-chat.int.spec.ts
@@ -13,6 +13,9 @@ import { getPayload } from 'payload'
 import type { PayloadRequest } from 'payload'
 import { agentChat } from '@/endpoints/agent/chat'
 
+// Skip tests if DATABASE_URL is not set (e.g., in CI without MongoDB service)
+const hasDatabaseUrl = !!process.env.DATABASE_URL
+
 // Mock AI and vector-related services to keep tests deterministic and offline.
 vi.mock('@/lib/ai/services/exercise-chat-service', () => ({
   chatWithExerciseHelper: vi.fn(async () => ({
@@ -59,39 +62,42 @@ let payload: Payload
 let testUserId: string
 let testExerciseId: string | undefined
 
-beforeAll(async () => {
-  payload = await getPayload({ config })
+beforeAll(
+  async () => {
+    payload = await getPayload({ config })
 
-  const user = await payload.create({
-    collection: 'users',
-    data: {
-      email: `agent-chat-int-${Date.now()}@example.com`,
-      password: 'test123456',
-      role: 'student',
-    },
-  })
-  testUserId = user.id
-
-  // Reuse an existing exercise if available; otherwise create a minimal one.
-  const existingExercises = await payload.find({
-    collection: 'exercises',
-    limit: 1,
-  })
-
-  if (existingExercises.docs.length > 0) {
-    testExerciseId = existingExercises.docs[0].id
-  } else {
-    const exercise = await payload.create({
-      collection: 'exercises',
+    const user = await payload.create({
+      collection: 'users',
       data: {
-        title: 'Agent Chat Integration Test Exercise',
-        slug: `agent-chat-int-${Date.now()}`,
-        _status: 'published',
-      } as any,
+        email: `agent-chat-int-${Date.now()}@example.com`,
+        password: 'test123456',
+        role: 'student',
+      },
     })
-    testExerciseId = exercise.id
-  }
-}, 30000)
+    testUserId = user.id
+
+    // Reuse an existing exercise if available; otherwise create a minimal one.
+    const existingExercises = await payload.find({
+      collection: 'exercises',
+      limit: 1,
+    })
+
+    if (existingExercises.docs.length > 0) {
+      testExerciseId = existingExercises.docs[0].id
+    } else {
+      const exercise = await payload.create({
+        collection: 'exercises',
+        data: {
+          title: 'Agent Chat Integration Test Exercise',
+          slug: `agent-chat-int-${Date.now()}`,
+          _status: 'published',
+        } as any,
+      })
+      testExerciseId = exercise.id
+    }
+  },
+  60000, // Increased timeout for Payload initialization
+)
 
 afterAll(async () => {
   if (!payload) return
@@ -104,7 +110,7 @@ afterAll(async () => {
   }
 }, 30000)
 
-describe('agentChat endpoint', () => {
+describe.skipIf(!hasDatabaseUrl)('agentChat endpoint', () => {
   it('returns 401 when user is not authenticated', async () => {
     const req = {
       payload,
@@ -155,4 +161,3 @@ describe('agentChat endpoint', () => {
     expect(conversation.messages!.length).toBeGreaterThanOrEqual(2)
   }, 60000)
 })
-

--- a/tests/unit/lib/ai/memory-extraction.spec.ts
+++ b/tests/unit/lib/ai/memory-extraction.spec.ts
@@ -8,7 +8,7 @@ vi.mock('fs', () => ({
   readFileSync: (...args: any[]) => readFileSyncMock(...args),
 }))
 
-// Mock OpenAI client so that generateSummary does not perform real network calls.
+// Mock OpenAI client so that extractMemoryCandidates does not perform real network calls.
 const createMock = vi.fn()
 
 class FakeOpenAI {
@@ -26,7 +26,7 @@ vi.mock('openai', () => ({
   OpenAI: FakeOpenAI,
 }))
 
-describe('summary service', () => {
+describe('memory extraction service', () => {
   beforeEach(() => {
     readFileSyncMock.mockReset()
     createMock.mockReset()
@@ -39,31 +39,47 @@ describe('summary service', () => {
     let callCount = 0
     readFileSyncMock.mockImplementation((path: string) => {
       callCount++
-      if (callCount === 1 && path.includes('summary-system-prompt.md') && !path.includes('.default')) {
+      if (callCount === 1 && path.includes('memory-extraction-system-prompt.md') && !path.includes('.default')) {
         const error: NodeJS.ErrnoException = new Error('ENOENT: file not found')
         error.code = 'ENOENT'
         throw error
       }
       // Return default fallback content
-      return 'You are a conversation summarizer for an educational chat system.'
+      return 'You are a memory extraction assistant for an educational platform.'
     })
 
     // Import after mocks so that module initialization uses the mocked fs
-    const { generateSummary } = await import('@/lib/ai/summary')
+    const { extractMemoryCandidates } = await import('@/lib/ai/memory-extraction')
 
     // Mock OpenAI response
     createMock.mockResolvedValue({
-      choices: [{ message: { content: 'mock summary' } }],
-      usage: { total_tokens: 42 },
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              memories: [
+                {
+                  type: 'preference',
+                  text: 'User prefers TypeScript',
+                  importance: 4,
+                  scope: 'user',
+                  reason: 'Explicitly stated preference',
+                },
+              ],
+            }),
+          },
+        },
+      ],
     })
 
     const now = new Date().toISOString()
-    const result = await generateSummary('', [
-      { role: 'user', content: 'Hello', timestamp: now },
-    ])
+    const result = await extractMemoryCandidates(
+      [{ role: 'user', content: 'I prefer TypeScript', timestamp: now }],
+      undefined,
+    )
 
-    expect(result.summary).toBe('mock summary')
-    expect(result.tokensUsed).toBe(42)
+    expect(result).toBeDefined()
+    expect(Array.isArray(result)).toBe(true)
     // Verify it tried to load the default fallback file
     expect(readFileSyncMock).toHaveBeenCalledTimes(2)
   })
@@ -77,21 +93,36 @@ describe('summary service', () => {
     })
 
     // Import after mocks so that module initialization uses the mocked fs
-    const { generateSummary } = await import('@/lib/ai/summary')
+    const { extractMemoryCandidates } = await import('@/lib/ai/memory-extraction')
 
     // Mock OpenAI response
     createMock.mockResolvedValue({
-      choices: [{ message: { content: 'mock summary' } }],
-      usage: { total_tokens: 42 },
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              memories: [
+                {
+                  type: 'preference',
+                  text: 'User prefers TypeScript',
+                  importance: 4,
+                  scope: 'user',
+                  reason: 'Explicitly stated preference',
+                },
+              ],
+            }),
+          },
+        },
+      ],
     })
 
     const now = new Date().toISOString()
-    const result = await generateSummary('', [
-      { role: 'user', content: 'Hello', timestamp: now },
-    ])
+    const result = await extractMemoryCandidates(
+      [{ role: 'user', content: 'I prefer TypeScript', timestamp: now }],
+      undefined,
+    )
 
-    expect(result.summary).toBe('mock summary')
-    expect(result.tokensUsed).toBe(42)
+    expect(result).toBeDefined()
+    expect(Array.isArray(result)).toBe(true)
   })
 })
-

--- a/tests/unit/lib/ai/memory-extraction.spec.ts
+++ b/tests/unit/lib/ai/memory-extraction.spec.ts
@@ -39,7 +39,11 @@ describe('memory extraction service', () => {
     let callCount = 0
     readFileSyncMock.mockImplementation((path: string) => {
       callCount++
-      if (callCount === 1 && path.includes('memory-extraction-system-prompt.md') && !path.includes('.default')) {
+      if (
+        callCount === 1 &&
+        path.includes('memory-extraction-system-prompt.md') &&
+        !path.includes('.default')
+      ) {
         const error: NodeJS.ErrnoException = new Error('ENOENT: file not found')
         error.code = 'ENOENT'
         throw error

--- a/tests/unit/lib/ai/prompts.spec.ts
+++ b/tests/unit/lib/ai/prompts.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests to validate that system prompt files exist and have content.
+ * These tests ensure that prompt files are present in the repository and
+ * not accidentally deleted or empty.
+ */
+import { describe, expect, it } from 'vitest'
+import { readFileSync, existsSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+// Path to prompts directory relative to test file location
+// From tests/unit/lib/ai/ we need to go up 4 levels to workspace root, then to src/lib/ai/prompts
+const promptsDir = join(__dirname, '../../../../src/lib/ai/prompts')
+
+describe('System prompt files validation', () => {
+  describe('Summary system prompts', () => {
+    it('should have summary-system-prompt.md file', () => {
+      const filePath = join(promptsDir, 'summary-system-prompt.md')
+      expect(existsSync(filePath)).toBe(true)
+    })
+
+    it('should have non-empty summary-system-prompt.md content', () => {
+      const filePath = join(promptsDir, 'summary-system-prompt.md')
+      const content = readFileSync(filePath, 'utf-8')
+      expect(content.trim().length).toBeGreaterThan(0)
+      expect(content).toContain('conversation summarizer')
+      expect(content).toContain('educational chat system')
+    })
+
+    it('should have summary-system-prompt.default.md fallback file', () => {
+      const filePath = join(promptsDir, 'summary-system-prompt.default.md')
+      expect(existsSync(filePath)).toBe(true)
+    })
+
+    it('should have non-empty summary-system-prompt.default.md content', () => {
+      const filePath = join(promptsDir, 'summary-system-prompt.default.md')
+      const content = readFileSync(filePath, 'utf-8')
+      expect(content.trim().length).toBeGreaterThan(0)
+      expect(content).toContain('conversation summarizer')
+      expect(content).toContain('educational chat system')
+    })
+
+    it('should have matching content between main and default summary prompts', () => {
+      const mainPath = join(promptsDir, 'summary-system-prompt.md')
+      const defaultPath = join(promptsDir, 'summary-system-prompt.default.md')
+      const mainContent = readFileSync(mainPath, 'utf-8').trim()
+      const defaultContent = readFileSync(defaultPath, 'utf-8').trim()
+
+      // They should have the same core content (allowing for minor formatting differences)
+      expect(mainContent).toContain('conversation summarizer')
+      expect(defaultContent).toContain('conversation summarizer')
+      expect(mainContent).toContain('500 words')
+      expect(defaultContent).toContain('500 words')
+    })
+  })
+
+  describe('Memory extraction system prompts', () => {
+    it('should have memory-extraction-system-prompt.md file', () => {
+      const filePath = join(promptsDir, 'memory-extraction-system-prompt.md')
+      expect(existsSync(filePath)).toBe(true)
+    })
+
+    it('should have non-empty memory-extraction-system-prompt.md content', () => {
+      const filePath = join(promptsDir, 'memory-extraction-system-prompt.md')
+      const content = readFileSync(filePath, 'utf-8')
+      expect(content.trim().length).toBeGreaterThan(0)
+      expect(content).toContain('memory extraction assistant')
+      expect(content).toContain('educational platform')
+    })
+
+    it('should have memory-extraction-system-prompt.default.md fallback file', () => {
+      const filePath = join(promptsDir, 'memory-extraction-system-prompt.default.md')
+      expect(existsSync(filePath)).toBe(true)
+    })
+
+    it('should have non-empty memory-extraction-system-prompt.default.md content', () => {
+      const filePath = join(promptsDir, 'memory-extraction-system-prompt.default.md')
+      const content = readFileSync(filePath, 'utf-8')
+      expect(content.trim().length).toBeGreaterThan(0)
+      expect(content).toContain('memory extraction assistant')
+      expect(content).toContain('educational platform')
+    })
+
+    it('should have matching content between main and default memory extraction prompts', () => {
+      const mainPath = join(promptsDir, 'memory-extraction-system-prompt.md')
+      const defaultPath = join(promptsDir, 'memory-extraction-system-prompt.default.md')
+      const mainContent = readFileSync(mainPath, 'utf-8').trim()
+      const defaultContent = readFileSync(defaultPath, 'utf-8').trim()
+
+      // They should have the same core content
+      expect(mainContent).toContain('memory extraction assistant')
+      expect(defaultContent).toContain('memory extraction assistant')
+      expect(mainContent).toContain('JSON')
+      expect(defaultContent).toContain('JSON')
+    })
+  })
+
+  describe('Exercise chat agent prompt', () => {
+    it('should have exercise-chat-agent-prompt.md file', () => {
+      const filePath = join(promptsDir, 'exercise-chat-agent-prompt.md')
+      expect(existsSync(filePath)).toBe(true)
+    })
+
+    it('should have non-empty exercise-chat-agent-prompt.md content', () => {
+      const filePath = join(promptsDir, 'exercise-chat-agent-prompt.md')
+      const content = readFileSync(filePath, 'utf-8')
+      expect(content.trim().length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('Prompt file structure', () => {
+    it('should have prompts directory', () => {
+      expect(existsSync(promptsDir)).toBe(true)
+    })
+
+    it('should have at least the required prompt files', () => {
+      const requiredFiles = [
+        'summary-system-prompt.md',
+        'summary-system-prompt.default.md',
+        'memory-extraction-system-prompt.md',
+        'memory-extraction-system-prompt.default.md',
+        'exercise-chat-agent-prompt.md',
+      ]
+
+      for (const fileName of requiredFiles) {
+        const filePath = join(promptsDir, fileName)
+        expect(existsSync(filePath)).toBe(true)
+      }
+    })
+  })
+})

--- a/tests/unit/lib/ai/summary.spec.ts
+++ b/tests/unit/lib/ai/summary.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+// We need to mock fs BEFORE importing the module under test because the prompt
+// is loaded at module initialization time.
+const readFileSyncMock = vi.fn()
+
+vi.mock('fs', () => ({
+  readFileSync: (...args: any[]) => readFileSyncMock(...args),
+}))
+
+// Mock OpenAI client so that generateSummary does not perform real network calls.
+const createMock = vi.fn()
+
+class FakeOpenAI {
+  chat = {
+    completions: {
+      create: createMock,
+    },
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  constructor(_options: any) {}
+}
+
+vi.mock('openai', () => ({
+  OpenAI: FakeOpenAI,
+}))
+
+describe('summary service', () => {
+  beforeEach(() => {
+    readFileSyncMock.mockReset()
+    createMock.mockReset()
+    // Ensure OPENAI_API_KEY check passes
+    process.env.OPENAI_API_KEY = 'test-key'
+  })
+
+  it('falls back to default prompt when markdown file cannot be read', async () => {
+    // Simulate ENOENT error when trying to read the markdown file
+    readFileSyncMock.mockImplementation(() => {
+      const error: NodeJS.ErrnoException = new Error('ENOENT: file not found')
+      error.code = 'ENOENT'
+      throw error
+    })
+
+    // Import after mocks so that module initialization uses the mocked fs
+    const { generateSummary } = await import('@/lib/ai/summary')
+
+    // Mock OpenAI response
+    createMock.mockResolvedValue({
+      choices: [{ message: { content: 'mock summary' } }],
+      usage: { total_tokens: 42 },
+    })
+
+    const now = new Date().toISOString()
+    const result = await generateSummary('', [
+      { role: 'user', content: 'Hello', timestamp: now },
+    ])
+
+    expect(result.summary).toBe('mock summary')
+    expect(result.tokensUsed).toBe(42)
+  })
+})
+

--- a/tests/unit/lib/ai/summary.spec.ts
+++ b/tests/unit/lib/ai/summary.spec.ts
@@ -39,7 +39,11 @@ describe('summary service', () => {
     let callCount = 0
     readFileSyncMock.mockImplementation((path: string) => {
       callCount++
-      if (callCount === 1 && path.includes('summary-system-prompt.md') && !path.includes('.default')) {
+      if (
+        callCount === 1 &&
+        path.includes('summary-system-prompt.md') &&
+        !path.includes('.default')
+      ) {
         const error: NodeJS.ErrnoException = new Error('ENOENT: file not found')
         error.code = 'ENOENT'
         throw error
@@ -58,9 +62,7 @@ describe('summary service', () => {
     })
 
     const now = new Date().toISOString()
-    const result = await generateSummary('', [
-      { role: 'user', content: 'Hello', timestamp: now },
-    ])
+    const result = await generateSummary('', [{ role: 'user', content: 'Hello', timestamp: now }])
 
     expect(result.summary).toBe('mock summary')
     expect(result.tokensUsed).toBe(42)
@@ -86,12 +88,9 @@ describe('summary service', () => {
     })
 
     const now = new Date().toISOString()
-    const result = await generateSummary('', [
-      { role: 'user', content: 'Hello', timestamp: now },
-    ])
+    const result = await generateSummary('', [{ role: 'user', content: 'Hello', timestamp: now }])
 
     expect(result.summary).toBe('mock summary')
     expect(result.tokensUsed).toBe(42)
   })
 })
-


### PR DESCRIPTION
Fix agent chat crashes due to missing summary prompt file and add new unit and integration tests for chat.

The `/api/agent/chat` endpoint was failing with an `ENOENT` error when `summary-system-prompt.md` was not found at runtime. This PR updates the summary service to gracefully fall back to a default inline prompt if the markdown file cannot be read, ensuring the chat functionality remains operational. Additionally, a unit test validates this fallback behavior, and a new integration test covers the `/api/agent/chat` endpoint's authentication and happy path. Minor updates to the `Conversation` type were also included to support more flexible chat contexts.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd4bad8a-9e02-401e-b96c-cb1bf1df5369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bd4bad8a-9e02-401e-b96c-cb1bf1df5369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

