### PR TITLE
feat(i18n): Improve locale utilities and navigation

### DIFF
--- a/.github/workflows/dev-agent-smith-openhands.yml
+++ b/.github/workflows/dev-agent-smith-openhands.yml
@@ -2,7 +2,8 @@ name: OpenHands Agent
 
 on:
   issue_comment:
-    types: [created]
+    types:
+      - created
 
 permissions:
   contents: write
@@ -15,15 +16,12 @@ concurrency:
 
 jobs:
   openhands:
-    if: |
-      startsWith(github.event.comment.body, '@openhands-agent') &&
-      github.event.comment.user.type != 'Bot'
-    timeout-minutes: 60
+    if: startsWith(github.event.comment.body, '@openhands-agent') && github.event.comment.user.type != 'Bot'
     uses: OpenHands/OpenHands/.github/workflows/openhands-resolver.yml@main
     with:
       macro: '@openhands-agent'
       max_iterations: 25
-      target_branch: 'dev'
+      target_branch: dev
       llm_model: minimax/MiniMax-M2.1
       pr_type: ready
     secrets:

--- a/docs/ai/indexes/pattern-index.json
+++ b/docs/ai/indexes/pattern-index.json
@@ -205,6 +205,7 @@
         "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/MathPalette/index.tsx",
         "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/NotebookChat/index.tsx",
         "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/NotebookWorkspace/index.tsx",
+        "src/app/(frontend)/courses/_components/LessonHeader/index.tsx",
         "src/app/(frontend)/layout.tsx",
         "src/blocks/Banner/Component.tsx",
         "src/blocks/Content/Component.tsx",
@@ -296,12 +297,14 @@
         "src/collections/ExerciseAssets.ts",
         "src/collections/Exercises/index.ts",
         "src/collections/Lessons.ts",
+        "src/collections/MCPAuditLogs.ts",
         "src/collections/Media/index.ts",
         "src/collections/MemoryItems.ts",
         "src/collections/Pages/index.ts",
         "src/collections/Posts/index.ts",
         "src/collections/PricingPlans.ts",
         "src/collections/Prompts.ts",
+        "src/collections/Tenants.ts",
         "src/collections/UserProgress.ts",
         "src/collections/Users/index.ts"
       ]
@@ -685,7 +688,7 @@
       "aiSummary": "",
       "dependencies": [
         "lucide-react",
-        "next/link"
+        "next/navigation"
       ]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ExercisePageContent/index.tsx": {
@@ -945,11 +948,15 @@
       "type": "unknown",
       "domain": "general",
       "patterns": [
+        "tailwind-component",
         "i18n-component",
         "client-component"
       ],
       "aiSummary": "",
-      "dependencies": []
+      "dependencies": [
+        "lucide-react",
+        "next/navigation"
+      ]
     },
     "src/app/(frontend)/courses/_components/LessonsSectionTitle/index.tsx": {
       "path": "src/app/(frontend)/courses/_components/LessonsSectionTitle/index.tsx",
@@ -1107,9 +1114,9 @@
       ],
       "aiSummary": "",
       "dependencies": [
-        "react",
-        "next/navigation",
         "next/link",
+        "next/navigation",
+        "react",
         "sonner"
       ]
     },
@@ -1443,6 +1450,18 @@
         "payload"
       ]
     },
