### PR TITLE
OpenHands agent workflow

### DIFF
--- a/.github/workflows/dev-agent-smith-openhands.yml
+++ b/.github/workflows/dev-agent-smith-openhands.yml
@@ -9,9 +9,15 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: openhands-${{ github.repository }}-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
   openhands:
-    if: contains(github.event.comment.body, '@openhands-agent')
+    if: |
+      startsWith(github.event.comment.body, '@openhands-agent') &&
+      github.event.comment.user.type != 'Bot'
     uses: OpenHands/OpenHands/.github/workflows/openhands-resolver.yml@main
     with:
       macro: '@openhands-agent'
@@ -19,9 +25,8 @@ jobs:
       target_branch: 'dev'
       llm_model: minimax/MiniMax-M2.1
       pr_type: ready
-
     secrets:
-      LLM_API_KEY: ${{secrets.AI_KEY }}
-      LLM_BASE_URL: ${{secrets.AI_BASE_URL }}
+      LLM_API_KEY: ${{ secrets.AI_KEY }}
+      LLM_BASE_URL: ${{ secrets.AI_BASE_URL }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
       PAT_USERNAME: ${{ secrets.PAT_USERNAME }}


### PR DESCRIPTION
Add concurrency control and refine the trigger condition for the OpenHands Agent workflow.

Concurrency control prevents multiple workflow runs for the same issue, while the updated trigger condition uses `startsWith()` for more precise activation and excludes bot users to prevent unintended triggers.

---
<a href="https://cursor.com/background-agent?bcId=bc-c10a396f-0502-4cfd-b664-6aac5445e93b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c10a396f-0502-4cfd-b664-6aac5445e93b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

