### PR TITLE
feat: Add course-specific chat to Ask tab with admin-configurable pro…

### DIFF
--- a/src/app/(frontend)/ask/_components/AskContent/index.tsx
+++ b/src/app/(frontend)/ask/_components/AskContent/index.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { getUserProfile } from '@/client/state/localStorage/userProfile'
+import { ChatInterface } from '@/ui/web/chat'
+import { logger } from '@/infra/utils/logger'
+import { Loader2 } from 'lucide-react'
+import { useTranslations } from '@/ui/web/providers/I18n'
+
+export function AskContent() {
+  const t = useTranslations('homepage.ask')
+  const [courseId, setCourseId] = useState<string>('')
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    async function loadCourse() {
+      const profile = getUserProfile()
+      if (!profile?.gradeLevel) {
+        window.location.href = '/'
+        return
+      }
+
+      try {
+        // Fetch course by grade level
+        const response = await fetch(`/api/chapters/by-grade?grade=${profile.gradeLevel}`)
+        if (response.ok) {
+          const data = await response.json()
+          const chapters = data.chapters || []
+          if (chapters.length > 0) {
+            const course = chapters[0].course
+            const id = typeof course === 'string' ? course : course?.id
+            if (id) {
+              setCourseId(id)
+            } else {
+              logger.error('Course ID not found in response')
+            }
+          }
+        }
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error('Unknown error')
+        logger.error({ err }, 'Failed to load course')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    loadCourse()
+  }, [])
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex items-center justify-center p-8">
+          <Loader2 className="w-6 h-6 animate-spin mr-2 text-muted-foreground" />
+          <span className="text-muted-foreground">{t('loading')}</span>
+        </div>
+      </div>
+    )
+  }
+
+  if (!courseId) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="text-center text-muted-foreground py-12">{t('noCourse')}</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 h-[calc(100vh-200px)]">
+      <ChatInterface courseId={courseId} translationNamespace="homepage.ask" />
+    </div>
+  )
+}

--- a/src/app/(frontend)/ask/page.tsx
+++ b/src/app/(frontend)/ask/page.tsx
@@ -1,15 +1,13 @@
 import { RequireCourseSelection } from '@/ui/web/guards/RequireCourseSelection'
 import { NavigationBar } from '@/ui/web/homepage/NavigationBar'
+import { AskContent } from './_components/AskContent'
 
 export default function AskPage() {
   return (
     <RequireCourseSelection>
       <div>
         <NavigationBar />
-        <div className="container mx-auto px-4 py-8">
-          <h1 className="text-3xl font-bold mb-8">שאלות</h1>
-          <div className="text-center text-muted-foreground py-12">תכונה זו תגיע בקרוב</div>
-        </div>
+        <AskContent />
       </div>
     </RequireCourseSelection>
   )

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ChatInterface/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseId]/_components/ChatInterface/index.tsx
@@ -5,10 +5,9 @@ import { useTranslations } from '@/ui/web/providers/I18n'
 import { cn } from '@/infra/utils/ui'
 import { BookOpen, Loader2, Plus, Send, MessageSquare, FileText } from 'lucide-react'
 import React, { useEffect, useState } from 'react'
-import { ChatMessageContent } from '@/ui/web/chat'
+import { ChatMessageContent, useNotebookChat } from '@/ui/web/chat'
 import { FormulaPanel } from '../FormulaPanel'
 import { MathPalette } from '../MathPalette'
