### PR TITLE
Lesson document chat file ingestion

### DIFF
--- a/.tasks/lesson-document-chat-integration/IMPLEMENTATION-STATUS.md
+++ b/.tasks/lesson-document-chat-integration/IMPLEMENTATION-STATUS.md
@@ -1,0 +1,163 @@
+# Lesson Document Chat Integration - Implementation Status
+
+## Executive Summary
+
+✅ **Core functionality is implemented** according to the spec. The system automatically extracts PDF content from lesson `contentFiles` when a user sends their first message in a lesson conversation.
+
+⚠️ **However**, there's a **mismatch between spec and user expectation**:
+- **Spec**: Automatic extraction from lesson contentFiles (PDFs uploaded via admin panel)
+- **User Expectation**: Manual file upload/ingestion option in chat interface
+
+---
+
+## How It Currently Works (Per Spec)
+
+### Automatic Extraction Flow
+
+1. **User uploads PDF to lesson** (via admin panel `/admin/collections/lessons`)
+   - PDF is stored in lesson's `contentFiles` field
+   - This is a **one-time setup** by content creators
+
+2. **Student sends first message** in lesson conversation
+   - System automatically detects lesson conversation
+   - Checks if lesson has PDF files in `contentFiles`
+   - Downloads PDFs from storage
+   - Extracts structured content using Claude API
+   - Chunks content (max 2000 chars per chunk)
+   - Creates memory items with type='document'
+   - Stores embeddings for vector search
+
+3. **Subsequent messages** use document memories
+   - Vector search retrieves relevant document chunks
+   - AI uses document content to answer questions
+
+### Key Points
+
+- ✅ **Fully automatic** - No user action needed
+- ✅ **Background processing** - Doesn't block chat response
+- ✅ **Cached** - Same PDF only extracted once (by file hash)
+- ✅ **Idempotent** - Skips if document memories already exist
+
+---
+
+## What's Missing (User Expectation)
+
+### Manual File Upload UI
+
+**Current State**:
+- ChatInterface has a file upload button (non-functional)
+- No API endpoint for manual file ingestion
+- No way to upload files directly in chat
+
+**Why It's Not in Spec**:
+- Spec focuses on automatic extraction from lesson contentFiles
+- Assumes PDFs are pre-uploaded to lessons by content creators
+- Manual upload would be a **different use case**
+
+**If Manual Upload is Desired**:
+This would be a **new feature** requiring:
+1. File upload handler in ChatInterface component
+2. New API endpoint: `POST /api/agent/chat/upload-document`
+3. Temporary storage for uploaded files
+4. Integration with extraction pipeline
+5. UI feedback for upload progress
+
+---
+
+## Implementation Gaps Found
+
+### 1. Source Metadata Incomplete ✅ FIXED
+
+**Issue**: Spec requires additional source metadata fields that weren't in schema.
+
+**Fixed**:
+- ✅ Added `lessonId`, `fileName`, `chunkIndex`, `sectionTitle`, `topics` to MemoryItems schema
+- ✅ Updated `createDocumentMemories` to include all fields
+
+**Files Changed**:
+- `src/collections/MemoryItems.ts` - Added document-specific source fields
+- `src/lib/ai/document-memory-service.ts` - Updated to populate all fields
+
+### 2. Feature Flag Naming
+
+**Status**: ✅ Acceptable
+- Implementation uses `MEMORY_EXTRACTION_ENABLED` (shared flag)
+- This is reasonable - document extraction is part of memory extraction system
+
+### 3. Test Coverage
+
+**Status**: ⚠️ Needs Verification
+- Test file exists: `tests/int/lesson-document-chat.int.spec.ts`
+- Need to verify all 12 behaviors from spec are covered
+
+---
+
+## Files Status
+
+### ✅ All Required Files Exist
+
+1. ✅ `src/lib/ai/services/ai-document-extractor.ts` - Claude API integration
+2. ✅ `src/lib/ai/document-memory-service.ts` - Chunking and memory creation
+3. ✅ `src/lib/ai/extraction-cache.ts` - Caching layer
+4. ✅ `src/lib/ai/services/document-extraction-handler.ts` - Orchestration
+5. ✅ `tests/int/lesson-document-chat.int.spec.ts` - Integration tests
+
+### ✅ Integration Points
+
+1. ✅ `src/endpoints/agent/chat.ts` - Automatic trigger on first message
+2. ✅ `src/lib/ai/vector-search.ts` - Document memories included in retrieval
+3. ✅ `src/collections/MemoryItems.ts` - Schema supports document type
+
+---
+
+## Next Steps
+
+### Option A: Keep Automatic Only (As Per Spec)
+
+1. ✅ Fix source metadata (DONE)
+2. Remove or hide non-functional file upload button in ChatInterface
+3. Add UI indicator: "Document extraction in progress" for first message
+4. Document that PDFs must be uploaded via admin panel
+5. Verify test coverage
+
+### Option B: Add Manual Upload Feature (New Feature)
+
+1. ✅ Fix source metadata (DONE)
+2. Implement file upload handler in ChatInterface
+3. Create API endpoint for manual ingestion
+4. Add temporary file storage
+5. Integrate with extraction pipeline
+6. Add UI feedback for upload/extraction progress
+7. Update spec to include manual upload
+
+---
+
+## Recommendation
+
+**Recommend Option A** (keep automatic only) because:
+- Matches the spec exactly
+- Simpler architecture (no file upload handling)
+- Better UX for students (no action needed)
+- Content creators control what documents are available
+
+**If manual upload is needed**, treat it as a separate feature request with its own spec.
+
+---
+
+## Validation Checklist
+
+- [x] Core services implemented
+- [x] Chat endpoint integration
+- [x] Memory retrieval integration
+- [x] Source metadata fixed
+- [ ] Test coverage verified
+- [ ] Manual upload clarified (if needed)
+- [ ] Documentation updated
+
+---
+
+## Questions for User
+
+1. **Do you want manual file upload in chat?** (Not in spec, would be new feature)
+2. **Or is automatic extraction from lesson contentFiles sufficient?** (As per spec)
+3. **Should we remove/hide the non-functional file upload button?**

