### PR TITLE
Gemini API key configuration

### DIFF
--- a/src/lib/ai/gemini-ai-provider.server.ts
+++ b/src/lib/ai/gemini-ai-provider.server.ts
@@ -6,10 +6,23 @@ import { GoogleGenerativeAI } from '@google/generative-ai'
 
 let geminiClient: GoogleGenerativeAI | null = null
 
+/**
+ * Check if Gemini API key is configured
+ */
+export function isGeminiApiKeyConfigured(): boolean {
+  return !!process.env.GEMINI_API_KEY
+}
+
+/**
+ * Get Gemini client instance
+ * @throws Error if GEMINI_API_KEY is not configured
+ */
 export function getGeminiClient(): GoogleGenerativeAI {
   if (!geminiClient) {
     if (!process.env.GEMINI_API_KEY) {
-      throw new Error('GEMINI_API_KEY environment variable is not configured')
+      throw new Error(
+        'GEMINI_API_KEY environment variable is not configured. Please set it in your .env file. See .env.example for details.',
+      )
     }
     geminiClient = new GoogleGenerativeAI(process.env.GEMINI_API_KEY)
   }

--- a/src/lib/ai/index.ts
+++ b/src/lib/ai/index.ts
@@ -8,7 +8,7 @@
  * - Auto-grading assistance
  */
 
-export { getGeminiClient } from './gemini-ai-provider.server'
+export { getGeminiClient, isGeminiApiKeyConfigured } from './gemini-ai-provider.server'
 export { AI_MODELS, type AIModelKey, type AIModelConfig } from './models'
 export { optimizeImageForAI, type OptimizedImage } from './services/image-optimizer-service'
 export {

--- a/tests/e2e/memory-system.e2e.spec.ts
+++ b/tests/e2e/memory-system.e2e.spec.ts
@@ -11,11 +11,16 @@ import { expect, test, type Page } from '@playwright/test'
 import { setupAuthenticatedUser, generateTestUserEmail, cleanupTestUsers } from './helpers/auth'
 import { getTestCourseData, buildLessonUrl, seedTestCourseData } from './helpers/courses'
 
-// Skip all tests if OPENAI_API_KEY is not set
+// Skip all tests if required API keys are not set
 const hasOpenAIKey = !!process.env.OPENAI_API_KEY
+const hasGeminiKey = !!process.env.GEMINI_API_KEY
+const hasRequiredKeys = hasOpenAIKey && hasGeminiKey
 
 test.describe('Memory System E2E Tests', () => {
-  test.skip(!hasOpenAIKey, 'Skipping Memory System E2E Tests: OPENAI_API_KEY is not set')
+  test.skip(
+    !hasRequiredKeys,
+    `Skipping Memory System E2E Tests: Missing required API keys. OPENAI_API_KEY: ${hasOpenAIKey ? 'set' : 'missing'}, GEMINI_API_KEY: ${hasGeminiKey ? 'set' : 'missing'}`,
+  )
 
   let testCourseData: Awaited<ReturnType<typeof getTestCourseData>>
 


### PR DESCRIPTION
Improve error handling for missing `GEMINI_API_KEY` and update E2E tests to skip when required AI API keys are not configured.

The previous setup caused E2E tests to time out with an unhelpful error message when the `GEMINI_API_KEY` environment variable was not set, leading to failed CI/CD runs in environments where the key was intentionally absent. This change provides a clear error message and allows tests to gracefully skip, similar to how `OPENAI_API_KEY` is handled.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3f438e2-2a1a-4424-9e16-31dbe48ed3fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3f438e2-2a1a-4424-9e16-31dbe48ed3fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

