### PR TITLE
feat: Add maxLength validation to lessonContextText field

### DIFF
--- a/.tasks/lesson-context-text/plan.md
+++ b/.tasks/lesson-context-text/plan.md
@@ -1,0 +1,203 @@
+TDD Plan: Lesson Full-Context Injection (MVP)
+Goal
+Inject lesson-level textual context into chat prompts at runtime without persisting in conversations or messages.
+
+Architecture Overview
+
+┌─────────────────────────────────────────────────────────────────┐
+│                      Chat Request Flow                          │
+├─────────────────────────────────────────────────────────────────┤
+│  1. User sends message with lessonId                            │
+│  2. Fetch lesson.lessonContextText from DB                      │
+│  3. Call buildLessonContextPrompt(systemPrompt, lessonContext)  │
+│  4. Pass enriched prompt to composePrompt()                     │
+│  5. Send to AI model                                            │
+│  6. Store ONLY user message + AI response (NO lesson context)   │
+└─────────────────────────────────────────────────────────────────┘
+Key Constraint: Lesson context is injected at runtime via buildLessonContextPrompt() and NEVER stored in conversations/messages.
+
+Files to Modify/Create
+File	Action	Purpose
+src/collections/Lessons.ts	MODIFY	Add lessonContextText field
+src/lib/ai/lesson-context.ts	CREATE	Single-responsibility injection function
+src/endpoints/agent/chat.ts	MODIFY	Fetch lesson + call buildLessonContextPrompt
+tests/unit/collections/lessons-schema.spec.ts	CREATE	Schema tests
+tests/unit/lib/ai/lesson-context.spec.ts	CREATE	Unit tests for injection function
+tests/int/lesson-context-injection.int.spec.ts	CREATE	Integration tests
+Test Strategy (Test-First)
+1. Schema Tests
+File: tests/unit/collections/lessons-schema.spec.ts
+
+Test	Assertion
+should have lessonContextText field	Field exists in Lessons.fields
+should be textarea type	field.type === 'textarea'
+should be optional	field.required is falsy
+should NOT be indexed	field.index is falsy
+2. Conversation Integrity Tests
+File: tests/unit/collections/conversations-schema.spec.ts (extend)
+
+Test	Assertion
+should NOT have lessonContext field	Field undefined in Conversations
+messages should NOT have lessonContext	No such field in messages array schema
+3. Prompt Composition Unit Tests
+File: tests/unit/lib/ai/lesson-context.spec.ts
+
+Test	Assertion
+should inject lessonContextText into system prompt	Result contains lesson content + delimiters
+should preserve original system prompt	Base prompt still present
+should return original when lessonContext is undefined	Unchanged, no delimiters
+should return original when lessonContext is empty	Unchanged
+should reject oversized lessonContext	Throws error with "exceeds maximum"
+should accept context at exactly max size	No error
+should wrap context in delimiters	LESSON_CONTEXT_START before content, LESSON_CONTEXT_END after
+4. Integration Tests
+File: tests/int/lesson-context-injection.int.spec.ts
+
+Test	Assertion
+should inject lessonContextText into composed prompt	Model receives prompt with lesson content
+should NOT persist lessonContextText in messages	DB query shows no lesson markers in stored messages
+should inject only current lesson context	Lesson A context present, Lesson B absent
+should reject oversized context without calling model	400 response, mock not called
+should verify stored messages never contain lesson markers	After multiple messages, no LESSON_CONTEXT_START in DB
+Implementation Details
+1. Lessons Collection Field
+
+// src/collections/Lessons.ts - Add after contentFiles field
+{
+  name: 'lessonContextText',
+  type: 'textarea',
+  admin: {
+    description: 'AI context text for this lesson. Injected into chat prompts at runtime. NOT indexed or searchable.',
+  },
+  // NOT indexed, NOT required
+},
+2. Lesson Context Module
+
+// src/lib/ai/lesson-context.ts
+export const LESSON_CONTEXT_MAX_CHARS = 100_000  // ~50K tokens
+export const LESSON_CONTEXT_BLOCK_START = 'LESSON_CONTEXT_START'
+export const LESSON_CONTEXT_BLOCK_END = 'LESSON_CONTEXT_END'
+
+export function buildLessonContextPrompt(
+  baseSystemPrompt: string,
+  lessonContextText: string | undefined | null,
+): string {
+  if (!lessonContextText?.trim()) return baseSystemPrompt
+
+  if (lessonContextText.length > LESSON_CONTEXT_MAX_CHARS) {
+    throw new Error(`Lesson context exceeds maximum allowed size`)
+  }
+
+  return [
+    baseSystemPrompt,
+    '',
+    LESSON_CONTEXT_BLOCK_START,
+    '## Lesson Context',
+    lessonContextText.trim(),
+    LESSON_CONTEXT_BLOCK_END,
+  ].join('\n')
+}
+3. Chat Endpoint Integration
+Location: src/endpoints/agent/chat.ts (around line 257, before composePrompt call)
+
+
+// Fetch lesson context if applicable
+let lessonContextText: string | undefined
+if (context.relationTo === 'lessons') {
+  const lesson = await req.payload.findByID({
+    collection: 'lessons',
+    id: context.value,
+    depth: 0,
+  })
+  lessonContextText = lesson.lessonContextText ?? undefined
+} else if (context.relationTo === 'exercises') {
+  // Exercises inherit lesson context
+  const exercise = await req.payload.findByID({
+    collection: 'exercises',
+    id: context.value,
+    depth: 0,
+  })
+  if (exercise.lesson) {
+    const lessonId = typeof exercise.lesson === 'string' ? exercise.lesson : exercise.lesson.id
+    const lesson = await req.payload.findByID({
+      collection: 'lessons',
+      id: lessonId,
+      depth: 0,
+    })
+    lessonContextText = lesson.lessonContextText ?? undefined
+  }
+}
+
+// Inject lesson context (single responsibility)
+let systemInstructions = getSystemPrompt()
+try {
+  systemInstructions = buildLessonContextPrompt(systemInstructions, lessonContextText)
+} catch (error) {
+  if (error instanceof Error && error.message.includes('exceeds maximum')) {
+    return Response.json({ error: 'Lesson context exceeds maximum allowed size' }, { status: 400 })
+  }
+  throw error
+}
+Execution Order
+Write unit tests first (all should fail)
+
+tests/unit/collections/lessons-schema.spec.ts
+tests/unit/lib/ai/lesson-context.spec.ts
+Implement schema change
+
+Add lessonContextText field to src/collections/Lessons.ts
+Run pnpm generate:types
+Write integration tests (will fail)
+
+tests/int/lesson-context-injection.int.spec.ts
+Implement injection function
+
+Create src/lib/ai/lesson-context.ts
+Integrate into chat endpoint
+
+Modify src/endpoints/agent/chat.ts
+Run all tests - All should pass
+
+Verify persistence invariant
+
+Manually test: send chat in lesson context
+Query DB: verify messages don't contain lesson markers
+Verification Commands
+
+# Run unit tests
+pnpm exec vitest run tests/unit/collections/lessons-schema.spec.ts
+pnpm exec vitest run tests/unit/lib/ai/lesson-context.spec.ts
+
+# Run integration tests
+pnpm exec vitest run tests/int/lesson-context-injection.int.spec.ts
+
+# Run all tests
+pnpm test
+
+# Verify no lesson context in conversations (manual)
+# In MongoDB shell or Compass:
+db.conversations.find({ "messages.content": /LESSON_CONTEXT_START/ })
+# Should return empty
+Single Responsibility Verification
+After implementation, grep the codebase:
+
+
+grep -r "lessonContextText" src/
+Should ONLY appear in:
+
+src/collections/Lessons.ts (field definition)
+src/lib/ai/lesson-context.ts (injection function)
+src/endpoints/agent/chat.ts (fetch + call)
+src/payload-types.ts (generated types)
+If it appears elsewhere, the single responsibility principle is violated.
+
+Out of Scope
+PDF parsing
+Text extraction
+Chunking
+Vector search
+Embeddings
+LangChain
+memory_items
+Engineering Rule
+If a future refactor replaces full-context injection with retrieval-based logic, only buildLessonContextPrompt() tests and implementation should change.