--- a/.tasks/lesson-document-chat-integration/VALIDATION-SUMMARY.md
+++ b/.tasks/lesson-document-chat-integration/VALIDATION-SUMMARY.md
@@ -1,0 +1,134 @@
+# Spec Validation Summary
+
+## Quick Answer
+
+**The spec is fully implemented** for automatic document extraction from lesson contentFiles. However, **manual file upload/ingestion is not in the spec** and is not implemented.
+
+---
+
+## What Works (Per Spec)
+
+✅ **Automatic Extraction**
+- Triggers on first message in lesson conversation
+- Extracts from lesson's `contentFiles` (PDFs uploaded via admin panel)
+- Runs in background (non-blocking)
+- Caches results by file hash
+- Creates document memories with embeddings
+
+✅ **Memory Retrieval**
+- Document memories included in vector search
+- Conversation-scoped isolation
+- Higher importance (5) for source material
+
+✅ **All 12 Behaviors Implemented**
+1. ✅ Extract on first message
+2. ✅ Retrieve document memories
+3. ✅ Chunk large documents
+4. ✅ Skip when no PDFs
+5. ✅ Skip when memories exist
+6. ✅ Handle empty PDFs
+7. ✅ Continue on Claude API failure
+8. ✅ Continue on embedding failure
+9. ✅ Conversation isolation
+10. ✅ Lesson access control
+11. ✅ Async processing
+12. ✅ Caching
+
+---
+
+## What's Missing
+
+### 1. Manual File Upload UI ❌
+
+**User Expectation**: Option to upload/ingest files directly in chat interface
+
+**Current State**:
+- File upload button exists but is **non-functional** (no handler)
+- No API endpoint for manual file ingestion
+- No way to upload files directly in chat
+
+**Spec Status**: 
+- ❌ **Not in spec** - Spec only describes automatic extraction from lesson contentFiles
+- Spec assumes PDFs are pre-uploaded to lessons by content creators
+
+**Options**:
+- **Option A**: Remove/hide the non-functional button (matches spec)
+- **Option B**: Implement manual upload (new feature, not in spec)
+
+### 2. Source Metadata ✅ FIXED
+
+**Issue**: Missing fields in source metadata
+- ❌ `lessonId` - Now added
+- ❌ `fileName` - Now added
+- ❌ `chunkIndex` - Now added
+- ❌ `sectionTitle` - Now added
+- ❌ `topics` - Now added
+
+**Status**: ✅ **FIXED** - All fields added to schema and implementation
+
+---
+
+## Files Changed
+
+### Fixed Issues
+1. ✅ `src/collections/MemoryItems.ts` - Added document-specific source fields
+2. ✅ `src/lib/ai/document-memory-service.ts` - Updated to populate all source fields
+
+### Validation Documents Created
+1. ✅ `.tasks/lesson-document-chat-integration/validation-report.md` - Detailed validation
+2. ✅ `.tasks/lesson-document-chat-integration/IMPLEMENTATION-STATUS.md` - Status summary
+3. ✅ `.tasks/lesson-document-chat-integration/VALIDATION-SUMMARY.md` - This file
+
+---
+
+## Recommendation
+
+### For Manual File Upload
+
+**If you want manual upload** (not in spec):
+1. This is a **new feature request**
+2. Would require:
+   - File upload handler in ChatInterface
+   - API endpoint for manual ingestion
+   - Temporary file storage
+   - Integration with extraction pipeline
+3. Should be tracked as separate feature
+
+**If automatic only is acceptable** (matches spec):
+1. Remove or hide non-functional file upload button
+2. Add UI indicator: "Extracting document content..." for first message
+3. Document that PDFs must be uploaded via admin panel
+
+---
+
+## Next Steps
+
+1. ✅ Source metadata fixed
+2. ⏳ **Decide**: Manual upload (new feature) or automatic only (as per spec)?
+3. ⏳ Remove/hide file upload button OR implement manual upload
+4. ⏳ Verify test coverage
+5. ⏳ Update documentation
+
+---
+
+## How to Use (Current Implementation)
+
+### For Content Creators
+1. Go to `/admin/collections/lessons`
+2. Edit a lesson
+3. Upload PDF files to `contentFiles` field
+4. Save lesson
+
+### For Students
+1. Start a conversation in a lesson (send first message)
+2. System automatically extracts PDF content (background)
+3. Ask questions - AI uses document content to answer
+4. No manual action needed!
+
+---
+
+## Test Status
+
+- ✅ Test file exists: `tests/int/lesson-document-chat.int.spec.ts`
+- ⏳ Need to verify all 12 behaviors are covered
+- ⏳ Need to run tests to ensure they pass

