### PR TITLE
Summary prompt file path

### DIFF
--- a/src/lib/ai/memory-extraction.ts
+++ b/src/lib/ai/memory-extraction.ts
@@ -10,19 +10,16 @@
  */
 
 import { logger } from '@/utilities/logger'
-import { readFileSync } from 'fs'
 import { OpenAI } from 'openai'
-import { dirname, join } from 'path'
 import type { Payload } from 'payload'
-import { fileURLToPath } from 'url'
 import { ChatRole } from './chat-message-role'
 import type { Message } from './context-policy'
 import { generateEmbeddings } from './embeddings'
 import { logMaintenance } from './observability'
 import { findSimilarMemoryItem, type MemoryItem } from './vector-search'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
+// Import prompts directly - webpack will bundle them as strings
+import memoryExtractionPrompt from './prompts/memory-extraction-system-prompt.md'
+import memoryExtractionPromptDefault from './prompts/memory-extraction-system-prompt.default.md'
 
 // Lazy initialization to avoid errors at module load time
 let openai: OpenAI | null = null
@@ -40,66 +37,44 @@ function getOpenAIClient(): OpenAI {
   return openai
 }
 
-// Load prompt from external file with a safe fallback so that missing files
-// do not crash the agent chat endpoint at module load time (e.g. in serverless environments).
-// First tries to load the main prompt file, then falls back to the default file, then to inline default.
-let MEMORY_EXTRACTION_PROMPT: string = ''
-
-try {
-  const promptPath = join(__dirname, 'prompts/memory-extraction-system-prompt.md')
-  MEMORY_EXTRACTION_PROMPT = readFileSync(promptPath, 'utf-8')
-} catch (error: unknown) {
-  logger.warn(
-    { err: error, path: join(__dirname, 'prompts/memory-extraction-system-prompt.md') },
-    '[MemoryExtraction] Failed to load memory extraction prompt from markdown file, trying default fallback',
-  )
-
-  // Try to load the default fallback file
-  try {
-    const defaultPath = join(__dirname, 'prompts/memory-extraction-system-prompt.default.md')
-    MEMORY_EXTRACTION_PROMPT = readFileSync(defaultPath, 'utf-8')
-    logger.info('[MemoryExtraction] Loaded default memory extraction prompt from fallback file')
-  } catch (fallbackError: unknown) {
-    logger.warn(
-      { err: fallbackError },
-      '[MemoryExtraction] Failed to load default fallback file, using inline default',
-    )
-    // Final fallback: inline default (matches memory-extraction-system-prompt.default.md)
-    MEMORY_EXTRACTION_PROMPT = [
-      'You are a memory extraction assistant for an educational platform.',
-      '',
-      'Analyze the conversation and extract important information worth remembering long-term.',
-      '',
-      'Focus on:',
-      '',
-      '- User preferences (learning style, pace, topics of interest)',
-      '- Decisions made (chose X over Y, wants to focus on Z)',
-      "- Important facts (user's background, goals, constraints)",
-      '- Open loops (questions to follow up on later)',
-      '- Profile information (skill level, prior knowledge)',
-      '',
-      'Output format (JSON):',
-      '{',
-      '"memories": [',
-      '{',
-      '"type": "preference|decision|fact|open_loop|profile|constraint|other",',
-      '"text": "Concise statement (max 200 chars)",',
-      '"importance": 1-5,',
-      '"scope": "user|conversation",',
-      '"reason": "Why this is worth remembering"',
-      '}',
-      ']',
-      '}',
-      '',
-      'Filtering rules:',
-      '',
-      '- Omit greetings, acknowledgments, small talk',
-      '- Omit temporary/ephemeral content',
-      '- Be selective: quality over quantity (max 3-5 items per extraction)',
-      '- Each item must be actionable or informative',
-    ].join('\n')
-  }
-}
+// Load prompt from imported markdown file with fallback
+// Webpack bundles .md files as strings via next.config.js webpack loader
+const MEMORY_EXTRACTION_PROMPT: string =
+  memoryExtractionPrompt ||
+  memoryExtractionPromptDefault ||
+  [
+    'You are a memory extraction assistant for an educational platform.',
+    '',
+    'Analyze the conversation and extract important information worth remembering long-term.',
+    '',
+    'Focus on:',
+    '',
+    '- User preferences (learning style, pace, topics of interest)',
+    '- Decisions made (chose X over Y, wants to focus on Z)',
+    "- Important facts (user's background, goals, constraints)",
+    '- Open loops (questions to follow up on later)',
+    '- Profile information (skill level, prior knowledge)',
+    '',
+    'Output format (JSON):',
+    '{',
+    '"memories": [',
+    '{',
+    '"type": "preference|decision|fact|open_loop|profile|constraint|other",',
+    '"text": "Concise statement (max 200 chars)",',
+    '"importance": 1-5,',
+    '"scope": "user|conversation",',
+    '"reason": "Why this is worth remembering"',
+    '}',
+    ']',
+    '}',
+    '',
+    'Filtering rules:',
+    '',
+    '- Omit greetings, acknowledgments, small talk',
+    '- Omit temporary/ephemeral content',
+    '- Be selective: quality over quantity (max 3-5 items per extraction)',
+    '- Each item must be actionable or informative',
+  ].join('\n')
 
 interface MemoryCandidate {
   type: 'preference' | 'decision' | 'fact' | 'open_loop' | 'profile' | 'constraint' | 'other'

--- a/src/lib/ai/summary.ts
+++ b/src/lib/ai/summary.ts
@@ -10,14 +10,11 @@
  */
 
 import { OpenAI } from 'openai'
-import { readFileSync } from 'fs'
-import { join, dirname } from 'path'
-import { fileURLToPath } from 'url'
 import { logger } from '@/utilities/logger'
 import type { Message } from './context-policy'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
+// Import prompts directly - webpack will bundle them as strings
+import summaryPrompt from './prompts/summary-system-prompt.md'
+import summaryPromptDefault from './prompts/summary-system-prompt.default.md'
 
 // Lazy initialization to avoid errors at module load time
 let openai: OpenAI | null = null
@@ -41,48 +38,24 @@ export interface SummaryResult {
   tokensUsed: number
 }
 
-// Load prompt from external file with a safe fallback so that missing files
-// do not crash the agent chat endpoint at module load time (e.g. in serverless environments).
-// First tries to load the main prompt file, then falls back to the default file, then to inline default.
-let SUMMARY_SYSTEM_PROMPT: string = ''
-
-try {
-  const promptPath = join(__dirname, 'prompts/summary-system-prompt.md')
-  SUMMARY_SYSTEM_PROMPT = readFileSync(promptPath, 'utf-8')
-} catch (error: unknown) {
-  logger.warn(
-    { err: error, path: join(__dirname, 'prompts/summary-system-prompt.md') },
-    '[Summary] Failed to load summary system prompt from markdown file, trying default fallback',
-  )
-
-  // Try to load the default fallback file
-  try {
-    const defaultPath = join(__dirname, 'prompts/summary-system-prompt.default.md')
-    SUMMARY_SYSTEM_PROMPT = readFileSync(defaultPath, 'utf-8')
-    logger.info('[Summary] Loaded default summary prompt from fallback file')
-  } catch (fallbackError: unknown) {
-    logger.warn(
-      { err: fallbackError },
-      '[Summary] Failed to load default fallback file, using inline default',
-    )
-    // Final fallback: inline default (matches summary-system-prompt.default.md)
-    SUMMARY_SYSTEM_PROMPT = [
-      'You are a conversation summarizer for an educational chat system.',
-      '',
-      'Your task is to create a concise, factual summary that preserves:',
-      '',
-      '- Key decisions made',
-      '- User preferences and constraints',
-      '- Important facts and context',
-      '- Open loops (unresolved questions)',
-      '- Learning progress and goals',
-      '',
-      'Keep the summary under 500 words. Use clear, structured format.',
-      'Omit greetings, small talk, and ephemeral content.',
-      'Focus on information that will help continue the conversation later.',
-    ].join('\n')
-  }
-}
+// Load prompt from imported markdown file with fallback
+// Webpack bundles .md files as strings via next.config.js webpack loader
+const SUMMARY_SYSTEM_PROMPT: string =
+  summaryPrompt || summaryPromptDefault || [
+    'You are a conversation summarizer for an educational chat system.',
+    '',
+    'Your task is to create a concise, factual summary that preserves:',
+    '',
+    '- Key decisions made',
+    '- User preferences and constraints',
+    '- Important facts and context',
+    '- Open loops (unresolved questions)',
+    '- Learning progress and goals',
+    '',
+    'Keep the summary under 500 words. Use clear, structured format.',
+    'Omit greetings, small talk, and ephemeral content.',
+    'Focus on information that will help continue the conversation later.',
+  ].join('\n')
 
 /**
  * Generate or update conversation summary


### PR DESCRIPTION
Switch to direct markdown imports for AI prompts to fix `ENOENT` errors in serverless environments.

`readFileSync` fails in Next.js serverless environments (e.g., Vercel) because the file paths are not accessible at runtime. This PR updates `src/lib/ai/summary.ts` and `src/lib/ai/memory-extraction.ts` to directly import markdown files, which Next.js webpack bundles as strings via the `asset/source` loader, ensuring the prompt content is available without filesystem access. The existing fallback logic for prompts is preserved.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1103e77-9a29-4859-a75a-cd7a16466d36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d1103e77-9a29-4859-a75a-cd7a16466d36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

