### PR TITLE
feat: Add authenticated user icon on ExerciseHeader with returnTo support

### DIFF
--- a/.tasks/lesson-auth-buttons/plan.md
+++ b/.tasks/lesson-auth-buttons/plan.md
@@ -4,48 +4,154 @@
 
 Display authenticated user's avatar/dropdown in the ExerciseHeader component on desktop view, replacing Login/Signup buttons when user is logged in.
 
+**Key improvement:** Create a reusable `useCurrentUser()` hook instead of duplicating fetch logic.
+
 ---
 
 ## Files to Modify
 
-### ExerciseHeader Component (1 file)
-
-| File                                                                                                                                                                            | Purpose                                   |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
-| [`ExerciseHeader/index.tsx`](<src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ExerciseHeader/index.tsx>) | Add user props and UserDropdown component |
+| File | Change |
+|------|--------|
+| [`src/hooks/useCurrentUser.ts`](src/hooks/useCurrentUser.ts) | **NEW** - Reusable client-side auth hook |
+| [`src/ui/web/header/Component.client.tsx`](src/ui/web/header/Component.client.tsx) | Refactor to use `useCurrentUser()` hook |
+| [`src/app/.../ExerciseWorkspace/index.tsx`](src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ExerciseWorkspace/index.tsx) | Use `useCurrentUser()` hook, pass to header |
+| [`src/app/.../ExerciseHeader/index.tsx`](src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ExerciseHeader/index.tsx) | Add user props and auth UI |
 
 ---
 
 ## Implementation Details
 
-### 1. Update ExerciseHeader Interface
+### Step 1: Create `useCurrentUser` Hook
 
-Add `user`, `isAuthLoading`, and `currentUrl` props:
+**File:** `src/hooks/useCurrentUser.ts`
+
+Extract the auth fetch logic from `HeaderClient` into a reusable hook:
 
 ```typescript
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import type { User } from '@/payload-types'
+
+interface UseCurrentUserReturn {
+  user: User | null
+  isLoading: boolean
+  error: Error | null
+  refetch: () => Promise<void>
+}
+
+export function useCurrentUser(): UseCurrentUserReturn {
+  const [user, setUser] = useState<User | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  const fetchUser = useCallback(async () => {
+    setIsLoading(true)
+    setError(null)
+    try {
+      const response = await fetch('/api/users/me', {
+        credentials: 'include',
+        cache: 'no-store',
+      })
+      if (response.ok) {
+        const data = await response.json()
+        setUser(data.user || null)
+      } else {
+        setUser(null)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Failed to fetch user'))
+      setUser(null)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  // Fetch on mount
+  useEffect(() => {
+    fetchUser()
+  }, [fetchUser])
+
+  // Listen for auth changes (login/logout)
+  useEffect(() => {
+    const handleAuthChange = () => fetchUser()
+    window.addEventListener('auth:changed', handleAuthChange)
+    return () => window.removeEventListener('auth:changed', handleAuthChange)
+  }, [fetchUser])
+
+  return { user, isLoading, error, refetch: fetchUser }
+}
+```
+
+### Step 2: Refactor HeaderClient
+
+**File:** `src/ui/web/header/Component.client.tsx`
+
+Replace inline fetch logic with the new hook:
+
+```typescript
+import { useCurrentUser } from '@/hooks/useCurrentUser'
+
+export function HeaderClient({ data }: { data: HeaderType }) {
+  const { user, isLoading: isAuthLoading } = useCurrentUser()
+  const pathname = usePathname()
+  // ... rest unchanged
+}
+```
+
+**Remove:**
+- `useState` for `user` and `isAuthLoading`
+- `fetchUser` callback
+- Both `useEffect` hooks (mount fetch + auth:changed listener)
+
+### Step 3: Update ExerciseWorkspace
+
+**File:** `src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ExerciseWorkspace/index.tsx`
+
+```typescript
+import { useCurrentUser } from '@/hooks/useCurrentUser'
+import { usePathname } from 'next/navigation'
+
+// Inside component:
+const { user, isLoading: isAuthLoading } = useCurrentUser()
+const pathname = usePathname()
+
+// Pass to ExerciseHeader:
+<ExerciseHeader
+  exerciseTitle={exerciseTitle}
+  backUrl={backUrl}
+  onMenuClick={handleMenuClick}
+  user={user}
+  isAuthLoading={isAuthLoading}
+  currentUrl={pathname}
+/>
+```
+
+### Step 4: Update ExerciseHeader Interface
+
+**File:** `src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ExerciseHeader/index.tsx`
+
+```typescript
+import type { User } from '@/payload-types'
+import { UserDropdown } from '@/ui/web/UserDropdown'
+import { Button } from '@/ui/web/components/button'
+import Link from 'next/link'
+
 interface ExerciseHeaderProps {
   exerciseTitle: string
   backUrl?: string
   onMenuClick?: () => void
-  user?: User | null // NEW: authenticated user
-  isAuthLoading?: boolean // NEW: auth loading state
-  currentUrl?: string // NEW: current URL for returnTo
+  user?: User | null
+  isAuthLoading?: boolean
+  currentUrl?: string
 }
 ```
 