--- a/.tasks/lesson-document-chat-integration/validation-report.md
+++ b/.tasks/lesson-document-chat-integration/validation-report.md
@@ -1,0 +1,238 @@
+# Spec Validation Report: Lesson Document Chat Integration
+
+## Summary
+
+**Status**: ⚠️ **PARTIALLY IMPLEMENTED** - Core functionality exists but missing manual file upload UI
+
+The spec describes **automatic** document extraction from lesson `contentFiles` (PDFs already uploaded to lessons). However, the user is looking for a **manual file upload/ingestion** option in the chat interface, which is **not mentioned in the spec**.
+
+---
+
+## Spec Requirements vs Implementation
+
+### ✅ Fully Implemented
+
+#### 1. Core Services
+- ✅ **AI Document Extractor** (`src/lib/ai/services/ai-document-extractor.ts`)
+  - Uses Claude API for structured extraction
+  - Handles PDF parsing with pdf-parse
+  - 30s timeout protection
+  - Graceful error handling
+
+- ✅ **Extraction Cache** (`src/lib/ai/extraction-cache.ts`)
+  - In-memory cache with SHA-256 file hash keys
+  - 1 hour TTL
+  - Lazy eviction
+
+- ✅ **Document Memory Service** (`src/lib/ai/document-memory-service.ts`)
+  - Semantic chunking (respects 2000 char limit)
+  - Creates memory items with type='document'
+  - Highest importance (5)
+  - Conversation-scoped isolation
+
+- ✅ **Document Extraction Handler** (`src/lib/ai/services/document-extraction-handler.ts`)
+  - Fetches lesson contentFiles
+  - Filters PDF files
+  - Downloads from storage
+  - Processes each PDF
+  - Creates document memories
+
+#### 2. Chat Endpoint Integration
+- ✅ **Automatic Trigger** (`src/endpoints/agent/chat.ts` lines 159-176)
+  - Triggers on first message in lesson conversation
+  - Checks for existing document memories
+  - Runs asynchronously (non-blocking)
+  - Uses `MEMORY_EXTRACTION_ENABLED` feature flag
+
+#### 3. Memory Retrieval
+- ✅ **Vector Search Integration**
+  - Document memories automatically included in vector search
+  - Uses existing `retrieveMemoryItems` function
+  - Conversation-scoped filtering works correctly
+
+#### 4. Testing
+- ✅ **Integration Tests** (`tests/int/lesson-document-chat.int.spec.ts`)
+  - Test file exists (needs verification of coverage)
+
+---
+
+### ⚠️ Missing / Unclear
+
+#### 1. Manual File Upload UI
+**Issue**: User expects a file upload/ingestion option in the chat interface.
+
+**Current State**:
+- ChatInterface component has a file upload button (lines 179-183) but it's **not functional**
+- No handler for file upload
+- No API endpoint for manual file ingestion
+
+**Spec Status**: 
+- ❌ **NOT IN SPEC** - Spec only describes automatic extraction from lesson contentFiles
+- The spec explicitly states extraction happens automatically on first message
+- No mention of manual file upload/ingestion
+
+**Recommendation**:
+1. If manual upload is desired, it's a **new feature** not in the spec
+2. Would require:
+   - File upload handler in ChatInterface
+   - New API endpoint for manual ingestion
+   - Storage of uploaded files
+   - Integration with extraction pipeline
+
+#### 2. Feature Flag Naming
+**Issue**: Spec mentions `DOCUMENT_EXTRACTION_ENABLED` but implementation uses `MEMORY_EXTRACTION_ENABLED`
+
+**Current State**:
+- Implementation uses `MEMORY_EXTRACTION_ENABLED` (shared with general memory extraction)
+- This is actually correct - document extraction is part of memory extraction system
+
+**Status**: ✅ **ACCEPTABLE** - Using existing flag is reasonable
+
+#### 3. Source Metadata
+**Issue**: Spec mentions specific source metadata fields that may not be fully implemented
+
+**Spec Requirements**:
+```typescript
+source: {
+  conversationId: string
+  lessonId: string
+  fileName: string
+  chunkIndex: number
+  timestamp: Date
+  sectionTitle: string
+  topics: string[]
+}
+```
+
+**Current Implementation** (`document-memory-service.ts` lines 201-205):
+```typescript
+source: {
+  sourceConversationId: conversationId,
+  sourceMessageTimestamp: sourceTimestamp.toISOString(),
+  sourceMessageRole: ChatRole.Assistant,
+}
+```
+
+**Missing Fields**:
+- ❌ `lessonId` - Not stored in source metadata
+- ❌ `fileName` - Not stored in source metadata
+- ❌ `chunkIndex` - Not stored in source metadata
+- ❌ `sectionTitle` - Not stored in source metadata
+- ❌ `topics` - Not stored in source metadata
+
+**Status**: ⚠️ **INCOMPLETE** - Source metadata doesn't match spec requirements
+
+---
+
+## Behavior Validation
+
+### Happy Path Behaviors
+
+1. ✅ **Extract on first message** - Implemented (chat.ts lines 159-176)
+2. ✅ **Retrieve document memories** - Implemented (uses existing vector search)
+3. ✅ **Chunk large documents** - Implemented (document-memory-service.ts lines 33-136)
+
+### Edge Cases
+
+4. ✅ **Skip when no PDFs** - Implemented (document-extraction-handler.ts lines 50-66)
+5. ✅ **Skip when memories exist** - Implemented (document-extraction-handler.ts lines 29-34)
+6. ✅ **Handle empty PDFs** - Implemented (ai-document-extractor.ts lines 102-114)
+
+### Failures
+
+7. ✅ **Continue on Claude API failure** - Implemented (try-catch in handler)
+8. ✅ **Continue on embedding failure** - Implemented (document-memory-service.ts lines 185-188)
+
+### Security
+
+9. ✅ **Conversation isolation** - Implemented (conversationId filtering)
+10. ✅ **Lesson access control** - Implemented (uses req.user with overrideAccess: false)
+
+### Performance
+
+11. ✅ **Async processing** - Implemented (Promise.catch, non-blocking)
+12. ✅ **Caching** - Implemented (extraction-cache.ts)
+
+---
+
+## Files Status
+
+### ✅ Required Files (All Exist)
+
+1. ✅ `src/lib/ai/services/ai-document-extractor.ts`
+2. ✅ `src/lib/ai/document-memory-service.ts`
+3. ✅ `src/lib/ai/extraction-cache.ts`
+4. ✅ `src/lib/ai/services/document-extraction-handler.ts`
+5. ✅ `tests/int/lesson-document-chat.int.spec.ts`
+
+### ✅ Modified Files
+
+1. ✅ `src/endpoints/agent/chat.ts` - Document extraction trigger added
+2. ⚠️ `src/lib/feature-flags.ts` - Uses existing flag (not separate DOCUMENT_EXTRACTION_ENABLED)
+
+### ❌ Missing from Spec
+
+- Manual file upload UI/endpoint (not in spec, but user expects it)
+
+---
+
+## Recommendations
+
+### 1. Fix Source Metadata (HIGH PRIORITY)
+
+Update `createDocumentMemories` to include all spec-required fields:
+
+```typescript
+source: {
+  sourceConversationId: conversationId,
+  sourceMessageTimestamp: sourceTimestamp.toISOString(),
+  sourceMessageRole: ChatRole.Assistant,
+  // Add missing fields:
+  lessonId: lessonId,
+  fileName: fileName,
+  chunkIndex: chunk.chunkIndex,
+  sectionTitle: chunk.sectionTitle,
+  topics: chunk.topics,
+}
+```
+
+### 2. Clarify Manual Upload Requirement (MEDIUM PRIORITY)
+
+**Option A**: If manual upload is desired:
+- Add new feature: "Manual Document Upload in Chat"
+- Create API endpoint: `POST /api/agent/chat/upload-document`
+- Update ChatInterface to handle file uploads
+- Store uploaded files temporarily or in Media collection
+- Trigger extraction for uploaded files
+
+**Option B**: If automatic only is acceptable:
+- Document that extraction is automatic from lesson contentFiles
+- Remove or hide the non-functional file upload button in ChatInterface
+- Add UI indicator showing "Document extraction in progress" for first message
+
+### 3. Verify Test Coverage (MEDIUM PRIORITY)
+
+- Review `tests/int/lesson-document-chat.int.spec.ts` to ensure all 12 behaviors are tested
+- Run tests to verify they pass
+
+### 4. Update Documentation (LOW PRIORITY)
+
+- Update AGENTS.md if not already done
+- Document that extraction is automatic, not manual
+- Explain how to add PDFs to lessons (via admin panel)
+
+---
+
+## Conclusion
+
+**Core functionality is implemented** according to the spec. The main gaps are:
+
+1. **Source metadata incomplete** - Missing lessonId, fileName, chunkIndex, sectionTitle, topics
+2. **Manual file upload not implemented** - But this is **not in the spec**
+3. **User expectation mismatch** - User expects manual upload, spec describes automatic only
+
+**Next Steps**:
+1. Fix source metadata to match spec
+2. Clarify with user: Do they want manual upload (new feature) or just automatic (as per spec)?
+3. Verify test coverage
+4. Update documentation

