### PR TITLE
feat: Add email and name to analytics user profiles

### DIFF
--- a/src/app/(frontend)/signup/SignupForm.tsx
+++ b/src/app/(frontend)/signup/SignupForm.tsx
@@ -65,6 +65,16 @@ export function SignupForm() {
             role: 'student', // Default role for new signups
           }
 
+          // Add email and name from form (using Mixpanel reserved properties)
+          const email = formData.get('email') as string
+          const name = formData.get('name') as string
+          if (email) {
+            userProperties.$email = email
+          }
+          if (name) {
+            userProperties.$name = name
+          }
+
           // Add locale from browser
           if (typeof window !== 'undefined') {
             userProperties.locale = detectBrowserLocale()

--- a/src/lib/analytics/components/UserIdentificationTracker.tsx
+++ b/src/lib/analytics/components/UserIdentificationTracker.tsx
@@ -54,13 +54,23 @@ export function UserIdentificationTracker() {
             const trackedUserId = sessionStorage.getItem('analytics_tracked_user_id')
 
             if (trackedUserId !== user.id || needsRefresh) {
-              // Extract non-PII user properties
+              // Extract user properties
               const userProperties: Record<string, unknown> = {
                 user_id: user.id,
                 is_new_user: false, // Existing user logging in
               }
 
-              // Add enriched user profile properties (non-PII)
+              // Add user email (using Mixpanel reserved property)
+              if (user.email) {
+                userProperties.$email = user.email
+              }
+
+              // Add user name (using Mixpanel reserved property)
+              if (user.name) {
+                userProperties.$name = user.name
+              }
+
+              // Add enriched user profile properties
               if (user.role) {
                 userProperties.role = user.role
               }

--- a/src/lib/analytics/contracts/schemas.ts
+++ b/src/lib/analytics/contracts/schemas.ts
@@ -42,11 +42,15 @@ export const SessionStartedSchema = z.object({
  */
 export const UserIdentifiedSchema = z.object({
   user_id: z.string().describe('MongoDB user ID'),
-  // NO email, NO name, NO PII - only ID
+
+  // User identity (using Mixpanel reserved properties for better integration)
+  $email: z.string().email().optional().describe('User email address'),
+  $name: z.string().optional().describe('User display name'),
+
   is_new_user: z.boolean().optional().describe('First time signup'),
   auth_method: z.enum(['google', 'email']).optional().describe('Auth provider'),
 
-  // User profile properties (non-PII)
+  // User profile properties
   signup_date: z.string().optional().describe('ISO signup date'),
   role: z.string().optional().describe('User role (student, teacher, admin)'),
   locale: z.string().optional().describe('User locale preference (en/he)'),

--- a/src/lib/analytics/utils/user-properties-cache.ts
+++ b/src/lib/analytics/utils/user-properties-cache.ts
@@ -2,15 +2,15 @@
  * User Properties Cache
  *
  * Manages persistent storage of user properties for analytics
- * Stores non-PII user properties in localStorage for cross-session persistence
- *
- * CRITICAL: Only store non-PII properties (no emails, names, etc.)
+ * Stores user properties in localStorage for cross-session persistence
  */
 
 const CACHE_KEY = 'analytics_user_properties'
 
 export interface CachedUserProperties {
   user_id: string
+  $email?: string
+  $name?: string
   role?: string
   signup_date?: string
   locale?: string


### PR DESCRIPTION
Add user email and name to Mixpanel People profiles using Mixpanel's reserved property names ($email, $name) for better integration.

Changes:
- Update UserIdentifiedSchema to include $email and $name fields
- Update UserIdentificationTracker to extract email/name from user
- Update CachedUserProperties interface with new fields
- Update SignupForm to send email/name on registration

This enables user identification in Mixpanel's Users tab with email and display name for better user management.