+    "src/collections/MCPAuditLogs.ts": {
+      "path": "src/collections/MCPAuditLogs.ts",
+      "type": "unknown",
+      "domain": "general",
+      "patterns": [
+        "access-control"
+      ],
+      "aiSummary": "",
+      "dependencies": [
+        "payload"
+      ]
+    },
     "src/collections/Media/index.ts": {
       "path": "src/collections/Media/index.ts",
       "type": "unknown",
@@ -1514,6 +1533,18 @@
     },
     "src/collections/Prompts.ts": {
       "path": "src/collections/Prompts.ts",
+      "type": "unknown",
+      "domain": "general",
+      "patterns": [
+        "access-control"
+      ],
+      "aiSummary": "",
+      "dependencies": [
+        "payload"
+      ]
+    },
+    "src/collections/Tenants.ts": {
+      "path": "src/collections/Tenants.ts",
       "type": "unknown",
       "domain": "general",
       "patterns": [
@@ -2963,8 +2994,8 @@
     }
   },
   "metadata": {
-    "generatedAt": "2026-01-19T14:34:31.196Z",
-    "totalFiles": 191,
+    "generatedAt": "2026-01-21T06:37:03.402Z",
+    "totalFiles": 193,
     "totalPatterns": 22
   }
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { cookieName, defaultLocale, type Locale, locales } from './src/i18n/config'
+import {
+  cookieName,
+  defaultLocale,
+  type Locale,
+  locales,
+  getLocaleFromSubdomain,
+} from './src/i18n/config'
 
 function resolveCookieDomain(host: string): string | undefined {
   // If you're on *.vercel.app, sharing cookies across subdomains via Domain=.vercel.app
@@ -37,11 +43,9 @@ export function middleware(request: NextRequest) {
   let shouldSetCookie = false
 
   // Subdomain-based locale forcing
-  if (host.startsWith('he.')) {
-    locale = 'he'
-    shouldSetCookie = true
-  } else if (host.startsWith('en.')) {
-    locale = 'en'
+  const subdomainLocale = getLocaleFromSubdomain(host)
+  if (subdomainLocale) {
+    locale = subdomainLocale
     shouldSetCookie = true
   } else {
     // On primary domain, check cookie first

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ExerciseHeader/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ExerciseHeader/index.tsx
@@ -1,34 +1,46 @@
 'use client'
 
 import { TelescopeLogo } from '@/components/TelescopeLogo'
+import { isRTL } from '@/i18n/config'
 import { useLocale, useTranslations } from '@/providers/I18n'
 import { cn } from '@/utilities/ui'
 import { ArrowLeft, ArrowRight } from 'lucide-react'
-import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 
 interface ExerciseHeaderProps {
   exerciseTitle: string
-  backUrl: string
+  backUrl?: string
 }
 
 export function ExerciseHeader({ exerciseTitle, backUrl }: ExerciseHeaderProps) {
   const t = useTranslations('courses')
   const locale = useLocale()
-  const isRTL = locale === 'he'
+  const rtl = isRTL(locale as 'en' | 'he')
+  const router = useRouter()
+
+  const handleBack = () => {
+    if (window.history.length > 1) {
+      router.back()
+    } else if (backUrl) {
+      router.push(backUrl)
+    } else {
+      router.push('/courses')
+    }
+  }
 
   return (
     <header className="h-[60px] bg-card border-b border-border flex items-center flex-shrink-0 z-[100] relative">
       {/* Left side in LTR (back arrow) / Right side in RTL (back arrow) */}
-      <Link
-        href={backUrl}
+      <button
+        onClick={handleBack}
         className={cn(
-          'flex items-center justify-center p-2 text-foreground hover:text-primary transition-colors flex-shrink-0 absolute',
-          isRTL ? 'right-5' : 'left-5',
+          'flex items-center justify-center p-2 text-foreground hover:text-primary transition-colors flex-shrink-0 absolute cursor-pointer',
+          rtl ? 'right-5' : 'left-5',
         )}
         aria-label={t('backToLesson')}
       >
-        {isRTL ? <ArrowRight className="w-6 h-6" /> : <ArrowLeft className="w-6 h-6" />}
-      </Link>
+        {rtl ? <ArrowRight className="w-6 h-6" /> : <ArrowLeft className="w-6 h-6" />}
+      </button>
 
       {/* Center: Exercise Title */}
       <h1 className="absolute left-1/2 -translate-x-1/2 text-primary text-lg font-extrabold tracking-tight cursor-move max-w-[40%] text-center truncate">
@@ -39,10 +51,10 @@ export function ExerciseHeader({ exerciseTitle, backUrl }: ExerciseHeaderProps) 
       <div
         className={cn(
           'flex items-center gap-1 flex-shrink-0 fixed top-[10px] z-[101]',
-          isRTL ? 'flex-row-reverse' : 'flex-row',
+          rtl ? 'flex-row-reverse' : 'flex-row',
         )}
         style={{
-          [isRTL ? 'left' : 'right']: '20px',
+          [rtl ? 'left' : 'right']: '20px',
         }}
       >
         <TelescopeLogo className="h-8 w-auto" />

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ExerciseWorkspace/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ExerciseWorkspace/index.tsx
@@ -1,13 +1,13 @@
 'use client'
 
-import React from 'react'
-import { ExerciseHeader } from '../ExerciseHeader'
 import { ResizablePane } from '@/components/ui/resizable-pane'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
+import React from 'react'
+import { ExerciseHeader } from '../ExerciseHeader'
 
 interface ExerciseWorkspaceProps {
   exerciseTitle: string
-  backUrl: string
+  backUrl?: string
   pdfContent: React.ReactNode
   chatContent: React.ReactNode
 }

--- a/src/app/(frontend)/courses/_components/LessonHeader/index.tsx
+++ b/src/app/(frontend)/courses/_components/LessonHeader/index.tsx
@@ -1,6 +1,10 @@
 'use client'
 
-import { useTranslations } from '@/providers/I18n'
+import { isRTL } from '@/i18n/config'
+import { useLocale, useTranslations } from '@/providers/I18n'
+import { cn } from '@/utilities/ui'
+import { ArrowLeft, ArrowRight } from 'lucide-react'
+import { useRouter } from 'next/navigation'
 
 interface LessonHeaderProps {
   order: number
@@ -10,10 +14,32 @@ interface LessonHeaderProps {
 
 export function LessonHeader({ order, title, description }: LessonHeaderProps) {
   const t = useTranslations('courses')
+  const locale = useLocale()
+  const rtl = isRTL(locale as 'en' | 'he')
+  const router = useRouter()
+
+  const handleBack = () => {
+    if (window.history.length > 1) {
+      router.back()
+    } else {
+      router.push('/courses')
+    }
+  }
 
   return (
-    <header className="mb-8">
-      <div className="mb-2">
+    <header className="mb-8 relative">
+      <button
+        onClick={handleBack}
+        className={cn(
+          'absolute -top-2 flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors cursor-pointer',
+          rtl ? 'right-0' : 'left-0',
+        )}
+        aria-label={t('back')}
+      >
+        {rtl ? <ArrowRight className="w-4 h-4" /> : <ArrowLeft className="w-4 h-4" />}
+        <span className="text-sm">{t('back')}</span>
+      </button>
+      <div className="mb-2 mt-8">
         <span className="text-sm font-semibold text-muted-foreground">
           {t('lesson')} {order}
         </span>

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -14,11 +14,11 @@ import { Providers } from '@/providers'
 import { InitTheme } from '@/providers/Theme/InitTheme'
 import { mergeOpenGraph } from '@/utilities/mergeOpenGraph'
 
-import './globals.css'
-import { getServerSideURL } from '@/utilities/getURL'
+import { cookieName, defaultLocale, getDirection, type Locale, locales } from '@/i18n/config'
 import { I18nProvider } from '@/providers/I18n'
-import { defaultLocale, cookieName, type Locale, locales } from '@/i18n/config'
-import { headers, cookies } from 'next/headers'
+import { getServerSideURL } from '@/utilities/getURL'
+import { cookies, headers } from 'next/headers'
+import './globals.css'
 import { LayoutClient } from './LayoutClient'
 
 const assistant = Assistant({
@@ -68,7 +68,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const messages = await getMessages(locale)
 
   // Determine text direction based on locale
-  const dir = locale === 'he' ? 'rtl' : 'ltr'
+  const dir = getDirection(locale)
 
   return (
     <html

--- a/src/app/(frontend)/signup/SignupForm.tsx
+++ b/src/app/(frontend)/signup/SignupForm.tsx
@@ -1,18 +1,19 @@
 'use client'
 
-import React, { useState } from 'react'
-import { useRouter } from 'next/navigation'
-import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card'
-import { signupAction } from './actions/signup_createUser-action'
-import { toast } from 'sonner'
-import { useTranslations } from '@/providers/I18n'
-import { SignupFormFields } from './SignupFormFields'
-import { validateSignupForm } from './actions/signup_validation-action'
-import { useAnalytics } from '@/lib/analytics/providers/AnalyticsProvider'
+import { detectBrowserLocale } from '@/i18n/config'
 import { PRODUCT_EVENTS } from '@/lib/analytics/contracts/events'
+import { useAnalytics } from '@/lib/analytics/providers/AnalyticsProvider'
 import { updateCachedUserProperties } from '@/lib/analytics/utils/user-properties-cache'
+import { useTranslations } from '@/providers/I18n'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import React, { useState } from 'react'
+import { toast } from 'sonner'
+import { SignupFormFields } from './SignupFormFields'
+import { signupAction } from './actions/signup_createUser-action'
+import { validateSignupForm } from './actions/signup_validation-action'
 
 export function SignupForm() {
   const t = useTranslations('auth.signup')
@@ -66,8 +67,7 @@ export function SignupForm() {
 
           // Add locale from browser
           if (typeof window !== 'undefined') {
-            const locale = window.navigator.language.startsWith('he') ? 'he' : 'en'
-            userProperties.locale = locale
+            userProperties.locale = detectBrowserLocale()
           }
 
           // Cache user properties for future sessions

--- a/src/components/LanguageSwitcher/index.tsx
+++ b/src/components/LanguageSwitcher/index.tsx
@@ -1,9 +1,5 @@
 'use client'
 
-import { useLocale, useTranslations } from '@/providers/I18n'
-import { cookieName, type Locale, locales } from '@/i18n/config'
-import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
 import {
   Select,
   SelectContent,
@@ -12,6 +8,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { cookieName, getDirection, isForcedLocaleDomain, type Locale, locales } from '@/i18n/config'
+import { useLocale, useTranslations } from '@/providers/I18n'
+import { useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
 
 export function LanguageSwitcher() {
   const t = useTranslations('common.languageSwitcher')
@@ -37,7 +37,7 @@ export function LanguageSwitcher() {
     // 2. Update HTML attributes immediately (instant RTL/LTR visual feedback)
     // This matches the Theme provider pattern for instant client-side updates
     document.documentElement.setAttribute('lang', newLocale)
-    document.documentElement.setAttribute('dir', newLocale === 'he' ? 'rtl' : 'ltr')
+    document.documentElement.setAttribute('dir', getDirection(newLocale as Locale))
 
     // 3. Set the locale cookie (source of truth for middleware)
     document.cookie = `${cookieName}=${newLocale}; path=/; max-age=31536000; samesite=lax`
@@ -61,8 +61,7 @@ export function LanguageSwitcher() {
 
   // Check if we're on a forced locale subdomain
   const isOnForcedDomain =
-    typeof window !== 'undefined' &&
-    (window.location.host.startsWith('he.') || window.location.host.startsWith('en.'))
+    typeof window !== 'undefined' && isForcedLocaleDomain(window.location.host)
 
   const localeLabels: Record<Locale, string> = {
     en: t('english'),

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -6,3 +6,46 @@ export const defaultLocale: Locale = 'en'
 export const localeDetection = true
 
 export const cookieName = 'NEXT_LOCALE'
+
+// RTL locales set
+export const rtlLocales: ReadonlySet<Locale> = new Set(['he'])
+
+// Direction type
+export type Direction = 'ltr' | 'rtl'
+
+// Locale direction map
+export const localeDirections: Record<Locale, Direction> = {
+  en: 'ltr',
+  he: 'rtl',
+}
+
+// Utility functions
+export function isRTL(locale: Locale): boolean {
+  return rtlLocales.has(locale)
+}
+
+export function getDirection(locale: Locale): Direction {
+  return isRTL(locale) ? 'rtl' : 'ltr'
+}
+
+export function detectBrowserLocale(): Locale {
+  if (typeof window === 'undefined') return defaultLocale
+
+  const browserLang = window.navigator.language
+  const detected = locales.find((loc) => browserLang.startsWith(loc))
+  return detected ?? defaultLocale
+}
+
+// Subdomain locale detection
+export function getLocaleFromSubdomain(host: string): Locale | null {
+  for (const locale of locales) {
+    if (host.startsWith(`${locale}.`)) {
+      return locale
+    }
+  }
+  return null
+}
+
+export function isForcedLocaleDomain(host: string): boolean {
+  return locales.some((locale) => host.startsWith(`${locale}.`))
+}

--- a/src/lib/analytics/components/UserIdentificationTracker.tsx
+++ b/src/lib/analytics/components/UserIdentificationTracker.tsx
@@ -1,12 +1,13 @@
 'use client'
 
+import { detectBrowserLocale } from '@/i18n/config'
 import { useEffect } from 'react'
-import { useAnalytics } from '../providers/AnalyticsProvider'
 import { PRODUCT_EVENTS } from '../contracts/events'
+import { useAnalytics } from '../providers/AnalyticsProvider'
 import {
   getCachedUserProperties,
-  updateCachedUserProperties,
   shouldRefreshUserProperties,
+  updateCachedUserProperties,
 } from '../utils/user-properties-cache'
 
 /**
@@ -73,8 +74,7 @@ export function UserIdentificationTracker() {
 
               // Add locale if available from browser or user settings
               if (typeof window !== 'undefined') {
-                const locale = window.navigator.language.startsWith('he') ? 'he' : 'en'
-                userProperties.locale = locale
+                userProperties.locale = detectBrowserLocale()
               }
 
               // Cache user properties for future sessions


### PR DESCRIPTION
- Add RTL utilities (isRTL, getDirection, detectBrowserLocale) to i18n/config
- Refactor subdomain locale detection into reusable functions
- Update middleware to use getLocaleFromSubdomain helper
- Improve LanguageSwitcher with isForcedLocaleDomain helper
- Convert back buttons from Link to button with router.back() fallback
- Make backUrl optional in ExerciseWorkspace/ExerciseHeader
- Consolidate locale detection across SignupForm and UserIdentificationTracker
- Add back button to LessonHeader with RTL support
- Update AI pattern index