### PR TITLE
docs: Add missing readme files with agent guardrails

### DIFF
--- a/src/components/README.md
+++ b/src/components/README.md
@@ -1,0 +1,155 @@
+# Payload Admin Components
+
+**@domain** ui-admin
+**@fileType** component
+**@ai-summary** Custom Payload admin panel components: AdminBar, Logo, BeforeDashboard, BeforeLogin, etc.
+
+---
+
+## Component Registry
+
+### Admin Bar
+
+| Component    | Path                   | Purpose                 |
+| ------------ | ---------------------- | ----------------------- |
+| **AdminBar** | `components/AdminBar/` | Frontend admin controls |
+
+### Branding
+
+| Component | Path               | Purpose              |
+| --------- | ------------------ | -------------------- |
+| **Logo**  | `components/Logo/` | Custom branding logo |
+
+### Admin Panel
+
+| Component             | Path                            | Purpose                  |
+| --------------------- | ------------------------------- | ------------------------ |
+| **BeforeDashboard**   | `components/BeforeDashboard/`   | Dashboard header         |
+| **BeforeLogin**       | `components/BeforeLogin/`       | Login page customization |
+| **CollectionArchive** | `components/CollectionArchive/` | Archive list views       |
+
+### Media
+
+| Component | Path                | Purpose         |
+| --------- | ------------------- | --------------- |
+| **Media** | `components/Media/` | Media rendering |
+
+### Navigation
+
+| Component | Path               | Purpose               |
+| --------- | ------------------ | --------------------- |
+| **Link**  | `components/Link/` | Custom link component |
+
+### Pagination
+
+| Component      | Path                     | Purpose             |
+| -------------- | ------------------------ | ------------------- |
+| **PageRange**  | `components/PageRange/`  | Pagination range    |
+| **Pagination** | `components/Pagination/` | Pagination controls |
+
+### Rich Text
+
+| Component    | Path                   | Purpose             |
+| ------------ | ---------------------- | ------------------- |
+| **RichText** | `components/RichText/` | Rich text rendering |
+
+### Utilities
+
+| Component               | Path                              | Purpose               |
+| ----------------------- | --------------------------------- | --------------------- |
+| **PayloadRedirects**    | `components/PayloadRedirects/`    | Client-side redirects |
+| **LivePreviewListener** | `components/LivePreviewListener/` | Live preview          |
+
+### UI Kit (Shadcn/UI)
+
+| Component  | Path                        |
+| ---------- | --------------------------- |
+| Button     | `components/ui/button/`     |
+| Card       | `components/ui/card/`       |
+| Checkbox   | `components/ui/checkbox/`   |
+| Input      | `components/ui/input/`      |
+| Label      | `components/ui/label/`      |
+| Pagination | `components/ui/pagination/` |
+| Select     | `components/ui/select/`     |
+| Textarea   | `components/ui/textarea/`   |
+
+---
+
+## Structure
+
+```
+components/
+├── AdminBar/                 # Frontend admin controls
+├── BeforeDashboard/          # Dashboard header
+├── BeforeLogin/              # Login customization
+├── CollectionArchive/        # Archive list views
+├── Logo/                     # Branding
+├── Media/                    # Media components
+├── PageRange/                # Pagination range
+├── Pagination/               # Pagination controls
+├── PayloadRedirects/         # Client redirects
+├── LivePreviewListener/      # Live preview
+├── RichText/                 # Rich text
+├── Link/                     # Custom link
+└── ui/                       # Shadcn/UI components
+    ├── button/
+    ├── card/
+    ├── checkbox/
+    ├── input/
+    ├── label/
+    ├── pagination/
+    ├── select/
+    └── textarea/
+```
+
+---
+
+## Usage in Payload Config
+
+```typescript
+// payload.config.ts
+import { buildConfig } from 'payload'
+
+export default buildConfig({
+  admin: {
+    components: {
+      graphics: {
+        Logo: '/components/Logo',
+      },
+      beforeDashboard: ['/components/BeforeDashboard'],
+      beforeLogin: ['/components/BeforeLogin'],
+    },
+  },
+})
+```
+
+---
+
+## Agent Guardrails
+
+### Must
+
+- Register admin components in `payload.config.ts` admin.components
+- Use `importMap` paths (e.g., `/components/Logo` not relative paths)
+- Export default for components used in Payload config
+- Follow `index.tsx` + `index.scss` naming convention
+
+### Must Not
+
+- Import admin components directly (use importMap paths)
+- Create admin components outside `components/` directory
+- Skip import map regeneration after adding components
+- Mix client/server components incorrectly
+
+### Should
+
+- Use shadcn/ui components from `components/ui/` for new UI
+- Follow existing component structure when creating new ones
+- Add JSDoc comments for component props
+
+---
+
+## Related Documentation
+
+- [`docs/admin-components/README.md`](../../docs/admin-components/README.md) - Admin component patterns
+- [AGENTS.md](https://github.com/a-guy/A-Guy/blob/main/AGENTS.md) - Complete Payload patterns

--- a/src/infra/llm/README.md
+++ b/src/infra/llm/README.md
@@ -1,0 +1,279 @@
+# LLM Infrastructure
+
+**@domain** ai
+**@fileType** infrastructure
+**@ai-summary** LLM providers, embeddings, vector search, and AI services
+
+---
+
+## Architecture Overview
+
+```
+src/infra/llm/
+├── index.ts                      # Public API exports
+├── models.ts                     # AI model configurations
+├── providers/                    # LLM provider implementations
+│   ├── factory.ts               # Provider abstraction + runtime switching
+│   ├── gemini/                  # Google Gemini provider
+│   └── openai/                  # OpenAI-compatible provider
+├── services/                    # High-level AI services
+│   ├── data-extractor-service.ts
+│   ├── exercise-chat-service.ts
+│   └── image-optimizer-service.ts
+├── embeddings.ts                # Text embeddings for vector search
+├── vector-search.ts             # Vector database operations
+├── doc-search.ts                # Documentation search
+├── smart-doc-loader.ts          # Context-aware doc loading
+├── observability.ts             # AI telemetry + metrics
+├── prompt-composer.server.ts    # Prompt template composition
+├── prompt-resolver.server.ts    # Prompt resolution logic
+├── system-prompts.server.ts     # System prompt management
+├── lesson-context.ts            # Lesson context injection
+├── memory-extraction.ts         # Memory extraction from chat
+├── summary.ts                   # Conversation summarization
+└── multimodal/                  # Multimodal (image) processing
+```
+
+---
+
+## Providers
+
+### Provider Factory
+
+**File:** [`providers/factory.ts`](providers/factory.ts)
+
+Unified interface for switching between LLM providers at runtime.
+
+```typescript
+import { getLLMProvider, detectBestProvider, LLMProviderType } from './providers/factory'
+
+// Get provider based on LLM_PROVIDER env var
+const provider = await getLLMProvider(payload)
+
+// Auto-detect best available provider
+const bestProvider = await detectBestProvider(payload)
+```
+
+**Environment Variables:**
+
+- `LLM_PROVIDER` - Provider selection: `gemini` (default) or `openai-compatible`
+- `GEMINI_API_KEY` - Google Gemini API key
+- `OPENAI_COMPATIBLE_API_KEY` - OpenAI-compatible API key
+- `OPENAI_COMPATIBLE_BASE_URL` - Custom endpoint for OpenAI-compatible providers
+
+### Gemini Provider
+
+**Files:** [`providers/gemini/`](providers/gemini/)
+
+```typescript
+import { generateChatCompletion, isGeminiApiKeyConfigured } from './providers/gemini'
+
+const configured = await isGeminiApiKeyConfigured(payload)
+```
+
+### OpenAI-Compatible Provider
+
+**Files:** [`providers/openai/`](providers/openai/)
+
+```typescript
+import { generateChatCompletion, isOpenAIApiKeyConfigured } from './providers/openai'
+
+const configured = await isOpenAIApiKeyConfigured(payload)
+```
+
+---
+
+## Model Configurations
+
+**File:** [`models.ts`](models.ts)
+
+Centralized model selection and parameters.
+
+```typescript
+import { AI_MODELS } from '@/infra/llm/models'
+
+const config = AI_MODELS.IMAGE_TO_EXERCISE
+// { name: 'gemini-2.0-flash-001', temperature: 0.2, maxOutputTokens: 8192 }
+```
+
+| Model Key           | Model                | Temperature | Max Tokens | Use Case                   |
+| ------------------- | -------------------- | ----------- | ---------- | -------------------------- |
+| `IMAGE_TO_EXERCISE` | gemini-2.0-flash-001 | 0.2         | 8192       | Structured JSON extraction |
+| `EXERCISE_CHAT`     | gemini-2.0-flash-001 | 0.7         | 2048       | Conversational chat        |
+| `PDF_TO_EXERCISE`   | gemini-2.0-flash-001 | 0.1         | 8192       | PDF parsing                |
+
+---
+
+## Services
+
+### Data Extractor Service
+
+Extract structured exercise data from images.
+
+```typescript
+import { extractFromImage } from '@/infra/llm/services/data-extractor-service'
+
+const result = await extractFromImage({
+  imageBuffer: file.buffer,
+  mimeType: 'image/png',
+})
+```
+
+### Exercise Chat Service
+
+Conversational assistance for students.
+
+```typescript
+import { chatWithExerciseHelper } from '@/infra/llm/services/exercise-chat-service'
+
+const result = await chatWithExerciseHelper({
+  message: "I don't understand this problem",
+  acknowledgment: "I'll help guide you step by step.",
+})
+```
+
+### Image Optimizer Service
+
+Optimize images for AI processing.
+
+```typescript
+import { optimizeImageForAI } from '@/infra/llm/services/image-optimizer-service'
+
+const optimized = await optimizeImageForAI(buffer, 2048)
+```
+
+---
+
+## Vector Search
+
+### Embeddings
+
+**File:** [`embeddings.ts`](embeddings.ts)
+
+Generate text embeddings for similarity search.
+
+### Vector Search
+
+**File:** [`vector-search.ts`](vector-search.ts)
+
+```typescript
+import { vectorSearch, upsertMemoryVector, deleteMemoryVector } from '@/infra/llm/vector-search'
+
+// Search for similar memories
+const results = await vectorSearch(query, { limit: 5 })
+
+// Upsert memory embedding
+await upsertMemoryVector(memoryId, text, metadata)
+
+// Delete memory embedding
+await deleteMemoryVector(memoryId)
+```
+
+### Doc Search
+
+**File:** [`doc-search.ts`](doc-search.ts)
+
+Documentation keyword search with scoring.
+
+```typescript
+import { getDocSearch } from '@/infra/llm/doc-search'
+
+const search = getDocSearch()
+const results = search.query('access control patterns')
+```
+
+### Smart Doc Loader
+
+**File:** [`smart-doc-loader.ts`](smart-doc-loader.ts)
+
+Context-aware documentation loading for AI agents.
+
+```typescript
+import { SmartDocLoader } from '@/infra/llm/smart-doc-loader'
+
+const docs = SmartDocLoader.forCollection('create') // ~380 tokens
+```
+
+---
+
+## Observability
+
+**File:** [`observability.ts`](observability.ts)
+
+AI telemetry, metrics, and tracing.
+
+```typescript
+import { observability } from '@/infra/llm/observability'
+
+// Record a trace
+await observability.recordTrace({
+  name: 'chat-completion',
+  input: messages,
+  output: response,
+  metadata: { model, duration: 1234 },
+})
+```
+
+---
+
+## Prompts
+
+**Directory:** [`prompts/`](prompts/)
+
+System prompts for different AI tasks.
+
+| File                                         | Purpose              |
+| -------------------------------------------- | -------------------- |
+| `prompts/exercise-chat-agent-prompt.md`      | Exercise chat agent  |
+| `prompts/memory-extraction-system-prompt.md` | Memory extraction    |
+| `prompts/summary-system-prompt.md`           | Conversation summary |
+
+---
+
+## Agent Guardrails
+
+### Must
+
+- Use `getLLMProvider()` for all LLM operations (singleton pattern)
+- Use `AI_MODELS` for model configurations (no magic strings)
+- Pass `payload` to provider methods for proper access control
+- Handle errors gracefully with `try/catch` and return structured responses
+
+### Must Not
+
+- Create multiple LLM client instances (use singleton)
+- Hardcode model names or temperatures
+- Expose API keys in client code
+- Call providers without `payload` context
+
+### Should
+
+- Use structured responses `{ success, data, error, metadata }`
+- Log errors with context using logger utilities
+- Validate API responses before using them
+- Use `optimizeImageForAI()` before sending images
+
+---
+
+## Related Documentation
+
+- [`AGENTS.md`](../../../AGENTS.md) - Complete Payload patterns
+- [`docs/ai-services/README.md`](../../../docs/ai-services/README.md) - AI services guide
+- [`docs/ai/README.md`](../../../docs/ai/README.md) - AI documentation overview
+
+---
+
+## Quick Reference
+
+```typescript
+// Import everything from the public API
+import {
+  generateChatCompletion,
+  getLLMProvider,
+  AI_MODELS,
+  extractFromImage,
+  chatWithExerciseHelper,
+  vectorSearch,
+  getDocSearch,
+} from '@/infra/llm'
+```

--- a/src/server/payload/blocks/README.md
+++ b/src/server/payload/blocks/README.md
@@ -1,0 +1,157 @@
+# Payload CMS Blocks
+
+**@domain** content
+**@fileType** block-config
+**@ai-summary** Lexical editor blocks for rich content: Archive, Banner, Code, Form, Media, etc.
+
+---
+
+## Block Registry
+
+| Block            | Path                   | Purpose                   | Frontend Component                                         |
+| ---------------- | ---------------------- | ------------------------- | ---------------------------------------------------------- |
+| **Archive**      | `blocks/ArchiveBlock/` | Post/archive list display | [`ArchiveBlock/Component.tsx`](ArchiveBlock/Component.tsx) |
+| **Banner**       | `blocks/Banner/`       | Hero banner section       | [`Banner/Component.tsx`](Banner/Component.tsx)             |
+| **CallToAction** | `blocks/CallToAction/` | CTA section with button   | [`CallToAction/Component.tsx`](CallToAction/Component.tsx) |
+| **Code**         | `blocks/Code/`         | Syntax-highlighted code   | [`Code/Component.tsx`](Code/Component.tsx)                 |
+| **Content**      | `blocks/Content/`      | Rich text content         | [`Content/Component.tsx`](Content/Component.tsx)           |
+| **Form**         | `blocks/Form/`         | Contact form builder      | [`Form/Component.tsx`](Form/Component.tsx)                 |
+| **HtmlBlock**    | `blocks/HtmlBlock/`    | Raw HTML injection        | [`HtmlBlock/Component.tsx`](HtmlBlock/Component.tsx)       |
+| **MediaBlock**   | `blocks/MediaBlock/`   | Media embed               | [`MediaBlock/Component.tsx`](MediaBlock/Component.tsx)     |
+| **RelatedPosts** | `blocks/RelatedPosts/` | Related content list      | [`RelatedPosts/Component.tsx`](RelatedPosts/Component.tsx) |
+
+---
+
+## Structure
+
+```
+blocks/
+├── RenderBlocks.tsx              # Block renderer (maps types to components)
+├── ArchiveBlock/
+│   ├── Component.tsx             # Archive list UI
+│   └── config.ts                 # Block schema
+├── Banner/
+│   ├── Component.tsx
+│   └── config.ts
+├── CallToAction/
+│   ├── Component.tsx
+│   └── config.ts
+├── Code/
+│   ├── Component.client.tsx      # Client component
+│   ├── Component.tsx             # Server wrapper
+│   ├── config.ts
+│   └── CopyButton.tsx
+├── Content/
+│   ├── Component.tsx
+│   └── config.ts
+├── Form/
+│   ├── Component.tsx
+│   ├── config.ts
+│   ├── fields.tsx                # Form field components
+│   ├── Checkbox/
+│   ├── Country/
+│   ├── Email/
+│   ├── Error/
+│   ├── Message/
+│   ├── Number/
+│   ├── Select/
+│   ├── State/
+│   ├── Text/
+│   ├── Textarea/
+│   └── Width/
+├── HtmlBlock/
+│   ├── Component.tsx
+│   └── config.ts
+├── MediaBlock/
+│   ├── Component.tsx
+│   └── config.ts
+└── RelatedPosts/
+    ├── Component.tsx
+    └── config.ts
+```
+
+---
+
+## Block Configuration Pattern
+
+```typescript
+// blocks/Banner/config.ts
+import type { Block } from 'payload'
+
+export const BannerBlock: Block = {
+  slug: 'banner',
+  fields: [
+    { name: 'title', type: 'text', required: true },
+    { name: 'subtitle', type: 'textarea' },
+    { name: 'backgroundImage', type: 'upload', relationTo: 'media' },
+    { name: 'alignment', type: 'select', options: ['left', 'center', 'right'] },
+  ],
+}
+```
+
+## Usage in Collections
+
+```typescript
+// collections/Pages/index.ts
+import { BannerBlock } from '@/server/payload/blocks/Banner/config'
+import { ContentBlock } from '@/server/payload/blocks/Content/config'
+
+export const Pages: CollectionConfig = {
+  slug: 'pages',
+  fields: [
+    {
+      name: 'content',
+      type: 'blocks',
+      blocks: [BannerBlock, ContentBlock],
+    },
+  ],
+}
+```
+
+---
+
+## Rendering Blocks
+
+**File:** [`RenderBlocks.tsx`](RenderBlocks.tsx)
+
+```typescript
+import { RenderBlocks } from '@/server/payload/blocks/RenderBlocks'
+
+// In a page component
+const blocks = await getPageBlocks(slug)
+
+return <RenderBlocks blocks={blocks} />
+```
+
+---
+
+## Agent Guardrails
+
+### Must
+
+- Use `RenderBlocks` component for rendering block arrays (not manual mapping)
+- Import blocks from `@/server/payload/blocks/` paths
+- Define blocks with `type Block = { slug: string, fields: Field[] }` pattern
+- Include server components for blocks that need SSR
+
+### Must Not
+
+- Hardcode block configs inline in collections
+- Skip block imports in collections (causes hydration mismatches)
+- Mix client and server block components incorrectly
+- Use `blocks` field type without registering blocks in Payload config
+
+### Should
+
+- Follow `Block/config.ts` naming convention
+- Use consistent field naming (camelCase for internal, localized for user-facing)
+- Export both component and config from block directories
+- Add TypeScript types for block-specific data
+
+---
+
+## Related Documentation
+
+- [`docs/block-rendering/README.md`](../../../../docs/block-rendering/README.md) - Block rendering patterns
+- [`AGENTS.md`](../../../../AGENTS.md) - Complete Payload patterns
+- [`src/server/payload/collections/README.md`](../collections/README.md) - Collection configurations

--- a/src/server/payload/endpoints/README.md
+++ b/src/server/payload/endpoints/README.md
@@ -1,0 +1,155 @@
+# Payload CMS Custom Endpoints
+
+**@domain** api
+**@fileType** endpoint
+**@ai-summary** Custom API endpoints: agent chat, cron jobs, exercise import, database seeding
+
+---
+
+## Endpoint Registry
+
+| Endpoint               | Path                                        | Method   | Purpose                 | Auth          |
+| ---------------------- | ------------------------------------------- | -------- | ----------------------- | ------------- |
+| **Agent Chat**         | `endpoints/agent/chat/`                     | POST     | AI chat completion      | Authenticated |
+| **Get Conversation**   | `endpoints/agent/get-conversation.ts`       | GET      | Retrieve chat history   | Authenticated |
+| **Reset Chat**         | `endpoints/agent/reset-chat.ts`             | POST     | Clear conversation      | Authenticated |
+| **Media Expiry**       | `endpoints/cron/media-expiry.ts`            | GET/POST | Cleanup expired media   | Cron/API      |
+| **Import from Image**  | `endpoints/exercises/import-from-image.ts`  | POST     | Image to exercise       | Authenticated |
+| **Import from Lesson** | `endpoints/exercises/import-from-lesson.ts` | POST     | Copy lesson as exercise | Authenticated |
+| **Seed Contact Form**  | `endpoints/seed/contact-form.ts`            | POST     | Create contact form     | Admin         |
+| **Seed Contact Page**  | `endpoints/seed/contact-page.ts`            | POST     | Create contact page     | Admin         |
+| **Seed System Params** | `endpoints/seed/system-params.ts`           | POST     | Initialize config       | Admin         |
+| **Run Seeding**        | `endpoints/seed/index.ts`                   | POST     | Run all seeds           | Admin         |
+
+---
+
+## Structure
+
+```
+endpoints/
+├── agent/
+│   ├── chat.ts                   # Main chat endpoint (deprecated, use chat/)
+│   ├── get-conversation.ts       # GET /api/agent/conversation
+│   ├── reset-chat.ts             # POST /api/agent/reset-chat
+│   └── chat/                     # Modular chat implementation
+│       ├── index.ts              # Main handler
+│       ├── request-validation.ts # Input validation
+│       ├── context-resolution.ts # Context building
+│       ├── prompt-composition.ts # Prompt assembly
+│       ├── memory-retrieval.ts   # Memory/search retrieval
+│       └── background-tasks.ts   # Async tasks
+├── cron/
+│   ├── cron-middleware.ts        # Cron authentication
+│   └── media-expiry.ts           # Media cleanup job
+├── exercises/
+│   ├── import-from-image.ts      # Image OCR → exercise
+│   └── import-from-lesson.ts     # Lesson → exercise copy
+└── seed/
+    ├── index.ts                  # Seed orchestrator
+    ├── contact-form.ts           # Contact form seed
+    ├── contact-page.ts           # Contact page seed
+    └── system-params.ts          # Config entries seed
+```
+
+---
+
+## Endpoint Pattern
+
+```typescript
+// endpoints/agent/get-conversation.ts
+import type { Endpoint } from 'payload'
+
+export const getConversationEndpoint: Endpoint = {
+  path: '/conversation',
+  method: 'get',
+  handler: async (req) => {
+    if (!req.user) {
+      throw new APIError('Unauthorized', 401)
+    }
+
+    const { conversationId } = req.routeParams
+
+    const conversation = await req.payload.findByID({
+      collection: 'conversations',
+      id: conversationId,
+      user: req.user,
+      overrideAccess: false,
+    })
+
+    return Response.json(conversation)
+  },
+}
+```
+
+---
+
+## Agent Chat Architecture
+
+```
+endpoints/agent/chat/
+┌─────────────────────────────────────────────────────────┐
+│  index.ts - Main Entry Point                            │
+│  ├── Validates request (request-validation.ts)          │
+│  ├── Builds context (context-resolution.ts)             │
+│  ├── Composes prompt (prompt-composition.ts)            │
+│  └── Returns response                                   │
+└────────────────┬────────────────────────────────────────┘
+                 │
+    ┌────────────▼────────────┐
+    │  Background Tasks       │
+    │  (background-tasks.ts)  │
+    │  ├── Memory storage     │
+    │  └── Metrics recording  │
+    └─────────────────────────┘
+```
+
+---
+
+## Cron Endpoints
+
+**File:** [`cron/cron-middleware.ts`](cron/cron-middleware.ts)
+
+Cron endpoints require a secret token for authentication.
+
+```typescript
+// Verify cron secret
+const CRON_SECRET = process.env.CRON_SECRET
+const authHeader = req.headers.get('x-cron-secret')
+
+if (authHeader !== CRON_SECRET) {
+  throw new APIError('Unauthorized', 401)
+}
+```
+
+---
+
+## Agent Guardrails
+
+### Must
+
+- Check authentication with `req.user` before any operations
+- Throw `APIError` for unauthorized access (401)
+- Use `overrideAccess: false` when passing `user` to Local API
+- Return `Response.json()` for all responses
+
+### Must Not
+
+- Skip authentication checks in endpoints
+- Return raw objects without `Response.json()`
+- Use `req.payload.find()` without access control
+- Expose sensitive data in error responses
+
+### Should
+
+- Validate request body with Zod schemas before processing
+- Use `req.routeParams` for path parameters
+- Log errors with context using logger
+- Return structured error responses `{ error: string }`
+
+---
+
+## Related Documentation
+
+- [`AGENTS.md`](../../../../AGENTS.md) - Complete Payload patterns
+- [`src/server/payload/services/`](../services/) - Business logic services
+- [`src/app/api/`](../../../../src/app/api/) - Next.js API routes

--- a/src/server/repos/README.md
+++ b/src/server/repos/README.md
@@ -1,0 +1,153 @@
+# Repository Layer
+
+**@domain** data-access
+**@fileType** repository
+**@ai-summary** Database query utilities: MCP client, queries, tenant resolution
+
+---
+
+## Repository Registry
+
+### Query Repositories
+
+| Repository       | Path                            | Purpose                    |
+| ---------------- | ------------------------------- | -------------------------- |
+| **Courses**      | `repos/queries/courses.ts`      | Course queries + hierarchy |
+| **Chapters**     | `repos/queries/chapters.ts`     | Chapter queries            |
+| **Lessons**      | `repos/queries/lessons.ts`      | Lesson queries             |
+| **Exercises**    | `repos/queries/exercises.ts`    | Exercise queries           |
+| **UserProgress** | `repos/queries/userProgress.ts` | Progress tracking          |
+| **Pages**        | `repos/queries/pages.ts`        | Page queries               |
+| **Posts**        | `repos/queries/posts.ts`        | Post queries               |
+
+### MCP Integration
+
+| Component              | Path                                         | Purpose                 |
+| ---------------------- | -------------------------------------------- | ----------------------- |
+| **MCP Client**         | `repos/mcp/client/mcp-client.ts`             | MCP protocol client     |
+| **Chat Integration**   | `repos/mcp/chat-integration.ts`              | MCP in chat context     |
+| **Tool Allowlist**     | `repos/mcp/tool-allowlist.ts`                | MCP tool permissions    |
+| **Audit Service**      | `repos/mcp/audit/audit-service.ts`           | MCP audit logging       |
+| **Argument Validator** | `repos/mcp/validation/argument-validator.ts` | MCP argument validation |
+| **Transforms**         | `repos/mcp/transforms/index.ts`              | Data transformations    |
+
+### Tenant
+
+| Component          | Path                                 | Purpose           |
+| ------------------ | ------------------------------------ | ----------------- |
+| **Default Tenant** | `repos/tenant/get-default-tenant.ts` | Tenant resolution |
+
+---
+
+## Structure
+
+```
+repos/
+├── queries/
+│   ├── courses.ts              # getCourseBySlug, getChaptersByCourse
+│   ├── chapters.ts             # getChapterBySlug, getLessonsByChapter
+│   ├── lessons.ts              # getLessonBySlug, getExercisesByLesson
+│   ├── exercises.ts            # getExerciseById, searchExercises
+│   ├── userProgress.ts         # getProgress, updateProgress
+│   ├── pages.ts                # getPageBySlug
+│   └── posts.ts                # getPosts, getPostBySlug
+├── mcp/
+│   ├── chat-integration.ts     # MCP in chat context
+│   ├── tool-allowlist.ts       # Allowed tools config
+│   ├── audit/
+│   │   └── audit-service.ts    # Audit logging
+│   ├── client/
+│   │   ├── mcp-client.ts       # MCP protocol implementation
+│   │   └── types.ts            # MCP type definitions
+│   ├── transforms/
+│   │   └── index.ts            # Data transforms
+│   └── validation/
+│       └── argument-validator.ts
+└── tenant/
+    └── get-default-tenant.ts   # Current tenant resolution
+```
+
+---
+
+## Query Pattern
+
+```typescript
+// repos/queries/courses.ts
+import { getPayload } from 'payload'
+import config from '@payload-config'
+
+export async function getCourseBySlug(slug: string) {
+  const payload = await getPayload({ config })
+
+  const result = await payload.find({
+    collection: 'courses',
+    where: { slug: { equals: slug } },
+    depth: 2,
+  })
+
+  return result.docs[0] || null
+}
+
+export async function getChaptersByCourse(courseId: string) {
+  const payload = await getPayload({ config })
+
+  return payload.find({
+    collection: 'chapters',
+    where: { course: { equals: courseId } },
+    sort: 'order',
+  })
+}
+```
+
+---
+
+## MCP Client Pattern
+
+```typescript
+// repos/mcp/client/mcp-client.ts
+import { createMCPAgent } from '@anthropic-ai/mcp'
+
+export async function createMCPChat(messages: ChatMessage[]) {
+  const client = await createMCPAgent({
+    serverParams: {
+      command: process.env.MCP_SERVER_COMMAND,
+    },
+  })
+
+  const response = await client.sendMessage(messages)
+  return response
+}
+```
+
+---
+
+## Agent Guardrails
+
+### Must
+
+- Use query repositories for all collection access (not direct Local API)
+- Pass `user` with `overrideAccess: false` for user-scoped queries
+- Handle `null` returns from query functions (document may not exist)
+- Use `depth` parameter appropriately (0 for IDs, 2+ for relationships)
+
+### Must Not
+
+- Use raw `payload.find()`/`findByID()` in business logic (use repos)
+- Skip access control in repositories
+- Hardcode collection slugs (use constants or config)
+- Return sensitive fields without field-level access checks
+
+### Should
+
+- Follow `getXByY` naming convention for query functions
+- Use `depth: 0` when only IDs are needed (performance)
+- Add JSDoc comments for query function signatures
+- Cache expensive queries in `req.context` for request lifetime
+
+---
+
+## Related Documentation
+
+- [`AGENTS.md`](../../../AGENTS.md) - Complete Payload patterns
+- [`src/server/payload/collections/`](../payload/collections/) - Collection configurations
+- [`src/server/payload/endpoints/`](../payload/endpoints/) - Custom endpoints

--- a/src/ui/shared/README.md
+++ b/src/ui/shared/README.md
@@ -1,0 +1,86 @@
+# Shared UI Components
+
+**@domain** ui
+**@fileType** component
+**@ai-summary** Cross-platform UI components used in both admin and web contexts
+
+---
+
+## Component Registry
+
+### Chat Components
+
+| Component              | Path                                 | Purpose                 |
+| ---------------------- | ------------------------------------ | ----------------------- |
+| **ChatInterface**      | `ui/shared/chat/ChatInterface/`      | Main chat UI wrapper    |
+| **ChatMessageContent** | `ui/shared/chat/ChatMessageContent/` | Message bubble renderer |
+
+### Styles
+
+| Component       | Path                                   | Purpose           |
+| --------------- | -------------------------------------- | ----------------- |
+| **CSS Adapter** | `ui/shared/chat/styles/css-adapter.ts` | CSS token mapping |
+| **Chat Tokens** | `ui/shared/chat/styles/chat-tokens.ts` | Design tokens     |
+
+---
+
+## Structure
+
+```
+ui/shared/
+├── chat/
+│   ├── ChatInterface/
+│   │   └── index.tsx           # Chat wrapper + state
+│   ├── ChatMessageContent/
+│   │   └── index.tsx           # Message rendering
+│   └── styles/
+│       ├── css-adapter.ts      # CSS variable mapping
+│       └── chat-tokens.ts      # Design tokens
+```
+
+---
+
+## Usage
+
+```typescript
+// In a page component
+import { ChatInterface } from '@/ui/shared/chat/ChatInterface'
+
+export default function ExercisePage() {
+  return (
+    <ChatInterface
+      conversationId={conversationId}
+      onMessage={handleMessage}
+    />
+  )
+}
+```
+
+---
+
+## Agent Guardrails
+
+### Must
+
+- Use shared components for chat features (avoid duplication)
+- Follow design tokens from `chat-tokens.ts` for styling
+- Import from `@/` paths (e.g., `@/ui/shared/chat/...`)
+
+### Must Not
+
+- Duplicate chat components in admin/web (use shared)
+- Hardcode colors (use CSS variables from tokens)
+- Create new chat components without checking shared first
+
+### Should
+
+- Use `ChatInterface` wrapper for new chat features
+- Follow existing component patterns for new shared components
+
+---
+
+## Related Documentation
+
+- [`src/ui/admin/`](../../ui/admin/README.md) - Admin-specific components
+- [`src/ui/web/`](../../ui/web/README.md) - Web-specific components
+- [`AGENTS.md`](../../../AGENTS.md) - Complete Payload patterns

--- a/tests/unit/infra/llm/observability.test.ts
+++ b/tests/unit/infra/llm/observability.test.ts
@@ -142,11 +142,12 @@ describe('Observability', () => {
       })
 
       expect(logger.info).toHaveBeenCalled()
-      const infoCall = logger.info.mock.calls[0][0] as {
-        conversationId: string
-        operation: string
-        success: boolean
-      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const infoCall = (
+        logger.info as unknown as {
+          mock: { calls: Array<[{ conversationId: string; operation: string; success: boolean }]> }
+        }
+      ).mock.calls[0][0]
       expect(infoCall.conversationId).toBe('conv-123')
       expect(infoCall.operation).toBe('summary')
       expect(infoCall.success).toBe(true)
@@ -164,11 +165,12 @@ describe('Observability', () => {
       })
 
       expect(logger.error).toHaveBeenCalled()
-      const errorCall = logger.error.mock.calls[0][0] as {
-        conversationId: string
-        success: boolean
-        error: string
-      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const errorCall = (
+        logger.error as unknown as {
+          mock: { calls: Array<[{ conversationId: string; success: boolean; error: string }]> }
+        }
+      ).mock.calls[0][0]
       expect(errorCall.conversationId).toBe('conv-123')
       expect(errorCall.success).toBe(false)
       expect(errorCall.error).toBe('Rate limit exceeded')


### PR DESCRIPTION
- src/infra/llm/README.md: LLM providers, embeddings, vector search, services
- src/server/payload/blocks/README.md: 9 block types with config patterns
- src/server/payload/endpoints/README.md: Agent, cron, exercises, seed endpoints
- src/server/repos/README.md: Query repos, MCP client, tenant resolution
- src/ui/shared/README.md: Shared chat UI components
- src/components/README.md: Payload admin components, UI kit

Each README includes:
- AI-optimized metadata (@domain, @fileType, @ai-summary)
- Component registry tables
- Code patterns
- Agent guardrails (Must/Must Not/Should rules)
- Cross-references to related docs

Also fixed TypeScript error in observability.test.ts (mock type mismatch).