### PR TITLE
chore: Add Node options to increase memory in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,7 @@ jobs:
     needs: [fast-gate]
     timeout-minutes: 15
     env:
+      NODE_OPTIONS: --max-old-space-size=4096
       DATABASE_URL: mongodb://localhost:27017/test
       PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET || 'test-secret-for-ci' }}
       NEXT_PUBLIC_SERVER_URL: ${{ secrets.NEXT_PUBLIC_SERVER_URL || 'http://localhost:3000' }}


### PR DESCRIPTION
Increases Node.js heap size to 4GB in CI workflows to prevent out-of-memory crashes during test execution.