### PR TITLE
Dev agent smith workflow

### DIFF
--- a/.github/workflows/dev-agent-smith-openhands.yml
+++ b/.github/workflows/dev-agent-smith-openhands.yml
@@ -18,6 +18,7 @@ jobs:
     if: |
       startsWith(github.event.comment.body, '@openhands-agent') &&
       github.event.comment.user.type != 'Bot'
+    timeout-minutes: 60
     uses: OpenHands/OpenHands/.github/workflows/openhands-resolver.yml@main
     with:
       macro: '@openhands-agent'

--- a/.github/workflows/dev-agent-smith-openhands.yml
+++ b/.github/workflows/dev-agent-smith-openhands.yml
@@ -2,7 +2,8 @@ name: OpenHands Agent
 
 on:
   issue_comment:
-    types: [created]
+    types:
+      - created
 
 permissions:
   contents: write
@@ -15,15 +16,12 @@ concurrency:
 
 jobs:
   openhands:
-    if: |
-      startsWith(github.event.comment.body, '@openhands-agent') &&
-      github.event.comment.user.type != 'Bot'
-    timeout-minutes: 60
+    if: startsWith(github.event.comment.body, '@openhands-agent') && github.event.comment.user.type != 'Bot'
     uses: OpenHands/OpenHands/.github/workflows/openhands-resolver.yml@main
     with:
       macro: '@openhands-agent'
       max_iterations: 25
-      target_branch: 'dev'
+      target_branch: dev
       llm_model: minimax/MiniMax-M2.1
       pr_type: ready
     secrets:


### PR DESCRIPTION
Add a 60-minute timeout to the OpenHands agent workflow to prevent jobs from running indefinitely.

---
<a href="https://cursor.com/background-agent?bcId=bc-83a5d46a-9a82-4ec9-9bc4-abed6fc845f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-83a5d46a-9a82-4ec9-9bc4-abed6fc845f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

