### PR TITLE
fix: implement Mixpanel anonymous user tracking with cookie persistence

### DIFF
--- a/src/infra/analytics/adapters/mixpanel/adapter.ts
+++ b/src/infra/analytics/adapters/mixpanel/adapter.ts
@@ -10,6 +10,7 @@
 import { analyticsConfig } from '../../config'
 import type { EventPayload } from '../../types'
 import { transformToMixpanel } from './transform'
+import { clearAnonymousIdCookie, getOrCreateAnonymousId } from '../../utils/anonymous-id'
 
 /**
  * Declare Mixpanel global for TypeScript
@@ -24,11 +25,17 @@ declare global {
       reset: () => void
       people?: {
         set: (properties: Record<string, unknown>) => void
+        set_once: (properties: Record<string, unknown>) => void
       }
       get_distinct_id: () => string
     }
   }
 }
+
+/**
+ * Track if we've created a People profile for the current user
+ */
+let hasCreatedPeopleProfile = false
 
 /**
  * Send event to Mixpanel
@@ -54,6 +61,12 @@ export function sendToMixpanel(payload: EventPayload): void {
 
     // Send to Mixpanel
     mixpanel.track(mixpanelEvent.name, mixpanelEvent.properties)
+
+    // Create People profile on first event (for both anonymous and authenticated users)
+    if (!hasCreatedPeopleProfile && mixpanel.people) {
+      createPeopleProfile(mixpanel)
+      hasCreatedPeopleProfile = true
+    }
 
     // Special handling for user_identified event
     // Also set user properties in Mixpanel People
@@ -91,6 +104,59 @@ export function sendToMixpanel(payload: EventPayload): void {
     }
   } catch (err) {
     console.error('[Analytics/Mixpanel] Send failed:', err)
+  }
+}
+
+/**
+ * Create Mixpanel People profile for anonymous users
+ *
+ * @param mixpanel - Mixpanel instance
+ */
+function createPeopleProfile(mixpanel: NonNullable<typeof window.mixpanel>): void {
+  if (!mixpanel.people) return
+
+  try {
+    const now = new Date().toISOString()
+
+    // Set initial People properties
+    const peopleProps: Record<string, unknown> = {
+      $created: now,
+      last_seen: now,
+    }
+
+    // Add browser/OS info if available from user agent
+    if (navigator.userAgent) {
+      // Simple browser detection
+      const ua = navigator.userAgent
+      if (ua.includes('Chrome')) peopleProps.$browser = 'Chrome'
+      else if (ua.includes('Firefox')) peopleProps.$browser = 'Firefox'
+      else if (ua.includes('Safari')) peopleProps.$browser = 'Safari'
+      else if (ua.includes('Edge')) peopleProps.$browser = 'Edge'
+
+      // Simple OS detection
+      if (ua.includes('Windows')) peopleProps.$os = 'Windows'
+      else if (ua.includes('Mac')) peopleProps.$os = 'macOS'
+      else if (ua.includes('Linux')) peopleProps.$os = 'Linux'
+      else if (ua.includes('Android')) peopleProps.$os = 'Android'
+      else if (ua.includes('iOS')) peopleProps.$os = 'iOS'
+    }
+
+    // Add referrer info
+    if (document.referrer) {
+      peopleProps.initial_referrer = document.referrer
+    }
+
+    // Add landing page
+    peopleProps.initial_landing_page = window.location.href
+
+    // Set People properties (use set_once so we don't overwrite on subsequent visits)
+    mixpanel.people.set_once(peopleProps)
+
+    if (analyticsConfig.debugMode) {
+      console.log('[Analytics/Mixpanel] People profile created:', peopleProps)
+    }
+  } catch (err) {
+    console.error('[Analytics/Mixpanel] Failed to create People profile:', err)
   }
 }
 