-### 2. Import Required Components
-
-```typescript
-import { Button } from '@/ui/web/components/button'
-import { UserDropdown } from '@/ui/web/UserDropdown'
-import type { User } from '@/payload-types'
-```
-
-### 3. Add Auth Section in Header
-
-Replace/augment the right-side section with auth UI:
+### Step 5: Add Auth Section in Header
 
 ```tsx
+const returnToParam = currentUrl ? `?returnTo=${encodeURIComponent(currentUrl)}` : ''
+
 {/* Desktop Auth Section */}
 <div className="hidden lg:flex items-center gap-2" data-testid="exercise-header-auth">
   {isAuthLoading ? (
@@ -56,60 +162,43 @@ Replace/augment the right-side section with auth UI:
     <>
       <Button variant="ghost" size="sm" asChild>
         <Link href={`/login${returnToParam}`}>
-          {tCommon('login')}
+          {t('common.login')}
         </Link>
       </Button>
       <Button size="sm" asChild>
         <Link href={`/signup${returnToParam}`}>
-          {tCommon('signup')}
+          {t('common.signup')}
         </Link>
       </Button>
     </>
   )}
-}
+</div>
 ```
-
-### 4. Build returnTo Param
-
-The `returnTo` parameter ensures users return to the same lesson page after login/signup:
-
-```typescript
-const returnToParam = currentUrl ? `?returnTo=${encodeURIComponent(currentUrl)}` : ''
-```
-
-**Desktop Usage:**
-
-- Login link: `/login?returnTo=/courses/.../lessons/...`
-- Signup link: `/signup?returnTo=/courses/.../lessons/...`
-
-**Mobile Usage:**
-
-- Mobile login/signup buttons are in `MobileMenu` component
-- ReturnTo for mobile is handled via `currentUrl` prop passed to `MobileMenu`
-- See `.tasks/login-entry-point/plan.md` for full mobile implementation:
-  - `Component.client.tsx` passes `pathname` to `MobileMenu`
-  - `MobileMenu` accepts `currentUrl` and passes to `MobileMenuAuthSection`
-  - `MobileMenuAuthSection` builds returnTo for login/signup links
-
-### 5. User Dropdown
-
-The `UserDropdown` component (existing at `src/ui/web/UserDropdown`) displays:
-
-- User avatar (from `user.image` or initials)
-- Dropdown menu with logout option
 
 ---
 
 ## Data Flow
 
 ```
-ExerciseWorkspace (fetches user via /api/users/me)
-    ↓ passes user, isAuthLoading, currentUrl
+useCurrentUser() hook (fetches /api/users/me)
+    ↓ returns { user, isLoading }
+ExerciseWorkspace (uses hook)
+    ↓ passes user, isAuthLoading, currentUrl (from usePathname)
 ExerciseHeader
     ↓ renders UserDropdown when user exists
 UserDropdown (existing component)
-    ↓ shows avatar + dropdown menu
+    ↓ shows avatar + dropdown menu with logout
 ```
+
+---
+
+## Benefits of Hook Approach
+
+1. **DRY** - Single source of truth for client-side auth
+2. **Consistent** - HeaderClient and ExerciseWorkspace use same logic
+3. **Testable** - Hook can be unit tested independently
+4. **Maintainable** - Fix bugs or add features in one place
+5. **Future-proof** - Easy to add caching, optimistic updates, etc.
 
 ---
 
@@ -121,27 +210,37 @@ The auth section uses `flex-row` (LTR) or `flex-row-reverse` (RTL) via the paren
 
 ## Test Cases
 
