### PR TITLE
# Add Exercise Preview to Admin Sidebar

### DIFF
--- a/.github/PR-exercise-preview.md
+++ b/.github/PR-exercise-preview.md
@@ -1,0 +1,42 @@
+# Add Exercise Preview to Admin Sidebar
+
+## Summary
+
+Adds a "View Exercise" link in the Payload CMS admin sidebar that opens the exercise preview in the web frontend with the full design system.
+
+## Changes
+
+### New component: `src/ui/admin/ExercisePreview/index.tsx`
+
+UI field component that:
+
+- Links to `/exercises/{id}` for saved exercises
+- Shows "Add content blocks to enable preview" when no content
+- Shows "Save the exercise to preview it" for unsaved drafts
+
+### Collection update: `src/server/payload/collections/Exercises/index.ts`
+
+- Added `preview` field with `type: 'ui'` in sidebar
+- Uses the ExercisePreview component
+
+### Auto-generated: `src/app/(payload)/admin/importMap.js`
+
+- Updated with ExercisePreview import
+
+## Behavior
+
+| State           | UI                                                        |
+| --------------- | --------------------------------------------------------- |
+| Saved exercises | Shows "View Exercise" button linking to `/exercises/{id}` |
+| Unsaved drafts  | Shows "Save the exercise to preview it" message           |
+| No content      | Shows "Add content blocks to enable preview" message      |
+
+The preview opens in a new tab, allowing editors to see the exercise with the full web design system (Tailwind, components, etc.).
+
+## Files Changed
+
+```
+M src/app/(payload)/admin/importMap.js
+M src/server/payload/collections/Exercises/index.ts
+A src/ui/admin/ExercisePreview/index.tsx
+```

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -17,6 +17,7 @@ import { PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860 }
 import { SlugField as SlugField_3817bf644402e67bfe6577f60ef982de } from '@payloadcms/ui'
 import { LessonConversionPanel as LessonConversionPanel_057daf3b86f654d90edf003b44c43703 } from '@/ui/admin/exercise-conversion/LessonConversionPanel'
 import { ExerciseContentEditor as ExerciseContentEditor_d0c5d070052b5cabcf602f1e9878afd8 } from '@/ui/admin/ExerciseContentEditor'
+import { ExercisePreview as ExercisePreview_79d54f4a9901df303ad8ae2cc7d44435 } from '@/ui/admin/ExercisePreview'
 import { MediaPreview as MediaPreview_4b980c9a407724ef7c1755e3482d0258 } from '@/ui/admin/MediaPreview'
 import { FolderTableCell as FolderTableCell_ab83ff7e88da8d3530831f296ec4756a } from '@payloadcms/ui/rsc'
 import { FolderField as FolderField_ab83ff7e88da8d3530831f296ec4756a } from '@payloadcms/ui/rsc'
@@ -53,6 +54,7 @@ export const importMap = {
   "@payloadcms/ui#SlugField": SlugField_3817bf644402e67bfe6577f60ef982de,
   "@/ui/admin/exercise-conversion/LessonConversionPanel#LessonConversionPanel": LessonConversionPanel_057daf3b86f654d90edf003b44c43703,
   "@/ui/admin/ExerciseContentEditor#ExerciseContentEditor": ExerciseContentEditor_d0c5d070052b5cabcf602f1e9878afd8,
+  "@/ui/admin/ExercisePreview#ExercisePreview": ExercisePreview_79d54f4a9901df303ad8ae2cc7d44435,
   "@/ui/admin/MediaPreview#MediaPreview": MediaPreview_4b980c9a407724ef7c1755e3482d0258,
   "@payloadcms/ui/rsc#FolderTableCell": FolderTableCell_ab83ff7e88da8d3530831f296ec4756a,
   "@payloadcms/ui/rsc#FolderField": FolderField_ab83ff7e88da8d3530831f296ec4756a,

--- a/src/server/payload/collections/Exercises/index.ts
+++ b/src/server/payload/collections/Exercises/index.ts
@@ -184,6 +184,18 @@ export const Exercises: CollectionConfig = {
         },
       ],
     },
