### PR TITLE
Prettier markdown formatting

### DIFF
--- a/.tasks/lesson-document-chat-integration/plan.md
+++ b/.tasks/lesson-document-chat-integration/plan.md
@@ -12,20 +12,20 @@
 
 ## 2. Requirements → Plan Map (Trace Table)
 
-| Spec Requirement | Stage(s) | Deliverables | Tests |
-|------------------|----------|--------------|-------|
-| Extract document content on first message | Stage 1, 3 | pdf-extractor-service.ts, chat.ts modifications | Behaviors 1, 11 |
-| Retrieve document memories in answers | Stage 3 | context-policy.ts modifications | Behavior 2 |
-| Chunk documents respecting 2000 char limit | Stage 1 | Chunking algorithm in pdf-extractor-service.ts | Behavior 3 |
-| Skip extraction when no PDFs | Stage 3 | Logic in chat.ts | Behavior 4 |
-| Skip extraction when memories exist | Stage 2 | hasDocumentMemories() in document-memory-service.ts | Behavior 5 |
-| Handle empty/unreadable PDFs gracefully | Stage 1 | Error handling in pdf-extractor-service.ts | Behavior 6 |
-| Continue chat when extraction fails | Stage 3 | Try-catch with graceful fallback in chat.ts | Behavior 7 |
-| Continue chat when embedding fails | Stage 2 | Error handling in document-memory-service.ts | Behavior 8 |
-| Enforce conversation-level access control | Stage 4 | Filter updates in vector-search.ts | Behavior 9 |
-| Respect lesson access control | Stage 3 | Access check in chat.ts | Behavior 10 |
-| Process extraction asynchronously | Stage 3 | Promise.allSettled() in chat.ts | Behavior 11 |
-| Cache PDF extraction results | Stage 1 | Buffer caching in extraction loop | Behavior 12 |
+| Spec Requirement                           | Stage(s)   | Deliverables                                        | Tests           |
+| ------------------------------------------ | ---------- | --------------------------------------------------- | --------------- |
+| Extract document content on first message  | Stage 1, 3 | pdf-extractor-service.ts, chat.ts modifications     | Behaviors 1, 11 |
+| Retrieve document memories in answers      | Stage 3    | context-policy.ts modifications                     | Behavior 2      |
+| Chunk documents respecting 2000 char limit | Stage 1    | Chunking algorithm in pdf-extractor-service.ts      | Behavior 3      |
+| Skip extraction when no PDFs               | Stage 3    | Logic in chat.ts                                    | Behavior 4      |
+| Skip extraction when memories exist        | Stage 2    | hasDocumentMemories() in document-memory-service.ts | Behavior 5      |
+| Handle empty/unreadable PDFs gracefully    | Stage 1    | Error handling in pdf-extractor-service.ts          | Behavior 6      |
+| Continue chat when extraction fails        | Stage 3    | Try-catch with graceful fallback in chat.ts         | Behavior 7      |
+| Continue chat when embedding fails         | Stage 2    | Error handling in document-memory-service.ts        | Behavior 8      |
+| Enforce conversation-level access control  | Stage 4    | Filter updates in vector-search.ts                  | Behavior 9      |
+| Respect lesson access control              | Stage 3    | Access check in chat.ts                             | Behavior 10     |
+| Process extraction asynchronously          | Stage 3    | Promise.allSettled() in chat.ts                     | Behavior 11     |
+| Cache PDF extraction results               | Stage 1    | Buffer caching in extraction loop                   | Behavior 12     |
 
 **Validation**: All 12 spec behaviors mapped to implementation stages ✓
 
@@ -34,9 +34,11 @@
 ## 3. Stages (Risk-Ordered)
 
 ### Stage 1: PDF Extraction Service (Core Infrastructure)
+
 **Risk Level**: Medium - New dependency, external library integration
 
 **Scope**:
+
 - Create PDF text extraction service with chunking algorithm
 - Add `pdf-parse` dependency
 - Implement sentence-boundary chunking (max 2000 chars)
@@ -44,24 +46,28 @@
 - Buffer caching to avoid re-downloading
 
 **Deliverables**:
+
 - `src/lib/ai/services/pdf-extractor-service.ts` (new)
 - `tests/int/pdf-extractor.int.spec.ts` (new)
 - `tests/fixtures/pdfs/` directory with 4 test PDFs
 - Updated `package.json` with `pdf-parse` dependency
 
 **Verification**:
+
 - Unit tests pass for text extraction
 - Chunking algorithm respects 2000 char limit
 - Empty PDF returns empty string without error
 - Corrupted PDF throws handled error
 
 **Exit Criteria**:
+
 - ✓ All 4 PDF fixtures tested
 - ✓ Chunking produces no mid-sentence splits
 - ✓ Error cases logged, not thrown
 - ✓ `pnpm test:int && pnpm typecheck` passes
 
 **Constraints Check**: Compliant
+
 - Separation of concerns: pure service function
 - No UI logic mixed with extraction
 - Observable behavior tested
@@ -71,32 +77,38 @@
 ---
 
 ### Stage 2: Document Memory Service (Storage Layer)
+
 **Risk Level**: Medium - Integrates with existing memory system
 
 **Scope**:
+
 - Create document memory service for creating and checking memory items
 - Batch embedding generation (reuse existing pattern)
 - Deduplication check (prevent duplicate memories)
 - Type-safe memory item creation with document metadata
 
 **Deliverables**:
+
 - `src/lib/ai/document-memory-service.ts` (new)
 - `tests/int/document-memory.int.spec.ts` (new)
 - Extended MemoryItems schema with `type: 'document'` support
 
 **Verification**:
+
 - Memory items created with correct structure
 - `hasDocumentMemories()` correctly identifies existing memories
 - Embedding generation errors handled gracefully
 - Source metadata includes conversationId, lessonId, fileName
 
 **Exit Criteria**:
+
 - ✓ 3 integration tests pass (create, skip, fail gracefully)
 - ✓ Memory items queryable by conversationId + type='document'
 - ✓ Deduplication prevents duplicate memories
 - ✓ `pnpm test:int && pnpm typecheck` passes
 
 **Constraints Check**: Compliant
+
 - Payload-first: Uses Payload API for memory creation
 - No direct DB bypass
 - Server-side only (access control preserved)
@@ -106,9 +118,11 @@
 ---
 
 ### Stage 3: Chat Integration (Orchestration)
+
 **Risk Level**: High - Modifies critical chat endpoint
 
 **Scope**:
+
 - Integrate document extraction into chat flow on first message
 - Check if first message in conversation
 - Fetch lesson contentFiles (PDFs only)
@@ -117,17 +131,20 @@
 - Graceful degradation if extraction fails
 
 **Deliverables**:
+
 - Modified `src/endpoints/agent/chat.ts`
 - `tests/int/lesson-document-chat.int.spec.ts` (new)
 - Feature flag: `ENABLE_DOCUMENT_MEMORY` in env
 
 **Verification**:
+
 - Document extraction triggers on first message only
 - Extraction runs asynchronously (doesn't block response)
 - Chat responds normally if extraction fails
 - Lesson access control enforced before extraction
 
 **Exit Criteria**:
+
 - ✓ 3 integration tests pass (first message, skip subsequent, fail gracefully)
 - ✓ Chat response time < 3s (extraction in background)
 - ✓ 403 when user lacks lesson access
@@ -135,6 +152,7 @@
 - ✓ `pnpm test:int && pnpm typecheck && pnpm lint` passes
 
 **Constraints Check**: Compliant
+
 - Payload-first: Uses Payload's lesson query API
 - No hardcoded strings (logs only)
 - Minimal change to chat.ts (single async function call)
@@ -144,31 +162,37 @@
 ---
 
 ### Stage 4: Access Control & Security (Critical Path)
+
 **Risk Level**: Critical - Security implications
 
 **Scope**:
+
 - Update vector search filter to enforce conversation-scoped isolation
 - Ensure userId + conversationId always included in filters
 - Security audit of memory retrieval paths
 - Verify no cross-user memory leakage
 
 **Deliverables**:
+
 - Modified `src/lib/ai/vector-search.ts` (filter enhancement)
 - Security tests in `tests/int/lesson-document-chat.int.spec.ts`
 
 **Verification**:
+
 - Vector search filters by both userId AND conversationId
 - User A cannot retrieve User B's document memories
 - All memory retrieval paths audited
 - Test: Create memories for User A, query as User B, expect 0 results
 
 **Exit Criteria**:
+
 - ✓ 2 security tests pass (conversation isolation, lesson access)
 - ✓ All vector search queries include userId filter
 - ✓ No cross-tenant data leakage in any scenario
 - ✓ `pnpm test:int && pnpm typecheck` passes
 
 **Constraints Check**: Compliant
+
 - Payload-first: Uses Payload's user context
 - Security-first: Tenant isolation enforced at query level
 
@@ -177,31 +201,37 @@
 ---
 
 ### Stage 5: Documentation & Polish (Quality Gate)
+
 **Risk Level**: Low - Non-functional improvements
 
 **Scope**:
+
 - Update AGENTS.md with PDF extraction patterns
 - Add inline code comments for chunking algorithm
 - Document error handling patterns
 - Add feature flag configuration guide
 
 **Deliverables**:
+
 - Updated `docs/AGENTS.md`
 - Code comments in new services
 - Feature flag in `src/lib/feature-flags.ts`
 
 **Verification**:
+
 - Documentation complete and accurate
 - Code comments explain non-obvious logic
 - Feature flag documented in AGENTS.md
 
 **Exit Criteria**:
+
 - ✓ AGENTS.md includes PDF extraction section
 - ✓ All new functions have JSDoc comments
 - ✓ Feature flag behavior documented
 - ✓ `pnpm lint` passes (comment style checked)
 
 **Constraints Check**: Compliant
+
 - Documentation requirement met
 - No scope creep
 
@@ -212,7 +242,9 @@
 ## 4. Test Plan (Staged)
 
 ### Stage 1 Tests (PDF Extraction)
+
 **Behaviors Covered**: 3, 6, 12
+
 - ✅ Extract text from valid PDF (sample-lesson.pdf)
 - ✅ Chunk long text with sentence boundaries (long-lesson.pdf)
 - ✅ Handle empty PDF gracefully (empty.pdf)
@@ -222,7 +254,9 @@
 **Red-First Test**: Corrupted PDF extraction (expect graceful error, not crash)
 
 ### Stage 2 Tests (Memory Service)
+
 **Behaviors Covered**: 5, 8
+
 - ✅ Create document memories from chunks
 - ✅ Skip if memories already exist (hasDocumentMemories returns true)
 - ✅ Handle embedding API failure gracefully
@@ -230,7 +264,9 @@
 **Red-First Test**: Embedding generation fails (OpenAI API mocked to throw error)
 
 ### Stage 3 Tests (Chat Integration)
+
 **Behaviors Covered**: 1, 4, 7, 10, 11
+
 - ✅ Extract documents on first message (verify memory items created)
 - ✅ Skip extraction when lesson has no PDFs
 - ✅ Skip extraction on subsequent messages
@@ -241,14 +277,18 @@
 **Red-First Test**: Chat on first message with PDF (expect memory items in DB after response)
 
 ### Stage 4 Tests (Security)
+
 **Behaviors Covered**: 9, 10
+
 - ✅ Enforce conversation-level isolation (User A can't see User B's memories)
 - ✅ Respect lesson access control (no extraction for unauthorized users)
 
 **Red-First Test**: Cross-tenant memory leakage (User B queries, expect 0 results from User A)
 
 ### Stage 5 Tests (Documentation)
+
 **Behaviors Covered**: None (quality gate)
+
 - ✅ Verify all existing tests still pass
 - ✅ Verify build succeeds
 
@@ -259,11 +299,13 @@
 **Changes**: Schema extension (non-breaking)
 
 **Migration**: None required
+
 - `type: 'document'` is a new enum value (existing types unchanged)
 - `source` fields are optional (existing memories unaffected)
 - No data backfill needed
 
 **Rollback Implication**: Safe
+
 - New memory items remain in database (harmless)
 - Feature flag disables creation of new document memories
 - Existing memories unaffected
@@ -276,6 +318,7 @@
 **Environments**: dev → staging → prod
 
 **Feature Flag Strategy**:
+
 ```typescript
 // In .env
 ENABLE_DOCUMENT_MEMORY=false  // Start disabled
@@ -287,23 +330,27 @@ ENABLE_DOCUMENT_MEMORY=false  // Start disabled
 ```
 
 **Monitoring**:
+
 - **Errors**: PDF extraction failures (log rate)
 - **Performance**: Chat response time (p95 < 3s)
 - **Usage**: Document memories created per day
 - **Quality**: Memory retrieval success rate in chat
 
 **Key User Flows**:
+
 1. Student sends first message in lesson → memories created → chat responds
 2. Student asks document question → memories retrieved → accurate answer
 3. Extraction fails → chat still responds (graceful degradation)
 
 **Success Signals**:
+
 - ✅ Chat response time remains < 3s (p95)
 - ✅ Zero security incidents (cross-user leakage)
 - ✅ Document extraction success rate > 90%
 - ✅ Memory retrieval includes document memories in top 4 results
 
 **Failure Signals**:
+
 - ❌ Chat response time > 5s (p95) → disable feature flag
 - ❌ PDF extraction failure rate > 20% → investigate library compatibility
 - ❌ Security alert (cross-tenant data) → immediate rollback
@@ -329,6 +376,7 @@ ENABLE_DOCUMENT_MEMORY=false  // Start disabled
   - Change discipline: ✓ (minimal changes, no scope creep)
 
 **Explicit Defers**:
+
 - Admin UI for document memories → future enhancement
 - Video transcript extraction → out of scope
 - OCR for scanned PDFs → future enhancement
@@ -338,6 +386,7 @@ ENABLE_DOCUMENT_MEMORY=false  // Start disabled
 ## 8. Implementation Sequence
 
 ### Day 1-2: Stage 1 (PDF Extraction)
+
 - Add `pdf-parse` dependency
 - Create `pdf-extractor-service.ts`
 - Implement chunking algorithm
@@ -349,6 +398,7 @@ ENABLE_DOCUMENT_MEMORY=false  // Start disabled
 ---
 
 ### Day 3-4: Stage 2 (Memory Service)
+
 - Create `document-memory-service.ts`
 - Implement `createDocumentMemories()` and `hasDocumentMemories()`
 - Batch embedding generation
@@ -359,6 +409,7 @@ ENABLE_DOCUMENT_MEMORY=false  // Start disabled
 ---
 
 ### Day 5-7: Stage 3 (Chat Integration)
+
 - Modify `src/endpoints/agent/chat.ts`
 - Add document extraction logic (async)
 - Fetch lesson contentFiles
@@ -371,6 +422,7 @@ ENABLE_DOCUMENT_MEMORY=false  // Start disabled
 ---
 
 ### Day 8: Stage 4 (Security)
+
 - Update `vector-search.ts` filters
 - Add conversation-scoped isolation
 - Write 2 security tests
@@ -381,6 +433,7 @@ ENABLE_DOCUMENT_MEMORY=false  // Start disabled
 ---
 
 ### Day 9: Stage 5 (Documentation)
+
 - Update AGENTS.md
 - Add code comments
 - Configure feature flag
@@ -392,14 +445,14 @@ ENABLE_DOCUMENT_MEMORY=false  // Start disabled
 
 ## 9. Constraints Compliance Summary
 
-| Constraint | Compliance | Evidence |
-|------------|------------|----------|
-| Payload-First | ✓ Compliant | Uses Payload APIs for lesson queries, memory creation |
-| i18n Only | ✓ Compliant | No UI strings (backend only, logs exempted) |
-| Microcomponents | N/A | Backend services only |
+| Constraint             | Compliance  | Evidence                                                               |
+| ---------------------- | ----------- | ---------------------------------------------------------------------- |
+| Payload-First          | ✓ Compliant | Uses Payload APIs for lesson queries, memory creation                  |
+| i18n Only              | ✓ Compliant | No UI strings (backend only, logs exempted)                            |
+| Microcomponents        | N/A         | Backend services only                                                  |
 | Separation of Concerns | ✓ Compliant | Service layer (pdf-extractor, document-memory), endpoint orchestration |
-| Testing Alignment | ✓ Compliant | 12 integration tests, observable behavior validated |
-| Change Discipline | ✓ Compliant | Minimal changes to chat.ts, no unrelated refactors |
+| Testing Alignment      | ✓ Compliant | 12 integration tests, observable behavior validated                    |
+| Change Discipline      | ✓ Compliant | Minimal changes to chat.ts, no unrelated refactors                     |
 
 **Violations**: None
 
@@ -410,6 +463,7 @@ ENABLE_DOCUMENT_MEMORY=false  // Start disabled
 ## 10. Dependencies
 
 ### New NPM Dependencies
+
 ```json
 {
   "pdf-parse": "^1.1.1"
@@ -417,6 +471,7 @@ ENABLE_DOCUMENT_MEMORY=false  // Start disabled
 ```
 
 ### Development Dependencies
+
 ```json
 {
   "@types/pdf-parse": "^1.1.4"
@@ -424,6 +479,7 @@ ENABLE_DOCUMENT_MEMORY=false  // Start disabled
 ```
 
 ### Existing Dependencies (Already Available)
+
 - `openai` - Embedding generation
 - `mongodb` - Vector search
 - `zod` - Validation
@@ -433,20 +489,21 @@ ENABLE_DOCUMENT_MEMORY=false  // Start disabled
 
 ## 11. Risk Mitigation Matrix
 
-| Risk | Likelihood | Impact | Mitigation |
-|------|------------|--------|------------|
-| PDF library compatibility issues | Medium | Medium | Comprehensive error handling, test with diverse PDFs |
-| Chat response time degradation | Low | High | Async processing (Promise.allSettled), timeout (10s) |
-| OpenAI API failure | Medium | Low | Graceful degradation, retry in background |
-| Cross-user memory leakage | Low | Critical | Mandatory userId filter, security tests, audit |
-| Large document token overflow | Medium | Medium | Chunking limit (max 50 chunks), preview extraction |
-| Feature breaks existing chat | Low | High | Feature flag, extensive integration tests |
+| Risk                             | Likelihood | Impact   | Mitigation                                           |
+| -------------------------------- | ---------- | -------- | ---------------------------------------------------- |
+| PDF library compatibility issues | Medium     | Medium   | Comprehensive error handling, test with diverse PDFs |
+| Chat response time degradation   | Low        | High     | Async processing (Promise.allSettled), timeout (10s) |
+| OpenAI API failure               | Medium     | Low      | Graceful degradation, retry in background            |
+| Cross-user memory leakage        | Low        | Critical | Mandatory userId filter, security tests, audit       |
+| Large document token overflow    | Medium     | Medium   | Chunking limit (max 50 chunks), preview extraction   |
+| Feature breaks existing chat     | Low        | High     | Feature flag, extensive integration tests            |
 
 ---
 
 ## 12. Code Patterns Reference
 
 ### Pattern 1: Payload-First Query
+
 ```typescript
 // ✅ Correct: Use Payload API
 const lesson = await payload.findByID({
@@ -460,6 +517,7 @@ const lesson = await db.collection('lessons').findOne({ _id: lessonId })
 ```
 
 ### Pattern 2: Async Background Processing
+
 ```typescript
 // ✅ Correct: Non-blocking
 const extractionPromise = extractAndStoreDocuments(lesson, conversation)
@@ -472,6 +530,7 @@ return res.json({ message: 'Chat response' })
 ```
 
 ### Pattern 3: Tenant-Safe Vector Search
+
 ```typescript
 // ✅ Correct: Always filter by userId
 const memories = await retrieveMemoryItems(db, userId, query, conversationId)
@@ -481,6 +540,7 @@ const memories = await collection.find({ conversationId })
 ```
 
 ### Pattern 4: Graceful Error Handling
+
 ```typescript
 // ✅ Correct: Fail gracefully
 try {

--- a/.tasks/lesson-document-chat-integration/spec.md
+++ b/.tasks/lesson-document-chat-integration/spec.md
@@ -15,6 +15,7 @@ Impact: high
 ## 2. Behaviors to Cover
 
 ### Happy Path
+
 1. **Should extract and store document content when user sends first message in lesson conversation**
    - Given: Lesson has contentFiles with PDFs
    - When: User sends first message in conversation
@@ -31,6 +32,7 @@ Impact: high
    - Then: Creates 5+ memory items with semantic chunking
 
 ### Edge Cases
+
 4. **Should skip document extraction when lesson has no PDF files**
    - Given: Lesson contentFiles contains only images/videos
    - When: First message sent
@@ -47,6 +49,7 @@ Impact: high
    - Then: Logs warning, continues chat without document context
 
 ### Failures
+
 7. **Should continue chat when PDF extraction fails**
    - Given: PDF extraction throws error (corrupted file, network timeout)
    - When: First message processing
@@ -58,6 +61,7 @@ Impact: high
    - Then: Chat responds normally, logs error, retries embedding in background
 
 ### Security
+
 9. **Should enforce conversation-level access control for document memories**
    - Given: User A has conversation with lesson document
    - When: User B queries their own lesson conversation
@@ -69,6 +73,7 @@ Impact: high
     - Then: Returns 403, does not extract or store document content
 
 ### Performance
+
 11. **Should process document extraction asynchronously without blocking chat response**
     - Given: User sends first message
     - When: Chat response generation starts
@@ -84,6 +89,7 @@ Impact: high
 ## 3. Expected Outcomes
 
 **Behavior 1 → Outcome**:
+
 - Database: MemoryItems collection contains records with:
   - `userId`: Current user ID
   - `conversationId`: Current conversation ID
@@ -96,55 +102,66 @@ Impact: high
 - Count: 1+ memory items (depends on document length)
 
 **Behavior 2 → Outcome**:
+
 - API: Chat response includes content that references document text
 - Logs: Context usage includes document memory items with source citations
 
 **Behavior 3 → Outcome**:
+
 - Database: Multiple MemoryItems with same conversationId, sequential chunkIndex
 - Each item: `text.length <= 2000`
 - Chunking: Respects sentence/paragraph boundaries (no mid-sentence cuts)
 
 **Behavior 4 → Outcome**:
+
 - Database: No document-type memory items created
 - API: 200 response with chat answer
 - Logs: Info log "No PDF documents found for lesson {lessonId}"
 
 **Behavior 5 → Outcome**:
+
 - Database: No new memory items created (count unchanged)
 - Query: `db.memory_items.countDocuments({ conversationId: X, type: 'document' })` > 0
 - Logs: Debug log "Document memories already exist, skipping extraction"
 
 **Behavior 6 → Outcome**:
+
 - API: 200 response with chat answer
 - Logs: Warn log "PDF {fileName} contains no extractable text"
 - Database: No memory items created for empty PDF
 
 **Behavior 7 → Outcome**:
+
 - API: 200 response with chat answer (no failure exposed to user)
 - Logs: Error log with PDF extraction error details + stack trace
 - Database: No document memory items created
 
 **Behavior 8 → Outcome**:
+
 - API: 200 response with chat answer
 - Logs: Error log "Embedding generation failed, will retry in background"
 - Background: Task queued to retry embedding generation
 
 **Behavior 9 → Outcome**:
+
 - Vector Search: Filter includes `{ conversationId: <user's conversation>, userId: <current user> }`
 - Results: Only memories from user's own conversation returned
 - Test: User B queries → 0 document memories from User A's conversation
 
 **Behavior 10 → Outcome**:
+
 - API: 403 response with message "Access denied to lesson"
 - Database: No conversation created, no memory items created
 - Logs: Security log "Unauthorized lesson access attempt by user {userId}"
 
 **Behavior 11 → Outcome**:
+
 - API: Chat response time < 3s (measured in integration test)
 - Background: Document extraction task spawned with `Promise.allSettled()` (non-blocking)
 - Logs: Two separate log entries with timestamps showing async execution
 
 **Behavior 12 → Outcome**:
+
 - Network: Single `fetch()` call to Vercel Blob URL per PDF
 - Memory: Buffer stored in scope/closure during chunking loop
 - Logs: Debug log showing "Processing chunk 2/5 from cached buffer"
@@ -156,6 +173,7 @@ Impact: high
 **Explicitly excluded from this task:**
 
 ### Feature Exclusions
+
 - Image OCR extraction (only PDF text extraction)
 - Video transcript extraction (future enhancement)
 - Document summarization (will be handled by existing memory extraction)
@@ -165,11 +183,13 @@ Impact: high
 - Document search/filtering UI
 
 ### Test Type Exclusions
+
 - E2E tests (chat interaction tested at integration level)
 - Performance benchmarks (extraction time variance too high for CI)
 - Load testing (background processing behavior)
 
 ### Technical Exclusions
+
 - PDF table/form extraction (only plain text)
 - PDF image extraction (only text content)
 - Scanned PDF OCR (requires Gemini vision API - future)
@@ -177,6 +197,7 @@ Impact: high
 - Real-time document updates (batch processing only)
 
 ### Domain Exclusions
+
 - Exercise-level document context (only lesson-level)
 - Document access analytics (usage tracking)
 - Document quality scoring (readability metrics)
@@ -194,6 +215,7 @@ Database: real (test MongoDB with vector search)
 ```
 
 **Rationale**:
+
 - Integration tests verify full flow: API request → PDF extraction → memory creation → vector retrieval
 - Mock OpenAI to avoid cost and rate limits (use deterministic fake embeddings)
 - Mock Vercel Blob fetch to avoid network dependency (use fixture PDF buffers)
@@ -201,6 +223,7 @@ Database: real (test MongoDB with vector search)
 - No E2E needed - chat behavior already covered by existing chat integration tests
 
 **Test Data**:
+
 - Fixture PDFs: `tests/fixtures/pdfs/` directory
   - `sample-lesson.pdf` (3 pages, ~2000 chars, single chunk)
   - `long-lesson.pdf` (10 pages, ~10,000 chars, multi-chunk)
@@ -212,18 +235,21 @@ Database: real (test MongoDB with vector search)
 ## 6. Stop Conditions
 
 **All tests must pass:**
+
 - ✓ 12 behaviors → 12 integration tests passing
 - ✓ `pnpm test:int` (all existing + new tests pass)
 - ✓ `pnpm typecheck && pnpm lint && pnpm build` (no errors)
 - ✓ `pnpm generate:types` (Payload types regenerated if collections modified)
 
 **Code quality gates:**
+
 - ✓ No unrelated test modifications
 - ✓ No snapshot-only tests (all assertions explicit)
 - ✓ All new code covered by tests (100% for new service layer)
 - ✓ Error handling paths tested (failures don't crash)
 
 **Functional completeness:**
+
 - ✓ Document extraction service implemented and tested
 - ✓ Memory chunking respects 2000 char limit
 - ✓ Vector search retrieves document memories correctly
@@ -231,6 +257,7 @@ Database: real (test MongoDB with vector search)
 - ✓ Access control enforced (conversation-scoped isolation)
 
 **Documentation:**
+
 - ✓ AGENTS.md updated with PDF extraction patterns
 - ✓ Inline code comments for chunking algorithm
 - ✓ Error handling documented in service layer
@@ -249,18 +276,21 @@ Types: yes (pnpm generate:types if Conversation schema changes)
 ```
 
 **New Files**:
+
 1. `src/lib/ai/services/pdf-extractor-service.ts` - PDF text extraction + chunking
 2. `src/lib/ai/document-memory-service.ts` - Document memory creation + retrieval
 3. `tests/int/lesson-document-chat.int.spec.ts` - Integration test suite
 4. `tests/fixtures/pdfs/` - Test PDF files (4 fixtures)
 
 **Modified Files**:
+
 1. `src/endpoints/agent/chat.ts` - Add document extraction logic to Step 3-4
 2. `src/lib/ai/context-policy.ts` - Document memory retrieval in compose step
 3. `docs/AGENTS.md` - Add PDF extraction service documentation
 4. `package.json` - Add `pdf-parse` dependency
 
 **Dependencies to Add**:
+
 - `pdf-parse` (^1.1.1) - Server-side PDF text extraction
 - `@types/pdf-parse` (dev dependency)
 
@@ -269,6 +299,7 @@ Types: yes (pnpm generate:types if Conversation schema changes)
 ## 8. Risk & Rollback
 
 ### Breaking Changes
+
 ```yaml
 Breaking: Chat responses may be delayed if PDF extraction blocks
 Blast radius: module (lesson conversations only)
@@ -277,6 +308,7 @@ Data safety: medium (large memory items created, quota impact)
 ```
 
 **Risk Mitigation**:
+
 1. **Performance risk**: Background processing prevents blocking
    - Mitigation: `Promise.allSettled()` + timeout (10s max per PDF)
    - Fallback: Skip extraction, log error, chat continues
@@ -294,18 +326,21 @@ Data safety: medium (large memory items created, quota impact)
    - Testing: Verify retrieval precision in integration tests
 
 ### Rollback Strategy
+
 1. **Immediate rollback**: Revert PR (single commit)
 2. **Feature flag**: `ENABLE_DOCUMENT_MEMORY=false` (env var)
 3. **Data cleanup**: Document memories remain (no breaking change)
 4. **Monitoring**: Track chat response latency in logs
 
 ### Data Safety
+
 - **No destructive operations**: Only creates memory items
 - **Idempotent**: Checks for existing memories before creating
 - **User isolation**: Conversation-scoped, no cross-user contamination
 - **Quota impact**: ~10-50 memory items per lesson conversation (within limits)
 
 ### Blast Radius
+
 - **Affected**: Lesson conversations with PDF documents
 - **Unaffected**: Exercise-only conversations, image-only lessons
 - **Scope**: New conversations only (existing conversations unaffected)


### PR DESCRIPTION
Fix formatting issues in two Markdown files to pass `pnpm format:check`.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c68b9c5-f0bf-429a-9beb-cc8216f2a8e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2c68b9c5-f0bf-429a-9beb-cc8216f2a8e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

