### PR TITLE
feat(config): Add SystemParam kind for runtime-configurable system co…

### DIFF
--- a/src/infra/config/config-constants.ts
+++ b/src/infra/config/config-constants.ts
@@ -13,6 +13,7 @@
 export const ConfigKind = {
   Variable: 'variable',
   Secret: 'secret',
+  SystemParam: 'system_param',
 } as const
 
 export type ConfigKind = (typeof ConfigKind)[keyof typeof ConfigKind]

--- a/src/infra/config/runtime/runtime-config.ts
+++ b/src/infra/config/runtime/runtime-config.ts
@@ -158,7 +158,8 @@ export async function loadRuntimeConfig(
       }
 
       try {
-        if (kind === ConfigKind.Variable) {
+        // SystemParam is treated like Variable (plaintext, no encryption)
+        if (kind === ConfigKind.Variable || kind === ConfigKind.SystemParam) {
           variables.get(tId)!.set(key, value)
         } else if (kind === ConfigKind.Secret && value && value.length > 0) {
           secrets.get(tId)!.set(key, decryptSecret(value))

--- a/src/infra/config/system-params.ts
+++ b/src/infra/config/system-params.ts
@@ -1,0 +1,70 @@
+/**
+ * System Parameters
+ *
+ * @fileType wrapper
+ * @domain config.system-params
+ * @pattern type-safe-accessor
+ * @ai-summary Type-safe accessors for system parameters stored in ConfigEntries
+ *
+ * These parameters are application constants that can be managed at runtime
+ * by admins via the ConfigEntries collection with kind="system_param".
+ *
+ * Defaults match src/server/config/constants.ts values.
+ */
+
+import { getVariable } from './runtime/runtime-config'
+
+/**
+ * System parameters accessors
+ * Provide optional tenantId for multi-tenant scenarios; defaults to default tenant
+ */
+export const SystemParams = {
+  // =========================================
+  // PDF Conversion
+  // =========================================
+
+  /**
+   * Maximum number of PDF pages per segment during PDF→Exercises conversion
+   *
+   * @param tenantId - Optional tenant ID (uses default if not provided)
+   * @default 2
+   * @returns Number of pages per segment
+   */
+  getPdfConversionMaxSegmentPages(tenantId?: string): number {
+    const raw = getVariable(tenantId, 'pdf_conversion_max_segment_pages', {
+      defaultValue: '2',
+      throwIfNotFound: false,
+    })
+    return parseInt(raw || '2', 10)
+  },
+
+  /**
+   * Maximum exercises allowed per PDF segment (truncates if exceeded)
+   *
+   * @param tenantId - Optional tenant ID (uses default if not provided)
+   * @default 1000
+   * @returns Max exercises per segment
+   */
+  getPdfConversionMaxExercisesPerSegment(tenantId?: string): number {
+    const raw = getVariable(tenantId, 'pdf_conversion_max_exercises_per_segment', {
+      defaultValue: '1000',
+      throwIfNotFound: false,
+    })
+    return parseInt(raw || '1000', 10)
+  },
+
+  /**
+   * Maximum allowed size for extractor/verifier prompts in bytes
+   *
+   * @param tenantId - Optional tenant ID (uses default if not provided)
+   * @default 51200 (50KB)
+   * @returns Max prompt size in bytes
+   */
+  getPdfConversionMaxPromptSizeBytes(tenantId?: string): number {
+    const raw = getVariable(tenantId, 'pdf_conversion_max_prompt_size_bytes', {
+      defaultValue: '51200',
+      throwIfNotFound: false,
+    })
+    return parseInt(raw || '51200', 10)
+  },
+}

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -877,9 +877,9 @@ export interface ConfigEntry {
    */
   tenant: string | Tenant;
   /**
-   * Variable: stored as plaintext. Secret: encrypted at rest.
+   * Variable: stored as plaintext. Secret: encrypted at rest. System Param: application constants.
    */
-  kind: 'variable' | 'secret';
+  kind: 'variable' | 'secret' | 'system_param';
   /**
    * Configuration value. Secrets are write-only after save.
    */

--- a/src/server/payload/collections/ConfigEntries.ts
+++ b/src/server/payload/collections/ConfigEntries.ts
@@ -74,10 +74,12 @@ export const ConfigEntries: CollectionConfig = {
       options: [
         { label: 'Variable', value: ConfigKind.Variable },
         { label: 'Secret', value: ConfigKind.Secret },
+        { label: 'System Param', value: ConfigKind.SystemParam },
       ],
       defaultValue: ConfigKind.Variable,
       admin: {
-        description: 'Variable: stored as plaintext. Secret: encrypted at rest.',
+        description:
+          'Variable: stored as plaintext. Secret: encrypted at rest. System Param: application constants.',
         position: 'sidebar',
       },
     },

--- a/src/server/payload/endpoints/seed/index.ts
+++ b/src/server/payload/endpoints/seed/index.ts
@@ -1,7 +1,9 @@
 import type { CollectionSlug, GlobalSlug, Payload, PayloadRequest } from 'payload'
 
+import { getDefaultTenantId } from '@/server/repos/tenant/get-default-tenant'
 import { contactForm as contactFormData } from './contact-form'
 import { contact as contactPageData } from './contact-page'
+import { seedSystemParams } from './system-params'
 
 const collections: CollectionSlug[] = ['categories', 'pages', 'forms', 'form-submissions', 'search']
 
@@ -135,6 +137,12 @@ export const seed = async ({
       },
     }),
   ])
+
+  // Seed system parameters
+  const defaultTenantId = await getDefaultTenantId(payload)
+  if (defaultTenantId) {
+    await seedSystemParams(payload, defaultTenantId)
+  }
 
   payload.logger.info('Seeded database successfully!')
 }

