### PR TITLE
Missing payload secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,8 @@ jobs:
       # DATABASE_URL is required for postinstall -> generate:types
       # Falls back to a dummy connection string if secret is not available (e.g., fork PRs)
       DATABASE_URL: ${{ secrets.DATABASE_URL || 'mongodb://localhost:27017/test' }}
+      # PAYLOAD_SECRET is required for Payload CMS initialization in E2E tests
+      PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET || 'test-secret-for-ci' }}
       # OPENAI_API_KEY is required for memory system E2E tests
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || '' }}
 


### PR DESCRIPTION
Add `PAYLOAD_SECRET` to the CI `test` job environment to resolve E2E test failures during course data seeding.

The CI `test` job was missing the `PAYLOAD_SECRET` environment variable. E2E tests call `getPayload({ config })` when seeding test course data, which requires `PAYLOAD_SECRET` to initialize Payload CMS. This change ensures E2E tests can initialize Payload and includes a fallback value for consistency with the `build` job.

---
<a href="https://cursor.com/background-agent?bcId=bc-a866ebd8-62ce-4969-99be-b88eac51ddf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a866ebd8-62ce-4969-99be-b88eac51ddf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