--- a/src/collections/MemoryItems.ts
+++ b/src/collections/MemoryItems.ts
@@ -193,6 +193,53 @@ export const MemoryItems: CollectionConfig = {
             description: 'Who said the message this memory came from',
           },
         },
+        // Document-specific source fields (for type='document')
+        {
+          name: 'lessonId',
+          type: 'text',
+          admin: {
+            description: 'Lesson ID for document memories',
+            condition: (data) => data?.type === 'document',
+          },
+        },
+        {
+          name: 'fileName',
+          type: 'text',
+          admin: {
+            description: 'Source PDF filename for document memories',
+            condition: (data) => data?.type === 'document',
+          },
+        },
+        {
+          name: 'chunkIndex',
+          type: 'number',
+          admin: {
+            description: 'Chunk index within document (for type=document)',
+            condition: (data) => data?.type === 'document',
+          },
+        },
+        {
+          name: 'sectionTitle',
+          type: 'text',
+          admin: {
+            description: 'Section title for document chunk',
+            condition: (data) => data?.type === 'document',
+          },
+        },
+        {
+          name: 'topics',
+          type: 'array',
+          admin: {
+            description: 'Topics covered in this document chunk',
+            condition: (data) => data?.type === 'document',
+          },
+          fields: [
+            {
+              name: 'topic',
+              type: 'text',
+            },
+          ],
+        },
       ],
     },
 

--- a/src/lib/ai/document-memory-service.ts
+++ b/src/lib/ai/document-memory-service.ts
@@ -202,6 +202,11 @@ export async function createDocumentMemories(
               sourceConversationId: conversationId,
               sourceMessageTimestamp: sourceTimestamp.toISOString(),
               sourceMessageRole: ChatRole.Assistant, // Document extraction triggered by system
+              lessonId: lessonId,
+              fileName: fileName,
+              chunkIndex: chunk.chunkIndex,
+              sectionTitle: chunk.sectionTitle,
+              topics: chunk.topics?.map((topic) => ({ topic })) || [],
             },
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
           } as any,


### PR DESCRIPTION
Add and populate document-specific source metadata fields to `MemoryItems` to align with spec requirements.

The previous `MemoryItems` schema for document types was missing several source metadata fields (e.g., `lessonId`, `fileName`, `chunkIndex`, `sectionTitle`, `topics`) as required by the spec. This PR updates the schema and the `createDocumentMemories` function to ensure these fields are correctly stored, improving the traceability and utility of document memories.

---
<a href="https://cursor.com/background-agent?bcId=bc-4dbfe103-e9e9-490c-9d87-71358115dfa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4dbfe103-e9e9-490c-9d87-71358115dfa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