--- a/src/server/payload/endpoints/seed/system-params.ts
+++ b/src/server/payload/endpoints/seed/system-params.ts
@@ -1,0 +1,68 @@
+/**
+ * System Parameters Seed
+ *
+ * @fileType seed-function
+ * @domain config.seed
+ * @pattern data-seeding
+ * @ai-summary Seeds default system parameters into the database
+ *
+ * System parameters are application constants that can be managed at runtime.
+ * These values match src/server/config/constants.ts defaults.
+ */
+
+import { ConfigKind } from '@/infra/config/config-constants'
+import type { Payload } from 'payload'
+
+/**
+ * System parameters to seed
+ * Key-value pairs matching src/server/config/constants.ts defaults
+ */
+const SYSTEM_PARAMS = [
+  // PDF Conversion
+  { key: 'pdf_conversion_max_segment_pages', value: '2' },
+  { key: 'pdf_conversion_max_exercises_per_segment', value: '1000' },
+  { key: 'pdf_conversion_max_prompt_size_bytes', value: '51200' },
+] as const
+
+/**
+ * Seed system parameters for a given tenant
+ *
+ * @param payload - Payload instance
+ * @param tenantId - Tenant ID to seed params for
+ */
+export async function seedSystemParams(payload: Payload, tenantId: string): Promise<void> {
+  payload.logger.info('— Seeding system params...')
+
+  for (const param of SYSTEM_PARAMS) {
+    // Check if param already exists
+    const existing = await payload.find({
+      collection: 'config_entries',
+      where: {
+        key: { equals: param.key },
+        tenant: { equals: tenantId },
+      },
+      limit: 1,
+      overrideAccess: true,
+    })
+
+    if (existing.docs.length > 0) {
+      payload.logger.info(`  Skipped (exists): ${param.key}`)
+      continue
+    }
+
+    // Create the system param
+    await payload.create({
+      collection: 'config_entries',
+      data: {
+        key: param.key,
+        value: param.value,
+        kind: ConfigKind.SystemParam,
+        tenant: tenantId,
+        enabled: true,
+      },
+      overrideAccess: true,
+    })
+
+    payload.logger.info(`  Created: ${param.key} = ${param.value}`)
+  }
+}

