### PR TITLE
Vector search results validation

### DIFF
--- a/tests/int/vector-search-validation.int.spec.ts
+++ b/tests/int/vector-search-validation.int.spec.ts
@@ -276,9 +276,38 @@ describe.skipIf(!hasOpenAIKey)('Vector Search Validation Integration Tests', () 
       })
       memoryId3 = memory3.id
 
-      // Wait for indexing
-      await new Promise((resolve) => setTimeout(resolve, 5000))
-    }, 60000)
+      // Wait for vector search index to update (can take 10-30 seconds on Atlas)
+      // Poll until documents are searchable or timeout after 60 seconds
+      if (db && testUserId && testConversationId) {
+        const maxWaitTime = 60000 // 60 seconds
+        const pollInterval = 2000 // 2 seconds
+        const startTime = Date.now()
+
+        while (Date.now() - startTime < maxWaitTime) {
+          // Try a simple search to see if documents are indexed
+          const testResult = await retrieveMemoryItems(
+            db,
+            testUserId,
+            'TypeScript',
+            testConversationId,
+          )
+
+          if (testResult.items.length > 0) {
+            // Documents are indexed, we can proceed
+            break
+          }
+
+          // Wait before next poll
+          await new Promise((resolve) => setTimeout(resolve, pollInterval))
+        }
+
+        // Additional short wait to ensure all documents are fully indexed
+        await new Promise((resolve) => setTimeout(resolve, 2000))
+      } else {
+        // Fallback: wait a fixed amount if polling isn't possible
+        await new Promise((resolve) => setTimeout(resolve, 10000))
+      }
+    }, 120000)
 
     afterAll(async () => {
       if (!payload || !hasVectorSearch) return


### PR DESCRIPTION
Fixes failing vector search validation tests by adding a polling mechanism for Atlas vector search indexing.

The previous fixed 5-second wait was insufficient for Atlas vector search indexing. This PR introduces a polling mechanism to wait for documents to become searchable in the vector index, with a maximum wait time of 60 seconds, and increases the overall test timeout to 120 seconds to accommodate this.

---
<a href="https://cursor.com/background-agent?bcId=bc-22f6ca9b-290e-48fd-ac5e-48c12432c6fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-22f6ca9b-290e-48fd-ac5e-48c12432c6fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