--- a/.tasks/lesson-context-text/spec.md
+++ b/.tasks/lesson-context-text/spec.md
@@ -1,0 +1,109 @@
+# TDD Task: Lesson Full-Context Injection (MVP)
+
+## Goal
+Guarantee that lesson-level textual context is injected into chat prompts at runtime,
+without being persisted in conversations or messages.
+
+The implementation must be driven entirely by tests.
+
+---
+
+## Test Strategy (Test-First)
+
+### 1. Schema Tests
+**Test: Lesson has AI context field**
+- Assert that `Lesson` schema includes:
+  - `lessonContextText` (string / long text)
+- Assert that:
+  - Field is optional
+  - Field is NOT indexed for search
+  - Field is NOT referenced by any other collection
+
+---
+
+### 2. Conversation Integrity Tests
+**Test: Conversation schema is unchanged**
+- Assert no new fields added to:
+  - `Conversation`
+  - `Message`
+- Assert no message contains lesson context text
+
+**Failure Condition**
+- If lesson context appears inside stored messages → test fails
+
+---
+
+### 3. Prompt Composition Tests
+**Test: Lesson context is injected at runtime**
+- Given:
+  - A lesson with `lessonContextText = "LESSON CONTENT"`
+  - A conversation with user messages
+- When:
+  - A chat request is built
+- Then:
+  - The final prompt contains `"LESSON CONTENT"`
+  - The prompt contains the user question
+  - The prompt contains recent messages only
+
+**Negative Assertion**
+- Lesson context must NOT appear in:
+  - Stored conversation
+  - Stored messages
+
+---
+
+### 4. Isolation Tests
+**Test: Lesson context is lesson-scoped only**
+- Given:
+  - Two lessons with different `lessonContextText`
+- When:
+  - Chat is executed in lesson A
+- Then:
+  - Only lesson A context is injected
+  - Lesson B context never appears
+
+---
+
+### 5. Guardrail Tests
+**Test: Oversized lesson context is blocked**
+- Given:
+  - `lessonContextText` exceeding model context limit
+- When:
+  - Chat request is built
+- Then:
+  - Request is rejected with a clear error
+  - No model call is made
+
+---
+
+### 6. Single Responsibility Tests
+**Test: Context injection is centralized**
+- Assert:
+  - A single function exists: `buildLessonContextPrompt()`
+  - No other code path injects lesson context
+- If lesson context is injected elsewhere → test fails
+
+---
+
+## Explicit Non-Tests (Out of Scope)
+- PDF parsing
+- Text extraction
+- Chunking
+- Vector search
+- Embeddings
+- LangChain
+- memory_items
+
+---
+
+## Acceptance Criteria
+- All tests pass before implementation is considered complete
+- Chat answers demonstrably depend on `lessonContextText`
+- Lesson context is never persisted in conversation data
+- The system remains replaceable with retrieval-based logic later
+
+---
+
+## Engineering Rule
+If a future refactor replaces full-context injection,
+only `buildLessonContextPrompt()` tests should change.

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ChatInterface/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ChatInterface/index.tsx
@@ -1,13 +1,13 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
-import { Send, Plus, BookOpen, Loader2 } from 'lucide-react'
-import { cn } from '@/utilities/ui'
-import { MathPalette } from '../MathPalette'
-import { FormulaPanel } from '../FormulaPanel'
-import { useTranslations } from '@/providers/I18n'
-import { useNotebookChat } from '../NotebookChat/useNotebookChat'
 import { ChatMessageRole } from '@/lib/ai/chat-message-role'
