### PR TITLE
feat: Enhance mixpanel user identity persistence with enriched profiles

### DIFF
--- a/deleteme.txt
+++ b/deleteme.txt
@@ -1,0 +1,1 @@
+deleteme

--- a/deleteme.txt
+++ b/deleteme.txt
@@ -1,1 +1,0 @@
-deleteme

--- a/src/app/(frontend)/signup/SignupForm.tsx
+++ b/src/app/(frontend)/signup/SignupForm.tsx
@@ -12,6 +12,7 @@ import { SignupFormFields } from './SignupFormFields'
 import { validateSignupForm } from './actions/signup_validation-action'
 import { useAnalytics } from '@/lib/analytics/providers/AnalyticsProvider'
 import { PRODUCT_EVENTS } from '@/lib/analytics/contracts/events'
+import { updateCachedUserProperties } from '@/lib/analytics/utils/user-properties-cache'
 
 export function SignupForm() {
   const t = useTranslations('auth.signup')
@@ -53,10 +54,30 @@ export function SignupForm() {
             user_id: result.userId,
             auth_method: 'email',
           })
-          analytics.track(PRODUCT_EVENTS.USER_IDENTIFIED, {
+
+          // Track user_identified with enriched user properties
+          const userProperties: Record<string, unknown> = {
             user_id: result.userId,
             is_new_user: true,
-          })
+            auth_method: 'email',
+            signup_date: new Date().toISOString(),
+            role: 'student', // Default role for new signups
+          }
+
+          // Add locale from browser
+          if (typeof window !== 'undefined') {
+            const locale = window.navigator.language.startsWith('he') ? 'he' : 'en'
+            userProperties.locale = locale
+          }
+
+          // Cache user properties for future sessions
+          updateCachedUserProperties(userProperties)
+
+          // Track event with enriched properties
+          analytics.track(PRODUCT_EVENTS.USER_IDENTIFIED, userProperties)
+
+          // Also call identify() to ensure Mixpanel People properties are set
+          analytics.identify(result.userId, userProperties)
         }
 
         // Auto-login successful - redirect to home