-| Test | Description                                   |
-| ---- | --------------------------------------------- |
-| T1   | Unauthenticated: shows Login/Signup buttons   |
-| T2   | Authenticated: shows UserDropdown with avatar |
-| T3   | Loading: shows skeleton pulse                 |
-| T4   | RTL: auth section positioned correctly        |
+| Test | Description |
+|------|-------------|
+| T1 | Unauthenticated: shows Login/Signup buttons |
+| T2 | Authenticated: shows UserDropdown with avatar |
+| T3 | Loading: shows skeleton pulse |
+| T4 | RTL: auth section positioned correctly |
+| T5 | Hook: refetch on `auth:changed` event |
+
+---
+
+## Scope
+
+**In scope:**
+- Create `useCurrentUser` hook
+- Refactor HeaderClient to use hook
+- Add auth UI to ExerciseHeader (desktop)
+
+**Out of scope:**
+- Mobile auth buttons (separate task)
+- returnTo handling in login/signup pages (separate task)
+- Full AuthProvider context (hook is sufficient)
 
 ---
 
 ## Implementation Order
 
-This plan covers **desktop** auth UI in ExerciseHeader.
-
-**Desktop (this plan):**
-
-1. ✅ Update ExerciseHeader interface with user props
-2. ✅ Import UserDropdown component
-3. ✅ Build returnTo param from currentUrl
-4. ✅ Add auth section with conditional rendering (Login/Signup vs UserDropdown)
-5. ✅ Commit and push to branch
-
-**Mobile (see `.tasks/login-entry-point/plan.md`):**
-
-- Mobile returnTo is handled in `Component.client.tsx` → `MobileMenu` → `MobileMenuAuthSection`
+1. [ ] Create `src/hooks/useCurrentUser.ts`
+2. [ ] Run typecheck to verify hook
+3. [ ] Refactor `HeaderClient` to use hook
+4. [ ] Verify header still works correctly
+5. [ ] Update `ExerciseWorkspace` to use hook
+6. [ ] Update `ExerciseHeader` with auth UI
+7. [ ] Test all scenarios
+8. [ ] Commit and push

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ExerciseHeader/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ExerciseHeader/index.tsx
@@ -1,23 +1,40 @@
 'use client'
 
-import { TelescopeLogo } from '@/ui/web/TelescopeLogo'
 import { isRTL } from '@/i18n/config'
-import { useLocale, useTranslations } from '@/ui/web/providers/I18n'
 import { cn } from '@/infra/utils/ui'
+import type { User } from '@/payload-types'
+import { TelescopeLogo } from '@/ui/web/TelescopeLogo'
+import { UserDropdown } from '@/ui/web/UserDropdown'
+import { Button } from '@/ui/web/components/button'
+import { useLocale, useTranslations } from '@/ui/web/providers/I18n'
 import { ArrowLeft, ArrowRight, Menu } from 'lucide-react'
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 
 interface ExerciseHeaderProps {
   exerciseTitle: string
   backUrl?: string
   onMenuClick?: () => void
+  user?: User | null
+  isAuthLoading?: boolean
+  currentUrl?: string
 }
 