+import { useTranslations } from '@/providers/I18n'
+import { cn } from '@/utilities/ui'
+import { BookOpen, Loader2, Plus, Send } from 'lucide-react'
+import React, { useEffect, useState } from 'react'
+import { FormulaPanel } from '../FormulaPanel'
+import { MathPalette } from '../MathPalette'
+import { useNotebookChat } from '../NotebookChat/useNotebookChat'
 
 interface ChatInterfaceProps {
   exerciseId?: string

--- a/src/collections/Lessons.ts
+++ b/src/collections/Lessons.ts
@@ -113,6 +113,7 @@ export const Lessons: CollectionConfig = {
     {
       name: 'lessonContextText',
       type: 'textarea',
+      maxLength: 100_000, // Match LESSON_CONTEXT_MAX_CHARS in src/lib/ai/lesson-context.ts
       admin: {
         description: 'AI context text for this lesson. Injected into chat prompts at runtime. NOT indexed or searchable.',
       },

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -956,6 +956,10 @@ export interface Lesson {
    */
   contentFiles?: (string | Media)[] | null;
   /**
+   * AI context text for this lesson. Injected into chat prompts at runtime. NOT indexed or searchable.
+   */
+  lessonContextText?: string | null;
+  /**
    * URL-friendly identifier (auto-generated from title if empty)
    */
   slug?: string | null;
@@ -1824,6 +1828,7 @@ export interface LessonsSelect<T extends boolean = true> {
   status?: T;
   isActive?: T;
   contentFiles?: T;
+  lessonContextText?: T;
   slug?: T;
   createdBy?: T;
   updatedAt?: T;

--- a/tests/int/lesson-context-injection.int.spec.ts
+++ b/tests/int/lesson-context-injection.int.spec.ts
@@ -281,43 +281,24 @@ describe.skipIf(!hasDatabaseUrl)('Lesson Context Injection', () => {
   }, 60000)
 
   it('should reject oversized context without calling model', async () => {
-    // Create a lesson with oversized context
+    // Create a lesson with oversized context - should be rejected by Payload validation
     const oversizedContext = 'a'.repeat(LESSON_CONTEXT_MAX_CHARS + 1)
-    const oversizedLesson = await payload.create({
-      collection: 'lessons',
-      data: {
-        chapter: testChapterId,
-        title: 'Oversized Lesson',
-        lessonContextText: oversizedContext,
-        status: 'published',
-        isActive: true,
-        order: 2,
-      } as any,
-      draft: false,
-    })
 
-    const req = {
-      payload,
-      user: { id: testUserId } as PayloadRequest['user'],
-      json: async () => ({
-        message: 'Hello',
-        acknowledgment: 'ack-5',
-        lessonId: oversizedLesson.id,
+    // Payload field validation should reject oversized context (maxLength: 100_000)
+    await expect(
+      payload.create({
+        collection: 'lessons',
+        data: {
+          chapter: testChapterId,
+          title: 'Oversized Lesson',
+          lessonContextText: oversizedContext,
+          status: 'published',
+          isActive: true,
+          order: 2,
+        } as any,
+        draft: false,
       }),
-    } as unknown as PayloadRequest & { json: () => Promise<unknown> }
-
-    const res = await agentChat(req)
-
-    // Should return 400 error
-    expect(res.status).toBe(400)
-    const body = await res.json()
-    expect(body.error).toContain('exceeds maximum')
-
-    // Cleanup
-    await payload.delete({
-      collection: 'lessons',
-      id: oversizedLesson.id,
-    })
+    ).rejects.toThrow(/invalid/)
   }, 60000)
 
   it('should verify stored messages never contain lesson markers', async () => {


### PR DESCRIPTION
Added maxLength: 100_000 constraint to the lessonContextText textarea field to match the LESSON_CONTEXT_MAX_CHARS limit defined in the service layer. This provides earlier validation at the Payload admin level instead of waiting for API-level rejection. Also includes import ordering fix in ChatInterface and updated integration test to expect Payload validation error.