### PR TITLE
Chat history user context

### DIFF
--- a/src/app/api/agent/conversation/route.ts
+++ b/src/app/api/agent/conversation/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import { getConversation } from '@/endpoints/agent/get-conversation'
+import { logger } from '@/utilities/logger/logger'
+
+export async function POST(request: NextRequest) {
+  const requestId = crypto.randomUUID()
+
+  try {
+    logger.info({ requestId, url: request.url }, 'Get conversation request received')
+
+    // Parse request body early to validate
+    const body = await request.json()
+
+    // Validate required fields
+    if (!body.contextKey) {
+      logger.warn({ requestId }, 'Missing contextKey in get conversation request')
+      return NextResponse.json({ error: 'Missing contextKey', requestId }, { status: 400 })
+    }
+
+    const payload = await getPayload({ config })
+    const { user } = await payload.auth({ headers: request.headers })
+
+    const payloadRequest = {
+      payload,
+      user,
+      url: request.url,
+      headers: request.headers,
+      json: async () => body, // Return the already-parsed body
+    } as Parameters<typeof getConversation>[0]
+
+    logger.info({ requestId, contextKey: body.contextKey }, 'Processing get conversation request')
+    return await getConversation(payloadRequest)
+  } catch (error) {
+    logger.error({ err: error, requestId }, 'Get conversation route error')
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : 'Internal server error',
+        requestId,
+        ...(process.env.NODE_ENV === 'development' && error instanceof Error
+          ? { stack: error.stack }
+          : {}),
+      },
+      { status: 500 },
+    )
+  }
+}

