### PR TITLE
feat(shop): Add course pricing and user membership tiers

### DIFF
--- a/src/app/(frontend)/signup/actions/signup_createUser-action.ts
+++ b/src/app/(frontend)/signup/actions/signup_createUser-action.ts
@@ -74,6 +74,7 @@ export async function signupAction(formData: FormData): Promise<SignupResult> {
           email,
           password,
           role: AccountRole.Student, // Force role - never trust client input
+          tier: 'free', // Default tier for new signups
         },
       })
 

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -427,6 +427,14 @@ export interface User {
   id: string;
   name?: string | null;
   role: 'admin' | 'student';
+  /**
+   * User membership tier
+   */
+  tier: 'free' | 'standard' | 'premium';
+  /**
+   * Courses owned by this user
+   */
+  ownedCourses?: (string | Course)[] | null;
   googleSub?: string | null;
   verifiedEmail?: string | null;
   registrationMethod?: ('google' | 'email') | null;
@@ -475,6 +483,10 @@ export interface Course {
    * Detailed description of the course
    */
   description?: string | null;
+  /**
+   * Course price in ILS (₪). Leave empty for free courses.
+   */
+  price?: number | null;
   /**
    * Upload course-related media files (images, videos, documents, etc.)
    */
@@ -2248,6 +2260,7 @@ export interface CoursesSelect<T extends boolean = true> {
   courseLabel?: T;
   title?: T;
   description?: T;
+  price?: T;
   mediaFiles?: T;
   order?: T;
   status?: T;
@@ -2370,6 +2383,8 @@ export interface ExerciseAssetsSelect<T extends boolean = true> {
 export interface UsersSelect<T extends boolean = true> {
   name?: T;
   role?: T;
+  tier?: T;
+  ownedCourses?: T;
   googleSub?: T;
   verifiedEmail?: T;
   registrationMethod?: T;

--- a/src/server/payload/collections/Courses.ts
+++ b/src/server/payload/collections/Courses.ts
@@ -80,6 +80,15 @@ export const Courses: CollectionConfig = {
       },
     },
     {
+      name: 'price',
+      type: 'number',
+      required: false,
+      min: 0,
+      admin: {
+        description: 'Course price in ILS (₪). Leave empty for free courses.',
+      },
+    },
+    {
       name: 'mediaFiles',
       type: 'upload',
       relationTo: 'media',

--- a/src/server/payload/collections/Users/index.ts
+++ b/src/server/payload/collections/Users/index.ts
@@ -28,7 +28,7 @@ export const Users: CollectionConfig = {
     update: adminOrSelf, // Admins can update all, users can update their own
   },
   admin: {
-    defaultColumns: ['name', 'email', 'role'],
+    defaultColumns: ['name', 'email', 'role', 'tier'],
     useAsTitle: 'name',
   },
   auth: {
@@ -63,6 +63,31 @@ export const Users: CollectionConfig = {
       },
       admin: {
         position: 'sidebar',
+      },
+    },
+    {
+      name: 'tier',
+      type: 'select',
+      required: true,
+      defaultValue: 'free',
+      options: [
+        { label: 'Free', value: 'free' },
+        { label: 'Standard', value: 'standard' },
+        { label: 'Premium', value: 'premium' },
+      ],
+      admin: {
+        position: 'sidebar',
+        description: 'User membership tier',
+      },
+    },
+    {
+      name: 'ownedCourses',
+      type: 'relationship',
+      relationTo: 'courses',
+      hasMany: true,
+      admin: {
+        position: 'sidebar',
+        description: 'Courses owned by this user',
       },
     },
     // OAuth fields

--- a/src/server/payload/collections/Users/index.ts
+++ b/src/server/payload/collections/Users/index.ts
@@ -88,6 +88,7 @@ export const Users: CollectionConfig = {
       admin: {
         position: 'sidebar',
         description: 'Courses owned by this user',
+        allowCreate: false, // Don't allow creating new courses from here - select from existing only
       },
     },
     // OAuth fields

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -61,6 +61,7 @@ export async function createTestUser(user: TestUser): Promise<TestUser> {
       email: user.email,
       password: user.password, // Payload will hash this automatically
       role: 'student',
+      tier: 'free',
     },
   })
 

--- a/tests/factories/user.factory.ts
+++ b/tests/factories/user.factory.ts
@@ -16,6 +16,7 @@ export function buildUserData(input: UserFactoryInput = {}) {
     password: input.password ?? 'test123456',
     name: input.name ?? `Test User ${timestamp}`,
     role: input.role ?? AccountRole.Student,
+    tier: 'free' as const,
   }
 }
 

--- a/tests/int/agent-chat.int.spec.ts
+++ b/tests/int/agent-chat.int.spec.ts
@@ -67,6 +67,7 @@ beforeAll(
         email: `agent-chat-int-${Date.now()}@example.com`,
         password: 'test123456',
         role: 'student',
+        tier: 'free',
       },
     })
     testUserId = user.id

