### PR TITLE
fix: Resolve E2E chat history test race conditions

### DIFF
--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/NotebookChat/useNotebookChat.ts
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/NotebookChat/useNotebookChat.ts
@@ -133,11 +133,15 @@ export function useNotebookChat({
                 // React will batch these updates, but we need to ensure messages
                 // are actually in the DOM before hiding the loading indicator
                 setMessages(loadedMessages)
-                // Use a longer delay to ensure React has rendered the messages
-                // This is critical for E2E tests that check for message presence
-                setTimeout(() => {
-                  setIsLoadingHistory(false)
-                }, 150)
+                // Wait for React to render using double rAF pattern
+                // First rAF: schedules callback before next paint
+                // Second rAF: ensures the paint cycle completed
+                // This ensures loading indicator hides only after messages are in DOM
+                requestAnimationFrame(() => {
+                  requestAnimationFrame(() => {
+                    setIsLoadingHistory(false)
+                  })
+                })
                 return
               }
             }


### PR DESCRIPTION
Fixed flaky E2E tests in lesson-chat-history.e2e.spec.ts that were timing out due to race conditions between React state updates and DOM rendering. Replaced the fixed 150ms setTimeout with a double requestAnimationFrame pattern to ensure the loading indicator stays visible until after React has painted messages to the DOM. All 3 E2E tests now pass reliably.