--- a/src/endpoints/agent/get-conversation.ts
+++ b/src/endpoints/agent/get-conversation.ts
@@ -108,7 +108,7 @@ export async function getConversation(req: PayloadRequest & { json?: () => Promi
     const messages = rawMessages
       .filter((msg) => msg && msg.role && msg.content) // Filter out invalid messages
       .map((msg) => ({
-        role: msg.role === ChatRole.User || msg.role === 'user' ? ChatRole.User : ChatRole.Assistant,
+        role: msg.role === 'user' ? ChatRole.User : ChatRole.Assistant,
         content: msg.content,
       }))
 

--- a/src/endpoints/agent/get-conversation.ts
+++ b/src/endpoints/agent/get-conversation.ts
@@ -1,0 +1,141 @@
+/**
+ * GET /api/agent/conversation
+ * Fetch user's conversation history for a context
+ *
+ * @fileType endpoint
+ * @domain chat
+ * @pattern authenticated-endpoint, validated-endpoint, context-scoped
+ * @ai-summary Get conversation endpoint with explicit user isolation
+ *
+ * Security: Explicitly filters by authenticated user ID to guarantee isolation
+ * This endpoint ensures users can only access their own conversations, even if
+ * multiple users have conversations with the same contextKey.
+ *
+ * Access: Authenticated users only
+ */
+import { ChatRole } from '@/lib/ai/chat-message-role'
+import { logger } from '@/utilities/logger'
+import { PayloadRequest } from 'payload'
+import { z } from 'zod'
+
+const requestSchema = z.object({
+  contextKey: z.string().min(1),
+})
+
+export async function getConversation(req: PayloadRequest & { json?: () => Promise<unknown> }) {
+  const requestId = crypto.randomUUID()
+  const reqLogger = logger.child({ requestId })
+
+  // 1) Auth check - endpoints not authenticated by default
+  if (!req.user) {
+    return Response.json({ error: 'Authentication required' }, { status: 401 })
+  }
+
+  try {
+    // 2) Parse and validate request body
+    if (!req.json) {
+      return Response.json({ error: 'Invalid request' }, { status: 400 })
+    }
+
+    const body = await req.json()
+    const validated = requestSchema.parse(body)
+
+    reqLogger.info(
+      {
+        userId: req.user.id,
+        contextKey: validated.contextKey,
+      },
+      'Fetching conversation',
+    )
+
+    // 3) Query with EXPLICIT user filter - guarantees user isolation
+    // This ensures that even if multiple users have conversations with the same contextKey,
+    // only the authenticated user's conversation is returned
+    const result = await req.payload.find({
+      collection: 'conversations',
+      where: {
+        and: [
+          { user: { equals: req.user.id } }, // Explicit user filter - CRITICAL for security
+          { contextKey: { equals: validated.contextKey } },
+          { archivedAt: { exists: false } }, // Only active conversations
+        ],
+      },
+      limit: 1,
+      sort: '-lastMessageAt', // Most recent first
+      depth: 0, // No relationship population needed
+      user: req.user,
+      overrideAccess: false, // Enforce access control
+    })
+
+    if (result.docs.length === 0) {
+      reqLogger.debug(
+        {
+          userId: req.user.id,
+          contextKey: validated.contextKey,
+        },
+        'No conversation found',
+      )
+
+      return Response.json({
+        success: true,
+        exists: false,
+        messages: [],
+        contextKey: validated.contextKey,
+      })
+    }
+
+    const conversation = result.docs[0]
+
+    // Verify conversation ownership (defense in depth)
+    const conversationUserId =
+      typeof conversation.user === 'object' ? conversation.user.id : conversation.user
+
+    if (conversationUserId !== req.user.id) {
+      reqLogger.error(
+        {
+          userId: req.user.id,
+          conversationId: conversation.id,
+          conversationUserId,
+          contextKey: validated.contextKey,
+        },
+        'SECURITY: Conversation user mismatch - this should never happen',
+      )
+      return Response.json({ error: 'Unauthorized' }, { status: 403 })
+    }
+
+    // Format messages for client
+    const rawMessages = conversation.messages || []
+    const messages = rawMessages
+      .filter((msg) => msg && msg.role && msg.content) // Filter out invalid messages
+      .map((msg) => ({
+        role: msg.role === ChatRole.User || msg.role === 'user' ? ChatRole.User : ChatRole.Assistant,
+        content: msg.content,
+      }))
+
+    reqLogger.info(
+      {
+        userId: req.user.id,
+        conversationId: conversation.id,
+        contextKey: validated.contextKey,
+        messageCount: messages.length,
+      },
+      'Conversation loaded successfully',
+    )
+
+    return Response.json({
+      success: true,
+      exists: true,
+      conversationId: conversation.id,
+      messages,
+      contextKey: conversation.contextKey || validated.contextKey,
+    })
+  } catch (error) {
+    reqLogger.error({ err: error }, 'Get conversation endpoint error')
+
+    if (error instanceof z.ZodError) {
+      return Response.json({ error: 'Invalid request', details: error.issues }, { status: 400 })
+    }
+
+    return Response.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/services/api/api-service.ts
+++ b/src/services/api/api-service.ts
@@ -92,118 +92,43 @@ export const apiService = {
   },
 
   /**
-   * Fetch existing conversation history for a context using Payload's REST API
-   * Access control (isOwner) automatically filters by authenticated user
-   * Payload merges the access control constraint with the where query
+   * Fetch existing conversation history for a context using dedicated endpoint
+   * The endpoint explicitly filters by authenticated user ID to guarantee isolation
    *
    * @param contextKey - The context key (e.g., "exercises:abc123")
    * @returns Conversation history with messages
    */
   async getConversation(contextKey: string): Promise<ConversationApiResponse> {
     try {
-      // Use Payload's auto-generated REST API endpoint
-      // The isOwner access control automatically adds { user: { equals: user.id } } to the query
-      // Payload merges this with our where query, ensuring only the authenticated user's conversations are returned
-      // 
-      // IMPORTANT: The where query should NOT include user filter - access control handles it automatically
-      // Including it explicitly would cause issues if access control isn't working
-      const whereQuery = JSON.stringify({
-        and: [
-          { contextKey: { equals: contextKey } },
-          { archivedAt: { exists: false } },
-        ],
-      })
+      logger.debug({ contextKey }, '[getConversation] Fetching via dedicated endpoint')
 
-      // Sort by lastMessageAt descending to get the most recent conversation for this user+contextKey
-      const url = `/api/conversations?where=${encodeURIComponent(whereQuery)}&limit=1&sort=-lastMessageAt&depth=0`
-      
-      logger.debug({ contextKey, url }, '[getConversation] Fetching conversation via Payload REST API')
-
-      const response = await fetch(url, {
-        method: 'GET',
+      const response = await fetch('/api/agent/conversation', {
+        method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        credentials: 'include', // CRITICAL: Include cookies for authentication (required for access control)
+        credentials: 'include',
+        body: JSON.stringify({ contextKey }),
       })
 
       const data = await response.json()
 
       if (!response.ok) {
-        // Log the full error for debugging
-        logger.error(
-          {
-            status: response.status,
-            statusText: response.statusText,
-            data,
-            contextKey,
-          },
-          '[getConversation] API error',
-        )
-
-        if (response.status === 401 || response.status === 403) {
+        if (response.status === 401) {
           return { success: false, exists: false, messages: [], authRequired: true }
         }
-        return {
-          success: false,
-          exists: false,
-          messages: [],
-          error: data.error || 'Request failed',
-        }
+        return { success: false, exists: false, messages: [], error: data.error || 'Request failed' }
       }
 
-      // Payload REST API returns { docs: [...], totalDocs, ... }
-      if (data.docs && data.docs.length > 0) {
-        const conversation = data.docs[0] as {
-          id: string
-          user?: string | { id: string }
-          contextKey?: string
-          messages?: Array<{ role: string; content: string; timestamp?: string }>
-        }
-
-        // Verify the conversation matches the expected contextKey
-        if (conversation.contextKey && conversation.contextKey !== contextKey) {
-          logger.warn(
-            {
-              conversationId: conversation.id,
-              expectedContextKey: contextKey,
-              actualContextKey: conversation.contextKey,
-            },
-            '[getConversation] Conversation contextKey mismatch',
-          )
-        }
-
-        // Log conversation user ID for debugging (access control should have already filtered by user)
-        // Note: We can't verify user ownership on client side without making another API call
-        // Payload's REST API with isOwner access control should ensure only current user's conversations are returned
-        const conversationUserId =
-          typeof conversation.user === 'object' ? conversation.user.id : conversation.user
-        logger.debug(
-          {
-            conversationId: conversation.id,
-            conversationUserId,
-            contextKey,
-            note: 'Access control (isOwner) should have filtered to current user only',
-          },
-          '[getConversation] Conversation loaded (user filtered by access control)',
-        )
-
-        // Ensure messages array exists and is properly formatted
-        const rawMessages = conversation.messages || []
-        const messages = rawMessages
-          .filter((msg) => msg && msg.role && msg.content) // Filter out invalid messages
-          .map((msg) => ({
-            role: msg.role === ChatRole.User || msg.role === 'user' ? ChatRole.User : ChatRole.Assistant,
-            content: msg.content,
-          }))
+      if (data.success && data.exists) {
+        const messages = (data.messages || []).map((msg: { role: string; content: string }) => ({
+          role: msg.role === ChatRole.User || msg.role === 'user' ? ChatRole.User : ChatRole.Assistant,
+          content: msg.content,
+        }))
 
         logger.debug(
           {
-            conversationId: conversation.id,
-            contextKey,
-            conversationContextKey: conversation.contextKey,
-            userId: conversationUserId,
-            rawMessageCount: rawMessages.length,
-            validMessageCount: messages.length,
-            hasMessages: rawMessages.length > 0,
+            conversationId: data.conversationId,
+            contextKey: data.contextKey,
+            messageCount: messages.length,
           },
           '[getConversation] Loaded conversation',
         )
@@ -211,21 +136,14 @@ export const apiService = {
         return {
           success: true,
           exists: true,
-          conversationId: conversation.id,
-          contextKey,
+          conversationId: data.conversationId,
           messages,
+          contextKey: data.contextKey,
         }
       }
 
-      // No conversation exists yet
-      logger.debug({ contextKey }, '[getConversation] No conversation found for contextKey')
-
-      return {
-        success: true,
-        exists: false,
-        messages: [],
-        contextKey,
-      }
+      logger.debug({ contextKey }, '[getConversation] No conversation found')
+      return { success: true, exists: false, messages: [], contextKey }
     } catch (_error) {
       return { success: false, exists: false, messages: [], error: 'Network error' }
     }

--- a/tests/e2e/lesson-chat-history.e2e.spec.ts
+++ b/tests/e2e/lesson-chat-history.e2e.spec.ts
@@ -1,0 +1,284 @@
+/**
+ * E2E Tests for Lesson Page Chat History Loading
+ *
+ * Tests the fix for: Chat history on lesson pages loads conversations from the wrong user
+ *
+ * Tests:
+ * - Login as User A, send message, refresh, verify history loads
+ * - Login as User B on same lesson, verify User A's history NOT visible
+ * - Test logout clears conversation context properly
+ */
+import { expect, test } from '@playwright/test'
+import { setupAuthenticatedUser, generateTestUserEmail, cleanupTestUsers } from './helpers/auth'
+import { getTestCourseData, buildLessonUrl, seedTestCourseData } from './helpers/courses'
+
+test.describe('Lesson Chat History Loading', () => {
+  let testCourseData: Awaited<ReturnType<typeof getTestCourseData>>
+
+  test.beforeAll(async () => {
+    // Seed test course data if it doesn't exist
+    const seeded = await seedTestCourseData()
+    if (seeded) {
+      testCourseData = seeded
+    } else {
+      // If seeding failed, try to get existing data
+      testCourseData = await getTestCourseData()
+    }
+
+    if (!testCourseData) {
+      throw new Error(
+        'No test course data available. Failed to seed or find published course with chapters and lessons.',
+      )
+    }
+  })
+
+  // Clean up all test users after all tests complete
+  test.afterAll(async () => {
+    await cleanupTestUsers()
+  })
+
+  /**
+   * Helper to find chat input - works with both ChatInterface and NotebookChat
+   */
+  async function findChatInput(page: any) {
+    // Try different selectors for chat input
+    const selectors = [
+      'input[type="text"]:not([name="name"]):not([name="email"]):not([name="password"])',
+      'textarea[name="message"]',
+      'input[name="message"]',
+      'input[placeholder*="message" i]',
+      'input[placeholder*="ask" i]',
+    ]
+
+    for (const selector of selectors) {
+      const input = page.locator(selector).first()
+      if ((await input.count()) > 0) {
+        const isVisible = await input.isVisible().catch(() => false)
+        if (isVisible) {
+          return input
+        }
+      }
+    }
+
+    throw new Error('Could not find chat input field')
+  }
+
+  /**
+   * Helper to wait for chat message to appear
+   */
+  async function waitForChatMessage(page: any, timeout = 30000) {
+    // Wait for any message div (user or assistant)
+    await page.waitForSelector('.bg-primary, .bg-muted', { timeout })
+  }
+
+  /**
+   * Helper to get chat messages
+   */
+  async function getChatMessages(page: any) {
+    const userMessages = await page.locator('.bg-primary').all()
+    const assistantMessages = await page.locator('.bg-muted').all()
+    return { userMessages, assistantMessages }
+  }
+
+  /**
+   * Helper to wait for chat input to be enabled
+   */
+  async function waitForChatInputEnabled(chatInput: any, timeout = 30000) {
+    await chatInput.waitFor({ state: 'visible', timeout })
+    const startTime = Date.now()
+    while (Date.now() - startTime < timeout) {
+      const isDisabled = await chatInput.isDisabled().catch(() => true)
+      if (!isDisabled) {
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        return
+      }
+      await new Promise((resolve) => setTimeout(resolve, 200))
+    }
+    const stillDisabled = await chatInput.isDisabled().catch(() => true)
+    if (stillDisabled) {
+      throw new Error('Chat input remained disabled after timeout')
+    }
+  }
+
+  test('should load chat history after refresh for User A', async ({ page }) => {
+    // Authenticate User A
+    const userA = await setupAuthenticatedUser(page, {
+      email: generateTestUserEmail('chat-history-user-a'),
+      password: 'password123',
+    })
+
+    // Navigate to lesson page
+    const lessonUrl = buildLessonUrl(testCourseData!)
+    await page.goto(lessonUrl)
+    await page.waitForLoadState('networkidle')
+
+    // Wait for page to fully load
+    await page.waitForTimeout(2000)
+    const chatInput = await findChatInput(page)
+    await waitForChatInputEnabled(chatInput)
+
+    // Send a message
+    const testMessage = `Hello from User A - ${Date.now()}`
+    await chatInput.fill(testMessage)
+    await chatInput.press('Enter')
+
+    // Wait for response
+    await waitForChatMessage(page, 30000)
+
+    // Verify message appears
+    const messagesAfterSend = await getChatMessages(page)
+    expect(messagesAfterSend.userMessages.length).toBeGreaterThan(0)
+    expect(messagesAfterSend.assistantMessages.length).toBeGreaterThan(0)
+
+    // Refresh the page
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+    await page.waitForTimeout(2000)
+
+    // Verify chat history loads after refresh
+    const messagesAfterRefresh = await getChatMessages(page)
+    expect(messagesAfterRefresh.userMessages.length).toBeGreaterThan(0)
+    expect(messagesAfterRefresh.assistantMessages.length).toBeGreaterThan(0)
+
+    // Verify the original message is still present
+    const pageContent = await page.textContent('body')
+    expect(pageContent).toContain(testMessage)
+  })
+
+  test('should isolate chat history between different users', async ({ page }) => {
+    // Authenticate User A
+    const userA = await setupAuthenticatedUser(page, {
+      email: generateTestUserEmail('chat-history-isolation-a'),
+      password: 'password123',
+    })
+
+    // Navigate to lesson page
+    const lessonUrl = buildLessonUrl(testCourseData!)
+    await page.goto(lessonUrl)
+    await page.waitForLoadState('networkidle')
+
+    // Wait for page to fully load
+    await page.waitForTimeout(2000)
+    const chatInput = await findChatInput(page)
+    await waitForChatInputEnabled(chatInput)
+
+    // User A sends a message
+    const userAMessage = `Private message from User A - ${Date.now()}`
+    await chatInput.fill(userAMessage)
+    await chatInput.press('Enter')
+
+    // Wait for response
+    await waitForChatMessage(page, 30000)
+
+    // Verify User A's message appears
+    const messagesA = await getChatMessages(page)
+    expect(messagesA.userMessages.length).toBeGreaterThan(0)
+
+    // Logout User A
+    await page.goto('/logout')
+    await page.waitForLoadState('networkidle')
+
+    // Authenticate User B
+    const userB = await setupAuthenticatedUser(page, {
+      email: generateTestUserEmail('chat-history-isolation-b'),
+      password: 'password123',
+    })
+
+    // Navigate to same lesson page
+    await page.goto(lessonUrl)
+    await page.waitForLoadState('networkidle')
+
+    // Wait for page to fully load
+    await page.waitForTimeout(2000)
+    const chatInputB = await findChatInput(page)
+    await waitForChatInputEnabled(chatInputB)
+
+    // Verify User B does NOT see User A's messages
+    const messagesB = await getChatMessages(page)
+    const pageContent = await page.textContent('body')
+
+    // User B should have empty chat (no previous conversation)
+    // OR if there are messages, they should NOT contain User A's message
+    if (messagesB.userMessages.length > 0) {
+      // If messages exist, verify they don't contain User A's message
+      expect(pageContent).not.toContain(userAMessage)
+    } else {
+      // Empty chat is also valid - User B has no conversation yet
+      expect(messagesB.userMessages.length).toBe(0)
+    }
+
+    // User B sends their own message
+    const userBMessage = `Private message from User B - ${Date.now()}`
+    await chatInputB.fill(userBMessage)
+    await chatInputB.press('Enter')
+
+    // Wait for response
+    await waitForChatMessage(page, 30000)
+
+    // Verify User B's message appears
+    const messagesBAfterSend = await getChatMessages(page)
+    expect(messagesBAfterSend.userMessages.length).toBeGreaterThan(0)
+
+    // Verify User B still doesn't see User A's message
+    const pageContentAfter = await page.textContent('body')
+    expect(pageContentAfter).not.toContain(userAMessage)
+    expect(pageContentAfter).toContain(userBMessage)
+  })
+
+  test('should verify API endpoint returns correct user conversation', async ({ page }) => {
+    // Authenticate User A
+    const userA = await setupAuthenticatedUser(page, {
+      email: generateTestUserEmail('chat-history-api-a'),
+      password: 'password123',
+    })
+
+    // Navigate to lesson page
+    const lessonUrl = buildLessonUrl(testCourseData!)
+    await page.goto(lessonUrl)
+    await page.waitForLoadState('networkidle')
+
+    // Wait for page to fully load
+    await page.waitForTimeout(2000)
+    const chatInput = await findChatInput(page)
+    await waitForChatInputEnabled(chatInput)
+
+    // Send a message
+    const testMessage = `API test message - ${Date.now()}`
+    await chatInput.fill(testMessage)
+    await chatInput.press('Enter')
+
+    // Wait for response
+    await waitForChatMessage(page, 30000)
+
+    // Intercept API call to verify it uses the new endpoint
+    const apiCalls: any[] = []
+    page.on('response', (response: any) => {
+      if (response.url().includes('/api/agent/conversation')) {
+        apiCalls.push({
+          url: response.url(),
+          status: response.status(),
+        })
+      }
+    })
+
+    // Refresh the page to trigger conversation loading
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+    await page.waitForTimeout(2000)
+
+    // Verify the new endpoint was called
+    const conversationApiCalls = apiCalls.filter((call) =>
+      call.url.includes('/api/agent/conversation'),
+    )
+    expect(conversationApiCalls.length).toBeGreaterThan(0)
+
+    // Verify all calls were successful
+    for (const call of conversationApiCalls) {
+      expect(call.status).toBe(200)
+    }
+
+    // Verify chat history loaded
+    const messagesAfterRefresh = await getChatMessages(page)
+    expect(messagesAfterRefresh.userMessages.length).toBeGreaterThan(0)
+  })
+})

--- a/tests/int/get-conversation-endpoint.int.spec.ts
+++ b/tests/int/get-conversation-endpoint.int.spec.ts
@@ -1,0 +1,512 @@
+/**
+ * Integration tests for the /api/agent/conversation endpoint
+ *
+ * Tests:
+ * - Authenticated user gets only their conversation
+ * - Different users don't see each other's conversations
+ * - Unauthenticated request returns 401
+ * - Explicit user filtering guarantees isolation
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import type { Payload } from 'payload'
+import { getPayload } from 'payload'
+import type { PayloadRequest } from 'payload'
+import { getConversation } from '@/endpoints/agent/get-conversation'
+import { agentChat } from '@/endpoints/agent/chat'
+import { startMongoContainer, stopMongoContainer } from '@/utilities/test/mongodb-container'
+
+// Mock AI and vector-related services
+vi.mock('@/lib/ai/services/exercise-chat-service', () => ({
+  chatWithExerciseHelper: vi.fn(async () => ({
+    success: true,
+    message: 'Mock assistant response',
+  })),
+  getSystemPrompt: vi.fn(() => 'You are a helpful assistant.'),
+}))
+
+vi.mock('@/lib/ai/vector-index-check', () => ({
+  isVectorIndexAvailable: vi.fn(async () => false),
+}))
+
+vi.mock('@/lib/ai/vector-search', () => ({
+  retrieveMemoryItems: vi.fn(async () => ({
+    items: [],
+    latencyMs: 0,
+    localCount: 0,
+    contextCount: 0,
+    globalCount: 0,
+    hierarchyKeys: [],
+  })),
+}))
+
+vi.mock('@/lib/ai/memory-extraction', () => ({
+  extractMemoryCandidates: vi.fn(async () => []),
+  persistMemoryItems: vi.fn(async () => 0),
+}))
+
+vi.mock('@/lib/ai/maintenance', () => ({
+  runSummaryMaintenance: vi.fn(async () => ({
+    summaryUpdated: false,
+    messagesTrimmed: 0,
+  })),
+}))
+
+vi.mock('@/lib/feature-flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/feature-flags')>()
+  return {
+    ...actual,
+    featureFlags: {
+      SUMMARY_MAINTENANCE_ENABLED: true,
+      MEMORY_EXTRACTION_ENABLED: true,
+      MEMORY_RETRIEVAL_ENABLED: true,
+    },
+  }
+})
+
+let payload: Payload
+let testUserId: string
+let testUserId2: string
+let testExerciseId: string
+let originalDatabaseUrl: string | undefined
+
+beforeAll(
+  async () => {
+    // Save original DATABASE_URL and unset it before starting testcontainers
+    originalDatabaseUrl = process.env.DATABASE_URL
+    // @ts-expect-error - TypeScript doesn't allow delete on process.env, but it's safe here
+    delete process.env.DATABASE_URL
+
+    // Start MongoDB test container
+    const mongoUri = await startMongoContainer()
+    process.env.DATABASE_URL = mongoUri
+
+    // Import config AFTER setting DATABASE_URL
+    const config = await import('@payload-config')
+    payload = await getPayload({ config: config.default })
+
+    // Create first test user
+    const user1 = await payload.create({
+      collection: 'users',
+      data: {
+        email: `get-conv-${Date.now()}@example.com`,
+        password: 'test123456',
+        role: 'student',
+      },
+    })
+    testUserId = user1.id
+
+    // Create second test user
+    const user2 = await payload.create({
+      collection: 'users',
+      data: {
+        email: `get-conv-2-${Date.now()}@example.com`,
+        password: 'test123456',
+        role: 'student',
+      },
+    })
+    testUserId2 = user2.id
+
+    // Get or create test exercise
+    const existingExercises = await payload.find({
+      collection: 'exercises',
+      limit: 1,
+    })
+
+    if (existingExercises.docs.length > 0) {
+      testExerciseId = existingExercises.docs[0].id
+    } else {
+      // Need to create lesson first
+      const existingLessons = await payload.find({
+        collection: 'lessons',
+        limit: 1,
+      })
+
+      let testLessonId: string
+      if (existingLessons.docs.length > 0) {
+        testLessonId = existingLessons.docs[0].id
+      } else {
+        // Need to create chapter first
+        const existingChapters = await payload.find({
+          collection: 'chapters',
+          limit: 1,
+        })
+
+        let testChapterId: string
+        if (existingChapters.docs.length > 0) {
+          testChapterId = existingChapters.docs[0].id
+        } else {
+          // Need to create course first
+          const existingCourses = await payload.find({
+            collection: 'courses',
+            limit: 1,
+          })
+
+          let testCourseId: string
+          if (existingCourses.docs.length > 0) {
+            testCourseId = existingCourses.docs[0].id
+          } else {
+            const existingCategories = await payload.find({
+              collection: 'categories',
+              limit: 1,
+            })
+
+            let testCategoryId: string
+            if (existingCategories.docs.length > 0) {
+              testCategoryId = existingCategories.docs[0].id
+            } else {
+              const category = await payload.create({
+                collection: 'categories',
+                data: {
+                  title: 'Test Category',
+                  slug: `test-category-${Date.now()}`,
+                } as any,
+              })
+              testCategoryId = category.id
+            }
+
+            const course = await payload.create({
+              collection: 'courses',
+              data: {
+                courseLabel: 'Test',
+                title: 'Test Course',
+                slug: `test-course-${Date.now()}`,
+                order: 0,
+                status: 'published',
+                isActive: true,
+                categories: [testCategoryId],
+              } as any,
+            })
+            testCourseId = course.id
+          }
+
+          const chapter = await payload.create({
+            collection: 'chapters',
+            data: {
+              course: testCourseId,
+              title: 'Test Chapter',
+              slug: `test-chapter-${Date.now()}`,
+              order: 0,
+              status: 'published',
+              isActive: true,
+            } as any,
+          })
+          testChapterId = chapter.id
+        }
+
+        const lesson = await payload.create({
+          collection: 'lessons',
+          data: {
+            chapter: testChapterId,
+            title: 'Test Lesson',
+            slug: `test-lesson-${Date.now()}`,
+            order: 0,
+            status: 'published',
+            isActive: true,
+          } as any,
+        })
+        testLessonId = lesson.id
+      }
+
+      const exercise = await payload.create({
+        collection: 'exercises',
+        data: {
+          title: 'Test Exercise',
+          slug: `test-exercise-${Date.now()}`,
+          lesson: testLessonId,
+          order: 0,
+          _status: 'published',
+        } as any,
+      })
+      testExerciseId = exercise.id
+    }
+  },
+  60000,
+)
+
+afterAll(async () => {
+  if (!payload) {
+    return
+  }
+
+  // Clean up test conversations
+  const conversations = await payload.find({
+    collection: 'conversations',
+    where: {
+      or: [{ user: { equals: testUserId } }, { user: { equals: testUserId2 } }],
+    },
+    limit: 1000,
+  })
+
+  for (const conv of conversations.docs) {
+    await payload.delete({
+      collection: 'conversations',
+      id: conv.id,
+    })
+  }
+
+  // Clean up test users
+  if (testUserId) {
+    await payload.delete({
+      collection: 'users',
+      id: testUserId,
+    })
+  }
+
+  if (testUserId2) {
+    await payload.delete({
+      collection: 'users',
+      id: testUserId2,
+    })
+  }
+
+  if (payload.db?.destroy) {
+    await payload.db.destroy()
+  }
+
+  // Restore original DATABASE_URL
+  if (originalDatabaseUrl !== undefined) {
+    process.env.DATABASE_URL = originalDatabaseUrl
+  } else {
+    // @ts-expect-error - TypeScript doesn't allow delete on process.env, but it's safe here
+    delete process.env.DATABASE_URL
+  }
+
+  // Stop MongoDB container
+  await stopMongoContainer()
+}, 60000)
+
+describe('Get Conversation Endpoint', () => {
+  it('should return 401 when unauthenticated', async () => {
+    const req = {
+      payload,
+      user: null, // No user
+      json: async () => ({
+        contextKey: `exercises:${testExerciseId}`,
+      }),
+    } as unknown as PayloadRequest & { json: () => Promise<unknown> }
+
+    const res = await getConversation(req)
+    expect(res.status).toBe(401)
+
+    const body = await res.json()
+    expect(body.error).toBe('Authentication required')
+  })
+
+  it('should return empty result when no conversation exists', async () => {
+    const contextKey = `exercises:${testExerciseId}-nonexistent-${Date.now()}`
+
+    const req = {
+      payload,
+      user: { id: testUserId } as any,
+      json: async () => ({
+        contextKey,
+      }),
+    } as unknown as PayloadRequest & { json: () => Promise<unknown> }
+
+    const res = await getConversation(req)
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.exists).toBe(false)
+    expect(body.messages).toEqual([])
+    expect(body.contextKey).toBe(contextKey)
+  })
+
+  it('should return conversation for authenticated user', async () => {
+    const contextKey = `exercises:${testExerciseId}`
+
+    // Create conversation by sending a chat message
+    const chatReq = {
+      payload,
+      user: { id: testUserId } as any,
+      json: async () => ({
+        message: 'Test message',
+        acknowledgment: 'ack',
+        exerciseId: testExerciseId,
+      }),
+    } as unknown as PayloadRequest & { json: () => Promise<unknown> }
+
+    const chatRes = await agentChat(chatReq)
+    expect(chatRes.status).toBe(200)
+    const chatBody = await chatRes.json()
+    const conversationId = chatBody.conversationId
+
+    // Fetch conversation via new endpoint
+    const req = {
+      payload,
+      user: { id: testUserId } as any,
+      json: async () => ({
+        contextKey,
+      }),
+    } as unknown as PayloadRequest & { json: () => Promise<unknown> }
+
+    const res = await getConversation(req)
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.exists).toBe(true)
+    expect(body.conversationId).toBe(conversationId)
+    expect(Array.isArray(body.messages)).toBe(true)
+    expect(body.messages.length).toBeGreaterThan(0)
+  })
+
+  it('should enforce user isolation - different users see different conversations', async () => {
+    const contextKey = `exercises:${testExerciseId}`
+
+    // User 1 sends a message
+    const chatReq1 = {
+      payload,
+      user: { id: testUserId } as any,
+      json: async () => ({
+        message: 'User 1 private message',
+        acknowledgment: 'ack',
+        exerciseId: testExerciseId,
+      }),
+    } as unknown as PayloadRequest & { json: () => Promise<unknown> }
+
+    const chatRes1 = await agentChat(chatReq1)
+    expect(chatRes1.status).toBe(200)
+    const chatBody1 = await chatRes1.json()
+    const conversationId1 = chatBody1.conversationId
+
+    // User 2 sends a message (different conversation for same exercise)
+    const chatReq2 = {
+      payload,
+      user: { id: testUserId2 } as any,
+      json: async () => ({
+        message: 'User 2 private message',
+        acknowledgment: 'ack',
+        exerciseId: testExerciseId,
+      }),
+    } as unknown as PayloadRequest & { json: () => Promise<unknown> }
+
+    const chatRes2 = await agentChat(chatReq2)
+    expect(chatRes2.status).toBe(200)
+    const chatBody2 = await chatRes2.json()
+    const conversationId2 = chatBody2.conversationId
+
+    // Verify conversations are different
+    expect(conversationId1).not.toBe(conversationId2)
+
+    // User 1 should only see their own conversation
+    const req1 = {
+      payload,
+      user: { id: testUserId } as any,
+      json: async () => ({
+        contextKey,
+      }),
+    } as unknown as PayloadRequest & { json: () => Promise<unknown> }
+
+    const res1 = await getConversation(req1)
+    expect(res1.status).toBe(200)
+    const body1 = await res1.json()
+    expect(body1.success).toBe(true)
+    expect(body1.exists).toBe(true)
+    expect(body1.conversationId).toBe(conversationId1)
+    expect(body1.messages.some((m: { content: string }) => m.content.includes('User 1'))).toBe(true)
+    expect(body1.messages.some((m: { content: string }) => m.content.includes('User 2'))).toBe(false)
+
+    // User 2 should only see their own conversation
+    const req2 = {
+      payload,
+      user: { id: testUserId2 } as any,
+      json: async () => ({
+        contextKey,
+      }),
+    } as unknown as PayloadRequest & { json: () => Promise<unknown> }
+
+    const res2 = await getConversation(req2)
+    expect(res2.status).toBe(200)
+    const body2 = await res2.json()
+    expect(body2.success).toBe(true)
+    expect(body2.exists).toBe(true)
+    expect(body2.conversationId).toBe(conversationId2)
+    expect(body2.messages.some((m: { content: string }) => m.content.includes('User 2'))).toBe(true)
+    expect(body2.messages.some((m: { content: string }) => m.content.includes('User 1'))).toBe(false)
+  })
+
+  it('should explicitly filter by user ID in query', async () => {
+    const contextKey = `exercises:${testExerciseId}-explicit-filter-${Date.now()}`
+
+    // Create conversations for both users manually
+    const conv1 = await payload.create({
+      collection: 'conversations',
+      data: {
+        user: testUserId,
+        contextRef: { relationTo: 'exercises', value: testExerciseId },
+        contextKey,
+        messages: [
+          { role: 'user', content: 'User 1 message', timestamp: new Date().toISOString() },
+        ],
+        lastMessageAt: new Date().toISOString(),
+      } as any,
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    const conv2 = await payload.create({
+      collection: 'conversations',
+      data: {
+        user: testUserId2,
+        contextRef: { relationTo: 'exercises', value: testExerciseId },
+        contextKey,
+        messages: [
+          { role: 'user', content: 'User 2 message', timestamp: new Date().toISOString() },
+        ],
+        lastMessageAt: new Date().toISOString(),
+      } as any,
+    })
+
+    // User 1 should only get their conversation
+    const req1 = {
+      payload,
+      user: { id: testUserId } as any,
+      json: async () => ({
+        contextKey,
+      }),
+    } as unknown as PayloadRequest & { json: () => Promise<unknown> }
+
+    const res1 = await getConversation(req1)
+    expect(res1.status).toBe(200)
+    const body1 = await res1.json()
+    expect(body1.conversationId).toBe(conv1.id)
+    expect(body1.messages.some((m: { content: string }) => m.content.includes('User 1'))).toBe(true)
+
+    // User 2 should only get their conversation
+    const req2 = {
+      payload,
+      user: { id: testUserId2 } as any,
+      json: async () => ({
+        contextKey,
+      }),
+    } as unknown as PayloadRequest & { json: () => Promise<unknown> }
+
+    const res2 = await getConversation(req2)
+    expect(res2.status).toBe(200)
+    const body2 = await res2.json()
+    expect(body2.conversationId).toBe(conv2.id)
+    expect(body2.messages.some((m: { content: string }) => m.content.includes('User 2'))).toBe(true)
+
+    // Clean up
+    await payload.delete({ collection: 'conversations', id: conv1.id })
+    await payload.delete({ collection: 'conversations', id: conv2.id })
+  })
+
+  it('should return 400 for invalid request body', async () => {
+    const req = {
+      payload,
+      user: { id: testUserId } as any,
+      json: async () => ({
+        // Missing contextKey
+      }),
+    } as unknown as PayloadRequest & { json: () => Promise<unknown> }
+
+    const res = await getConversation(req)
+    expect(res.status).toBe(400)
+
+    const body = await res.json()
+    expect(body.error).toBe('Invalid request')
+  })
+})


### PR DESCRIPTION
Fixes chat history on lesson pages loading conversations from the wrong user.

The Payload REST API's authentication for `req.user` was unreliable, causing `isOwner` access control to fail and display incorrect chat history. This PR replaces the problematic REST API call with a dedicated endpoint that explicitly authenticates the user and filters conversations by `req.user.id`, ensuring strict user isolation.

---
<a href="https://cursor.com/background-agent?bcId=bc-9c65aad5-466c-438c-862e-961cb334c47a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9c65aad5-466c-438c-862e-961cb334c47a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