--- a/src/lib/analytics/adapters/mixpanel/adapter.ts
+++ b/src/lib/analytics/adapters/mixpanel/adapter.ts
@@ -66,13 +66,7 @@ export function sendToMixpanel(payload: EventPayload): void {
 
         // Extract user profile properties (exclude event metadata)
         const userProperties: Record<string, unknown> = {}
-        const eventMetadataKeys = [
-          'user_id',
-          'event_timestamp',
-          'session_id',
-          '$current_url',
-          '$referrer',
-        ]
+        const eventMetadataKeys = ['event_timestamp', 'session_id', '$current_url', '$referrer']
 
         Object.keys(mixpanelEvent.properties).forEach((key) => {
           if (!eventMetadataKeys.includes(key)) {
@@ -81,6 +75,7 @@ export function sendToMixpanel(payload: EventPayload): void {
         })
 
         // Set user properties in Mixpanel People
+        // This creates the user profile in Mixpanel
         if (Object.keys(userProperties).length > 0) {
           mixpanel.people.set(userProperties)
 

--- a/src/lib/analytics/adapters/mixpanel/adapter.ts
+++ b/src/lib/analytics/adapters/mixpanel/adapter.ts
@@ -55,6 +55,42 @@ export function sendToMixpanel(payload: EventPayload): void {
     // Send to Mixpanel
     mixpanel.track(mixpanelEvent.name, mixpanelEvent.properties)
 
+    // Special handling for user_identified event
+    // Also set user properties in Mixpanel People
+    if (mixpanelEvent.name === 'user_identified' && mixpanel.people) {
+      const userId = mixpanelEvent.properties.user_id as string
+
+      if (userId) {
+        // Identify user first
+        mixpanel.identify(userId)
+
+        // Extract user profile properties (exclude event metadata)
+        const userProperties: Record<string, unknown> = {}
+        const eventMetadataKeys = [
+          'user_id',
+          'event_timestamp',
+          'session_id',
+          '$current_url',
+          '$referrer',
+        ]
+
+        Object.keys(mixpanelEvent.properties).forEach((key) => {
+          if (!eventMetadataKeys.includes(key)) {
+            userProperties[key] = mixpanelEvent.properties[key]
+          }
+        })
+
+        // Set user properties in Mixpanel People
+        if (Object.keys(userProperties).length > 0) {
+          mixpanel.people.set(userProperties)
+
+          if (analyticsConfig.debugMode) {
+            console.log('[Analytics/Mixpanel] People.set:', { userId, userProperties })
+          }
+        }
+      }
+    }
+
     if (analyticsConfig.debugMode) {
       console.log('[Analytics/Mixpanel] Sent:', mixpanelEvent)
     }

--- a/src/lib/analytics/components/UserIdentificationTracker.tsx
+++ b/src/lib/analytics/components/UserIdentificationTracker.tsx
@@ -3,10 +3,18 @@
 import { useEffect } from 'react'
 import { useAnalytics } from '../providers/AnalyticsProvider'
 import { PRODUCT_EVENTS } from '../contracts/events'
+import {
+  getCachedUserProperties,
+  updateCachedUserProperties,
+  shouldRefreshUserProperties,
+} from '../utils/user-properties-cache'
 
 /**
  * Tracks user_identified event when user is logged in
  * Should be placed in the root layout after AnalyticsProvider
+ *
+ * Enhanced to send full user profile properties to Mixpanel People
+ * Uses localStorage cache to persist user properties across sessions
  */
 export function UserIdentificationTracker() {
   const analytics = useAnalytics()
@@ -15,6 +23,23 @@ export function UserIdentificationTracker() {
     // Check if user is authenticated by checking for payload-token cookie
     const checkAuth = async () => {
       try {
+        // Check cache first - avoid unnecessary API calls
+        const cached = getCachedUserProperties()
+        const needsRefresh = shouldRefreshUserProperties()
+
+        // If we have fresh cached data, use it without API call
+        if (cached && !needsRefresh) {
+          const trackedUserId = sessionStorage.getItem('analytics_tracked_user_id')
+
+          if (trackedUserId !== cached.user_id) {
+            // Identify user with cached properties
+            analytics.identify(cached.user_id, { ...cached })
+            sessionStorage.setItem('analytics_tracked_user_id', cached.user_id)
+          }
+          return
+        }
+
+        // Otherwise, fetch fresh user data from API
         const response = await fetch('/api/users/me', {
           credentials: 'include',
         })
@@ -27,12 +52,40 @@ export function UserIdentificationTracker() {
             // Check if we've already tracked this user in this session
             const trackedUserId = sessionStorage.getItem('analytics_tracked_user_id')
 
-            if (trackedUserId !== user.id) {
-              // Track user_identified for this session
-              analytics.track(PRODUCT_EVENTS.USER_IDENTIFIED, {
+            if (trackedUserId !== user.id || needsRefresh) {
+              // Extract non-PII user properties
+              const userProperties: Record<string, unknown> = {
                 user_id: user.id,
                 is_new_user: false, // Existing user logging in
-              })
+              }
+
+              // Add enriched user profile properties (non-PII)
+              if (user.role) {
+                userProperties.role = user.role
+              }
+
+              if (user.createdAt) {
+                userProperties.signup_date = new Date(user.createdAt).toISOString()
+              }
+
+              // Add current login timestamp
+              userProperties.last_login = new Date().toISOString()
+
+              // Add locale if available from browser or user settings
+              if (typeof window !== 'undefined') {
+                const locale = window.navigator.language.startsWith('he') ? 'he' : 'en'
+                userProperties.locale = locale
+              }
+
+              // Cache user properties for future sessions
+              updateCachedUserProperties(userProperties)
+
+              // Track user_identified event with enriched properties
+              // This will trigger both event tracking AND people.set() in Mixpanel
+              analytics.track(PRODUCT_EVENTS.USER_IDENTIFIED, userProperties)
+
+              // Additionally call identify() to ensure user properties are set
+              analytics.identify(user.id, userProperties)
 
               sessionStorage.setItem('analytics_tracked_user_id', user.id)
             }

--- a/src/lib/analytics/contracts/schemas.ts
+++ b/src/lib/analytics/contracts/schemas.ts
@@ -36,12 +36,21 @@ export const SessionStartedSchema = z.object({
  * user_identified - Track user authentication
  * Destination: Mixpanel
  * Priority: P0
+ *
+ * This schema now includes enriched user properties for Mixpanel People.
+ * These properties are sent via people.set() for user profile persistence.
  */
 export const UserIdentifiedSchema = z.object({
   user_id: z.string().describe('MongoDB user ID'),
   // NO email, NO name, NO PII - only ID
   is_new_user: z.boolean().optional().describe('First time signup'),
   auth_method: z.enum(['google', 'email']).optional().describe('Auth provider'),
+
+  // User profile properties (non-PII)
+  signup_date: z.string().optional().describe('ISO signup date'),
+  role: z.string().optional().describe('User role (student, teacher, admin)'),
+  locale: z.string().optional().describe('User locale preference (en/he)'),
+  last_login: z.string().optional().describe('ISO date of last login'),
 })
 
 /**

--- a/src/lib/analytics/core/tracker.ts
+++ b/src/lib/analytics/core/tracker.ts
@@ -15,6 +15,7 @@ import { getEventDestinations } from '../contracts/destinations'
 import { analyticsConfig, validateConfig } from '../config'
 import { validateEvent } from './validator'
 import type { Analytics, EventPayload } from '../types'
+import { clearCachedUserProperties } from '../utils/user-properties-cache'
 
 // Adapters will be imported dynamically to avoid SSR issues
 let ga4Adapter: typeof import('../adapters/ga4/adapter') | null = null
@@ -157,6 +158,12 @@ export function reset(): void {
     if (analyticsConfig.debugMode) {
       console.log('[Analytics] Reset')
     }
+
+    // Clear cached user properties
+    clearCachedUserProperties()
+
+    // Clear session tracking
+    sessionStorage.removeItem('analytics_tracked_user_id')
 
     void initializeAdapters().then(() => {
       // Only Mixpanel handles user reset

--- a/src/lib/analytics/utils/user-properties-cache.ts
+++ b/src/lib/analytics/utils/user-properties-cache.ts
@@ -1,0 +1,100 @@
+/**
+ * User Properties Cache
+ *
+ * Manages persistent storage of user properties for analytics
+ * Stores non-PII user properties in localStorage for cross-session persistence
+ *
+ * CRITICAL: Only store non-PII properties (no emails, names, etc.)
+ */
+
+const CACHE_KEY = 'analytics_user_properties'
+
+export interface CachedUserProperties {
+  user_id: string
+  role?: string
+  signup_date?: string
+  locale?: string
+  last_login?: string
+  auth_method?: 'google' | 'email'
+  is_new_user?: boolean
+}
+
+/**
+ * Get cached user properties from localStorage
+ */
+export function getCachedUserProperties(): CachedUserProperties | null {
+  if (typeof window === 'undefined') return null
+
+  try {
+    const cached = localStorage.getItem(CACHE_KEY)
+    if (!cached) return null
+
+    return JSON.parse(cached) as CachedUserProperties
+  } catch (_error) {
+    // Invalid JSON or storage error
+    return null
+  }
+}
+
+/**
+ * Set cached user properties in localStorage
+ */
+export function setCachedUserProperties(properties: CachedUserProperties): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify(properties))
+  } catch (_error) {
+    // Storage quota exceeded or other error - fail silently
+  }
+}
+
+/**
+ * Update cached user properties (merge with existing)
+ */
+export function updateCachedUserProperties(properties: Partial<CachedUserProperties>): void {
+  if (typeof window === 'undefined') return
+
+  const cached = getCachedUserProperties()
+  const updated = {
+    ...cached,
+    ...properties,
+  }
+
+  setCachedUserProperties(updated as CachedUserProperties)
+}
+
+/**
+ * Clear cached user properties (on logout)
+ */
+export function clearCachedUserProperties(): void {
+  if (typeof window === 'undefined') return
+
+  try {
+    localStorage.removeItem(CACHE_KEY)
+  } catch (_error) {
+    // Fail silently
+  }
+}
+
+/**
+ * Check if user properties need refresh (e.g., stale data)
+ * Returns true if last_login is older than 24 hours
+ */
+export function shouldRefreshUserProperties(): boolean {
+  if (typeof window === 'undefined') return false
+
+  const cached = getCachedUserProperties()
+  if (!cached || !cached.last_login) return true
+
+  try {
+    const lastLogin = new Date(cached.last_login)
+    const now = new Date()
+    const hoursSinceLastLogin = (now.getTime() - lastLogin.getTime()) / (1000 * 60 * 60)
+
+    // Refresh if more than 24 hours since last login
+    return hoursSinceLastLogin > 24
+  } catch (_error) {
+    return true
+  }
+}


### PR DESCRIPTION
Implement comprehensive fix for Mixpanel user identity and profile persistence issues.

Key changes:
- Enhanced UserIdentifiedSchema with non-PII user properties (signup_date, role, locale, last_login)
- Created user-properties-cache utility for localStorage persistence across sessions
- Updated UserIdentificationTracker to fetch and cache full user profiles
- Modified Mixpanel adapter to automatically call people.set() for user_identified events
- Enhanced SignupForm to send enriched user data on registration
- Integrated cache cleanup in analytics reset function

This ensures:
- User profiles persist in Mixpanel People dashboard
- Properties available for segmentation and analysis
- Reduced API calls via smart caching (24hr refresh window)
- Complete user journey tracking (anonymous → identified → engaged)
- Privacy compliance (no PII sent to analytics)

Fixes task 8: Mixpanel does not persist user identity or user data