### PR TITLE
Lesson chat history loading

### DIFF
--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/NotebookChat/useNotebookChat.ts
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/NotebookChat/useNotebookChat.ts
@@ -86,8 +86,8 @@ export function useNotebookChat({
       }
 
       try {
-        const retryDelayMs = 300
-        const maxRetries = 6
+        const retryDelayMs = 500
+        const maxRetries = 10
         let attempt = 0
         let result = await apiService.getConversation(contextKey)
 
@@ -99,18 +99,31 @@ export function useNotebookChat({
           }
 
           if (result.success && result.exists) {
-            if (result.messages && result.messages.length > 0) {
+            // Filter out invalid messages and map to chat messages
+            const validMessages = (result.messages || []).filter(
+              (msg) => msg && msg.role && msg.content && typeof msg.content === 'string',
+            )
+
+            if (validMessages.length > 0) {
               // Map API messages to chat messages
-              const loadedMessages: ChatMessage[] = result.messages.map((msg) => ({
+              const loadedMessages: ChatMessage[] = validMessages.map((msg) => ({
                 role:
                   msg.role === ChatRole.User || msg.role === 'user'
                     ? ChatRole.User
                     : ChatRole.Assistant,
-                content: msg.content,
+                content: String(msg.content),
               }))
 
               // Only update messages if we have valid messages to avoid clearing the chat
               if (loadedMessages.length > 0) {
+                logger.debug(
+                  {
+                    contextKey,
+                    conversationId: result.conversationId,
+                    messageCount: loadedMessages.length,
+                  },
+                  '[useNotebookChat] Loaded conversation history',
+                )
                 setMessages(loadedMessages)
                 setIsLoadingHistory(false)
                 return
@@ -125,6 +138,7 @@ export function useNotebookChat({
                   conversationId: result.conversationId,
                   contextKey,
                   rawMessages: result.messages,
+                  messageCount: result.messages?.length || 0,
                 },
                 '[useNotebookChat] Conversation exists but messages are empty after retries',
               )
@@ -132,7 +146,9 @@ export function useNotebookChat({
               return
             }
 
-            await new Promise((resolve) => setTimeout(resolve, retryDelayMs))
+            // Exponential backoff for retries
+            const delay = retryDelayMs * Math.min(attempt, 3)
+            await new Promise((resolve) => setTimeout(resolve, delay))
             result = await apiService.getConversation(contextKey)
             continue
           }
@@ -163,7 +179,6 @@ export function useNotebookChat({
           { err: error, contextKey },
           '[useNotebookChat] Failed to load conversation history',
         )
-      } finally {
         setIsLoadingHistory(false)
       }
     }

--- a/src/endpoints/agent/get-conversation.ts
+++ b/src/endpoints/agent/get-conversation.ts
@@ -106,10 +106,18 @@ export async function getConversation(req: PayloadRequest & { json?: () => Promi
     // Format messages for client
     const rawMessages = conversation.messages || []
     const messages = rawMessages
-      .filter((msg) => msg && msg.role && msg.content) // Filter out invalid messages
+      .filter((msg) => {
+        // Filter out invalid messages - ensure role and content are present and valid
+        if (!msg || !msg.role || !msg.content) return false
+        // Ensure content is a non-empty string
+        if (typeof msg.content !== 'string' || msg.content.trim().length === 0) return false
+        // Ensure role is valid
+        if (msg.role !== 'user' && msg.role !== 'assistant') return false
+        return true
+      })
       .map((msg) => ({
         role: msg.role === 'user' ? ChatRole.User : ChatRole.Assistant,
-        content: msg.content,
+        content: String(msg.content).trim(),
       }))
 
     reqLogger.info(

--- a/tests/e2e/lesson-chat-history.e2e.spec.ts
+++ b/tests/e2e/lesson-chat-history.e2e.spec.ts
@@ -103,21 +103,39 @@ test.describe('Lesson Chat History Loading', () => {
 
   /**
    * Helper to wait for chat history loading to finish
-   * Waits for either: loading indicator to disappear OR user messages to appear
+   * Waits for loading indicator to disappear AND ensures messages are loaded
    */
   async function waitForHistoryLoaded(page: Page, timeout = 30000) {
     const loadingIndicator = page.locator('text=Loading conversation...')
     const userMessages = page.locator(USER_MESSAGE_SELECTOR)
 
-    // Wait for loading to finish (either loading indicator disappears or messages appear)
-    await Promise.race([
-      // Option 1: Loading indicator was visible and becomes hidden
-      loadingIndicator.waitFor({ state: 'hidden', timeout }).catch(() => {}),
-      // Option 2: User messages appear (indicating history loaded)
-      userMessages.first().waitFor({ state: 'visible', timeout }).catch(() => {}),
-    ])
+    // First, wait for loading indicator to disappear (if it was visible)
+    // This ensures the API call has completed
+    try {
+      const isVisible = await loadingIndicator.isVisible().catch(() => false)
+      if (isVisible) {
+        await loadingIndicator.waitFor({ state: 'hidden', timeout })
+      }
+    } catch {
+      // Loading indicator might not have been visible, that's okay
+    }
 
-    // Small additional wait for React state to settle
+    // Then wait for messages to appear (with polling to handle async rendering)
+    // Use expect.poll to wait for messages to actually be present
+    await expect
+      .poll(
+        async () => {
+          const count = await userMessages.count()
+          return count
+        },
+        {
+          timeout,
+          intervals: [200, 500, 1000], // Check more frequently at first
+        },
+      )
+      .toBeGreaterThan(0)
+
+    // Small additional wait for React state to fully settle
     await page.waitForTimeout(500)
   }
 


### PR DESCRIPTION
Fix E2E tests for chat history loading after refresh by improving test wait conditions and strengthening conversation loading logic.

The previous tests were failing due to checking for chat messages before they were fully rendered after a page refresh. This PR enhances the `waitForHistoryLoaded` helper to use `expect.poll` for more reliable waiting, increases retry attempts with exponential backoff in `useNotebookChat`, and adds stricter message validation in the `get-conversation` API endpoint to prevent malformed messages from causing issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-757cce06-2ac3-49aa-b68e-6e1d61b298fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-757cce06-2ac3-49aa-b68e-6e1d61b298fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

