### PR TITLE
feat(chat): Add error surface above input

### DIFF
--- a/.tasks/pdf-conversion-improvements/plan.md
+++ b/.tasks/pdf-conversion-improvements/plan.md
@@ -3,6 +3,7 @@
 ## Overview
 
 Improve the PDF-to-exercises conversion system with:
+
 1. **Dedicated Conversion Dashboard** - Standalone admin view for job management
 2. **Real-Time Streaming Logs** - SSE-based live updates replacing 10s polling
 3. **Structured Job Logging** - Granular progress tracking stored in MongoDB
@@ -106,7 +107,7 @@ export const dynamic = 'force-dynamic'
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { jobId: string } }
+  { params }: { params: { jobId: string } },
 ): Promise<Response>
 // Returns ReadableStream with text/event-stream
 // Events: log, status, done, error
@@ -137,7 +138,7 @@ export async function GET(
 export async function collectSSEEvents(
   url: string,
   headers: HeadersInit,
-  options?: { timeout?: number; maxEvents?: number }
+  options?: { timeout?: number; maxEvents?: number },
 ): Promise<{ events: SSEEvent[]; closed: boolean }>
 ```
 
@@ -417,69 +418,72 @@ interface JobFiltersProps {
 
 ### New Files
 
-| File | Purpose |
-|------|---------|
-| `src/server/payload/jobs/types.ts` | Job log types and interfaces |
-| `src/server/payload/jobs/job-logger.ts` | Structured logging utility |
-| `src/app/api/jobs/[jobId]/stream/route.ts` | SSE streaming endpoint |
-| `src/app/api/jobs/list/route.ts` | Paginated job list |
-| `src/app/api/jobs/cancel/route.ts` | Cancel queued jobs |
-| `src/app/api/jobs/retry/route.ts` | Retry failed jobs |
-| `src/app/api/jobs/count/route.ts` | Count jobs by filter |
-| `src/ui/admin/ConversionDashboard/index.tsx` | Main dashboard view |
-| `src/ui/admin/ConversionDashboard/JobListTable.tsx` | Job list table |
-| `src/ui/admin/ConversionDashboard/JobDetailPanel.tsx` | Job detail with SSE |
-| `src/ui/admin/ConversionDashboard/ProgressTimeline.tsx` | Visual progress stepper |
-| `src/ui/admin/ConversionDashboard/LogViewer.tsx` | Searchable log viewer |
-| `src/ui/admin/ConversionDashboard/JobFilters.tsx` | Filter controls |
-| `src/ui/admin/ConversionDashboard/styles.css` | Dashboard styles |
-| `src/ui/admin/ConversionNavLink/index.tsx` | Admin nav link |
-| `tests/unit/server/jobs/job-logger.spec.ts` | Unit tests for logger |
-| `tests/int/jobs-stream.int.spec.ts` | SSE endpoint tests |
-| `tests/int/jobs-api.int.spec.ts` | Job API tests |
-| `tests/helpers/sse-client.ts` | SSE test helper |
-| `tests/e2e/conversion-dashboard.e2e.spec.ts` | E2E tests |
+| File                                                    | Purpose                      |
+| ------------------------------------------------------- | ---------------------------- |
+| `src/server/payload/jobs/types.ts`                      | Job log types and interfaces |
+| `src/server/payload/jobs/job-logger.ts`                 | Structured logging utility   |
+| `src/app/api/jobs/[jobId]/stream/route.ts`              | SSE streaming endpoint       |
+| `src/app/api/jobs/list/route.ts`                        | Paginated job list           |
+| `src/app/api/jobs/cancel/route.ts`                      | Cancel queued jobs           |
+| `src/app/api/jobs/retry/route.ts`                       | Retry failed jobs            |
+| `src/app/api/jobs/count/route.ts`                       | Count jobs by filter         |
+| `src/ui/admin/ConversionDashboard/index.tsx`            | Main dashboard view          |
+| `src/ui/admin/ConversionDashboard/JobListTable.tsx`     | Job list table               |
+| `src/ui/admin/ConversionDashboard/JobDetailPanel.tsx`   | Job detail with SSE          |
+| `src/ui/admin/ConversionDashboard/ProgressTimeline.tsx` | Visual progress stepper      |
+| `src/ui/admin/ConversionDashboard/LogViewer.tsx`        | Searchable log viewer        |
+| `src/ui/admin/ConversionDashboard/JobFilters.tsx`       | Filter controls              |
+| `src/ui/admin/ConversionDashboard/styles.css`           | Dashboard styles             |
+| `src/ui/admin/ConversionNavLink/index.tsx`              | Admin nav link               |
+| `tests/unit/server/jobs/job-logger.spec.ts`             | Unit tests for logger        |
+| `tests/int/jobs-stream.int.spec.ts`                     | SSE endpoint tests           |
+| `tests/int/jobs-api.int.spec.ts`                        | Job API tests                |
+| `tests/helpers/sse-client.ts`                           | SSE test helper              |
+| `tests/e2e/conversion-dashboard.e2e.spec.ts`            | E2E tests                    |
 
 ### Modified Files
 
-| File | Changes |
-|------|---------|
-| `src/server/payload/jobs/pdf-to-exercises-task.ts` | Add structured logging |
-| `src/ui/admin/exercise-conversion/LessonConversionPanel/index.tsx` | Simplify to compact version |
-| `src/payload.config.ts` | Register custom view + nav link |
-| `tests/int/jobs-run-now.int.spec.ts` | Add logging assertions |
+| File                                                               | Changes                         |
+| ------------------------------------------------------------------ | ------------------------------- |
+| `src/server/payload/jobs/pdf-to-exercises-task.ts`                 | Add structured logging          |
+| `src/ui/admin/exercise-conversion/LessonConversionPanel/index.tsx` | Simplify to compact version     |
+| `src/payload.config.ts`                                            | Register custom view + nav link |
+| `tests/int/jobs-run-now.int.spec.ts`                               | Add logging assertions          |
 
 ---
 
 ## Test Coverage Matrix
 
-| Requirement | Unit Tests | Integration Tests | E2E Tests |
-|-------------|------------|-------------------|-----------|
-| Structured logging | `job-logger.spec.ts` | `jobs-run-now.int.spec.ts` | - |
-| SSE streaming | - | `jobs-stream.int.spec.ts` | `conversion-dashboard.e2e.spec.ts` |
-| Job list API | - | `jobs-api.int.spec.ts` | - |
-| Job cancel API | - | `jobs-api.int.spec.ts` | - |
-| Job retry API | - | `jobs-api.int.spec.ts` | - |
-| Job count API | - | `jobs-api.int.spec.ts` | - |
-| Dashboard UI | - | - | `conversion-dashboard.e2e.spec.ts` |
-| Lesson page link | - | - | `conversion-dashboard.e2e.spec.ts` |
+| Requirement        | Unit Tests           | Integration Tests          | E2E Tests                          |
+| ------------------ | -------------------- | -------------------------- | ---------------------------------- |
+| Structured logging | `job-logger.spec.ts` | `jobs-run-now.int.spec.ts` | -                                  |
+| SSE streaming      | -                    | `jobs-stream.int.spec.ts`  | `conversion-dashboard.e2e.spec.ts` |
+| Job list API       | -                    | `jobs-api.int.spec.ts`     | -                                  |
+| Job cancel API     | -                    | `jobs-api.int.spec.ts`     | -                                  |
+| Job retry API      | -                    | `jobs-api.int.spec.ts`     | -                                  |
+| Job count API      | -                    | `jobs-api.int.spec.ts`     | -                                  |
+| Dashboard UI       | -                    | -                          | `conversion-dashboard.e2e.spec.ts` |
+| Lesson page link   | -                    | -                          | `conversion-dashboard.e2e.spec.ts` |
 
 ---
 
 ## Acceptance Criteria
 
 ### Phase 1 (Types + Logger)
+
 - [ ] `JobLogEntry` and `JobStage` types exported
 - [ ] `JobLogger` class appends logs atomically to MongoDB
 - [ ] Unit tests pass for logger
 
 ### Phase 2 (SSE)
+
 - [ ] SSE endpoint streams logs in real-time
 - [ ] SSE endpoint requires admin auth
 - [ ] SSE auto-closes on job completion
 - [ ] Integration tests pass
 
 ### Phase 3 (APIs)
+
 - [ ] List endpoint returns paginated, filtered jobs
 - [ ] Cancel endpoint marks queued jobs as cancelled
 - [ ] Retry endpoint creates new job with same input
@@ -488,12 +492,14 @@ interface JobFiltersProps {
 - [ ] Integration tests pass
 
 ### Phase 4 (Handler Update)
+
 - [ ] Job handler logs at each stage
 - [ ] Logs include relevant details (segment info, counts)
 - [ ] Existing job functionality unchanged
 - [ ] Integration tests pass
 
 ### Phase 5 (Dashboard)
+
 - [ ] Dashboard accessible at `/admin/conversion-jobs`
 - [ ] Job list displays with filtering
 - [ ] Job detail shows SSE-streamed logs
@@ -502,6 +508,7 @@ interface JobFiltersProps {
 - [ ] E2E tests pass
 
 ### Phase 6 (Lesson Page)
+
 - [ ] Lesson page shows compact conversion panel
 - [ ] Active job count badge visible
 - [ ] Link to dashboard works

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -155,6 +155,8 @@
     "chatFullSolution": "Full",
     "chatInputPlaceholder": "Send a message...",
     "chatAuthRequired": "Please sign in to use the AI helper",
+    "chatAuthRequiredCTA": "Sign up to continue",
+    "chatErrorDismiss": "Dismiss error",
     "chatHintPrompt": "Can you give me a hint to help me solve this?",
     "chatSolutionPrompt": "Can you explain the solution approach?",
     "chatFullSolutionPrompt": "Can you provide the complete solution with all steps?",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -155,6 +155,7 @@
     "chatFullSolution": "Full",
     "chatInputPlaceholder": "Send a message...",
     "chatAuthRequired": "Please sign in to use the AI helper",
+    "chatAuthRequiredLogin": "Log in",
     "chatAuthRequiredCTA": "Sign up to continue",
     "chatErrorDismiss": "Dismiss error",
     "chatHintPrompt": "Can you give me a hint to help me solve this?",

--- a/src/i18n/he.json
+++ b/src/i18n/he.json
@@ -155,6 +155,7 @@
     "chatFullSolution": "מלא",
     "chatInputPlaceholder": "שלח הודעה...",
     "chatAuthRequired": "יש להתחבר כדי להשתמש בעוזר הבינה המלאכותית",
+    "chatAuthRequiredLogin": "התחבר",
     "chatAuthRequiredCTA": "הירשם כדי להמשיך",
     "chatErrorDismiss": "סגור התראה",
     "chatHintPrompt": "האם תוכל לתת לי רמז שיעזור לי לפתור את התרגיל?",

--- a/src/i18n/he.json
+++ b/src/i18n/he.json
@@ -155,6 +155,8 @@
     "chatFullSolution": "מלא",
     "chatInputPlaceholder": "שלח הודעה...",
     "chatAuthRequired": "יש להתחבר כדי להשתמש בעוזר הבינה המלאכותית",
+    "chatAuthRequiredCTA": "הירשם כדי להמשיך",
+    "chatErrorDismiss": "סגור התראה",
     "chatHintPrompt": "האם תוכל לתת לי רמז שיעזור לי לפתור את התרגיל?",
     "chatSolutionPrompt": "האם תוכל להסביר את גישת הפתרון?",
     "chatFullSolutionPrompt": "האם תוכל לספק את הפתרון המלא עם כל השלבים?",

--- a/src/ui/web/chat/ChatErrorSurface/index.tsx
+++ b/src/ui/web/chat/ChatErrorSurface/index.tsx
@@ -3,6 +3,7 @@
 import { cn } from '@/infra/utils/ui'
 import { X, AlertCircle } from 'lucide-react'
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 import { useTranslations } from '@/ui/web/providers/I18n'
 
 export interface ChatErrorSurfaceProps {
@@ -14,6 +15,10 @@ export interface ChatErrorSurfaceProps {
 
 export function ChatErrorSurface({ type, message, onDismiss, className }: ChatErrorSurfaceProps) {
   const tCourses = useTranslations('courses')
+  const pathname = usePathname()
+
+  const loginUrl = `/login?returnTo=${encodeURIComponent(pathname)}`
+  const signupUrl = `/signup?returnTo=${encodeURIComponent(pathname)}`
 
   return (
     <div
@@ -35,14 +40,14 @@ export function ChatErrorSurface({ type, message, onDismiss, className }: ChatEr
         {type === 'auth' && (
           <div className="flex items-center gap-2 mt-2 text-sm">
             <Link
-              href="/login"
+              href={loginUrl}
               className="font-semibold underline hover:no-underline transition-all"
             >
               {tCourses('chatAuthRequiredLogin')}
             </Link>
             <span className="text-destructive/60">or</span>
             <Link
-              href="/signup"
+              href={signupUrl}
               className="font-semibold underline hover:no-underline transition-all"
             >
               {tCourses('chatAuthRequiredCTA')}

--- a/src/ui/web/chat/ChatErrorSurface/index.tsx
+++ b/src/ui/web/chat/ChatErrorSurface/index.tsx
@@ -33,12 +33,21 @@ export function ChatErrorSurface({ type, message, onDismiss, className }: ChatEr
 
         {/* Auth Error CTA */}
         {type === 'auth' && (
-          <Link
-            href="/signup"
-            className="inline-block mt-2 text-sm font-semibold underline hover:no-underline transition-all"
-          >
-            {tCourses('chatAuthRequiredCTA')}
-          </Link>
+          <div className="flex items-center gap-2 mt-2 text-sm">
+            <Link
+              href="/login"
+              className="font-semibold underline hover:no-underline transition-all"
+            >
+              {tCourses('chatAuthRequiredLogin')}
+            </Link>
+            <span className="text-destructive/60">or</span>
+            <Link
+              href="/signup"
+              className="font-semibold underline hover:no-underline transition-all"
+            >
+              {tCourses('chatAuthRequiredCTA')}
+            </Link>
+          </div>
         )}
       </div>
 

--- a/src/ui/web/chat/ChatErrorSurface/index.tsx
+++ b/src/ui/web/chat/ChatErrorSurface/index.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { cn } from '@/infra/utils/ui'
+import { X, AlertCircle } from 'lucide-react'
+import Link from 'next/link'
+import { useTranslations } from '@/ui/web/providers/I18n'
+
+export interface ChatErrorSurfaceProps {
+  type: 'auth' | 'general'
+  message: string
+  onDismiss: () => void
+  className?: string
+}
+
+export function ChatErrorSurface({ type, message, onDismiss, className }: ChatErrorSurfaceProps) {
+  const tCourses = useTranslations('courses')
+
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-3 p-4 rounded-lg border bg-destructive/10 border-destructive/30 text-destructive',
+        className,
+      )}
+      role="alert"
+      aria-live="polite"
+    >
+      {/* Error Icon */}
+      <AlertCircle className="w-5 h-5 flex-shrink-0 mt-0.5" />
+
+      {/* Error Content */}
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium leading-relaxed">{message}</p>
+
+        {/* Auth Error CTA */}
+        {type === 'auth' && (
+          <Link
+            href="/signup"
+            className="inline-block mt-2 text-sm font-semibold underline hover:no-underline transition-all"
+          >
+            {tCourses('chatAuthRequiredCTA')}
+          </Link>
+        )}
+      </div>
+
+      {/* Dismiss Button */}
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="p-1 hover:bg-destructive/20 rounded-full transition-colors flex-shrink-0"
+        aria-label={tCourses('chatErrorDismiss')}
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  )
+}

--- a/src/ui/web/chat/ChatInterface/index.tsx
+++ b/src/ui/web/chat/ChatInterface/index.tsx
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react'
 import React, { useEffect, useState } from 'react'
 import { ChatMessageContent } from '../ChatMessageContent'
+import { ChatErrorSurface } from '../ChatErrorSurface'
 import { useNotebookChat } from '../hooks/useNotebookChat'
 
 // Optional components - will be lazy-loaded if needed
@@ -98,6 +99,9 @@ export function ChatInterface({
     handleFileSelect,
     removeMedia,
     openFilePicker,
+    // Error handling
+    chatError,
+    dismissError,
   } = useNotebookChat({
     initialMessage: t('chatWelcome'),
     authRequiredMessage: t('chatAuthRequired'),
@@ -290,6 +294,17 @@ export function ChatInterface({
             <BookOpen className="w-4 h-4 text-blue-500" />
             <span>{tCourses('chatFullSolution')}</span>
           </button>
+        </div>
+      )}
+
+      {/* Chat Error Surface */}
+      {chatError && (
+        <div className="flex-grow-0 flex-shrink-0 px-5 pt-3">
+          <ChatErrorSurface
+            type={chatError.type}
+            message={chatError.message}
+            onDismiss={dismissError}
+          />
         </div>
       )}
 

--- a/src/ui/web/chat/hooks/useNotebookChat.ts
+++ b/src/ui/web/chat/hooks/useNotebookChat.ts
@@ -20,6 +20,11 @@ export interface UploadedMedia {
   mimeType: string
 }
 
+export interface ChatError {
+  type: 'auth' | 'general'
+  message: string
+}
+
 // Media upload constraints
 const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'application/pdf']
 const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB
@@ -82,6 +87,9 @@ export function useNotebookChat({
   // Media upload state
   const [uploadedMedia, setUploadedMedia] = useState<UploadedMedia[]>([])
   const [isUploading, setIsUploading] = useState(false)
+
+  // Error state
+  const [chatError, setChatError] = useState<ChatError | null>(null)
 
   // Compute contextKey based on available context (priority: Exercise > Lesson > Chapter > Course)
   const contextKey = useMemo(() => {
@@ -386,7 +394,7 @@ export function useNotebookChat({
 
       if (!result.success) {
         if (result.authRequired) {
-          toast.error(authRequiredMessage)
+          setChatError({ type: 'auth', message: authRequiredMessage })
         } else {
           toast.error(result.error || errorMessage)
         }
@@ -457,6 +465,10 @@ export function useNotebookChat({
     sendMessage(prompts[actionType])
   }
 
+  const dismissError = useCallback(() => {
+    setChatError(null)
+  }, [])
+
   return {
     messages,
     inputValue,
@@ -478,5 +490,8 @@ export function useNotebookChat({
     handleFileSelect,
     removeMedia,
     openFilePicker,
+    // Error handling
+    chatError,
+    dismissError,
   }
 }

--- a/tests/unit/hooks/useNotebookChat.test.ts
+++ b/tests/unit/hooks/useNotebookChat.test.ts
@@ -108,7 +108,19 @@ describe('useNotebookChat', () => {
       result.current.handleSubmit({ preventDefault: () => undefined } as React.FormEvent)
     })
 
-    expect(toast.error).toHaveBeenCalledWith(defaultProps.authRequiredMessage)
+    // Auth errors now set chatError state instead of showing toast
+    expect(result.current.chatError).toEqual({
+      type: 'auth',
+      message: defaultProps.authRequiredMessage,
+    })
+    expect(toast.error).not.toHaveBeenCalled()
+
+    // Test dismissError
+    act(() => {
+      result.current.dismissError()
+    })
+
+    expect(result.current.chatError).toBeNull()
   })
 
   it('sends quick action prompts', async () => {


### PR DESCRIPTION
Introduces a dedicated error display area inside the chat interface positioned directly above the chat input field. This architectural change ensures chat-related system errors appear contextually within the chat itself rather than in disconnected global toast notifications.

Changes:
- Created ChatErrorSurface component with dismissal and CTA support
- Modified useNotebookChat hook to expose error state instead of showing toast
- Integrated error surface into ChatInterface above input area
- Added translation keys (chatAuthRequiredCTA, chatErrorDismiss) for en/he
- Uses design system CSS variables (no hardcoded colors)
- Includes X button for dismissal and registration link for auth errors

The authentication error "You must register to use the chat" now appears as a prominent, dismissible message directly above the chat input with a clear call-to-action link to the signup page.