### PR TITLE
Lesson chat history refresh

### DIFF
--- a/tests/e2e/lesson-chat-history.e2e.spec.ts
+++ b/tests/e2e/lesson-chat-history.e2e.spec.ts
@@ -39,6 +39,12 @@ test.describe('Lesson Chat History Loading', () => {
   })
 
   /**
+   * Selector for user chat messages (excludes buttons and other bg-primary elements)
+   * User messages have: ml-auto bg-primary and contain text content
+   */
+  const USER_MESSAGE_SELECTOR = '.bg-primary.ml-auto'
+
+  /**
    * Helper to find chat input - works with both ChatInterface and NotebookChat
    */
   async function findChatInput(page: Page): Promise<Locator> {
@@ -69,8 +75,9 @@ test.describe('Lesson Chat History Loading', () => {
    */
   async function waitForChatMessage(page: Page, timeout = 30000) {
     // Wait for any message div (user or assistant)
+    // User messages have ml-auto class to distinguish from send button
     // ChatInterface uses bg-card for assistant messages, NotebookChat uses bg-muted
-    await page.waitForSelector('.bg-primary, .bg-muted, .bg-card', { timeout })
+    await page.waitForSelector(`${USER_MESSAGE_SELECTOR}, .bg-muted, .bg-card`, { timeout })
   }
 
   /**
@@ -80,7 +87,8 @@ test.describe('Lesson Chat History Loading', () => {
     userMessages: Locator[]
     assistantMessages: Locator[]
   }> {
-    const userMessages = await page.locator('.bg-primary').all()
+    // Use more specific selector for user messages (ml-auto distinguishes from send button)
+    const userMessages = await page.locator(USER_MESSAGE_SELECTOR).all()
     // ChatInterface uses bg-card for assistant messages, NotebookChat uses bg-muted
     const assistantMessages = await page.locator('.bg-muted, .bg-card').all()
     return { userMessages, assistantMessages }
@@ -95,12 +103,22 @@ test.describe('Lesson Chat History Loading', () => {
 
   /**
    * Helper to wait for chat history loading to finish
+   * Waits for either: loading indicator to disappear OR user messages to appear
    */
   async function waitForHistoryLoaded(page: Page, timeout = 30000) {
     const loadingIndicator = page.locator('text=Loading conversation...')
-    if (await loadingIndicator.isVisible().catch(() => false)) {
-      await loadingIndicator.waitFor({ state: 'hidden', timeout })
-    }
+    const userMessages = page.locator(USER_MESSAGE_SELECTOR)
+
+    // Wait for loading to finish (either loading indicator disappears or messages appear)
+    await Promise.race([
+      // Option 1: Loading indicator was visible and becomes hidden
+      loadingIndicator.waitFor({ state: 'hidden', timeout }).catch(() => {}),
+      // Option 2: User messages appear (indicating history loaded)
+      userMessages.first().waitFor({ state: 'visible', timeout }).catch(() => {}),
+    ])
+
+    // Small additional wait for React state to settle
+    await page.waitForTimeout(500)
   }
 
   /**
@@ -168,7 +186,7 @@ test.describe('Lesson Chat History Loading', () => {
     await expect
       .poll(
         async () => {
-          const userMessageTexts = await getChatMessageTexts(page, '.bg-primary')
+          const userMessageTexts = await getChatMessageTexts(page, USER_MESSAGE_SELECTOR)
           return userMessageTexts.join(' ')
         },
         { timeout: 30000 },
@@ -231,7 +249,7 @@ test.describe('Lesson Chat History Loading', () => {
     // OR if there are messages, they should NOT contain User A's message
     if (messagesB.userMessages.length > 0) {
       // If messages exist, verify they don't contain User A's message
-      const userMessageTexts = await getChatMessageTexts(page, '.bg-primary')
+      const userMessageTexts = await getChatMessageTexts(page, USER_MESSAGE_SELECTOR)
       expect(userMessageTexts.join(' ')).not.toContain(userAMessage)
     } else {
       // Empty chat is also valid - User B has no conversation yet


### PR DESCRIPTION
Fixes recurring E2E test failure for chat history loading after refresh by using a more specific selector for user messages.

The previous selector `.bg-primary` was too broad, matching both user messages and the "Send" button. This caused the test to incorrectly report no messages after a refresh (as the button has no text content), leading to timeouts. The fix introduces `USER_MESSAGE_SELECTOR = '.bg-primary.ml-auto'` to accurately target user messages and improves the `waitForHistoryLoaded` helper for robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-d359dc5f-210f-4620-9c3d-69a52ad640e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d359dc5f-210f-4620-9c3d-69a52ad640e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

