### PR TITLE
Test course data availability

### DIFF
--- a/tests/e2e/helpers/courses.ts
+++ b/tests/e2e/helpers/courses.ts
@@ -49,6 +49,7 @@ export async function seedTestCourseData(): Promise<TestCourseData | null> {
         collection: 'categories',
         data: {
           title: 'Test Category',
+          slug: 'test-category',
         },
         draft: false,
       })

--- a/tests/e2e/helpers/courses.ts
+++ b/tests/e2e/helpers/courses.ts
@@ -14,6 +14,108 @@ export interface TestCourseData {
 }
 
 /**
+ * Seed test course data if it doesn't exist
+ * Creates a test course with a chapter and lesson, all published and active
+ */
+export async function seedTestCourseData(): Promise<TestCourseData | null> {
+  try {
+    const payload = await getPayload({ config })
+
+    // Check if test course already exists
+    const existing = await getTestCourseData()
+    if (existing) {
+      console.log('Test course data already exists, skipping seed')
+      return existing
+    }
+
+    console.log('Seeding test course data...')
+
+    // Get or create a test category
+    let category
+    const categories = await payload.find({
+      collection: 'categories',
+      where: {
+        title: {
+          equals: 'Test Category',
+        },
+      },
+      limit: 1,
+    })
+
+    if (categories.docs.length > 0) {
+      category = categories.docs[0]
+    } else {
+      category = await payload.create({
+        collection: 'categories',
+        data: {
+          title: 'Test Category',
+        },
+      })
+    }
+
+    // Create test course
+    const course = await payload.create({
+      collection: 'courses',
+      data: {
+        courseLabel: 'TEST',
+        title: 'Test Course for E2E',
+        description: 'A test course created for E2E testing',
+        status: 'published',
+        isActive: true,
+        order: 0,
+        categories: [category.id],
+      },
+    })
+
+    // Create test chapter
+    const chapter = await payload.create({
+      collection: 'chapters',
+      data: {
+        course: course.id,
+        chapterLabel: '1',
+        title: 'Test Chapter',
+        description: 'A test chapter created for E2E testing',
+        status: 'published',
+        isActive: true,
+        order: 0,
+      },
+    })
+
+    // Create test lesson
+    const lesson = await payload.create({
+      collection: 'lessons',
+      data: {
+        chapter: chapter.id,
+        title: 'Test Lesson',
+        description: 'A test lesson created for E2E testing',
+        status: 'published',
+        isActive: true,
+        order: 0,
+      },
+    })
+
+    // Validate slugs exist
+    if (!course.slug || !chapter.slug || !lesson.slug) {
+      throw new Error('Course, chapter, or lesson missing slug field after creation')
+    }
+
+    console.log('Test course data seeded successfully')
+
+    return {
+      courseSlug: course.slug,
+      chapterSlug: chapter.slug,
+      lessonSlug: lesson.slug,
+      courseId: course.id,
+      chapterId: chapter.id,
+      lessonId: lesson.id,
+    }
+  } catch (error) {
+    console.error('Error seeding test course data:', error)
+    return null
+  }
+}
+
+/**
  * Get the first available published course with chapters and lessons
  * Returns null if no suitable course data is available
  */

--- a/tests/e2e/helpers/courses.ts
+++ b/tests/e2e/helpers/courses.ts
@@ -50,6 +50,7 @@ export async function seedTestCourseData(): Promise<TestCourseData | null> {
         data: {
           title: 'Test Category',
         },
+        draft: false,
       })
     }
 

--- a/tests/e2e/memory-system.e2e.spec.ts
+++ b/tests/e2e/memory-system.e2e.spec.ts
@@ -9,7 +9,7 @@
  */
 import { expect, test, type Page } from '@playwright/test'
 import { setupAuthenticatedUser, generateTestUserEmail, cleanupTestUsers } from './helpers/auth'
-import { getTestCourseData, buildLessonUrl } from './helpers/courses'
+import { getTestCourseData, buildLessonUrl, seedTestCourseData } from './helpers/courses'
 
 // Skip all tests if OPENAI_API_KEY is not set
 const hasOpenAIKey = !!process.env.OPENAI_API_KEY
@@ -20,11 +20,18 @@ test.describe('Memory System E2E Tests', () => {
   let testCourseData: Awaited<ReturnType<typeof getTestCourseData>>
 
   test.beforeAll(async () => {
-    // Get test course data once for all tests
-    testCourseData = await getTestCourseData()
+    // Seed test course data if it doesn't exist
+    const seeded = await seedTestCourseData()
+    if (seeded) {
+      testCourseData = seeded
+    } else {
+      // If seeding failed, try to get existing data
+      testCourseData = await getTestCourseData()
+    }
+
     if (!testCourseData) {
       throw new Error(
-        'No test course data available. Please ensure at least one published course with chapters and lessons exists.',
+        'No test course data available. Failed to seed or find published course with chapters and lessons.',
       )
     }
   })


### PR DESCRIPTION
Add automatic test data seeding for E2E tests to prevent failures due to missing course data.

The E2E tests were failing with "No test course data available" because the required course, chapter, and lesson data was not present. This PR introduces a `seedTestCourseData` function that creates this data if it doesn't already exist, ensuring tests have the necessary prerequisites.

---
<a href="https://cursor.com/background-agent?bcId=bc-b91f975d-0983-43e9-8700-44c531eadbde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b91f975d-0983-43e9-8700-44c531eadbde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

