### PR TITLE
fix: Pass SLACK_WEBHOOK_URL env var to semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: pnpm exec semantic-release
 
       - name: Create release summary

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -62,7 +62,7 @@
       {
         "notifyOnSuccess": true,
         "notifyOnFail": true,
-        "slackUrl": "${SLACK_WEBHOOK_URL}"
+        "slackWebhook": "${SLACK_WEBHOOK_URL}"
       }
     ]
   ]


### PR DESCRIPTION
- Use correct config option: slackWebhook instead of slackUrl
- Pass SLACK_WEBHOOK_URL secret as env var to release job