### PR TITLE
fix: Add missing DEFAULT_TENANT_SLUG for e2e tests

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,5 @@
+# Test environment configuration
+# This file is loaded by playwright.config.ts and overrides .env values
+
+DATABASE_URL=mongodb://127.0.0.1/your-database-name
+DEFAULT_TENANT_SLUG=default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
       DATABASE_URL: mongodb://localhost:27017/test
       PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET || 'test-secret-for-ci' }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || '' }}
+      DEFAULT_TENANT_SLUG: default
 
     services:
       mongodb:
@@ -229,6 +230,7 @@ jobs:
       DATABASE_URL: mongodb://localhost:27017/test
       PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET || 'test-secret-for-ci' }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || '' }}
+      DEFAULT_TENANT_SLUG: default
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY || '' }}
       NEXT_PUBLIC_SERVER_URL: http://localhost:3000
 

--- a/tests/e2e/helpers/courses.ts
+++ b/tests/e2e/helpers/courses.ts
@@ -5,8 +5,8 @@ import config from '@payload-config'
 import type { Payload } from 'payload'
 import { getPayload } from 'payload'
 
-import { logger } from '@/utilities/logger'
 import { getDefaultTenantSlug } from '@/lib/tenant/get-default-tenant'
+import { logger } from '@/utilities/logger'
 
 export interface TestCourseData {
   courseSlug: string
@@ -228,7 +228,7 @@ export async function seedTestCourseData(): Promise<TestCourseData | null> {
     }
   } catch (error) {
     const err = error instanceof Error ? error : new Error('Unknown error')
-    logger.error({ err }, 'Error seeding test course data')
+    logger.error({ err, message: err.message, stack: err.stack }, 'Error seeding test course data')
     return null
   }
 }


### PR DESCRIPTION
E2E tests were failing because seedTestCourseData() calls getDefaultTenantSlug() which throws when the environment variable is not set. Added DEFAULT_TENANT_SLUG=default to .env.test and CI workflows. Also improved error logging in courses.ts for better debugging of test failures.