--- a/tests/int/system-params.int.test.ts
+++ b/tests/int/system-params.int.test.ts
@@ -1,0 +1,110 @@
+/**
+ * SystemParams Integration Tests
+ *
+ * @fileType integration-test
+ * @domain config.system-params
+ * @pattern integration, database
+ */
+
+import { ConfigKind } from '@/infra/config/config-constants'
+import { clearConfigCache, loadRuntimeConfig } from '@/infra/config/runtime'
+import { SystemParams } from '@/infra/config/system-params'
+import config from '@payload-config'
+import { getPayload } from 'payload'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+const TEST_TENANT_SLUG = 'system-params-test-tenant'
+
+describe('SystemParams Integration', () => {
+  let payload: Awaited<ReturnType<typeof getPayload>>
+  let testTenantId: string
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+
+    // Get or create test tenant
+    const tenants = await payload.find({
+      collection: 'tenants',
+      where: { slug: { equals: TEST_TENANT_SLUG } },
+    })
+    if (tenants.docs.length > 0) {
+      testTenantId = tenants.docs[0].id
+    } else {
+      const created = await payload.create({
+        collection: 'tenants',
+        data: { name: 'System Params Test Tenant', slug: TEST_TENANT_SLUG },
+        overrideAccess: true,
+      })
+      testTenantId = created.id
+    }
+  })
+
+  afterAll(async () => {
+    clearConfigCache()
+    // Cleanup test entries
+    try {
+      await payload.delete({
+        collection: 'config_entries',
+        where: {
+          and: [{ key: { like: 'pdf_conversion_test_' } }, { tenant: { equals: testTenantId } }],
+        },
+      })
+    } catch {
+      // Ignore cleanup errors
+    }
+  })
+
+  test('should load system params with SystemParam kind', async () => {
+    // Create a test system param
+    await payload.create({
+      collection: 'config_entries',
+      draft: false,
+      data: {
+        key: 'pdf_conversion_test_max_pages',
+        kind: ConfigKind.SystemParam,
+        value: '10',
+        enabled: true,
+        tenant: testTenantId,
+      },
+      overrideAccess: true,
+    })
+
+    await loadRuntimeConfig(payload, testTenantId)
+
+    // Verify it loads via getVariable (since SystemParam is treated like Variable)
+    const { getVariable } = await import('@/infra/config/runtime')
+    expect(getVariable(testTenantId, 'pdf_conversion_test_max_pages')).toBe('10')
+  })
+
+  test('should return defaults when system params not seeded', async () => {
+    clearConfigCache()
+    await loadRuntimeConfig(payload, testTenantId)
+
+    // These should return defaults since params aren't seeded yet for this tenant
+    expect(SystemParams.getPdfConversionMaxSegmentPages(testTenantId)).toBe(2)
+    expect(SystemParams.getPdfConversionMaxExercisesPerSegment(testTenantId)).toBe(1000)
+    expect(SystemParams.getPdfConversionMaxPromptSizeBytes(testTenantId)).toBe(51200)
+  })
+
+  test('should handle SystemParam like Variable (no encryption)', async () => {
+    // Create system param
+    await payload.create({
+      collection: 'config_entries',
+      draft: false,
+      data: {
+        key: 'pdf_conversion_test_exercises',
+        kind: ConfigKind.SystemParam,
+        value: '2000',
+        enabled: true,
+        tenant: testTenantId,
+      },
+      overrideAccess: true,
+    })
+
+    await loadRuntimeConfig(payload, testTenantId)
+
+    // Should be accessible via getVariable (plaintext)
+    const { getVariable } = await import('@/infra/config/runtime')
+    expect(getVariable(testTenantId, 'pdf_conversion_test_exercises')).toBe('2000')
+  })
+})

