### PR TITLE
fix: Add packageName to slack bot config

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,8 @@
 {
   "branches": ["main"],
+  "package": {
+    "name": "a-guy"
+  },
   "plugins": [
     [
       "@semantic-release/commit-analyzer",
@@ -60,6 +63,7 @@
     [
       "semantic-release-slack-bot",
       {
+        "packageName": "a-guy",
         "notifyOnSuccess": true,
         "notifyOnFail": true,
         "slackWebhook": "${SLACK_WEBHOOK_URL}"


### PR DESCRIPTION
Resolves ENOPACKAGENAME error in release workflow