### PR TITLE
Vector search empty results

### DIFF
--- a/src/lib/ai/vector-search.ts
+++ b/src/lib/ai/vector-search.ts
@@ -216,13 +216,23 @@ export async function retrieveMemoryItems(
       })(),
     )
 
-    // Execute all queries in parallel
-    const queryResults = await Promise.all(queries)
+    // Execute all queries in parallel (use allSettled so one failure doesn't break all)
+    const querySettledResults = await Promise.allSettled(queries)
 
     // Process results with priority: conversation > context > global
     const seenIds = new Set<string>()
 
-    for (const queryResult of queryResults) {
+    for (const settledResult of querySettledResults) {
+      if (settledResult.status === 'rejected') {
+        // Log individual query failures but continue processing other queries
+        logger.warn(
+          { err: settledResult.reason },
+          '[VectorSearch] One query failed, continuing with others',
+        )
+        continue
+      }
+
+      const queryResult = settledResult.value
       for (const item of queryResult.items) {
         const itemId = item._id.toString()
         if (!seenIds.has(itemId)) {


### PR DESCRIPTION
Replace `Promise.all` with `Promise.allSettled` in `retrieveMemoryItems` to allow partial results from vector search queries.

This change prevents a single failing vector search query (e.g., conversation-scoped, context-hierarchy, or global) from causing the entire `retrieveMemoryItems` operation to return empty results, which was causing integration tests to fail. Now, individual query failures are logged, but other successful queries can still contribute to the final result set.

---
<a href="https://cursor.com/background-agent?bcId=bc-7bfffb05-8d38-47ad-8dcf-5f9ba765f16c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7bfffb05-8d38-47ad-8dcf-5f9ba765f16c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

