### PR TITLE
Aguy logo text styling

### DIFF
--- a/src/components/TelescopeLogo/index.tsx
+++ b/src/components/TelescopeLogo/index.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 import telescopeSvg from './telescope.svg'
 import React from 'react'
+import clsx from 'clsx'
 
 interface TelescopeLogoProps {
   className?: string
@@ -8,13 +9,16 @@ interface TelescopeLogoProps {
 
 export function TelescopeLogo({ className }: TelescopeLogoProps) {
   return (
-    <Image
-      src={telescopeSvg}
-      alt="Telescope Logo"
-      className={className}
-      width={224}
-      height={204}
-      priority
-    />
+    <div className={clsx('flex items-center gap-2', className)}>
+      <Image
+        src={telescopeSvg}
+        alt="Telescope Logo"
+        className="h-8 w-auto"
+        width={224}
+        height={204}
+        priority
+      />
+      <span className="text-primary font-bold text-xl">Aguy</span>
+    </div>
   )
 }


### PR DESCRIPTION
Add 'Aguy' text to the site header logo, styled in bold and the theme's primary red color.

---
<a href="https://cursor.com/background-agent?bcId=bc-810b2d8a-d676-4104-9f0e-9092fae19c24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-810b2d8a-d676-4104-9f0e-9092fae19c24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