--- a/tests/int/chat-config-values.int.spec.ts
+++ b/tests/int/chat-config-values.int.spec.ts
@@ -21,7 +21,7 @@ const TEST_TENANT_SLUG = 'chat-config-test-tenant'
 
 describe('ChatConfig Values', () => {
   let payload: Awaited<ReturnType<typeof getPayload>>
-  let adminUser: User
+  let __adminUser: User
   let tenant: Tenant
 
   beforeAll(async () => {
@@ -34,14 +34,15 @@ describe('ChatConfig Values', () => {
         where: { email: { equals: TEST_ADMIN_EMAIL } },
       })
       if (users.docs.length > 0) {
-        adminUser = users.docs[0]
+        _adminUser = users.docs[0]
       } else {
-        adminUser = await payload.create({
+        _adminUser = await payload.create({
           collection: 'users',
           data: {
             email: TEST_ADMIN_EMAIL,
             password: TEST_ADMIN_PASSWORD,
             role: 'admin',
+            tier: 'free',
           },
         })
       }
@@ -50,7 +51,7 @@ describe('ChatConfig Values', () => {
         collection: 'users',
         where: { email: { equals: TEST_ADMIN_EMAIL } },
       })
-      adminUser = users.docs[0]
+      _adminUser = users.docs[0]
     }
 
     // Create or find test tenant

--- a/tests/int/chat-config-values.int.spec.ts
+++ b/tests/int/chat-config-values.int.spec.ts
@@ -21,7 +21,7 @@ const TEST_TENANT_SLUG = 'chat-config-test-tenant'
 
 describe('ChatConfig Values', () => {
   let payload: Awaited<ReturnType<typeof getPayload>>
-  let __adminUser: User
+  let _adminUser: User
   let tenant: Tenant
 
   beforeAll(async () => {

--- a/tests/int/config-manager.int.test.ts
+++ b/tests/int/config-manager.int.test.ts
@@ -46,6 +46,7 @@ describe('Config Secrets (Tenant-Scoped)', () => {
             email: TEST_ADMIN_EMAIL,
             password: TEST_ADMIN_PASSWORD,
             role: 'admin',
+            tier: 'free',
           },
         })
       }

--- a/tests/int/config-values.int.spec.ts
+++ b/tests/int/config-values.int.spec.ts
@@ -46,6 +46,7 @@ describe('ConfigValues (Domain-Scoped Config)', () => {
             email: TEST_ADMIN_EMAIL,
             password: TEST_ADMIN_PASSWORD,
             role: 'admin',
+            tier: 'free',
           },
         })
       }

--- a/tests/int/conversation-history-loading.int.spec.ts
+++ b/tests/int/conversation-history-loading.int.spec.ts
@@ -89,6 +89,7 @@ beforeAll(async () => {
       email: `conv-history-${Date.now()}@example.com`,
       password: 'test123456',
       role: 'student',
+      tier: 'free',
     },
   })
   testUserId = user1.id
@@ -100,6 +101,7 @@ beforeAll(async () => {
       email: `conv-history-2-${Date.now()}@example.com`,
       password: 'test123456',
       role: 'student',
+      tier: 'free',
     },
   })
   testUserId2 = user2.id

--- a/tests/int/conversations.int.spec.ts
+++ b/tests/int/conversations.int.spec.ts
@@ -61,6 +61,7 @@ beforeAll(async () => {
       email: `conversations-int-${Date.now()}@example.com`,
       password: 'test123456',
       role: 'student',
+      tier: 'free',
     },
   })
   testUserId = user.id
@@ -846,6 +847,7 @@ describe.skipIf(!hasDatabaseUrl)('Conversations Collection', () => {
           email: `conversations-access-${Date.now()}@example.com`,
           password: 'test123456',
           role: 'student',
+          tier: 'free',
         },
       })
       const testUserId2 = user2.id
@@ -945,6 +947,7 @@ describe.skipIf(!hasDatabaseUrl)('Conversations Collection', () => {
           email: `conversations-access-2-${Date.now()}@example.com`,
           password: 'test123456',
           role: 'student',
+          tier: 'free',
         },
       })
       const testUserId2 = user2.id
@@ -1014,6 +1017,7 @@ describe.skipIf(!hasDatabaseUrl)('Conversations Collection', () => {
           email: `conversations-admin-test-${Date.now()}@example.com`,
           password: 'test123456',
           role: 'student',
+          tier: 'free',
         },
       })
       const testUserId2 = user2.id