--- a/tests/unit/lib/config/system-params.test.ts
+++ b/tests/unit/lib/config/system-params.test.ts
@@ -1,0 +1,121 @@
+/**
+ * SystemParams Unit Tests
+ *
+ * @fileType unit-test
+ * @domain config.system-params
+ * @pattern type-safe-accessor
+ */
+
+import { clearConfigCache, loadRuntimeConfig } from '@/infra/config/runtime'
+import { SystemParams } from '@/infra/config/system-params'
+import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+
+// Setup: Ensure tests run in a server-like environment (no window)
+const originalWindow = globalThis.window
+const originalEnv = process.env
+
+beforeAll(() => {
+  // @ts-expect-error: Deleting window for server-like environment in tests
+  delete globalThis.window
+  // Set required CONFIG_MASTER_KEY for encryption tests
+  process.env = { ...originalEnv, CONFIG_MASTER_KEY: '0123456789abcdef0123456789abcdef' }
+})
+
+afterAll(() => {
+  globalThis.window = originalWindow
+  process.env = originalEnv
+})
+
+// Mock Payload with minimal required properties - using any for test compatibility
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPayload: any = {
+  find: vi.fn(),
+  logger: { info: vi.fn(), warn: vi.fn() },
+}
+
+const TEST_TENANT_ID = 'test-tenant-123'
+
+describe('SystemParams', () => {
+  beforeEach(() => {
+    // CRITICAL: Clear cache before each test to ensure idempotent function is re-evaluated
+    clearConfigCache()
+    vi.clearAllMocks()
+    // Default mock implementation returns empty
+    mockPayload.find.mockResolvedValue({ docs: [] })
+  })
+
+  describe('getPdfConversionMaxSegmentPages', () => {
+    test('should return default value (2) when not configured', async () => {
+      await loadRuntimeConfig(mockPayload, TEST_TENANT_ID)
+
+      expect(SystemParams.getPdfConversionMaxSegmentPages(TEST_TENANT_ID)).toBe(2)
+    })
+
+    test('should return configured value from DB', async () => {
+      mockPayload.find.mockResolvedValue({
+        docs: [
+          {
+            key: 'pdf_conversion_max_segment_pages',
+            kind: 'system_param',
+            value: '5',
+            enabled: true,
+            tenant: { id: TEST_TENANT_ID },
+          },
+        ],
+      })
+      await loadRuntimeConfig(mockPayload, TEST_TENANT_ID)
+
+      expect(SystemParams.getPdfConversionMaxSegmentPages(TEST_TENANT_ID)).toBe(5)
+    })
+  })
+
+  describe('getPdfConversionMaxExercisesPerSegment', () => {
+    test('should return default value (1000) when not configured', async () => {
+      await loadRuntimeConfig(mockPayload, TEST_TENANT_ID)
+
+      expect(SystemParams.getPdfConversionMaxExercisesPerSegment(TEST_TENANT_ID)).toBe(1000)
+    })
+
+    test('should return configured value from DB', async () => {
+      mockPayload.find.mockResolvedValue({
+        docs: [
+          {
+            key: 'pdf_conversion_max_exercises_per_segment',
+            kind: 'system_param',
+            value: '500',
+            enabled: true,
+            tenant: { id: TEST_TENANT_ID },
+          },
+        ],
+      })
+      await loadRuntimeConfig(mockPayload, TEST_TENANT_ID)
+
+      expect(SystemParams.getPdfConversionMaxExercisesPerSegment(TEST_TENANT_ID)).toBe(500)
+    })
+  })
+
+  describe('getPdfConversionMaxPromptSizeBytes', () => {
+    test('should return default value (51200) when not configured', async () => {
+      await loadRuntimeConfig(mockPayload, TEST_TENANT_ID)
+
+      expect(SystemParams.getPdfConversionMaxPromptSizeBytes(TEST_TENANT_ID)).toBe(51200)
+    })
+
+    test('should return configured value from DB', async () => {
+      mockPayload.find.mockResolvedValue({
+        docs: [
+          {
+            key: 'pdf_conversion_max_prompt_size_bytes',
+            kind: 'system_param',
+            value: '102400',
+            enabled: true,
+            tenant: { id: TEST_TENANT_ID },
+          },
+        ],
+      })
+      await loadRuntimeConfig(mockPayload, TEST_TENANT_ID)
+
+      expect(SystemParams.getPdfConversionMaxPromptSizeBytes(TEST_TENANT_ID)).toBe(102400)
+    })
+  })
+})


### PR DESCRIPTION
…nstants

- Add SystemParam to ConfigKind enum (variable, secret, system_param)
- Update ConfigEntries collection to support System Param option
- Runtime config treats SystemParam like Variable (plaintext, no encryption)
- Create type-safe SystemParams wrapper for PDF conversion limits
- Add seed function for default system params (max pages, max exercises, max prompt size)
- Add unit and integration tests