### PR TITLE
Test media file paths

### DIFF
--- a/tests/int/lesson-document-chat.int.spec.ts
+++ b/tests/int/lesson-document-chat.int.spec.ts
@@ -142,9 +142,16 @@ async function createMediaFileWithFile(
   // Write the file to disk first (Payload will read from here during processing)
   fs.writeFileSync(filePath, content)
   
-  // Verify file was written
+  // Verify file was written and is readable
   if (!fs.existsSync(filePath)) {
     throw new Error(`Failed to create file at ${filePath}`)
+  }
+  
+  // Ensure file is readable (check permissions)
+  try {
+    fs.accessSync(filePath, fs.constants.R_OK)
+  } catch (error) {
+    throw new Error(`File at ${filePath} is not readable: ${error}`)
   }
   
   // Create media record with file buffer

--- a/tests/int/lesson-document-chat.int.spec.ts
+++ b/tests/int/lesson-document-chat.int.spec.ts
@@ -18,6 +18,9 @@ import { agentChat } from '@/endpoints/agent/chat'
 import sampleLessonExtraction from '../fixtures/ai-extractions/sample-lesson-extraction.json'
 import longLessonExtraction from '../fixtures/ai-extractions/long-lesson-extraction.json'
 import emptyExtraction from '../fixtures/ai-extractions/empty-extraction.json'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
 
 // Skip tests if DATABASE_URL is not set
 const hasDatabaseUrl = !!process.env.DATABASE_URL
@@ -113,6 +116,48 @@ let testUserId: string
 let testLessonId: string | undefined
 let testChapterId: string | undefined
 let testCourseId: string | undefined
+
+// Helper function to create a media file with actual file on disk
+async function createMediaFileWithFile(
+  payload: Payload,
+  filename: string,
+  content: Buffer = Buffer.from('%PDF-1.4\n1 0 obj\n<<\n/Type /Catalog\n>>\nendobj\nxref\n0 0\ntrailer\n<<\n/Size 1\n/Root 1 0 R\n>>\nstartxref\n9\n%%EOF'),
+): Promise<{ id: string; filePath: string }> {
+  // Get the media directory path (same as Media collection staticDir)
+  // Media collection: path.resolve(dirname, '../../public/media') where dirname is src/collections/Media
+  // This resolves to src/public/media
+  const testFile = fileURLToPath(import.meta.url)
+  const testDir = path.dirname(testFile) // tests/int
+  const projectRoot = path.resolve(testDir, '../..') // project root
+  const mediaDir = path.join(projectRoot, 'src', 'public', 'media')
+  
+  // Ensure directory exists
+  if (!fs.existsSync(mediaDir)) {
+    fs.mkdirSync(mediaDir, { recursive: true })
+  }
+  
+  const filePath = path.join(mediaDir, filename)
+  
+  // Write the file to disk first (Payload will read from here during processing)
+  fs.writeFileSync(filePath, content)
+  
+  // Create media record with file buffer
+  // Payload will process the file and may read it from disk for metadata extraction
+  const mediaFile = await payload.create({
+    collection: 'media',
+    data: {
+      filename,
+    } as any,
+    file: {
+      data: content,
+      mimetype: 'application/pdf',
+      name: filename,
+      size: content.length,
+    },
+  })
+  
+  return { id: mediaFile.id, filePath }
+}
 
 beforeAll(
   async () => {
@@ -227,14 +272,11 @@ describe.skipIf(!hasDatabaseUrl)('Lesson Document Chat Integration', () => {
     }
 
     // Create a media file (PDF) for the lesson
-    const mediaFile = await payload.create({
-      collection: 'media',
-      data: {
-        filename: 'sample-lesson.pdf',
-        mimeType: 'application/pdf',
-        url: '/media/sample-lesson.pdf',
-      } as any,
-    })
+    const { id: mediaFileId, filePath: mediaFilePath } = await createMediaFileWithFile(
+      payload,
+      'sample-lesson.pdf',
+    )
+    const mediaFile = { id: mediaFileId }
 
     // Update lesson with contentFiles
     await payload.update({
@@ -310,6 +352,9 @@ describe.skipIf(!hasDatabaseUrl)('Lesson Document Chat Integration', () => {
 
     // Cleanup
     await payload.delete({ collection: 'media', id: mediaFile.id })
+    if (fs.existsSync(mediaFilePath)) {
+      fs.unlinkSync(mediaFilePath)
+    }
   }, 60000)
 
   it('should skip document extraction when lesson has no PDF files', async () => {
@@ -440,14 +485,12 @@ describe.skipIf(!hasDatabaseUrl)('Lesson Document Chat Integration', () => {
     }
 
     // Create a media file for empty PDF
-    const mediaFile = await payload.create({
-      collection: 'media',
-      data: {
-        filename: 'empty.pdf',
-        mimeType: 'application/pdf',
-        url: '/media/empty.pdf',
-      } as any,
-    })
+    const { id: mediaFileId, filePath: mediaFilePath } = await createMediaFileWithFile(
+      payload,
+      'empty.pdf',
+      Buffer.from('%PDF-1.4\n'),
+    )
+    const mediaFile = { id: mediaFileId }
 
     await payload.update({
       collection: 'lessons',
@@ -505,6 +548,9 @@ describe.skipIf(!hasDatabaseUrl)('Lesson Document Chat Integration', () => {
 
     // Cleanup
     await payload.delete({ collection: 'media', id: mediaFile.id })
+    if (fs.existsSync(mediaFilePath)) {
+      fs.unlinkSync(mediaFilePath)
+    }
   }, 60000)
 
   it('should chunk large documents into multiple memory items', async () => {
@@ -513,14 +559,11 @@ describe.skipIf(!hasDatabaseUrl)('Lesson Document Chat Integration', () => {
     }
 
     // Create a media file for long PDF
-    const mediaFile = await payload.create({
-      collection: 'media',
-      data: {
-        filename: 'long-lesson.pdf',
-        mimeType: 'application/pdf',
-        url: '/media/long-lesson.pdf',
-      } as any,
-    })
+    const { id: mediaFileId, filePath: mediaFilePath } = await createMediaFileWithFile(
+      payload,
+      'long-lesson.pdf',
+    )
+    const mediaFile = { id: mediaFileId }
 
     await payload.update({
       collection: 'lessons',
@@ -594,5 +637,8 @@ describe.skipIf(!hasDatabaseUrl)('Lesson Document Chat Integration', () => {
 
     // Cleanup
     await payload.delete({ collection: 'media', id: mediaFile.id })
+    if (fs.existsSync(mediaFilePath)) {
+      fs.unlinkSync(mediaFilePath)
+    }
   }, 60000)
 })

--- a/tests/int/lesson-document-chat.int.spec.ts
+++ b/tests/int/lesson-document-chat.int.spec.ts
@@ -123,13 +123,14 @@ async function createMediaFileWithFile(
   filename: string,
   content: Buffer = Buffer.from('%PDF-1.4\n1 0 obj\n<<\n/Type /Catalog\n>>\nendobj\nxref\n0 0\ntrailer\n<<\n/Size 1\n/Root 1 0 R\n>>\nstartxref\n9\n%%EOF'),
 ): Promise<{ id: string; filePath: string }> {
-  // Get the media directory path (same as Media collection staticDir)
-  // Media collection: path.resolve(dirname, '../../public/media') where dirname is src/collections/Media
-  // This resolves to src/public/media
-  const testFile = fileURLToPath(import.meta.url)
-  const testDir = path.dirname(testFile) // tests/int
-  const projectRoot = path.resolve(testDir, '../..') // project root
-  const mediaDir = path.join(projectRoot, 'src', 'public', 'media')
+  // Get the media directory path using the same resolution as Media collection
+  // Media collection uses: path.resolve(dirname, '../../public/media')
+  // where dirname is the directory of src/collections/Media/index.ts
+  const mediaCollectionPath = fileURLToPath(
+    new URL('../../src/collections/Media/index.ts', import.meta.url),
+  )
+  const mediaCollectionDir = path.dirname(mediaCollectionPath)
+  const mediaDir = path.resolve(mediaCollectionDir, '../../public/media')
   
   // Ensure directory exists
   if (!fs.existsSync(mediaDir)) {
@@ -140,6 +141,11 @@ async function createMediaFileWithFile(
   
   // Write the file to disk first (Payload will read from here during processing)
   fs.writeFileSync(filePath, content)
+  
+  // Verify file was written
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Failed to create file at ${filePath}`)
+  }
   
   // Create media record with file buffer
   // Payload will process the file and may read it from disk for metadata extraction


### PR DESCRIPTION
Fixes failing integration tests by ensuring PDF files are created on disk before Payload media records are made.

The tests were failing with `FileRetrievalError: ENOENT` because Payload's media upload process expects the actual PDF file to exist on disk for processing, but the tests were only creating media records with metadata. The fix introduces a helper function to write the PDF content to the expected `src/public/media` directory and pass the file buffer to Payload's `create` operation, ensuring the files are present for processing.

---
<a href="https://cursor.com/background-agent?bcId=bc-f7e428b6-7383-4c03-ab44-67d6748061da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f7e428b6-7383-4c03-ab44-67d6748061da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