@@ -1025,6 +1029,7 @@ describe.skipIf(!hasDatabaseUrl)('Conversations Collection', () => {
           email: `conversations-admin-${Date.now()}@example.com`,
           password: 'test123456',
           role: 'admin',
+          tier: 'free',
         },
       })
       await payload.update({

--- a/tests/int/exercise-conversion-api.int.spec.ts
+++ b/tests/int/exercise-conversion-api.int.spec.ts
@@ -43,6 +43,7 @@ describe.skipIf(!hasDatabaseUrl)('Exercise Conversion API', () => {
         email: testEmail,
         password: 'test-password-123',
         role: 'admin',
+        tier: 'free',
       },
     })
 

--- a/tests/int/get-conversation-endpoint.int.spec.ts
+++ b/tests/int/get-conversation-endpoint.int.spec.ts
@@ -101,6 +101,7 @@ beforeAll(async () => {
       email: `get-conv-${Date.now()}@example.com`,
       password: 'test123456',
       role: 'student',
+      tier: 'free',
     },
   })
   testUserId = user1.id
@@ -112,6 +113,7 @@ beforeAll(async () => {
       email: `get-conv-2-${Date.now()}@example.com`,
       password: 'test123456',
       role: 'student',
+      tier: 'free',
     },
   })
   testUserId2 = user2.id

--- a/tests/int/jobs-run-now.int.spec.ts
+++ b/tests/int/jobs-run-now.int.spec.ts
@@ -75,6 +75,7 @@ describe('Jobs Run Now', () => {
         email: `test-${Date.now()}@example.com`,
         password: 'test-password-123',
         role: 'admin',
+        tier: 'free',
       },
     })
 

--- a/tests/int/lesson-context-injection.int.spec.ts
+++ b/tests/int/lesson-context-injection.int.spec.ts
@@ -12,7 +12,6 @@ import config from '@payload-config'
 import type { Payload } from 'payload'
 import { getPayload } from 'payload'
 import type { PayloadRequest } from 'payload'
-import type { Lesson } from '@/payload-types'
 import { LESSON_CONTEXT_BLOCK_START, LESSON_CONTEXT_MAX_CHARS } from '@/infra/llm/lesson-context'
 
 // Skip tests if DATABASE_URL is not set
@@ -92,6 +91,7 @@ beforeAll(async () => {
       email: `lesson-context-int-${Date.now()}@example.com`,
       password: 'test123456',
       role: 'student',
+      tier: 'free',
     },
   })
   testUserId = user.id

--- a/tests/int/memory-prompt-wiring.int.spec.ts
+++ b/tests/int/memory-prompt-wiring.int.spec.ts
@@ -67,6 +67,7 @@ async function createTestUser(prefix: string): Promise<string> {
       email,
       password: 'test123456',
       role: 'student',
+      tier: 'free',
     },
   })
   testUsers.set(email, user.id)

--- a/tests/int/memory-retriever-contract.int.spec.ts
+++ b/tests/int/memory-retriever-contract.int.spec.ts
@@ -91,6 +91,7 @@ async function createTestUser(prefix: string): Promise<string> {
       email,
       password: 'test123456',
       role: 'student',
+      tier: 'free',
     },
   })
   testUsers.set(email, user.id)

--- a/tests/int/memory-system.int.spec.ts
+++ b/tests/int/memory-system.int.spec.ts
@@ -58,6 +58,7 @@ describe.skipIf(!hasOpenAIKey)('Memory System Integration Tests', () => {
         email: `test-memory-${Date.now()}@example.com`,
         password: 'test123456',
         role: 'student',
+        tier: 'free',
       },
     })
     testUserId = user.id
@@ -759,6 +760,7 @@ describe.skipIf(!hasOpenAIKey)('Memory System Integration Tests', () => {
           email: `other-user-${Date.now()}@example.com`,
           password: 'test123456',
           role: 'student',
+          tier: 'free',
         },
       })
 

--- a/tests/int/vector-search-validation.int.spec.ts
+++ b/tests/int/vector-search-validation.int.spec.ts
@@ -101,6 +101,7 @@ describe.skipIf(!hasOpenAIKey || !hasAtlasUrl)('Vector Search Validation Integra
         email: `test-vector-${Date.now()}@example.com`,
         password: 'test123456',
         role: 'student',
+        tier: 'free',
       },
     })
     testUserId = user.id
@@ -473,6 +474,7 @@ describe.skipIf(!hasOpenAIKey || !hasAtlasUrl)('Vector Search Validation Integra
           email: `other-vector-${Date.now()}@example.com`,
           password: 'test123456',
           role: 'student',
+          tier: 'free',
         },
       })
       otherUserId = otherUser.id

--- a/tests/unit/server/payload/plugins/mcp-auth.test.ts
+++ b/tests/unit/server/payload/plugins/mcp-auth.test.ts
@@ -29,6 +29,7 @@ describe('overrideAuth', () => {
     createdAt: new Date().toISOString(),
     email: 'test@example.com',
     role,
+    tier: 'free',
     collection: 'users',
   })
 


### PR DESCRIPTION
Add data model support for shop functionality:
- Add price field to Courses collection (ILS pricing)
- Add tier enum to Users (free, standard, premium)
- Add ownedCourses relationship to Users
- Update admin columns to show tier field

This provides the backend foundation for the shop page. Admin can now:
- Set course prices
- Manage user membership tiers
- Assign/remove courses from users