+
+    // Preview field (sidebar)
+    {
+      name: 'preview',
+      type: 'ui',
+      admin: {
+        position: 'sidebar',
+        components: {
+          Field: '@/ui/admin/ExercisePreview#ExercisePreview',
+        },
+      },
+    },
   ],
 }
 
@@ -192,8 +204,8 @@ export { ExerciseBlockDefaults } from './defaults'
 export {
   ContentBlockSchema,
   ContentSchema,
-  QuestionFreeResponseBlockSchema,
   LatexBlockSchema,
+  QuestionFreeResponseBlockSchema,
   type ContentBlock,
   type LatexBlock,
 } from './schemas'

--- a/src/ui/admin/ExercisePreview/index.tsx
+++ b/src/ui/admin/ExercisePreview/index.tsx
@@ -1,0 +1,54 @@
+/**
+ * Exercise Preview Component
+ * Links to the web frontend preview of the exercise
+ */
+
+'use client'
+
+import type { ExerciseContentData } from '@/ui/web/exerciserenderer/types'
+import { useDocumentInfo, useFormFields } from '@payloadcms/ui'
+
+export const ExercisePreview: React.FC = () => {
+  // Read content from form state
+  const contentField = useFormFields(([fields]) => fields.content)
+  const content = contentField?.value as ExerciseContentData | undefined
+
+  // Get document ID from useDocumentInfo (not available in form fields)
+  const { id: exerciseId } = useDocumentInfo()
+
+  const hasContent = content?.blocks && Array.isArray(content.blocks) && content.blocks.length > 0
+
+  if (!hasContent) {
+    return (
+      <div className="p-4 text-center text-muted-foreground text-sm">
+        <p>Add content blocks to enable preview</p>
+      </div>
+    )
+  }
+
+  // If exercise is saved, link to the existing exercise page
+  if (exerciseId) {
+    return (
+      <div className="p-4">
+        <p className="text-sm text-muted-foreground mb-3">View the saved exercise</p>
+        <a
+          href={`/exercises/${exerciseId}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center justify-center px-4 py-2 bg-primary text-primary-foreground rounded-md text-sm font-medium hover:bg-primary/90"
+        >
+          View Exercise
+        </a>
+      </div>
+    )
+  }
+
+  // For unsaved drafts, show a message
+  return (
+    <div className="p-4">
+      <p className="text-sm text-muted-foreground">Save the exercise to preview it</p>
+    </div>
+  )
+}
+
+export default ExercisePreview


### PR DESCRIPTION
## Summary

Adds a "View Exercise" link in the Payload CMS admin sidebar that opens the exercise preview in the web frontend with the full design system.

## Changes

### New component: `src/ui/admin/ExercisePreview/index.tsx`

UI field component that:

- Links to `/exercises/{id}` for saved exercises
- Shows "Add content blocks to enable preview" when no content
- Shows "Save the exercise to preview it" for unsaved drafts

### Collection update: `src/server/payload/collections/Exercises/index.ts`

- Added `preview` field with `type: 'ui'` in sidebar
- Uses the ExercisePreview component

### Auto-generated: `src/app/(payload)/admin/importMap.js`

- Updated with ExercisePreview import

## Behavior

| State           | UI                                                        |
| --------------- | --------------------------------------------------------- |
| Saved exercises | Shows "View Exercise" button linking to `/exercises/{id}` |
| Unsaved drafts  | Shows "Save the exercise to preview it" message           |
| No content      | Shows "Add content blocks to enable preview" message      |

The preview opens in a new tab, allowing editors to see the exercise with the full web design system (Tailwind, components, etc.).

## Files Changed

```
M src/app/(payload)/admin/importMap.js
M src/server/payload/collections/Exercises/index.ts
A src/ui/admin/ExercisePreview/index.tsx
```