-export function ExerciseHeader({ exerciseTitle, backUrl, onMenuClick }: ExerciseHeaderProps) {
+export function ExerciseHeader({
+  exerciseTitle,
+  backUrl,
+  onMenuClick,
+  user,
+  isAuthLoading,
+  currentUrl,
+}: ExerciseHeaderProps) {
   const t = useTranslations('courses')
+  const tCommon = useTranslations('common.header')
   const locale = useLocale()
   const rtl = isRTL(locale as 'en' | 'he')
   const router = useRouter()
+
+  const returnToParam = currentUrl ? `?returnTo=${encodeURIComponent(currentUrl)}` : ''
 
   const handleBack = () => {
     if (window.history.length > 1) {
@@ -71,6 +88,24 @@ export function ExerciseHeader({ exerciseTitle, backUrl, onMenuClick }: Exercise
             <Menu className="w-6 h-6 text-foreground" />
           </button>
         )}
+
+        {/* Desktop Auth Section */}
+        <div className="hidden lg:flex items-center gap-2" data-testid="exercise-header-auth">
+          {isAuthLoading ? (
+            <div className="w-20 h-8 animate-pulse bg-muted rounded" aria-hidden="true" />
+          ) : user ? (
+            <UserDropdown user={user} />
+          ) : (
+            <>
+              <Button variant="ghost" size="sm" asChild>
+                <Link href={`/login${returnToParam}`}>{tCommon('login')}</Link>
+              </Button>
+              <Button size="sm" asChild>
+                <Link href={`/signup${returnToParam}`}>{tCommon('signup')}</Link>
+              </Button>
+            </>
+          )}
+        </div>
       </div>
     </header>
   )

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ExerciseWorkspace/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ExerciseWorkspace/index.tsx
@@ -1,9 +1,11 @@
 'use client'
 
-import { ResizablePane } from '@/ui/web/components/resizable-pane'
-import { useMediaQuery } from '@/server/payload/hooks/useMediaQuery'
-import React, { useState, useCallback, useEffect, useRef } from 'react'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { cn } from '@/infra/utils/ui'
+import { useMediaQuery } from '@/server/payload/hooks/useMediaQuery'
+import { ResizablePane } from '@/ui/web/components/resizable-pane'
+import { usePathname } from 'next/navigation'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { ExerciseHeader } from '../ExerciseHeader'
 import type { ViewMode } from './exercise-workspace-types'
 import { getInitialViewMode } from './exercise-workspace-utils'
@@ -21,6 +23,8 @@ export function ExerciseWorkspace({
   pdfContent,
   chatContent,
 }: ExerciseWorkspaceProps) {
+  const { user, isLoading: isAuthLoading } = useCurrentUser()
+  const pathname = usePathname()
   const isDesktop = useMediaQuery('(min-width: 1024px)')
 
   // Mobile mode state
@@ -124,6 +128,9 @@ export function ExerciseWorkspace({
           exerciseTitle={exerciseTitle}
           backUrl={backUrl}
           onMenuClick={handleMenuClick}
+          user={user}
+          isAuthLoading={isAuthLoading}
+          currentUrl={pathname}
         />
 
         <ResizablePane
@@ -153,6 +160,9 @@ export function ExerciseWorkspace({
         exerciseTitle={exerciseTitle}
         backUrl={backUrl}
         onMenuClick={handleMenuClick}
+        user={user}
+        isAuthLoading={isAuthLoading}
+        currentUrl={pathname}
       />
 
       {/* Mobile: Consistent flex container for all 3 states */}

--- a/src/app/(frontend)/login/LoginForm.tsx
+++ b/src/app/(frontend)/login/LoginForm.tsx
@@ -1,21 +1,24 @@
 'use client'
 
-import { useState } from 'react'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { Suspense, useState } from 'react'
 
+import { GoogleLoginButton } from '@/ui/web/auth/GoogleLoginButton'
 import { Button } from '@/ui/web/components/button'
 import { Card, CardContent, CardFooter, CardHeader } from '@/ui/web/components/card'
 import { Input } from '@/ui/web/components/input'
 import { Label } from '@/ui/web/components/label'
 import { useTranslations } from '@/ui/web/providers/I18n'
 import { loginAction } from './login_authenticate-action'
-import { GoogleLoginButton } from '@/ui/web/auth/GoogleLoginButton'
 
-export function LoginForm() {
+function LoginFormContent() {
   const t = useTranslations('auth.login')
   const tOauth = useTranslations('auth.oauth')
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const returnTo = searchParams?.get('returnTo') || '/'
+
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [isLoading, setIsLoading] = useState(false)
@@ -33,7 +36,7 @@ export function LoginForm() {
 
     if (result.success) {
       window.dispatchEvent(new Event('auth:changed'))
-      router.push('/')
+      router.push(returnTo)
       router.refresh()
       return
     }
@@ -49,7 +52,7 @@ export function LoginForm() {
       </CardHeader>
       <CardContent>
         <div className="space-y-4">
-          <GoogleLoginButton returnTo="/" className="w-full" />
+          <GoogleLoginButton returnTo={returnTo} className="w-full" />
           <div className="relative">
             <div className="absolute inset-0 flex items-center">
               <span className="w-full border-t" />
@@ -105,6 +108,46 @@ export function LoginForm() {
           </Link>
         </p>
       </CardFooter>
+    </Card>
+  )
+}
+
+export function LoginForm() {
+  return (
+    <Suspense fallback={<LoginFormSkeleton />}>
+      <LoginFormContent />
+    </Suspense>
+  )
+}
+
+function LoginFormSkeleton() {
+  const t = useTranslations('auth.login')
+  return (
+    <Card>
+      <CardHeader>
+        <p className="text-sm text-muted-foreground text-center">{t('subtitle')}</p>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <div className="w-full h-10 bg-muted animate-pulse rounded" />
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <span className="w-full border-t" />
+            </div>
+          </div>
+        </div>
+        <div className="space-y-4 mt-4">
+          <div className="space-y-2">
+            <div className="h-4 w-20 bg-muted animate-pulse rounded" />
+            <div className="h-10 bg-muted animate-pulse rounded" />
+          </div>
+          <div className="space-y-2">
+            <div className="h-4 w-24 bg-muted animate-pulse rounded" />
+            <div className="h-10 bg-muted animate-pulse rounded" />
+          </div>
+          <div className="h-10 bg-muted animate-pulse rounded" />
+        </div>
+      </CardContent>
     </Card>
   )
 }

--- a/src/app/(frontend)/signup/SignupForm.tsx
+++ b/src/app/(frontend)/signup/SignupForm.tsx
@@ -1,25 +1,27 @@
 'use client'
 
-import { Button } from '@/ui/web/components/button'
-import { Card, CardContent, CardFooter, CardHeader } from '@/ui/web/components/card'
 import { detectBrowserLocale } from '@/i18n/config'
 import { PRODUCT_EVENTS } from '@/infra/analytics/contracts/events'
 import { useAnalytics } from '@/infra/analytics/providers/AnalyticsProvider'
 import { updateCachedUserProperties } from '@/infra/analytics/utils/user-properties-cache'
+import { GoogleLoginButton } from '@/ui/web/auth/GoogleLoginButton'
+import { Button } from '@/ui/web/components/button'
+import { Card, CardContent, CardFooter, CardHeader } from '@/ui/web/components/card'
 import { useTranslations } from '@/ui/web/providers/I18n'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
-import React, { useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import React, { Suspense, useState } from 'react'
 import { toast } from 'sonner'
 import { SignupFormFields } from './SignupFormFields'
 import { signupAction } from './actions/signup_createUser-action'
 import { validateSignupForm } from './actions/signup_validation-action'
-import { GoogleLoginButton } from '@/ui/web/auth/GoogleLoginButton'
 
-export function SignupForm() {
+function SignupFormContent() {
   const t = useTranslations('auth.signup')
   const tOauth = useTranslations('auth.oauth')
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const returnTo = searchParams?.get('returnTo') || '/'
   const analytics = useAnalytics()
   const [isLoading, setIsLoading] = useState(false)
   const [errors, setErrors] = useState<Record<string, string>>({})
@@ -92,8 +94,8 @@ export function SignupForm() {
           analytics.identify(result.userId, userProperties)
         }
 
-        // Auto-login successful - redirect to home
-        router.push('/')
+        // Auto-login successful - redirect to returnTo
+        router.push(returnTo)
         router.refresh()
       }
     } catch (_error) {
@@ -112,7 +114,7 @@ export function SignupForm() {
       </CardHeader>
       <CardContent>
         <div className="space-y-4">
-          <GoogleLoginButton returnTo="/" className="w-full" />
+          <GoogleLoginButton returnTo={returnTo} className="w-full" />
           <div className="relative">
             <div className="absolute inset-0 flex items-center">
               <span className="w-full border-t" />
@@ -140,6 +142,52 @@ export function SignupForm() {
           </Link>
         </p>
       </CardFooter>
+    </Card>
+  )
+}
+
+export function SignupForm() {
+  return (
+    <Suspense fallback={<SignupFormSkeleton />}>
+      <SignupFormContent />
+    </Suspense>
+  )
+}
+
+function SignupFormSkeleton() {
+  const _t = useTranslations('auth.signup')
+  return (
+    <Card>
+      <CardHeader>
+        <p className="text-sm text-muted-foreground text-center">
+          Fill in the form below to create your account
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <div className="w-full h-10 bg-muted animate-pulse rounded" />
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <span className="w-full border-t" />
+            </div>
+          </div>
+        </div>
+        <div className="space-y-4 mt-4">
+          <div className="space-y-2">
+            <div className="h-4 w-16 bg-muted animate-pulse rounded" />
+            <div className="h-10 bg-muted animate-pulse rounded" />
+          </div>
+          <div className="space-y-2">
+            <div className="h-4 w-20 bg-muted animate-pulse rounded" />
+            <div className="h-10 bg-muted animate-pulse rounded" />
+          </div>
+          <div className="space-y-2">
+            <div className="h-4 w-32 bg-muted animate-pulse rounded" />
+            <div className="h-10 bg-muted animate-pulse rounded" />
+          </div>
+          <div className="h-10 bg-muted animate-pulse rounded" />
+        </div>
+      </CardContent>
     </Card>
   )
 }

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -1,0 +1,53 @@
+'use client'
+
+import type { User } from '@/payload-types'
+import { useCallback, useEffect, useState } from 'react'
+
+interface UseCurrentUserReturn {
+  user: User | null
+  isLoading: boolean
+  error: Error | null
+  refetch: () => Promise<void>
+}
+
+export function useCurrentUser(): UseCurrentUserReturn {
+  const [user, setUser] = useState<User | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  const fetchUser = useCallback(async () => {
+    setIsLoading(true)
+    setError(null)
+    try {
+      const response = await fetch('/api/users/me', {
+        credentials: 'include',
+        cache: 'no-store',
+      })
+      if (response.ok) {
+        const data = await response.json()
+        setUser(data.user || null)
+      } else {
+        setUser(null)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Failed to fetch user'))
+      setUser(null)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  // Fetch on mount
+  useEffect(() => {
+    fetchUser()
+  }, [fetchUser])
+
+  // Listen for auth changes (login/logout)
+  useEffect(() => {
+    const handleAuthChange = () => fetchUser()
+    window.addEventListener('auth:changed', handleAuthChange)
+    return () => window.removeEventListener('auth:changed', handleAuthChange)
+  }, [fetchUser])
+
+  return { user, isLoading, error, refetch: fetchUser }
+}

--- a/src/ui/web/header/Component.client.tsx
+++ b/src/ui/web/header/Component.client.tsx
@@ -2,63 +2,27 @@
 import { useHeaderTheme } from '@/ui/web/providers/HeaderTheme'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
-import type { Header, User } from '@/payload-types'
+import type { Header } from '@/payload-types'
 
+import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { TelescopeLogo } from '@/ui/web/TelescopeLogo'
-import { HeaderNav } from './Nav'
 import { MobileMenu, MobileMenuButton } from './MobileMenu'
+import { HeaderNav } from './Nav'
 
 interface HeaderClientProps {
   data: Header
 }
 
 export const HeaderClient: React.FC<HeaderClientProps> = ({ data }) => {
-  const [user, setUser] = useState<User | null>(null)
-  const [isAuthLoading, setIsAuthLoading] = useState(true)
+  const { user, isLoading: isAuthLoading } = useCurrentUser()
   /* Storing the value in a useState to avoid hydration errors */
   const [theme, setTheme] = useState<string | null>(null)
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
   const [isScrolled, setIsScrolled] = useState(false)
   const { headerTheme, setHeaderTheme } = useHeaderTheme()
   const pathname = usePathname()
-
-  // Fetch user on client side to avoid static-to-dynamic conversion
-  const fetchUser = useCallback(async () => {
-    setIsAuthLoading(true)
-    try {
-      const response = await fetch('/api/users/me', {
-        credentials: 'include', // Include cookies
-        cache: 'no-store',
-      })
-
-      if (response.ok) {
-        const data = await response.json()
-        setUser(data.user || null)
-      } else {
-        setUser(null)
-      }
-    } catch (_error) {
-      // Silently fail - user is not authenticated
-      setUser(null)
-    } finally {
-      setIsAuthLoading(false)
-    }
-  }, [])
-
-  useEffect(() => {
-    fetchUser()
-  }, [fetchUser, pathname])
-
-  useEffect(() => {
-    const handleAuthChange = () => {
-      fetchUser()
-    }
-
-    window.addEventListener('auth:changed', handleAuthChange)
-    return () => window.removeEventListener('auth:changed', handleAuthChange)
-  }, [fetchUser])
 
   useEffect(() => {
     setHeaderTheme(null)


### PR DESCRIPTION
- Create reusable useCurrentUser() hook for client-side auth
- Refactor HeaderClient to use the hook (DRY)
- Add auth UI to ExerciseHeader (Login/Signup/UserDropdown)
- Implement returnTo feature for login/signup pages
- Users redirected back to exercise after authentication

Files:
- src/hooks/useCurrentUser.ts (new)
- src/ui/web/header/Component.client.tsx
- ExerciseWorkspace/index.tsx
- ExerciseHeader/index.tsx
- LoginForm.tsx
- SignupForm.tsx