### PR TITLE
Gemini API key CI declaration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,8 @@ jobs:
       PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET || 'test-secret-for-ci' }}
       # OPENAI_API_KEY is required for memory system E2E tests
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || '' }}
+      # GEMINI_API_KEY is required for memory system E2E tests
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY || '' }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Add `GEMINI_API_KEY` to CI workflow to enable E2E tests using Gemini.

The E2E tests in `tests/e2e/memory-system.e2e.spec.ts` require `GEMINI_API_KEY`, but it was not declared in the CI workflow, causing these tests to be skipped.

---
<a href="https://cursor.com/background-agent?bcId=bc-540c0e39-000f-479e-8ba1-772053f4b666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-540c0e39-000f-479e-8ba1-772053f4b666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