-import { useNotebookChat } from '../NotebookChat/useNotebookChat'
 import type { ViewMode } from '../ExerciseWorkspace/exercise-workspace-types'
 
 interface ChatInterfaceProps {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -202,6 +202,13 @@
       "letsStart": "Let's start!",
       "loading": "Loading...",
       "noCoursesAvailable": "No courses available"
+    },
+    "ask": {
+      "chatWelcome": "Hi! Ask me anything about the course!",
+      "chatInputPlaceholder": "Ask a question...",
+      "chatAuthRequired": "Please sign in to ask questions",
+      "loading": "Loading...",
+      "noCourse": "No course selected. Please select a course from the home page."
     }
   },
   "study": {

--- a/src/i18n/he.json
+++ b/src/i18n/he.json
@@ -202,6 +202,13 @@
       "letsStart": "בואו נתחיל!",
       "loading": "טוען...",
       "noCoursesAvailable": "אין קורסים זמינים"
+    },
+    "ask": {
+      "chatWelcome": "היי! שאל אותי כל שאלה על הקורס!",
+      "chatInputPlaceholder": "שאל שאלה...",
+      "chatAuthRequired": "אנא התחבר כדי לשאול שאלות",
+      "loading": "טוען...",
+      "noCourse": "לא נבחר קורס. אנא בחר קורס מדף הבית."
     }
   },
   "study": {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -465,6 +465,14 @@ export interface Course {
   isActive: boolean;
   categories: (string | Category)[];
   /**
+   * AI system prompt for Ask tab chat in this course (uses default if not set)
+   */
+  prompt?: (string | null) | Prompt;
+  /**
+   * AI context text for this course. Injected into Ask tab chat prompts at runtime.
+   */
+  courseContextText?: string | null;
+  /**
    * URL-friendly identifier (auto-generated from title if empty)
    */
   slug?: string | null;
@@ -635,6 +643,39 @@ export interface FolderInterface {
     totalDocs?: number;
   };
   folderType?: 'media'[] | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "prompts".
+ */
+export interface Prompt {
+  id: string;
+  /**
+   * Human-readable prompt name
+   */
+  title: string;
+  /**
+   * Machine-readable key (e.g., "default-tutor-v1")
+   */
+  key?: string | null;
+  /**
+   * System prompts are always included. Context prompts are lesson-specific.
+   */
+  type: 'system' | 'context';
+  /**
+   * System prompt template for AI tutor
+   */
+  template: string;
+  /**
+   * Only "published" prompts are used at runtime
+   */
+  status: 'draft' | 'published' | 'archived';
+  /**
+   * Use as fallback when lesson has no prompt
+   */
+  isDefaultForAgentChat?: boolean | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -1113,39 +1154,6 @@ export interface Lesson {
    * User who created this document
    */
   createdBy?: (string | null) | User;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "prompts".
- */
-export interface Prompt {
-  id: string;
-  /**
-   * Human-readable prompt name
-   */
-  title: string;
-  /**
-   * Machine-readable key (e.g., "default-tutor-v1")
-   */
-  key?: string | null;
-  /**
-   * System prompts are always included. Context prompts are lesson-specific.
-   */
-  type: 'system' | 'context';
-  /**
-   * System prompt template for AI tutor
-   */
-  template: string;
-  /**
-   * Only "published" prompts are used at runtime
-   */
-  status: 'draft' | 'published' | 'archived';
-  /**
-   * Use as fallback when lesson has no prompt
-   */
-  isDefaultForAgentChat?: boolean | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -2094,6 +2102,8 @@ export interface CoursesSelect<T extends boolean = true> {
   status?: T;
   isActive?: T;
   categories?: T;
+  prompt?: T;
+  courseContextText?: T;
   slug?: T;
   meta?:
     | T

--- a/src/server/payload/collections/Courses.ts
+++ b/src/server/payload/collections/Courses.ts
@@ -141,6 +141,25 @@ export const Courses: CollectionConfig = {
       },
     },
     {
+      name: 'prompt',
+      type: 'relationship',
+      relationTo: 'prompts',
+      index: true,
+      admin: {
+        position: 'sidebar',
+        description: 'AI system prompt for Ask tab chat in this course (uses default if not set)',
+      },
+    },
+    {
+      name: 'courseContextText',
+      type: 'textarea',
+      maxLength: 100_000,
+      admin: {
+        description:
+          'AI context text for this course. Injected into Ask tab chat prompts at runtime.',
+      },
+    },
+    {
       name: 'slug',
       type: 'text',
       required: false,

--- a/src/server/payload/endpoints/agent/chat.ts
+++ b/src/server/payload/endpoints/agent/chat.ts
@@ -271,6 +271,8 @@ export async function agentChat(req: PayloadRequest & { json?: () => Promise<unk
 
     let lessonContextText: string | undefined
     let lessonPrompt: Prompt | null = null
+    let courseContextText: string | undefined
+    let coursePrompt: Prompt | null = null
 
     if (context.relationTo === 'lessons') {
       // Direct lesson context - fetch with access checks
@@ -362,6 +364,55 @@ export async function agentChat(req: PayloadRequest & { json?: () => Promise<unk
       }
     }
 
+    // 9.25) Fetch course prompt (for course-level context, e.g., Ask tab)
+    // This provides a fallback prompt when no lesson is specified
+    if (validated.courseId && !lessonPrompt) {
+      try {
+        const course = await req.payload.findByID({
+          collection: 'courses',
+          id: validated.courseId,
+          depth: 0,
+          user: req.user,
+          overrideAccess: false,
+        })
+
+        courseContextText = (course as { courseContextText?: string }).courseContextText ?? undefined
+
+        // Fetch course prompt separately if course has one (admin-only, requires override)
+        if ((course as { prompt?: unknown }).prompt) {
+          const promptId =
+            typeof (course as { prompt: unknown }).prompt === 'string'
+              ? (course as { prompt: string }).prompt
+              : (course as { prompt: { id: string } }).prompt.id
+
+          try {
+            coursePrompt = (await req.payload.findByID({
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              collection: 'prompts' as any,
+              id: promptId,
+              overrideAccess: true, // Prompts are admin-only
+            })) as Prompt | null
+
+            reqLogger.info(
+              { promptId, courseId: validated.courseId },
+              'Loaded course-specific prompt',
+            )
+          } catch (error) {
+            reqLogger.warn(
+              { err: error, promptId, courseId: validated.courseId },
+              'Failed to fetch course prompt',
+            )
+            // Continue with null - will fall back to default
+          }
+        }
+      } catch (error) {
+        reqLogger.warn(
+          { err: error, courseId: validated.courseId },
+          'Failed to fetch course for prompt resolution, continuing with defaults',
+        )
+      }
+    }
+
     // 9.5) Fetch published system prompts (always included)
     const systemPromptsResult = await fetchPublishedSystemPrompts(req.payload)
 
@@ -377,7 +428,11 @@ export async function agentChat(req: PayloadRequest & { json?: () => Promise<unk
     }
 
     // 10) Resolve system prompt using pre-loaded prompt object
-    const promptResolution = await resolveAgentSystemPrompt(req.payload, lessonPrompt)
+    // Priority: lesson prompt > course prompt > default prompt
+    const promptResolution = await resolveAgentSystemPrompt(
+      req.payload,
+      lessonPrompt || coursePrompt,
+    )
 
     reqLogger.info(
       {
@@ -385,17 +440,19 @@ export async function agentChat(req: PayloadRequest & { json?: () => Promise<unk
         promptTitle: promptResolution.promptTitle,
         resolvedFrom: promptResolution.resolvedFrom,
         ...(promptResolution.fallbackReason && { fallbackReason: promptResolution.fallbackReason }),
+        usedCoursePrompt: !lessonPrompt && !!coursePrompt,
       },
       'Resolved system prompt',
     )
 
-    // Compose final system instructions: system prompts + lesson prompt + lesson context
+    // Compose final system instructions: system prompts + lesson/course prompt + lesson/course context
+    // Priority: lesson context > course context
     let systemInstructions: string
     try {
       systemInstructions = composeSystemInstructions(
         systemPromptsResult.templates,
         promptResolution.template,
-        lessonContextText,
+        lessonContextText || courseContextText,
       )
     } catch (error) {
       if (error instanceof Error && error.message.includes('exceeds maximum')) {

--- a/src/server/payload/endpoints/agent/chat.ts
+++ b/src/server/payload/endpoints/agent/chat.ts
@@ -376,7 +376,8 @@ export async function agentChat(req: PayloadRequest & { json?: () => Promise<unk
           overrideAccess: false,
         })
 
-        courseContextText = (course as { courseContextText?: string }).courseContextText ?? undefined
+        courseContextText =
+          (course as { courseContextText?: string }).courseContextText ?? undefined
 
         // Fetch course prompt separately if course has one (admin-only, requires override)
         if ((course as { prompt?: unknown }).prompt) {

--- a/src/ui/web/chat/ChatInterface/index.tsx
+++ b/src/ui/web/chat/ChatInterface/index.tsx
@@ -62,10 +62,7 @@ export function ChatInterface({
   return (
     <div className="flex flex-col h-full min-h-0">
       {/* Messages Area */}
-      <div
-        ref={messagesContainerRef}
-        className="flex-grow overflow-y-auto p-5 space-y-4 min-h-0"
-      >
+      <div ref={messagesContainerRef} className="flex-grow overflow-y-auto p-5 space-y-4 min-h-0">
         {isLoadingHistory && (
           <div className="flex items-center justify-center p-4 text-muted-foreground text-sm">
             <Loader2 className="w-4 h-4 animate-spin mr-2" />

--- a/src/ui/web/chat/ChatInterface/index.tsx
+++ b/src/ui/web/chat/ChatInterface/index.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { ChatMessageRole } from '@/infra/llm/chat-message-role'
+import { useTranslations } from '@/ui/web/providers/I18n'
+import { cn } from '@/infra/utils/ui'
+import { Loader2, Send } from 'lucide-react'
+import React from 'react'
+import { ChatMessageContent } from '../ChatMessageContent'
+import { useNotebookChat } from '../hooks/useNotebookChat'
+
+interface ChatInterfaceProps {
+  courseId?: string
+  lessonId?: string
+  exerciseId?: string
+  translationNamespace?: string
+}
+
+export function ChatInterface({
+  courseId,
+  lessonId,
+  exerciseId,
+  translationNamespace = 'homepage.ask',
+}: ChatInterfaceProps) {
+  const t = useTranslations(translationNamespace)
+  const tCourses = useTranslations('courses')
+
+  const {
+    messages,
+    inputValue,
+    isLoading,
+    isLoadingHistory,
+    messagesContainerRef,
+    messagesEndRef,
+    inputRef,
+    setInputValue,
+    handleSubmit,
+  } = useNotebookChat({
+    initialMessage: t('chatWelcome'),
+    authRequiredMessage: t('chatAuthRequired'),
+    errorMessage: tCourses('chatError'),
+    hintPrompt: tCourses('chatHintPrompt'),
+    solutionPrompt: tCourses('chatSolutionPrompt'),
+    fullSolutionPrompt: tCourses('chatFullSolutionPrompt'),
+    resetConfirmMessage: tCourses('chatResetConfirm'),
+    resetSuccessMessage: tCourses('chatResetSuccess'),
+    resetErrorMessage: tCourses('chatResetError'),
+    acknowledgment: tCourses('chatAIAcknowledgment'),
+    courseId,
+    lessonId,
+    exerciseId,
+  })
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value)
+  }
+
+  const handleFormSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    handleSubmit(e)
+  }
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      {/* Messages Area */}
+      <div
+        ref={messagesContainerRef}
+        className="flex-grow overflow-y-auto p-5 space-y-4 min-h-0"
+      >
+        {isLoadingHistory && (
+          <div className="flex items-center justify-center p-4 text-muted-foreground text-sm">
+            <Loader2 className="w-4 h-4 animate-spin mr-2" />
+            {tCourses('chatLoadingHistory')}
+          </div>
+        )}
+        {!isLoadingHistory &&
+          messages.map((msg, idx) => (
+            <div
+              key={idx}
+              className={cn(
+                'max-w-[85%] px-[18px] py-3.5 text-base leading-relaxed shadow-sm',
+                msg.role === ChatMessageRole.User
+                  ? 'ml-auto bg-primary text-primary-foreground rounded-[20px] rounded-bl-[4px]'
+                  : 'mr-auto bg-card text-foreground border border-border rounded-[20px] rounded-br-[4px]',
+              )}
+            >
+              <ChatMessageContent content={msg.content} />
+            </div>
+          ))}
+        {isLoading && (
+          <div className="mr-auto bg-card text-foreground border border-border px-[18px] py-3.5 rounded-[20px] rounded-br-[4px] max-w-[85%] flex items-center gap-2 shadow-sm">
+            <Loader2 className="w-4 h-4 animate-spin" />
+            <span>{tCourses('chatThinking')}</span>
+          </div>
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Input Container */}
+      <div className="flex-grow-0 flex-shrink-0 bg-card border-t border-border p-5 pb-8">
+        <form onSubmit={handleFormSubmit}>
+          <div className="max-w-[850px] mx-auto bg-muted rounded-[30px] flex items-center px-4 py-1.5 border border-input gap-3">
+            <input
+              ref={inputRef}
+              type="text"
+              className="flex-1 bg-transparent border-none outline-none py-2.5 text-[17px] text-foreground placeholder:text-muted-foreground"
+              placeholder={t('chatInputPlaceholder')}
+              value={inputValue}
+              onChange={handleInputChange}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault()
+                  handleFormSubmit(e as unknown as React.FormEvent)
+                }
+              }}
+              disabled={isLoading}
+            />
+
+            {/* Send Button */}
+            <button
+              type="submit"
+              className="w-10 h-10 rounded-full bg-primary text-primary-foreground flex items-center justify-center shadow-input hover:bg-primary/90 transition-all hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={isLoading || !inputValue.trim()}
+              aria-label={tCourses('sendMessage')}
+            >
+              <Send className="w-5 h-5" />
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/ui/web/chat/hooks/useNotebookChat.ts
+++ b/src/ui/web/chat/hooks/useNotebookChat.ts
@@ -1,0 +1,350 @@
+import { ChatRole } from '@/infra/llm/chat-message-role'
+import { PRODUCT_EVENTS } from '@/infra/analytics/contracts/events'
+import { useAnalytics } from '@/infra/analytics/providers/AnalyticsProvider'
+// eslint-disable-next-line no-restricted-imports -- Client-side API service wrapper is safe to use in hooks
+import { apiService } from '@/server/services/api/api-service'
+import { logger } from '@/infra/utils/logger'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { toast } from 'sonner'
+
+export interface ChatMessage {
+  role: ChatRole
+  content: string
+}
+
+interface UseNotebookChatProps {
+  initialMessage: string
+  authRequiredMessage: string
+  errorMessage: string
+  hintPrompt: string
+  solutionPrompt: string
+  fullSolutionPrompt: string
+  resetConfirmMessage: string
+  resetSuccessMessage: string
+  resetErrorMessage: string
+  acknowledgment: string
+  exerciseId?: string
+  lessonId?: string
+  chapterId?: string
+  courseId?: string
+}
+
+export function useNotebookChat({
+  initialMessage,
+  authRequiredMessage,
+  errorMessage,
+  hintPrompt,
+  solutionPrompt,
+  fullSolutionPrompt,
+  resetConfirmMessage,
+  resetSuccessMessage,
+  resetErrorMessage,
+  acknowledgment,
+  exerciseId,
+  lessonId,
+  chapterId,
+  courseId,
+}: UseNotebookChatProps) {
+  const analytics = useAnalytics()
+  const messagesContainerRef = useRef<HTMLDivElement>(null)
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    { role: ChatRole.Assistant, content: initialMessage },
+  ])
+  const [inputValue, setInputValue] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [isLoadingHistory, setIsLoadingHistory] = useState(true)
+
+  // Compute contextKey based on available context (priority: Exercise > Lesson > Chapter > Course)
+  const contextKey = useMemo(() => {
+    if (exerciseId) return `exercises:${exerciseId}`
+    if (lessonId) return `lessons:${lessonId}`
+    if (chapterId) return `chapters:${chapterId}`
+    if (courseId) return `courses:${courseId}`
+    return null
+  }, [exerciseId, lessonId, chapterId, courseId])
+
+  // Simple scroll to bottom using scrollTop instead of scrollIntoView
+  // scrollIntoView can cause layout issues in nested flex containers
+  const scrollToBottom = useCallback(() => {
+    const container = messagesContainerRef.current
+    if (container) {
+      container.scrollTop = container.scrollHeight
+    }
+  }, [])
+
+  // Scroll to bottom when messages change
+  useEffect(() => {
+    // Use requestAnimationFrame to ensure DOM has updated
+    requestAnimationFrame(() => {
+      scrollToBottom()
+    })
+  }, [messages, scrollToBottom])
+
+  // Load existing conversation history on mount
+  useEffect(() => {
+    async function loadConversationHistory() {
+      if (!contextKey) {
+        setIsLoadingHistory(false)
+        return
+      }
+
+      // Ensure loading indicator shows for minimum duration to avoid race conditions
+      const minLoadingTime = Promise.all([new Promise((resolve) => setTimeout(resolve, 100))])
+
+      try {
+        const retryDelayMs = 500
+        const maxRetries = 10
+        let attempt = 0
+        let result = (
+          await Promise.all([apiService.getConversation(contextKey), minLoadingTime])
+        )[0]
+
+        while (attempt <= maxRetries) {
+          if (result.authRequired) {
+            // Keep initial message, user needs to log in
+            setIsLoadingHistory(false)
+            return
+          }
+
+          if (result.success && result.exists) {
+            // DEBUG: Log the raw result
+            logger.debug(
+              {
+                contextKey,
+                conversationId: result.conversationId,
+                rawMessages: result.messages,
+                rawMessagesLength: result.messages?.length,
+                rawMessagesType: typeof result.messages,
+                isArray: Array.isArray(result.messages),
+              },
+              '[useNotebookChat] API response received',
+            )
+
+            // Filter out invalid messages and map to chat messages
+            const rawMessages = result.messages || []
+            logger.debug(
+              { contextKey, rawMessagesLength: rawMessages.length },
+              '[useNotebookChat] Processing raw messages',
+            )
+
+            const validMessages = rawMessages.filter(
+              (msg) => msg && msg.role && msg.content && typeof msg.content === 'string',
+            )
+
+            logger.debug(
+              { contextKey, validMessagesLength: validMessages.length },
+              '[useNotebookChat] Valid messages count',
+            )
+
+            if (validMessages.length > 0) {
+              // Map API messages to chat messages
+              const loadedMessages: ChatMessage[] = validMessages.map((msg) => ({
+                role:
+                  msg.role === ChatRole.User || msg.role === 'user'
+                    ? ChatRole.User
+                    : ChatRole.Assistant,
+                content: String(msg.content),
+              }))
+
+              logger.debug(
+                {
+                  contextKey,
+                  conversationId: result.conversationId,
+                  messageCount: loadedMessages.length,
+                  messagesPreview: loadedMessages
+                    .slice(0, 2)
+                    .map((m) => ({ role: m.role, content: m.content.substring(0, 30) })),
+                },
+                '[useNotebookChat] Loaded conversation history',
+              )
+
+              // Only update messages if we have valid messages to avoid clearing the chat
+              if (loadedMessages.length > 0) {
+                // Set messages and loading state together
+                // React will batch these updates, but we need to ensure messages
+                // are actually in the DOM before hiding the loading indicator
+                setMessages(loadedMessages)
+                // Wait for React to render using double rAF pattern
+                // First rAF: schedules callback before next paint
+                // Second rAF: ensures the paint cycle completed
+                // This ensures loading indicator hides only after messages are in DOM
+                requestAnimationFrame(() => {
+                  requestAnimationFrame(() => {
+                    setIsLoadingHistory(false)
+                  })
+                })
+                return
+              }
+            }
+
+            // Conversation exists but messages may still be persisting
+            attempt += 1
+            if (attempt > maxRetries) {
+              logger.warn(
+                {
+                  conversationId: result.conversationId,
+                  contextKey,
+                  rawMessages: result.messages,
+                  messageCount: result.messages?.length || 0,
+                },
+                '[useNotebookChat] Conversation exists but messages are empty after retries',
+              )
+              setIsLoadingHistory(false)
+              return
+            }
+
+            // Exponential backoff for retries
+            const delay = retryDelayMs * Math.min(attempt, 3)
+            await new Promise((resolve) => setTimeout(resolve, delay))
+            result = await apiService.getConversation(contextKey)
+            continue
+          }
+
+          if (result.success && !result.exists) {
+            // No conversation exists yet - keep initial welcome message
+            logger.debug({ contextKey }, '[useNotebookChat] No conversation found for contextKey')
+            setIsLoadingHistory(false)
+            return
+          }
+
+          // API call failed
+          logger.error(
+            {
+              error: result.error,
+              contextKey,
+              success: result.success,
+              exists: result.exists,
+            },
+            '[useNotebookChat] Failed to load conversation',
+          )
+          setIsLoadingHistory(false)
+          return
+        }
+      } catch (error) {
+        // Fail silently - keep initial message
+        logger.error(
+          { err: error, contextKey },
+          '[useNotebookChat] Failed to load conversation history',
+        )
+        setIsLoadingHistory(false)
+      }
+    }
+
+    loadConversationHistory()
+  }, [contextKey])
+
+  const sendMessage = async (message: string) => {
+    if (!message.trim() || isLoading) return
+
+    const userMessage: ChatMessage = { role: ChatRole.User, content: message }
+    setMessages((prev) => [...prev, userMessage])
+    setInputValue('')
+    setIsLoading(true)
+
+    // Track chat message sent (message length only, NOT content)
+    analytics.track(PRODUCT_EVENTS.CHAT_MESSAGE_SENT, {
+      conversation_id: contextKey || 'unknown',
+      message_length: message.length,
+      lesson_id: lessonId,
+    })
+
+    try {
+      const result = await apiService.chat(message, acknowledgment, {
+        exerciseId,
+        lessonId,
+        chapterId,
+        courseId,
+      })
+
+      if (!result.success) {
+        if (result.authRequired) {
+          toast.error(authRequiredMessage)
+        } else {
+          toast.error(result.error || errorMessage)
+        }
+        return
+      }
+
+      if (result.message) {
+        const assistantMessage: ChatMessage = {
+          role: ChatRole.Assistant,
+          content: result.message,
+        }
+        setMessages((prev) => [...prev, assistantMessage])
+      }
+    } catch (_error) {
+      toast.error(errorMessage)
+    } finally {
+      setIsLoading(false)
+      inputRef.current?.focus()
+    }
+  }
+
+  const handleReset = useCallback(async () => {
+    if (!contextKey || isLoading) return
+
+    const confirmed = confirm(resetConfirmMessage)
+    if (!confirmed) return
+
+    try {
+      const result = await apiService.resetChat(contextKey)
+
+      if (result.success) {
+        // Clear messages and show welcome
+        setMessages([{ role: ChatRole.Assistant, content: initialMessage }])
+        toast.success(resetSuccessMessage)
+      } else {
+        toast.error(result.error || resetErrorMessage)
+      }
+    } catch (_error) {
+      toast.error(resetErrorMessage)
+    }
+  }, [
+    contextKey,
+    isLoading,
+    initialMessage,
+    resetConfirmMessage,
+    resetErrorMessage,
+    resetSuccessMessage,
+  ])
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    sendMessage(inputValue)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      sendMessage(inputValue)
+    }
+  }
+
+  const handleQuickAction = (actionType: 'hint' | 'solution' | 'full') => {
+    const prompts = {
+      hint: hintPrompt,
+      solution: solutionPrompt,
+      full: fullSolutionPrompt,
+    }
+    sendMessage(prompts[actionType])
+  }
+
+  return {
+    messages,
+    inputValue,
+    isLoading,
+    isLoadingHistory,
+    messagesContainerRef,
+    messagesEndRef,
+    inputRef,
+    contextKey,
+    setInputValue,
+    handleSubmit,
+    handleKeyDown,
+    handleQuickAction,
+    handleReset,
+  }
+}

--- a/src/ui/web/chat/index.ts
+++ b/src/ui/web/chat/index.ts
@@ -1,1 +1,3 @@
 export { ChatMessageContent } from './ChatMessageContent'
+export { ChatInterface } from './ChatInterface'
+export { useNotebookChat } from './hooks/useNotebookChat'


### PR DESCRIPTION
…mpts

- Add prompt and courseContextText fields to Course collection
- Update chat endpoint to support course prompt resolution with fallback hierarchy
- Create shared ChatInterface component at src/ui/web/chat/ChatInterface
- Move useNotebookChat hook to shared location for reuse
- Update Ask page to render chat with course-level context
- Add translations for Ask tab chat (en, he)
- Update lesson ChatInterface to use shared hook
- Generate TypeScript types for updated Course schema

The chat uses context key courses:${courseId} and resolves prompts in priority: lesson prompt > course prompt > default prompt. Admins can configure course-specific prompts in the Courses admin panel.