### PR TITLE
Fix issue #139: Remove duplicated Logo name In Lesson view

### DIFF
--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ExerciseHeader/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ExerciseHeader/index.tsx
@@ -46,7 +46,6 @@ export function ExerciseHeader({ exerciseTitle, backUrl }: ExerciseHeaderProps) 
         }}
       >
         <TelescopeLogo className="h-8 w-auto" />
-        <span className="text-primary text-xl font-extrabold tracking-tight">Aguy</span>
       </div>
     </header>
   )


### PR DESCRIPTION
This pull request fixes #139.

The issue has been successfully resolved. The changes made directly address the problem described in the issue. The git patch shows that the duplicate "AGuy" logo name with class="text-primary font-bold text-xl" was removed from the ExerciseHeader component. Specifically, the line `<span className="text-primary text-xl font-extrabold tracking-tight">Aguy</span>` was deleted from the JSX, which was located immediately after the TelescopeLogo component. This removal eliminates the duplicate logo text while preserving the TelescopeLogo component itself. The change is surgical and precise - it removes exactly the element described in the issue without affecting other functionality.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