@@ -186,13 +252,24 @@ export function resetUser(): void {
   }
 
   try {
+    // Reset Mixpanel SDK state
     mixpanel.reset()
 
     // Clear aliased flag
     localStorage.removeItem('mixpanel_aliased')
 
+    // Clear anonymous ID cookie so a new one is generated
+    clearAnonymousIdCookie()
+
+    // Reset People profile flag
+    hasCreatedPeopleProfile = false
+
+    // Generate new anonymous ID and identify with it
+    const newAnonymousId = getOrCreateAnonymousId()
+    mixpanel.identify(newAnonymousId)
+
     if (analyticsConfig.debugMode) {
-      console.log('[Analytics/Mixpanel] Reset')
+      console.log('[Analytics/Mixpanel] Reset with new anonymous ID:', newAnonymousId)
     }
   } catch (err) {
     console.error('[Analytics/Mixpanel] Reset failed:', err)

--- a/src/infra/analytics/adapters/mixpanel/scripts.tsx
+++ b/src/infra/analytics/adapters/mixpanel/scripts.tsx
@@ -34,24 +34,94 @@ export function MixpanelScripts() {
   }
 
   return (
-    <Script id="mixpanel-init" strategy="afterInteractive">
-      {`
-        (function(f,b){if(!b.__SV){var e,g,i,h;window.mixpanel=b;b._i=[];b.init=function(e,f,c){function g(a,d){var b=d.split(".");2==b.length&&(a=a[b[0]],d=b[1]);a[d]=function(){a.push([d].concat(Array.prototype.slice.call(arguments,0)))}}var a=b;"undefined"!==typeof c?a=b[c]=[]:c="mixpanel";a.people=a.people||[];a.toString=function(a){var d="mixpanel";"mixpanel"!==c&&(d+="."+c);a||(d+=" (stub)");return d};a.people.toString=function(){return a.toString(1)+".people (stub)"};i="disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking start_batch_senders people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(" ");
-        for(h=0;h<i.length;h++)g(a,i[h]);var j="set set_once union unset remove delete".split(" ");a.get_group=function(){function b(c){d[c]=function(){call2_args=arguments;call2=[c].concat(Array.prototype.slice.call(call2_args,0));a.push([e,call2])}}for(var d={},e=["get_group"].concat(Array.prototype.slice.call(arguments,0)),c=0;c<j.length;c++)b(j[c]);return d};b._i.push([e,f,c])};b.__SV=1.2;e=f.createElement("script");e.type="text/javascript";e.async=!0;e.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===f.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\\/\\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";g=f.getElementsByTagName("script")[0];g.parentNode.insertBefore(e,g)}})(document,window.mixpanel||[]);
+    <>
+      {/* Load Mixpanel SDK */}
+      <Script id="mixpanel-loader" strategy="afterInteractive">
+        {`
+          (function(f,b){if(!b.__SV){var e,g,i,h;window.mixpanel=b;b._i=[];b.init=function(e,f,c){function g(a,d){var b=d.split(".");2==b.length&&(a=a[b[0]],d=b[1]);a[d]=function(){a.push([d].concat(Array.prototype.slice.call(arguments,0)))}}var a=b;"undefined"!==typeof c?a=b[c]=[]:c="mixpanel";a.people=a.people||[];a.toString=function(a){var d="mixpanel";"mixpanel"!==c&&(d+="."+c);a||(d+=" (stub)");return d};a.people.toString=function(){return a.toString(1)+".people (stub)"};i="disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking start_batch_senders people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(" ");
+          for(h=0;h<i.length;h++)g(a,i[h]);var j="set set_once union unset remove delete".split(" ");a.get_group=function(){function b(c){d[c]=function(){call2_args=arguments;call2=[c].concat(Array.prototype.slice.call(call2_args,0));a.push([e,call2])}}for(var d={},e=["get_group"].concat(Array.prototype.slice.call(arguments,0)),c=0;c<j.length;c++)b(j[c]);return d};b._i.push([e,f,c])};b.__SV=1.2;e=f.createElement("script");e.type="text/javascript";e.async=!0;e.src="undefined"!==typeof MIXPANEL_CUSTOM_LIB_URL?MIXPANEL_CUSTOM_LIB_URL:"file:"===f.location.protocol&&"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\\/\\//)?"https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js":"//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";g=f.getElementsByTagName("script")[0];g.parentNode.insertBefore(e,g)}})(document,window.mixpanel||[]);
+        `}
+      </Script>
 
-        // Initialize Mixpanel
-        mixpanel.init('${token}', {
-          // NO auto-capture - we track explicitly
-          track_pageview: false,
+      {/* Initialize Mixpanel with anonymous ID from cookie */}
+      <Script id="mixpanel-init" strategy="afterInteractive">
+        {`
+          // Helper: Get cookie value by name
+          function getCookie(name) {
+            var cookies = document.cookie.split(';');
+            for (var i = 0; i < cookies.length; i++) {
+              var parts = cookies[i].split('=');
+              var cookieName = parts[0].trim();
+              var cookieValue = parts[1];
+              if (cookieName === name) {
+                return cookieValue || null;
+              }
+            }
+            return null;
+          }
 
-          // NO session recording in this phase
-          // (Will be added in a future task if needed)
-          record_sessions_percent: 0,
+          // Helper: Set cookie
+          function setCookie(name, value, expiryDays, isSecure) {
+            var maxAge = expiryDays * 24 * 60 * 60;
+            var cookieParts = [
+              name + '=' + value,
+              'path=/',
+              'max-age=' + maxAge,
+              'SameSite=Lax'
+            ];
+            if (isSecure) {
+              cookieParts.push('Secure');
+            }
+            document.cookie = cookieParts.join('; ');
+          }
 
-          // Debug mode (controlled by environment)
-          debug: ${analyticsConfig.debugMode},
-        });
-      `}
-    </Script>
+          // Helper: Generate anonymous ID
+          function generateAnonymousId() {
+            return 'anon_' + crypto.randomUUID();
+          }
+
+          // Get or create anonymous ID from cookie
+          var ANON_COOKIE_NAME = 'mp_anon_id';
+          var anonymousId = getCookie(ANON_COOKIE_NAME);
+
+          if (!anonymousId) {
+            anonymousId = generateAnonymousId();
+            var isProduction = window.location.protocol === 'https:';
+            setCookie(ANON_COOKIE_NAME, anonymousId, 365, isProduction);
+          }
+
+          // Initialize Mixpanel
+          mixpanel.init('${token}', {
+            // NO auto-capture - we track explicitly
+            track_pageview: false,
+
+            // NO session recording in this phase
+            record_sessions_percent: 0,
+
+            // Cookie-based persistence (fallback to localStorage)
+            persistence: 'localStorage+cookie',
+
+            // Cross-subdomain cookie support
+            cross_subdomain_cookie: true,
+
+            // Cookie expiration: 1 year
+            cookie_expiration: 365,
+
+            // Secure cookie in production
+            secure_cookie: window.location.protocol === 'https:',
+
+            // Debug mode (controlled by environment)
+            debug: ${analyticsConfig.debugMode},
+          });
+
+          // Identify with the anonymous ID immediately
+          mixpanel.identify(anonymousId);
+
+          if (${analyticsConfig.debugMode}) {
+            console.log('[Analytics/Mixpanel] Initialized with anonymous ID:', anonymousId);
+          }
+        `}
+      </Script>
+    </>
   )
 }

--- a/src/infra/analytics/core/tracker.ts
+++ b/src/infra/analytics/core/tracker.ts
@@ -148,6 +148,35 @@ export function identify(userId: string, properties?: Record<string, unknown>): 
 }
 
 /**
+ * Alias anonymous user to registered user
+ *
+ * CRITICAL: Call this BEFORE identify() during registration
+ * to merge anonymous event history with the new user account
+ *
+ * @param userId - New user ID
+ * @param anonymousId - Previous anonymous ID (optional - Mixpanel will use current distinct_id)
+ */
+export function alias(userId: string, anonymousId?: string): void {
+  if (typeof window === 'undefined') return
+  if (!analyticsConfig.enabled) return
+
+  try {
+    if (analyticsConfig.debugMode) {
+      console.log('[Analytics] Alias:', { userId, anonymousId })
+    }
+
+    void initializeAdapters().then(() => {
+      // Only Mixpanel handles aliasing
+      if (analyticsConfig.mixpanel.enabled && mixpanelAdapter) {
+        mixpanelAdapter.aliasUser(userId, anonymousId)
+      }
+    })
+  } catch (err) {
+    console.error('[Analytics] Alias failed:', err)
+  }
+}
+
+/**
  * Reset user identity (on logout)
  */
 export function reset(): void {
@@ -195,5 +224,6 @@ export function initializeAnalytics(): void {
 export const analytics: Analytics = {
   track,
   identify,
+  alias,
   reset,
 }

--- a/src/infra/analytics/system-events-subscriber.ts
+++ b/src/infra/analytics/system-events-subscriber.ts
@@ -194,8 +194,10 @@ export function initAnalyticsSubscriber(): () => void {
         user_id: payload.user_id,
         registration_method: payload.registration_method,
       })
-      // Also identify the new user
+      // Alias anonymous user to registered user, THEN identify
       if (payload.user_id) {
+        // CRITICAL: Call alias BEFORE identify to merge anonymous history
+        analytics.alias(payload.user_id)
         analytics.identify(payload.user_id, {
           registration_method: payload.registration_method,
         })

--- a/src/infra/analytics/types.ts
+++ b/src/infra/analytics/types.ts
@@ -50,6 +50,13 @@ export interface IdentifyFunction {
 }
 
 /**
+ * Alias function signature
+ */
+export interface AliasFunction {
+  (userId: string, anonymousId?: string): void
+}
+
+/**
  * Reset function signature
  */
 export interface ResetFunction {
@@ -62,6 +69,7 @@ export interface ResetFunction {
 export interface Analytics {
   track: TrackFunction
   identify: IdentifyFunction
+  alias: AliasFunction
   reset: ResetFunction
 }
 

--- a/src/infra/analytics/utils/anonymous-id.ts
+++ b/src/infra/analytics/utils/anonymous-id.ts
@@ -1,0 +1,78 @@
+/**
+ * Anonymous ID Management
+ *
+ * Generates and manages persistent anonymous IDs for tracking users before authentication
+ */
+
+import { getCookie, setCookie, deleteCookie } from './cookies'
+
+export const ANONYMOUS_ID_COOKIE_NAME = 'mp_anon_id'
+
+/**
+ * Generate a new anonymous ID
+ *
+ * Format: anon_<uuid-v4>
+ *
+ * @returns New anonymous ID
+ */
+export function generateAnonymousId(): string {
+  // Generate UUID v4
+  const uuid = crypto.randomUUID()
+  return `anon_${uuid}`
+}
+
+/**
+ * Validate that an ID matches the anonymous ID format
+ *
+ * @param id - ID to validate
+ * @returns True if valid anonymous ID format
+ */
+function isValidAnonymousId(id: string): boolean {
+  const uuidRegex = /^anon_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+  return uuidRegex.test(id)
+}
+
+/**
+ * Get existing anonymous ID from cookie, or generate new one
+ *
+ * @returns Anonymous ID
+ */
+export function getOrCreateAnonymousId(): string {
+  try {
+    // Try to get existing ID from cookie
+    const existingId = getCookie(ANONYMOUS_ID_COOKIE_NAME)
+
+    if (existingId && isValidAnonymousId(existingId)) {
+      return existingId
+    }
+  } catch (error) {
+    // Gracefully handle cookie read errors
+    console.warn('[Analytics] Failed to read anonymous ID cookie:', error)
+  }
+
+  // Generate new ID and store in cookie
+  const newId = generateAnonymousId()
+  setAnonymousIdCookie(newId)
+
+  return newId
+}
+
+/**
+ * Set the anonymous ID cookie
+ *
+ * @param id - Anonymous ID to store
+ * @param isSecure - Whether to set Secure flag (default: false, should be true in production)
+ */
+export function setAnonymousIdCookie(id: string, isSecure = false): void {
+  setCookie(ANONYMOUS_ID_COOKIE_NAME, id, {
+    expiryDays: 365, // 1 year
+    isSecure,
+  })
+}
+
+/**
+ * Clear the anonymous ID cookie
+ */
+export function clearAnonymousIdCookie(): void {
+  deleteCookie(ANONYMOUS_ID_COOKIE_NAME)
+}

--- a/src/infra/analytics/utils/cookies.ts
+++ b/src/infra/analytics/utils/cookies.ts
@@ -1,0 +1,66 @@
+/**
+ * Cookie Utilities
+ *
+ * Client-side cookie management for analytics tracking
+ */
+
+export interface SetCookieOptions {
+  expiryDays?: number
+  isSecure?: boolean
+}
+
+/**
+ * Get a cookie value by name
+ *
+ * @param name - Cookie name
+ * @returns Cookie value or null if not found
+ */
+export function getCookie(name: string): string | null {
+  if (typeof document === 'undefined') return null
+
+  const cookies = document.cookie.split(';')
+
+  for (const cookie of cookies) {
+    const [cookieName, cookieValue] = cookie.split('=').map((c) => c.trim())
+
+    if (cookieName === name) {
+      return cookieValue || null
+    }
+  }
+
+  return null
+}
+
+/**
+ * Set a cookie with the given name and value
+ *
+ * @param name - Cookie name
+ * @param value - Cookie value
+ * @param options - Cookie options (expiry, secure flag)
+ */
+export function setCookie(name: string, value: string, options: SetCookieOptions = {}): void {
+  if (typeof document === 'undefined') return
+
+  const { expiryDays = 365, isSecure = false } = options
+
+  const maxAge = expiryDays * 24 * 60 * 60 // Convert days to seconds
+
+  const cookieParts = [`${name}=${value}`, `path=/`, `max-age=${maxAge}`, `SameSite=Lax`]
+
+  if (isSecure) {
+    cookieParts.push('Secure')
+  }
+
+  document.cookie = cookieParts.join('; ')
+}
+
+/**
+ * Delete a cookie by name
+ *
+ * @param name - Cookie name to delete
+ */
+export function deleteCookie(name: string): void {
+  if (typeof document === 'undefined') return
+
+  document.cookie = `${name}=; path=/; max-age=0`
+}

--- a/tests/unit/analytics/anonymous-id.test.ts
+++ b/tests/unit/analytics/anonymous-id.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 /**
  * Anonymous ID Management Unit Tests
  */

--- a/tests/unit/analytics/anonymous-id.test.ts
+++ b/tests/unit/analytics/anonymous-id.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Anonymous ID Management Unit Tests
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  generateAnonymousId,
+  getOrCreateAnonymousId,
+  setAnonymousIdCookie,
+  clearAnonymousIdCookie,
+  ANONYMOUS_ID_COOKIE_NAME,
+} from '@/infra/analytics/utils/anonymous-id'
+import { getCookie, deleteCookie } from '@/infra/analytics/utils/cookies'
+
+describe('Anonymous ID Management', () => {
+  let originalCookieDescriptor: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    // Save original cookie descriptor
+    originalCookieDescriptor = Object.getOwnPropertyDescriptor(Document.prototype, 'cookie')
+
+    // Clear cookies and localStorage
+    document.cookie.split(';').forEach((c) => {
+      const name = c.split('=')[0].trim()
+      document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`
+    })
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    // Restore original cookie descriptor after EACH test
+    if (originalCookieDescriptor) {
+      Object.defineProperty(document, 'cookie', originalCookieDescriptor)
+    }
+  })
+
+  describe('generateAnonymousId()', () => {
+    it('should generate a UUID v4 format ID', () => {
+      const id = generateAnonymousId()
+      // UUID v4 format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+      const uuidRegex =
+        /^anon_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      expect(id).toMatch(uuidRegex)
+    })
+
+    it('should generate unique IDs on each call', () => {
+      const id1 = generateAnonymousId()
+      const id2 = generateAnonymousId()
+      const id3 = generateAnonymousId()
+
+      expect(id1).not.toBe(id2)
+      expect(id2).not.toBe(id3)
+      expect(id1).not.toBe(id3)
+    })
+
+    it('should prefix with "anon_" for easy identification', () => {
+      const id = generateAnonymousId()
+      expect(id).toMatch(/^anon_/)
+    })
+  })
+
+  describe('getOrCreateAnonymousId()', () => {
+    it('should return existing ID from cookie if present', () => {
+      const existingId = 'anon_12345678-1234-4123-8123-123456789012'
+      setAnonymousIdCookie(existingId)
+
+      const id = getOrCreateAnonymousId()
+      expect(id).toBe(existingId)
+    })
+
+    it('should generate and store new ID if cookie is missing', () => {
+      const id = getOrCreateAnonymousId()
+
+      expect(id).toMatch(/^anon_/)
+      expect(getCookie(ANONYMOUS_ID_COOKIE_NAME)).toBe(id)
+    })
+
+    it('should handle cookie read errors gracefully', () => {
+      // Simulate error by making getCookie throw
+      Object.defineProperty(document, 'cookie', {
+        get: () => {
+          throw new Error('Cookie read error')
+        },
+        set: () => {
+          // no-op
+        },
+        configurable: true,
+      })
+
+      const id = getOrCreateAnonymousId()
+      expect(id).toMatch(/^anon_/)
+    })
+
+    it('should generate new ID if cookie value is invalid', () => {
+      // Set invalid cookie value
+      document.cookie = `${ANONYMOUS_ID_COOKIE_NAME}=invalid; path=/`
+
+      const id = getOrCreateAnonymousId()
+      expect(id).toMatch(
+        /^anon_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      )
+    })
+  })
+
+  describe('setAnonymousIdCookie()', () => {
+    it('should set cookie with correct name "mp_anon_id"', () => {
+      const id = 'anon_test'
+      setAnonymousIdCookie(id)
+
+      expect(getCookie(ANONYMOUS_ID_COOKIE_NAME)).toBe(id)
+    })
+
+    it('should set cookie with 1 year expiry', () => {
+      let setCookieValue = ''
+      Object.defineProperty(document, 'cookie', {
+        get: () => setCookieValue,
+        set: (value: string) => {
+          setCookieValue = value
+        },
+        configurable: true,
+      })
+
+      setAnonymousIdCookie('anon_test')
+      expect(setCookieValue).toContain('max-age=31536000') // 365 days
+    })
+
+    it('should set SameSite=Lax for cross-page navigation', () => {
+      let setCookieValue = ''
+      Object.defineProperty(document, 'cookie', {
+        get: () => setCookieValue,
+        set: (value: string) => {
+          setCookieValue = value
+        },
+        configurable: true,
+      })
+
+      setAnonymousIdCookie('anon_test')
+      expect(setCookieValue).toContain('SameSite=Lax')
+    })
+
+    it('should set Secure flag in production (when isSecure=true)', () => {
+      let setCookieValue = ''
+      Object.defineProperty(document, 'cookie', {
+        get: () => setCookieValue,
+        set: (value: string) => {
+          setCookieValue = value
+        },
+        configurable: true,
+      })
+
+      setAnonymousIdCookie('anon_test', true)
+      expect(setCookieValue).toContain('Secure')
+    })
+  })
+
+  describe('clearAnonymousIdCookie()', () => {
+    it('should remove the anonymous ID cookie', () => {
+      setAnonymousIdCookie('anon_test')
+      expect(getCookie(ANONYMOUS_ID_COOKIE_NAME)).toBe('anon_test')
+
+      clearAnonymousIdCookie()
+      expect(getCookie(ANONYMOUS_ID_COOKIE_NAME)).toBeNull()
+    })
+
+    it('should handle clearing non-existent cookie gracefully', () => {
+      expect(() => clearAnonymousIdCookie()).not.toThrow()
+    })
+  })
+})

--- a/tests/unit/analytics/cookies.test.ts
+++ b/tests/unit/analytics/cookies.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 /**
  * Cookie Utilities Unit Tests
  */

--- a/tests/unit/analytics/cookies.test.ts
+++ b/tests/unit/analytics/cookies.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Cookie Utilities Unit Tests
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { getCookie, setCookie, deleteCookie } from '@/infra/analytics/utils/cookies'
+
+describe('Cookie Utilities', () => {
+  let originalCookieDescriptor: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    // Save original cookie descriptor
+    originalCookieDescriptor = Object.getOwnPropertyDescriptor(Document.prototype, 'cookie')
+
+    // Clear all cookies before each test
+    document.cookie.split(';').forEach((c) => {
+      const name = c.split('=')[0].trim()
+      document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`
+    })
+  })
+
+  afterEach(() => {
+    // Restore original cookie descriptor
+    if (originalCookieDescriptor) {
+      Object.defineProperty(Document.prototype, 'cookie', originalCookieDescriptor)
+    }
+  })
+
+  describe('getCookie()', () => {
+    it('should return value when cookie exists', () => {
+      document.cookie = 'test_cookie=test_value; path=/'
+      const value = getCookie('test_cookie')
+      expect(value).toBe('test_value')
+    })
+
+    it('should return null when cookie does not exist', () => {
+      const value = getCookie('nonexistent_cookie')
+      expect(value).toBeNull()
+    })
+
+    it('should parse cookie with special characters correctly', () => {
+      // URL-encoded value
+      document.cookie = 'special_cookie=hello%20world; path=/'
+      const value = getCookie('special_cookie')
+      expect(value).toBe('hello%20world')
+    })
+
+    it('should handle multiple cookies correctly', () => {
+      document.cookie = 'cookie1=value1; path=/'
+      document.cookie = 'cookie2=value2; path=/'
+      document.cookie = 'cookie3=value3; path=/'
+
+      expect(getCookie('cookie1')).toBe('value1')
+      expect(getCookie('cookie2')).toBe('value2')
+      expect(getCookie('cookie3')).toBe('value3')
+    })
+  })
+
+  describe('setCookie()', () => {
+    it('should set cookie with correct name and value', () => {
+      setCookie('test_cookie', 'test_value')
+      expect(getCookie('test_cookie')).toBe('test_value')
+    })
+
+    it('should set cookie with 1 year expiry by default', () => {
+      let setCookieValue = ''
+      Object.defineProperty(document, 'cookie', {
+        get: () => setCookieValue,
+        set: (value: string) => {
+          setCookieValue = value
+        },
+        configurable: true,
+      })
+
+      setCookie('test_cookie', 'test_value')
+      expect(setCookieValue).toContain('max-age=31536000') // 365 days in seconds
+    })
+
+    it('should set SameSite=Lax attribute', () => {
+      let setCookieValue = ''
+      Object.defineProperty(document, 'cookie', {
+        get: () => setCookieValue,
+        set: (value: string) => {
+          setCookieValue = value
+        },
+        configurable: true,
+      })
+
+      setCookie('test_cookie', 'test_value')
+      expect(setCookieValue).toContain('SameSite=Lax')
+    })
+
+    it('should set Secure flag when isSecure is true', () => {
+      // Mock Object.defineProperty to spy on cookie setter
+      let setCookieValue = ''
+      Object.defineProperty(document, 'cookie', {
+        get: () => setCookieValue,
+        set: (value: string) => {
+          setCookieValue = value
+        },
+        configurable: true,
+      })
+
+      setCookie('test_cookie', 'test_value', { isSecure: true })
+      expect(setCookieValue).toContain('Secure')
+    })
+
+    it('should NOT set Secure flag when isSecure is false', () => {
+      let setCookieValue = ''
+      Object.defineProperty(document, 'cookie', {
+        get: () => setCookieValue,
+        set: (value: string) => {
+          setCookieValue = value
+        },
+        configurable: true,
+      })
+
+      setCookie('test_cookie', 'test_value', { isSecure: false })
+      expect(setCookieValue).not.toContain('Secure')
+    })
+
+    it('should allow custom expiry days', () => {
+      let setCookieValue = ''
+      Object.defineProperty(document, 'cookie', {
+        get: () => setCookieValue,
+        set: (value: string) => {
+          setCookieValue = value
+        },
+        configurable: true,
+      })
+
+      setCookie('test_cookie', 'test_value', { expiryDays: 7 })
+      expect(setCookieValue).toContain('max-age=604800') // 7 days in seconds
+    })
+  })
+
+  describe('deleteCookie()', () => {
+    it('should remove cookie by setting max-age to 0', () => {
+      setCookie('test_cookie', 'test_value')
+      expect(getCookie('test_cookie')).toBe('test_value')
+
+      deleteCookie('test_cookie')
+      expect(getCookie('test_cookie')).toBeNull()
+    })
+
+    it('should handle deleting non-existent cookie gracefully', () => {
+      expect(() => deleteCookie('nonexistent_cookie')).not.toThrow()
+    })
+  })
+})


### PR DESCRIPTION
## What / Why

Implements persistent anonymous user tracking in Mixpanel to enable funnel analysis and user journey tracking. Resolves issues where anonymous users were not properly identified, breaking funnels and preventing conversion path analysis.

### Root Cause

- Mixpanel SDK relied solely on localStorage (can be cleared/blocked)
- No HTTP cookie-based anonymous ID persistence
- Aliasing function existed but was never called on registration
- No People profiles created for anonymous users

### Solution

- Cookie-based anonymous ID with 1-year expiry (`mp_anon_id`)
- Mixpanel SDK initialization with cookie persistence
- Proper identity aliasing: `alias()` → `identify()` on registration
- People profiles created for anonymous users
- Logout clears anonymous ID and generates new one

## Scope of Changes

### New Files
- `src/infra/analytics/utils/cookies.ts` - Cookie management utilities
- `src/infra/analytics/utils/anonymous-id.ts` - Anonymous ID generation & persistence
- `tests/unit/analytics/cookies.test.ts` - Cookie utilities tests (12 tests)
- `tests/unit/analytics/anonymous-id.test.ts` - Anonymous ID tests (13 tests)

### Modified Files
- `src/infra/analytics/adapters/mixpanel/scripts.tsx` - Initialize with cookie-based ID
- `src/infra/analytics/adapters/mixpanel/adapter.ts` - People profiles for anonymous users
- `src/infra/analytics/core/tracker.ts` - Added `alias()` method
- `src/infra/analytics/types.ts` - Added `AliasFunction` type
- `src/infra/analytics/system-events-subscriber.ts` - Call alias before identify on registration

## How It Was Tested

### Quality Gates
✓ `pnpm -s tsc --noEmit` - PASSED (only pre-existing errors in unrelated files)
✓ `pnpm -s lint` - PASSED (only pre-existing warnings in unrelated files)
✓ `pnpm -s format` - PASSED
✓ `pnpm exec vitest run tests/unit/analytics/` - PASSED (25/25 tests)

### Unit Tests
- Cookie utilities: 12 tests passing
- Anonymous ID management: 13 tests passing
- Coverage: get/set/delete cookies, ID generation, persistence, error handling

### Manual Testing Required
- [ ] Verify anonymous users appear in Mixpanel Users list
- [ ] Verify events from same anonymous user are grouped
- [ ] Verify registration aliases anonymous → user ID
- [ ] Verify logout generates new anonymous ID

## Definition of Done Checklist

- [x] All quality gates pass (typecheck, lint, format, tests)
- [x] Unit tests added for new utilities
- [x] Follows existing analytics patterns
- [x] No new dependencies
- [x] TDD approach (tests written first)
- [x] Conventional Commits format
- [x] Cookie security (SameSite=Lax, Secure in production)

## Implementation Details

### Cookie Configuration
```typescript
Cookie name: mp_anon_id
Expiry: 365 days (1 year)
Flags: SameSite=Lax, Secure (in production)
Format: anon_<uuid-v4>
```

### Mixpanel SDK Configuration
```javascript
persistence: 'localStorage+cookie'
cross_subdomain_cookie: true
cookie_expiration: 365
secure_cookie: true (in production)
```

### Critical: Alias Call Order
```typescript
// ✅ CORRECT
analytics.alias(userId)      // Link identities FIRST
analytics.identify(userId)   // Then switch identity

// ❌ WRONG (breaks history merge)
analytics.identify(userId)   // DON'T switch first
analytics.alias(userId)      // Too late
```

## Risks / Rollback Notes

**Low Risk**: Changes are additive and isolated to analytics layer
- No breaking changes to existing event tracking
- Backwards compatible (existing users unaffected)
- Cookie-based tracking is standard practice

**Rollback**: Revert commit + redeploy (analytics will continue with SDK defaults)

## Related Tasks

Implements: `.tasks/mixpanel-anonymous-tracking.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)