### PR TITLE
Prompt composition formatting

### DIFF
--- a/src/server/payload/endpoints/agent/chat/prompt-composition.ts
+++ b/src/server/payload/endpoints/agent/chat/prompt-composition.ts
@@ -80,7 +80,12 @@ async function fetchExerciseLessonContext(
   })
 
   if (!(exercise as { lesson?: unknown }).lesson) {
-    return { lessonContextText: undefined, lessonPrompt: null, courseContextText: undefined, coursePrompt: null }
+    return {
+      lessonContextText: undefined,
+      lessonPrompt: null,
+      courseContextText: undefined,
+      coursePrompt: null,
+    }
   }
 
   const lessonId =
@@ -126,7 +131,12 @@ async function fetchExerciseLessonContext(
       { err: error, lessonId, exerciseId },
       'Failed to fetch lesson for exercise context, continuing without lesson context',
     )
-    return { lessonContextText: undefined, lessonPrompt: null, courseContextText: undefined, coursePrompt: null }
+    return {
+      lessonContextText: undefined,
+      lessonPrompt: null,
+      courseContextText: undefined,
+      coursePrompt: null,
+    }
   }
 }
 
@@ -201,7 +211,12 @@ export async function fetchLessonContextForContext(
   } else if (context.relationTo === 'exercises') {
     lessonContext = await fetchExerciseLessonContext(payload, context.value, user, reqLogger)
   } else {
-    lessonContext = { lessonContextText: undefined, lessonPrompt: null, courseContextText: undefined, coursePrompt: null }
+    lessonContext = {
+      lessonContextText: undefined,
+      lessonPrompt: null,
+      courseContextText: undefined,
+      coursePrompt: null,
+    }
   }
 
   // Fetch course prompt if no lesson prompt and courseId is provided
@@ -260,7 +275,10 @@ export async function composeFullSystemInstructions(
 
   // Resolve system prompt using pre-loaded prompt object
   // Priority: lesson prompt > course prompt > default prompt
-  const promptResolution = await resolveAgentSystemPrompt(payload, lessonPrompt || coursePrompt || null)
+  const promptResolution = await resolveAgentSystemPrompt(
+    payload,
+    lessonPrompt || coursePrompt || null,
+  )
 
   reqLogger.info(
     {


### PR DESCRIPTION
Fix Prettier formatting errors in `prompt-composition.ts` to pass `pnpm format:check`.

---
<a href="https://cursor.com/background-agent?bcId=bc-3921e085-15c1-4608-a389-aa8ecfb38c3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3921e085-15c1-4608-a389-aa8ecfb38c3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

