### PR TITLE
feat: Add dedicated PDF conversion admin page

### DIFF
--- a/.tasks/genkit-migration/plan.md
+++ b/.tasks/genkit-migration/plan.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Replace the existing in-house LLM access layer with [Firebase Genkit](https://github.com/firebase/genkit) as the unified model interface, while preserving the configuration hierarchy and reusing existing utilities.
+Replace the existing in-house LLM access layer with [Firebase Genkit](https://github.com/firebase/genkit) as the unified model interface, while keeping ConfigValues as the source of truth for runtime configuration.
 
 ---
 
@@ -17,19 +17,11 @@ src/infra/llm/
 │   ├── factory.ts               # getLLMProvider(), getProviderTypeFromEnv(), UnifiedLLMProvider
 │   ├── types.ts                 # LLMProviderType enum (GEMINI, OPENAI_COMPATIBLE)
 │   ├── gemini/                  # Gemini SDK wrapper
-│   │   ├── gemini.provider.ts
-│   │   ├── gemini.client.ts
-│   │   ├── gemini.tools.ts
-│   │   └── multimodal-mapper.ts
 │   ├── openai-compatible/       # OpenAI-compatible SDK wrapper
-│   │   ├── openai.provider.ts
-│   │   ├── openai.client.ts
-│   │   ├── openai.tools.ts
-│   │   └── multimodal-mapper.ts
 │   └── shared/
-│       ├── chat-config.ts       # ChatConfig interface, getChatConfig()
-│       ├── retry.ts             # withRetry() exponential backoff (KEEP)
-│       └── errors.ts            # LLMError, error classification (KEEP)
+│       ├── chat-config.ts       # ChatConfig interface, getChatConfig(), getModelConfig()
+│       ├── retry.ts             # withRetry() exponential backoff
+│       └── errors.ts            # LLMError, error classification
 └── services/
     ├── exercise-chat-service.ts # Chat with exercises
     └── data-extractor-service.ts # Image → Exercise extraction
@@ -40,12 +32,10 @@ src/infra/llm/
 ```
 Priority (highest → lowest):
 1. process.env.* (LLM_PROVIDER, LLM_MODEL_OVERRIDE_*)
-2. ConfigSecrets (GEMINI_API_KEY, OPENAI_COMPATIBLE_API_KEY) - via runtime-config.ts
+2. ConfigSecrets (GEMINI_API_KEY, OPENAI_COMPATIBLE_API_KEY, OPENAI_COMPATIBLE_BASE_URL)
 3. ConfigValues/chat domain (models, timeouts, retry, temperature)
 4. MODEL_REGISTRY defaults (hardcoded fallbacks)
 ```
-
-**Note**: `OPENAI_COMPATIBLE_BASE_URL` should be added to ConfigSecrets for tenant-scoped configuration.
 
 ### Current Use Cases
 
@@ -62,14 +52,16 @@ Priority (highest → lowest):
 
 ### Q1: Config Shape Mapping
 
-| ConfigValues Key                    | Genkit Equivalent          | Action                         |
-| ----------------------------------- | -------------------------- | ------------------------------ |
-| `temperature.default`               | `config.temperature`       | Direct map                     |
-| `models.*.maxOutputTokens`          | `config.maxOutputTokens`   | Direct map                     |
-| `retry.*`                           | N/A (Genkit has no retry)  | **Keep** `withRetry()` wrapper |
-| `chatSettings.defaultChatTimeoutMs` | `config.timeout` (seconds) | Convert ms → s                 |
-| `models.*.gemini`                   | `googleai/{modelName}`     | Resolver prefixes              |
-| `models.*.openaiCompatible`         | `openai/{modelName}`       | Resolver prefixes              |
+| ConfigValues Key                    | Genkit Equivalent          | Action                     |
+| ----------------------------------- | -------------------------- | -------------------------- |
+| `temperature.default`               | `config.temperature`       | Direct map                 |
+| `models.*.maxOutputTokens`          | `config.maxOutputTokens`   | Direct map                 |
+| `retry.*`                           | N/A (Genkit has no retry)  | Keep `withRetry()` wrapper |
+| `chatSettings.defaultChatTimeoutMs` | `config.timeout` (seconds) | Convert ms → s             |
+| `models.*.gemini`                   | `googleai/{modelName}`     | Resolver prefixes          |
+| `models.*.openaiCompatible`         | `openai/{modelName}`       | Resolver prefixes          |
+
+**New keys needed**: None. Existing config is sufficient.
 
 ### Q2: Tenant Precedence
 
@@ -77,7 +69,7 @@ Priority (highest → lowest):
 
 ```
 1. Explicit tenantId parameter
-2. Cached defaultTenantId from runtime-config
+2. Cached defaultTenantId
 3. getDefaultTenantId(payload) fallback
 ```
 
@@ -122,9 +114,9 @@ Genkit instance initialized once per provider type. Model selection resolved per
 
 ### Q7: OpenAI-Compatible BaseURL Scope
 
-**Decision**: Per-tenant in ConfigSecrets (not environment-only).
+**Decision**: Per-tenant in ConfigValues (not environment-only).
 
-- Add `OPENAI_COMPATIBLE_BASE_URL` to ConfigSecrets key enumeration
+- Add `OPENAI_COMPATIBLE_BASE_URL` to ConfigSecrets (tenant-scoped)
 - Allows different OpenAI-compatible endpoints per tenant
 - Fallback to `process.env.OPENAI_COMPATIBLE_BASE_URL`
 
@@ -157,8 +149,6 @@ src/infra/llm/genkit/
 ├── adapters/
 │   ├── unified-adapter.ts       # UnifiedLLMProvider interface backed by Genkit
 │   └── error-adapter.ts         # Genkit errors → LLMError
-└── media/
-    └── media-adapter.ts         # Reuse existing multimodal mappers
 ```
 
 **Key implementation**:
@@ -177,7 +167,7 @@ export async function resolveGenkitConfig(
   tenantId?: string,
 ): Promise<GenkitModelConfig> {
   // 1. Check LLM_MODEL_OVERRIDE_* env vars
-  // 2. Load ConfigValues for tenant via getConfigDomain('chat')
+  // 2. Load ConfigValues for tenant
   // 3. Get model name from config.models[task][provider]
   // 4. Prefix with 'googleai/' or 'openai/'
   // 5. Return complete config
@@ -189,7 +179,6 @@ export async function resolveGenkitConfig(
 import { genkit } from 'genkit'
 import { googleAI } from '@genkit-ai/googleai'
 import { openAI } from 'genkitx-openai'
-import { getSecret } from '@/infra/config/runtime/runtime-config'
 
 // Cache per provider type (single provider per tenant)
 const instances = new Map<LLMProviderType, Genkit>()
@@ -201,17 +190,9 @@ export async function getGenkitInstance(payload: Payload, tenantId?: string): Pr
     return instances.get(providerType)!
   }
 
-  // Get API key from ConfigSecrets (tenant-scoped)
-  const apiKey =
-    providerType === LLMProviderType.GEMINI
-      ? getSecret('GEMINI_API_KEY', { tenantId })
-      : getSecret('OPENAI_COMPATIBLE_API_KEY', { tenantId })
-
-  // Get baseURL for OpenAI-compatible (tenant-scoped via ConfigSecrets)
-  const baseURL =
-    providerType === LLMProviderType.OPENAI_COMPATIBLE
-      ? getSecret('OPENAI_COMPATIBLE_BASE_URL', { tenantId, throwIfNotFound: false }) || undefined
-      : undefined
+  const apiKey = await getApiKeyForProvider(providerType, payload, tenantId)
+  // BaseURL now tenant-scoped via ConfigSecrets
+  const baseURL = await getOpenAICompatibleBaseUrl(payload, tenantId)
 
   const plugins =
     providerType === LLMProviderType.GEMINI ? [googleAI({ apiKey })] : [openAI({ apiKey, baseURL })]
@@ -295,7 +276,7 @@ export async function getLLMProvider(payload, config?): Promise<UnifiedLLMProvid
 ```
 src/infra/llm/genkit/tools/
 ├── mcp-tool-adapter.ts          # MCPTool → Genkit defineTool()
-└── tool-executor.ts              # Genkit tool execution wrapper
+└── tool-executor.ts             # Genkit tool execution wrapper
 ```
 
 **Files to modify**:
@@ -337,8 +318,8 @@ export function mcpToolToGenkitTool(mcpTool: MCPTool, executor: ToolExecutor) {
 ```
 src/infra/llm/genkit/flows/
 ├── index.ts
-├── pdf-extraction-flow.ts        # defineFlow for extraction
-└── pdf-verification-flow.ts       # defineFlow for verification
+├── pdf-extraction-flow.ts       # defineFlow for extraction
+└── pdf-verification-flow.ts     # defineFlow for verification
 ```
 
 **Files to modify**:
@@ -485,7 +466,7 @@ for (const exercise of exercises) {
 
 ### ConfigSecrets Addition
 
-- Add `OPENAI_COMPATIBLE_BASE_URL` as a tenant-scoped secret key (via ConfigSecrets collection)
+- Add `OPENAI_COMPATIBLE_BASE_URL` as a tenant-scoped secret key
 
 ---
 
@@ -529,20 +510,6 @@ Only enabled when `NODE_ENV !== 'production'`.
 
 ---
 
-## Reuse Opportunities
-
-### Existing Utilities to Preserve
-
-| Utility                   | Location                                           | Action                    |
-| ------------------------- | -------------------------------------------------- | ------------------------- |
-| `withRetry()`             | `shared/retry.ts`                                  | Wrap Genkit calls         |
-| `LLMError`                | `shared/errors.ts`                                 | Wrap Genkit errors        |
-| `createErrorClassifier()` | `shared/errors.ts`                                 | Classify retryable errors |
-| `mapMultimodalToGemini()` | `providers/gemini/multimodal-mapper.ts`            | Adapt for Genkit media    |
-| `mapMultimodalToOpenAI()` | `providers/openai-compatible/multimodal-mapper.ts` | Adapt for Genkit media    |
-
----
-
 ## Verification
 
 After implementation, verify:
@@ -554,29 +521,3 @@ After implementation, verify:
 5. **Tool calling**: Admin chat tools work as before
 6. **Error handling**: Retries and error classification preserved
 7. **Performance**: No significant degradation (< 20%)
-
----
-
-## Migration Timeline
-
-| Phase | Duration | Scope                       |
-| ----- | -------- | --------------------------- |
-| 1     | 1 week   | Foundation, config resolver |
-| 2     | 1 week   | Service migration           |
-| 3     | 1 week   | Tool calling                |
-| 4     | 1 week   | PDF flows                   |
-| 5     | 2 days   | Cleanup, observability      |
-
-**Total estimated time**: 5 weeks
-
----
-
-## Risk Mitigation
-
-| Risk                         | Mitigation                                      |
-| ---------------------------- | ----------------------------------------------- |
-| Genkit API changes           | Pin to specific version in package.json         |
-| Migration downtime           | Backward-compatible shim in factory.ts          |
-| Performance regression       | Benchmark before/after, monitor in production   |
-| Tool calling incompatibility | Comprehensive unit tests for MCP→Genkit adapter |
-| Tenant config issues         | Integration tests per tenant scenario           |

--- a/.tasks/pdf-conversion-page/pdf-conversion-page-fix.md
+++ b/.tasks/pdf-conversion-page/pdf-conversion-page-fix.md
@@ -1,0 +1,423 @@
+# PDF Conversion Page - Fix Plan
+
+## Root Cause
+
+**Tailwind CSS classes are used in every component, but Tailwind is NOT loaded in the Payload admin panel.**
+
+- Tailwind is imported only in `src/app/(frontend)/globals.css` via `@import 'tailwindcss'`
+- The `(payload)` route group loads `@payloadcms/next/css` + `custom.scss` -- no Tailwind
+- Every component uses Tailwind classes (`bg-white`, `rounded-lg`, `text-sm`, `space-y-4`, `border-gray-200`, etc.) which resolve to **nothing**
+- This is why the screenshot shows raw unstyled HTML: no backgrounds, no borders, no spacing, no typography
+
+### Full Issue List
+
+| #   | Issue                                           | Root Cause                                                                          |
+| --- | ----------------------------------------------- | ----------------------------------------------------------------------------------- |
+| 1   | No backgrounds, borders, spacing on any element | Tailwind classes don't work in Payload admin                                        |
+| 2   | Labels/selects jammed together horizontally     | `space-y-1`, `block`, `w-full` classes are no-ops                                   |
+| 3   | Lesson search dropdown never appears visually   | `absolute z-10 bg-white border shadow-lg` classes are no-ops                        |
+| 4   | No page header/nav back button                  | Page renders as bare `<div>`, not using Payload's page structure                    |
+| 5   | Form looks broken, controls too small           | `px-3 py-2 border rounded-md` classes don't apply                                   |
+| 6   | Status badges show no color                     | `bg-amber-100 text-amber-800` etc. are no-ops                                       |
+| 7   | Job cards have no visual separation             | `border`, `rounded-lg`, `p-3` classes are no-ops                                    |
+| 8   | Missing SCSS file                               | Plan specified `PdfConversionPage/index.scss` but it was never created              |
+| 9   | Page doesn't feel like admin panel              | No Payload Gutter/header wrapper, no back link                                      |
+| 10  | "Selected: undefined" when lesson picked        | `selectedLessonTitle` lookup searches `results` array which gets cleared on select  |
+| 11  | PdfSelector data shape mismatch                 | Assumes `file.media.mimeType` but contentFiles may be flat media objects at depth=1 |
+| 12  | Stats jammed together                           | "0/0 segments0 exercises" -- no separator between stats                             |
+
+---
+
+## Fix Strategy
+
+Replace ALL Tailwind utility classes with:
+
+1. **Dedicated SCSS** with BEM classes using Payload CSS variables -- for page layout
+2. **Inline styles** with `var(--theme-*)` -- for component-specific styling (matches existing pattern in `ConversionStatusPanel`, `AdminChatDashboardWidget`)
+3. **Payload built-in CSS classes** (`btn`, `btn--style-primary`, `btn--size-small`) -- for buttons
+4. **Shared style constants** -- extracted to a `styles.ts` file to avoid repetition
+
+---
+
+## File-by-File Changes
+
+### NEW: `src/ui/admin/PdfConversion/styles.ts` -- Shared Style Constants
+
+Reusable inline style objects for consistency across components:
+
+```typescript
+import type { CSSProperties } from 'react'
+
+export const cardStyle: CSSProperties = {
+  padding: 16,
+  backgroundColor: 'var(--theme-elevation-50)',
+  border: '1px solid var(--theme-elevation-200)',
+  borderRadius: 4,
+}
+
+export const labelStyle: CSSProperties = {
+  display: 'block',
+  fontSize: 13,
+  fontWeight: 500,
+  color: 'var(--theme-elevation-700)',
+  marginBottom: 4,
+}
+
+export const selectStyle: CSSProperties = {
+  width: '100%',
+  height: 36,
+  padding: '0 10px',
+  fontSize: 13,
+  border: '1px solid var(--theme-elevation-200)',
+  borderRadius: 4,
+  backgroundColor: 'var(--theme-elevation-0)',
+  color: 'var(--theme-elevation-1000)',
+}
+
+export const inputStyle: CSSProperties = {
+  width: '100%',
+  height: 36,
+  padding: '0 10px',
+  fontSize: 13,
+  border: '1px solid var(--theme-elevation-200)',
+  borderRadius: 4,
+  backgroundColor: 'var(--theme-elevation-0)',
+  color: 'var(--theme-elevation-1000)',
+  boxSizing: 'border-box' as const,
+}
+
+export const fieldGroupStyle: CSSProperties = {
+  marginBottom: 16,
+}
+
+export const sectionHeadingStyle: CSSProperties = {
+  fontSize: 16,
+  fontWeight: 600,
+  color: 'var(--theme-elevation-1000)',
+  margin: '0 0 16px 0',
+}
+
+export const errorBannerStyle: CSSProperties = {
+  padding: '8px 12px',
+  marginBottom: 12,
+  fontSize: 13,
+  color: 'var(--theme-error)',
+  backgroundColor: 'var(--theme-error-100)',
+  borderRadius: 4,
+}
+
+export const successBannerStyle: CSSProperties = {
+  padding: '8px 12px',
+  marginBottom: 12,
+  fontSize: 13,
+  color: 'var(--theme-success)',
+  backgroundColor: 'var(--theme-success-100)',
+  borderRadius: 4,
+}
+
+export const getBadgeStyle = (status: string): CSSProperties => {
+  const map: Record<string, CSSProperties> = {
+    queued: { backgroundColor: 'var(--theme-warning-100)', color: 'var(--theme-warning)' },
+    running: { backgroundColor: 'var(--theme-info-100)', color: 'var(--theme-info)' },
+    completed: { backgroundColor: 'var(--theme-success-100)', color: 'var(--theme-success)' },
+    failed: { backgroundColor: 'var(--theme-error-100)', color: 'var(--theme-error)' },
+    draft: { backgroundColor: 'var(--theme-elevation-200)', color: 'var(--theme-elevation-700)' },
+    published: { backgroundColor: 'var(--theme-success-100)', color: 'var(--theme-success)' },
+  }
+  return {
+    display: 'inline-block',
+    padding: '3px 8px',
+    borderRadius: 3,
+    fontSize: 11,
+    fontWeight: 600,
+    textTransform: 'uppercase',
+    ...(map[status] || map.draft),
+  }
+}
+```
+
+### NEW: `src/ui/admin/PdfConversion/PdfConversionPage/index.scss`
+
+```scss
+.pdf-conversion-page {
+  padding: calc(var(--base) * 1.5);
+  max-width: 1400px;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: calc(var(--base) * 0.75);
+    margin-bottom: calc(var(--base) * 1.25);
+    padding-bottom: calc(var(--base) * 1.25);
+    border-bottom: 1px solid var(--theme-elevation-150);
+  }
+
+  &__back-link {
+    color: var(--theme-elevation-500);
+    text-decoration: none;
+    font-size: 13px;
+    transition: color 0.15s;
+    &:hover {
+      color: var(--theme-elevation-800);
+    }
+  }
+
+  &__header-sep {
+    color: var(--theme-elevation-300);
+    font-size: 14px;
+  }
+
+  &__title {
+    font-size: 22px;
+    font-weight: 600;
+    color: var(--theme-text);
+    margin: 0;
+  }
+
+  &__layout {
+    display: grid;
+    grid-template-columns: 400px 1fr;
+    gap: calc(var(--base) * 1.5);
+    align-items: start;
+  }
+
+  &__left {
+    position: sticky;
+    top: calc(var(--base) * 1.5);
+  }
+
+  &__right {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--base) * 1.5);
+    min-width: 0; // prevent grid blowout
+  }
+}
+
+@media (max-width: 960px) {
+  .pdf-conversion-page {
+    &__layout {
+      grid-template-columns: 1fr;
+    }
+    &__left {
+      position: static;
+    }
+  }
+}
+```
+
+---
+
+### MODIFY: `src/app/(payload)/admin/pdf-conversion/page.tsx`
+
+Style loading/error states with Payload CSS variables instead of bare unstyled divs.
+
+---
+
+### MODIFY: `src/ui/admin/PdfConversion/PdfConversionPage/index.tsx`
+
+- Import `./index.scss`
+- Add page header with back link: `<a href="/admin">` + separator + `<h1>`
+- Replace all Tailwind className strings with BEM classes from the SCSS
+
+Target structure:
+
+```tsx
+<div className="pdf-conversion-page">
+  <div className="pdf-conversion-page__header">
+    <a href="/admin" className="pdf-conversion-page__back-link">← Dashboard</a>
+    <span className="pdf-conversion-page__header-sep">/</span>
+    <h1 className="pdf-conversion-page__title">PDF Conversion</h1>
+  </div>
+  <div className="pdf-conversion-page__layout">
+    <div className="pdf-conversion-page__left">
+      <ConversionForm onQueued={handleConversionQueued} />
+    </div>
+    <div className="pdf-conversion-page__right">
+      <JobHistory ... />
+      {selectedJobId && <ExerciseReview ... />}
+    </div>
+  </div>
+</div>
+```
+
+---
+
+### MODIFY: `src/ui/admin/PdfConversion/ConversionForm/index.tsx`
+
+Replace every Tailwind class with inline styles using shared constants from `styles.ts`:
+
+- Form wrapper: `style={cardStyle}`
+- Heading: `style={sectionHeadingStyle}`
+- Error banner: `style={errorBannerStyle}`
+- Success banner: `style={successBannerStyle}`
+- Each label: `style={labelStyle}`
+- Each select: `style={selectStyle}`
+- Field groups: `style={fieldGroupStyle}`
+- Submit button: `className="btn btn--style-primary"` + `style={{ width: '100%' }}`
+- "Loading prompts": `style={{ fontSize: 13, color: 'var(--theme-elevation-500)' }}`
+
+---
+
+### MODIFY: `src/ui/admin/PdfConversion/LessonSelector/index.tsx`
+
+Three bugs + styling:
+
+**Bug 1 -- Selected name lost**: Add `selectedLessonName` state. Store it in `handleSelect`. Display it instead of looking up in `results`.
+
+**Bug 2 -- Dropdown invisible**: Container needs `position: relative`. Dropdown uses inline styles:
+
+```typescript
+style={{
+  position: 'absolute',
+  zIndex: 10,
+  top: '100%',
+  left: 0,
+  right: 0,
+  marginTop: 4,
+  backgroundColor: 'var(--theme-elevation-0)',
+  border: '1px solid var(--theme-elevation-200)',
+  borderRadius: 4,
+  boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+  maxHeight: 240,
+  overflowY: 'auto',
+  listStyle: 'none',
+  padding: 0,
+  margin: 0,
+}}
+```
+
+**Bug 3 -- Dropdown item hover**: Use `onMouseEnter`/`onMouseLeave` with a `hoveredIndex` state to highlight, or use a `<style>` tag for hover.
+
+All labels/inputs: use shared `labelStyle`, `inputStyle` from `styles.ts`.
+
+---
+
+### MODIFY: `src/ui/admin/PdfConversion/PdfSelector/index.tsx`
+
+**Bug -- Data shape**: `contentFiles` at `depth=1` populates to media objects directly. Handle both shapes:
+
+```typescript
+const contentFiles = data.contentFiles || []
+const pdfs = contentFiles
+  .filter((file: any) => {
+    const mime = file.mimeType || file.media?.mimeType
+    return mime === 'application/pdf'
+  })
+  .map((file: any) => ({
+    id: file.id || file.media?.id,
+    filename: file.filename || file.media?.filename || 'Unknown',
+  }))
+```
+
+Replace all Tailwind with inline styles:
+
+- Label: `style={labelStyle}`
+- Radio items: inline styles with `var(--theme-elevation-*)` for borders, background on selected
+- Selected highlight: `border: 2px solid var(--theme-elevation-800)`, `backgroundColor: 'var(--theme-elevation-100)'`
+
+---
+
+### MODIFY: `src/ui/admin/PdfConversion/JobHistory/index.tsx`
+
+- Replace `getBadgeClasses` (Tailwind) with `getBadgeStyle` from shared `styles.ts`
+- Section wrapper: `style={cardStyle}`
+- Heading: `style={sectionHeadingStyle}`
+- Job card: inline styles with border, padding, border-radius, cursor:pointer
+- Selected card: `border: 2px solid var(--theme-elevation-800)`
+- Progress bar: inline styles (bg bar + fill bar with `var(--theme-success)`)
+- Stats: Add `·` separator between segments and exercises count
+- Buttons: `className="btn btn--size-small btn--style-secondary"` (Run Now) / `btn--style-primary` (View Exercises)
+- Error details: `<details>` with inline styled summary
+- Polling indicator: spinner character with inline animation
+
+---
+
+### MODIFY: `src/ui/admin/PdfConversion/ExerciseReview/index.tsx`
+
+- Section wrapper: `style={cardStyle}`
+- Heading: `style={sectionHeadingStyle}` with count
+- Exercise cards: inline styles with border, padding, flex layout
+- Title: `fontSize: 14, fontWeight: 500, color: 'var(--theme-elevation-1000)'`
+- Source pages: `fontSize: 12, color: 'var(--theme-elevation-500)'`
+- Status badge: `getBadgeStyle(exercise._status)` from shared `styles.ts`
+- "Open in Editor" link: `className="btn btn--size-small btn--style-secondary"`
+
+---
+
+### NOT MODIFIED
+
+| File                                    | Reason                                           |
+| --------------------------------------- | ------------------------------------------------ |
+| `SidebarLink/index.tsx`                 | Already correct (uses Payload nav classes)       |
+| `payload.config.ts`                     | Already has the sidebar link registered          |
+| `src/server/api/schemas/job-schemas.ts` | Schema change from previous plan already applied |
+
+---
+
+## Files Summary
+
+### Create (2)
+
+| File                                                      | Purpose                                        |
+| --------------------------------------------------------- | ---------------------------------------------- |
+| `src/ui/admin/PdfConversion/PdfConversionPage/index.scss` | Page layout styles with BEM + Payload CSS vars |
+| `src/ui/admin/PdfConversion/styles.ts`                    | Shared inline style constants + badge helper   |
+
+### Modify (7)
+
+| File                          | Key Changes                                                   |
+| ----------------------------- | ------------------------------------------------------------- |
+| `page.tsx`                    | Styled loading/error states                                   |
+| `PdfConversionPage/index.tsx` | Import SCSS, add header with back link, BEM classes           |
+| `ConversionForm/index.tsx`    | All Tailwind → inline styles + Payload btn classes            |
+| `LessonSelector/index.tsx`    | Fix dropdown, fix selected name, inline styles                |
+| `PdfSelector/index.tsx`       | Fix data shape, inline styles                                 |
+| `JobHistory/index.tsx`        | All Tailwind → inline styles + Payload btn classes, fix stats |
+| `ExerciseReview/index.tsx`    | All Tailwind → inline styles + Payload btn classes            |
+
+---
+
+## Verification
+
+### Automated
+
+```bash
+pnpm tsc --noEmit
+pnpm lint
+pnpm test:unit
+```
+
+### Manual Smoke Test
+
+- [ ] Sidebar shows "PDF Conversion" link
+- [ ] Page has header: "← Dashboard / PDF Conversion" with bottom border
+- [ ] Left panel has visible card with background and border
+- [ ] Search input has border, placeholder text, proper height
+- [ ] Typing 2+ chars shows floating dropdown with lesson results
+- [ ] Selecting a lesson shows name and loads PDFs below
+- [ ] PDF radio buttons visible with filenames
+- [ ] Prompt dropdowns have labels, proper sizing, work correctly
+- [ ] Submit button styled like Payload admin button, disabled when incomplete
+- [ ] Success/error banners show with proper colors
+- [ ] Job cards have visible borders, backgrounds, proper spacing
+- [ ] Status badges have correct colors (amber/blue/green/red)
+- [ ] Progress bar visible for running jobs
+- [ ] Stats show with separator: "4/4 segments · 16 exercises"
+- [ ] "Run Now" / "View Exercises" look like proper admin buttons
+- [ ] Error details expandable in failed jobs
+- [ ] Exercise review cards visible with borders
+- [ ] "Open in Editor" opens in new tab
+- [ ] Page stacks vertically on narrow viewport
+
+---
+
+## Commit
+
+```
+fix: restyle PDF conversion page with Payload admin design system
+
+Replace Tailwind utility classes (unavailable in admin panel) with inline
+styles using Payload CSS variables and dedicated SCSS. Fix lesson selector
+dropdown, selected name persistence, and PDF file data shape handling.
+```

--- a/.tasks/pdf-conversion-page/plan.md
+++ b/.tasks/pdf-conversion-page/plan.md
@@ -1,0 +1,718 @@
+# PDF Conversion Page - Detailed Implementation Plan
+
+## Problem
+
+The current PDF conversion UI is a `ui` field crammed inside the Lesson edit form (`src/server/payload/collections/Lessons.ts:156-165`). Three specific UX issues:
+
+1. **Cramped inline UI** -- The `LessonConversionPanel` is squeezed into a small UI field panel inside the Lesson edit form with tiny 11-12px text and compact controls
+2. **Poor job monitoring** -- Status polling is basic (10s interval), no history of past jobs, no error details, no way to see jobs across lessons
+3. **Awkward draft review** -- Viewing created exercises requires expanding inline lists and clicking through one by one in a minimal list
+
+## Solution
+
+A dedicated admin page at `/admin/pdf-conversion` following the established `admin/chat` page pattern, with a **convert-first** layout, proper job monitoring, and exercise review cards.
+
+## Architecture
+
+Follows the existing `admin/chat` pattern (see `src/app/(payload)/admin/chat/page.tsx`):
+
+1. Next.js page at `src/app/(payload)/admin/pdf-conversion/page.tsx`
+2. Sidebar nav link via `beforeNavLinks` in `payload.config.ts`
+3. Client components in `src/ui/admin/PdfConversion/`
+4. Uses Payload CSS variables and admin styling conventions
+5. Auth via `useCurrentUser()` hook from `src/client/hooks/useCurrentUser.ts`
+
+## Page Layout
+
+```
++-------------------------------------------------------------+
+|  PDF Conversion                                             |
++--------------------------+----------------------------------+
+|                          |                                  |
+|  CONVERSION FORM         |  JOB HISTORY & RESULTS           |
+|                          |                                  |
+|  1. Select Lesson v      |  +-----------------------------+ |
+|     (searchable select)  |  | Job: math-101.pdf           | |
+|                          |  | Status: * COMPLETED         | |
+|  2. Select PDF v         |  | 5/5 segments - 12 exercises | |
+|     (auto-populated      |  | [View Exercises] [Re-run]   | |
+|      from lesson files)  |  +-----------------------------+ |
+|                          |  | Job: physics-ch3.pdf        | |
+|  3. Extractor Prompt v   |  | Status: * RUNNING  [60%]   | |
+|  4. Verifier Prompt  v   |  | 3/5 segments - 6 exercises  | |
+|  5. Diagram Gen (opt) v  |  +-----------------------------+ |
+|                          |  | Job: algebra-hw.pdf         | |
+|  [Start Conversion]      |  | Status: * FAILED            | |
+|                          |  | Error: Prompt too large      | |
+|                          |  | [View Details] [Retry]      | |
+|                          |  +-----------------------------+ |
+|                          |                                  |
+|                          |  -- Exercises from selected --   |
+|                          |  +-----------------------------+ |
+|                          |  | Ex 1: "Find derivative..."  | |
+|                          |  | Pages 1-2 - Draft           | |
+|                          |  | [Open in Editor]            | |
+|                          |  | Ex 2: "Solve integral..."   | |
+|                          |  | Pages 3-4 - Draft           | |
+|                          |  | [Open in Editor]            | |
+|                          |  +-----------------------------+ |
++--------------------------+----------------------------------+
+```
+
+---
+
+## Implementation Steps
+
+### Phase 0: Setup
+
+**Branch**: `feat/pdf-conversion-page` off `dev`
+
+### Phase 1: Backend - Make Status Endpoint Support "All Jobs" Listing
+
+The current status endpoint (`src/app/api/exercises/convert/status/route.ts`) requires `lessonId` and `mediaId` as mandatory query params via `jobStatusQuerySchema`. We need to make them optional so the new page can fetch all recent jobs.
+
+#### Step 1.1: Update Zod Schema
+
+**File**: `src/server/api/schemas/job-schemas.ts`
+
+Current `jobStatusQuerySchema` requires `lessonId` and `mediaId`. Change both to `.optional()`:
+
+```typescript
+export const jobStatusQuerySchema = z.object({
+  lessonId: objectIdSchema.optional(),
+  mediaId: objectIdSchema.optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(10), // Change default from 1 to 10
+})
+```
+
+This is backward-compatible -- existing callers passing both params still work identically.
+
+#### Step 1.2: Update Status Route Handler
+
+**File**: `src/app/api/exercises/convert/status/route.ts`
+
+The `JobService.findByContext()` method already handles `undefined` values in the context object (it only adds filters for truthy keys -- see `job-service.ts:92-94`). So the route handler needs no logic changes. The Zod schema change alone is sufficient.
+
+#### Step 1.3: Test the Schema Change
+
+**File**: `tests/unit/api/schemas/job-schemas.spec.ts` (existing file)
+
+Add tests for the updated schema:
+
+```typescript
+describe('jobStatusQuerySchema - optional params', () => {
+  it('accepts empty query (all jobs)', () => {
+    const result = jobStatusQuerySchema.safeParse({})
+    expect(result.success).toBe(true)
+    expect(result.data.limit).toBe(10)
+  })
+
+  it('accepts only lessonId', () => {
+    const result = jobStatusQuerySchema.safeParse({ lessonId: '507f1f77bcf86cd799439011' })
+    expect(result.success).toBe(true)
+    expect(result.data.mediaId).toBeUndefined()
+  })
+
+  it('still accepts both params (backward compat)', () => {
+    const result = jobStatusQuerySchema.safeParse({
+      lessonId: '507f1f77bcf86cd799439011',
+      mediaId: '507f1f77bcf86cd799439012',
+    })
+    expect(result.success).toBe(true)
+  })
+})
+```
+
+---
+
+### Phase 2: Page Wiring & Navigation
+
+#### Step 2.1: Create Sidebar Nav Link
+
+**File**: `src/ui/admin/PdfConversion/SidebarLink/index.tsx`
+
+Follow the exact pattern of `src/ui/admin/AdminChat/SidebarLink/index.tsx`:
+
+```typescript
+'use client'
+import Link from 'next/link'
+import React from 'react'
+
+export const PdfConversionSidebarLink: React.FC = () => {
+  return (
+    <li className="nav__item">
+      <Link href="/admin/pdf-conversion" className="nav__link">
+        <span className="nav__label">PDF Conversion</span>
+      </Link>
+    </li>
+  )
+}
+export default PdfConversionSidebarLink
+```
+
+#### Step 2.2: Register in Payload Config
+
+**File**: `src/payload.config.ts`
+
+Add to `beforeNavLinks` array (line 81):
+
+```typescript
+beforeNavLinks: [
+  '@/ui/admin/AdminChat/SidebarLink',
+  '@/ui/admin/PdfConversion/SidebarLink',
+],
+```
+
+#### Step 2.3: Create Page Route
+
+**File**: `src/app/(payload)/admin/pdf-conversion/page.tsx`
+
+Follow the `admin/chat/page.tsx` pattern:
+
+```typescript
+'use client'
+import { useCurrentUser } from '@/client/hooks/useCurrentUser'
+import { PdfConversionPage } from '@/ui/admin/PdfConversion/PdfConversionPage'
+
+export default function AdminPdfConversionPage() {
+  const { user, isLoading } = useCurrentUser()
+
+  if (isLoading) {
+    return <div style={{ padding: 20 }}>Loading...</div>
+  }
+  if (!user) {
+    return <div style={{ padding: 20 }}>Please log in to access PDF conversion</div>
+  }
+  // Admin-only check
+  if (user.role !== 'admin') {
+    return <div style={{ padding: 20 }}>Admin access required</div>
+  }
+
+  return <PdfConversionPage />
+}
+```
+
+#### Step 2.4: Regenerate Import Map
+
+```bash
+pnpm payload generate:importmap
+```
+
+---
+
+### Phase 3: Main Page Layout Component
+
+#### Step 3.1: Create Page Component
+
+**File**: `src/ui/admin/PdfConversion/PdfConversionPage/index.tsx`
+
+Two-column layout. Manages shared state:
+
+- `selectedLessonId: string | null`
+- `selectedMediaId: string | null`
+- `selectedJobId: string | null`
+- `refreshKey: number` (incremented after successful queue to trigger job list refresh)
+
+```typescript
+'use client'
+import { useState, useCallback } from 'react'
+import { ConversionForm } from '../ConversionForm'
+import { JobHistory } from '../JobHistory'
+import { ExerciseReview } from '../ExerciseReview'
+import './index.scss'
+
+export function PdfConversionPage() {
+  const [selectedJobId, setSelectedJobId] = useState<string | null>(null)
+  const [refreshKey, setRefreshKey] = useState(0)
+
+  const handleConversionQueued = useCallback(() => {
+    setRefreshKey((k) => k + 1)
+  }, [])
+
+  return (
+    <div className="pdf-conversion-page">
+      <h1 className="pdf-conversion-page__title">PDF Conversion</h1>
+      <div className="pdf-conversion-page__layout">
+        <div className="pdf-conversion-page__left">
+          <ConversionForm onQueued={handleConversionQueued} />
+        </div>
+        <div className="pdf-conversion-page__right">
+          <JobHistory
+            refreshKey={refreshKey}
+            selectedJobId={selectedJobId}
+            onSelectJob={setSelectedJobId}
+          />
+          {selectedJobId && (
+            <ExerciseReview jobId={selectedJobId} />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+#### Step 3.2: Create SCSS Styles
+
+**File**: `src/ui/admin/PdfConversion/PdfConversionPage/index.scss`
+
+```scss
+.pdf-conversion-page {
+  padding: var(--base);
+  max-width: 1400px;
+
+  &__title {
+    font-size: 24px;
+    font-weight: 600;
+    color: var(--theme-text);
+    margin-bottom: var(--base);
+  }
+
+  &__layout {
+    display: grid;
+    grid-template-columns: 380px 1fr;
+    gap: var(--base);
+    align-items: start;
+  }
+
+  &__left {
+    position: sticky;
+    top: var(--base);
+  }
+
+  &__right {
+    display: flex;
+    flex-direction: column;
+    gap: var(--base);
+  }
+}
+
+// Responsive: stack on narrow screens
+@media (max-width: 900px) {
+  .pdf-conversion-page__layout {
+    grid-template-columns: 1fr;
+  }
+
+  .pdf-conversion-page__left {
+    position: static;
+  }
+}
+```
+
+---
+
+### Phase 4: Conversion Form (Left Panel)
+
+#### Step 4.1: Create LessonSelector
+
+**File**: `src/ui/admin/PdfConversion/LessonSelector/index.tsx`
+
+Searchable text input that fetches from `/api/lessons?where[title][contains]=<query>&limit=10&depth=1`.
+
+Props:
+
+- `selectedLessonId: string | null`
+- `onSelectLesson: (lessonId: string, lesson: LessonOption) => void`
+
+Behavior:
+
+- Text input with 300ms debounce
+- Dropdown of results showing: lesson title + parent chapter title (if depth=1 populates it)
+- Clicking a result selects it and collapses the dropdown
+- Shows selected lesson name when not searching
+
+#### Step 4.2: Create PdfSelector
+
+**File**: `src/ui/admin/PdfConversion/PdfSelector/index.tsx`
+
+Props:
+
+- `lessonId: string`
+- `selectedMediaId: string | null`
+- `onSelectMedia: (mediaId: string) => void`
+
+Behavior:
+
+- On mount / when `lessonId` changes, fetches lesson's `contentFiles` via `/api/lessons/<id>?depth=1`
+- Filters for `mimeType === 'application/pdf'`
+- Renders as a list of radio-style selectable items showing filename
+- If no PDFs found, shows "No PDFs attached to this lesson" message
+
+#### Step 4.3: Create ConversionForm
+
+**File**: `src/ui/admin/PdfConversion/ConversionForm/index.tsx`
+
+Orchestrates LessonSelector + PdfSelector + prompt dropdowns + submit.
+
+Props:
+
+- `onQueued: () => void` -- callback when a job is successfully queued
+
+State:
+
+- `selectedLessonId`, `selectedMediaId`
+- `extractorPromptId`, `verifierPromptId`, `diagramPromptId`
+- `isSubmitting`, `error`, `success`
+
+Prompt loading:
+
+- When `selectedLessonId` changes, fetch prompts from `/api/prompts/for-conversion` (POST with `{ lessonId }`)
+- Populate 3 select dropdowns: Extractor (required), Verifier (required), Diagram Generator (optional)
+- Each dropdown shows prompt `title`
+
+Submit:
+
+- POST to `/api/exercises/convert/queue` with `{ lessonId, mediaId, extractorPromptId, verifierPromptId, diagramPromptId }`
+- On success: show success message, call `onQueued()`, reset form state after 2s
+- On error: show error message from response
+
+UI:
+
+- Each form control has a proper `<label>` element
+- Proper spacing, full-width controls
+- Disabled state on submit button when missing required fields
+- Loading states for prompt fetching
+
+---
+
+### Phase 5: Job History Panel (Right Panel, Top)
+
+#### Step 5.1: Create JobHistory
+
+**File**: `src/ui/admin/PdfConversion/JobHistory/index.tsx`
+
+Props:
+
+- `refreshKey: number` -- when this changes, re-fetch jobs
+- `selectedJobId: string | null`
+- `onSelectJob: (jobId: string) => void`
+
+Behavior:
+
+- On mount + when `refreshKey` changes, fetch from `/api/exercises/convert/status?limit=20`
+- Poll: every 5s if any job is `queued` or `running`, otherwise every 30s
+- Each job card shows:
+  - Source filename (from `input.ctx.sourceDocId` -- need to resolve to media filename, or show ID prefix)
+  - Status badge with color (reuse `getBadgeStyle` from existing `ConversionStatusPanel`)
+  - Progress bar if `running`
+  - Stats: `segmentsDone/segmentsTotal` segments, `exercisesCreated` exercises
+  - Timestamp (`updatedAt` or `createdAt`)
+  - **Actions**:
+    - "Run Now" button for `queued`/`failed` jobs (POST to `/api/jobs/run-immediate`)
+    - "View Exercises" button for `completed` jobs (sets `selectedJobId`)
+- Error collapsible: if `output.errors` is non-empty, show expandable section with error list
+- Selected job gets a highlight border
+
+Note on filename resolution: The status endpoint returns `input.ctx.sourceDocId` (a media ID). To show the filename, the component will need to batch-fetch media records via `/api/media?where[id][in]=<ids>&select[filename]=true&limit=20`. This is done once after fetching jobs, not per-job.
+
+---
+
+### Phase 6: Exercise Review Panel (Right Panel, Bottom)
+
+#### Step 6.1: Create ExerciseReview
+
+**File**: `src/ui/admin/PdfConversion/ExerciseReview/index.tsx`
+
+Props:
+
+- `jobId: string`
+
+Behavior:
+
+- Fetch exercises from `/api/exercises?where[conversionJobId][equals]=<jobId>&limit=100&sort=sourceOrderInSegment`
+- Render as a list of cards, each showing:
+  - Title (truncated to ~80 chars)
+  - Source pages: "Pages X-Y"
+  - Status badge (draft/published)
+  - "Open in Editor" link: `<a href="/admin/collections/exercises/<id>" target="_blank">`
+- Empty state: "No exercises found for this job"
+- Loading state while fetching
+
+---
+
+### Phase 7: Tests
+
+All tests follow the project's existing patterns:
+
+- Vitest with `// @vitest-environment jsdom` for component tests
+- `@testing-library/react` for rendering and assertions
+- `vi.mock()` for module mocking
+- File naming: `*.spec.tsx` for components, `*.spec.ts` for logic
+
+#### Test 7.1: Schema Change
+
+**File**: `tests/unit/api/schemas/job-schemas.spec.ts` (modify existing)
+
+Add test cases for optional `lessonId`/`mediaId` in `jobStatusQuerySchema`:
+
+- `{}` -> success, limit defaults to 10
+- `{ lessonId: validId }` -> success, mediaId undefined
+- `{ mediaId: validId }` -> success, lessonId undefined
+- `{ lessonId: validId, mediaId: validId }` -> success (backward compat)
+- `{ lessonId: 'bad' }` -> fail (invalid ObjectId still rejected)
+
+#### Test 7.2: SidebarLink Component
+
+**File**: `tests/unit/components/pdf-conversion/SidebarLink.spec.tsx`
+
+```
+- renders a nav link to /admin/pdf-conversion
+- has correct Payload nav CSS classes (nav__item, nav__link, nav__label)
+- displays "PDF Conversion" label text
+```
+
+Mocks: `next/link` (or verify href attribute directly)
+
+#### Test 7.3: PdfConversionPage Layout
+
+**File**: `tests/unit/components/pdf-conversion/PdfConversionPage.spec.tsx`
+
+```
+- renders page title "PDF Conversion"
+- renders the conversion form section
+- renders the job history section
+- does not render exercise review when no job selected
+```
+
+Mocks: All child components mocked via `vi.mock()`:
+
+- `vi.mock('@/ui/admin/PdfConversion/ConversionForm', ...)`
+- `vi.mock('@/ui/admin/PdfConversion/JobHistory', ...)`
+- `vi.mock('@/ui/admin/PdfConversion/ExerciseReview', ...)`
+
+#### Test 7.4: LessonSelector
+
+**File**: `tests/unit/components/pdf-conversion/LessonSelector.spec.tsx`
+
+```
+- renders search input
+- shows loading state while fetching
+- displays lesson results on search
+- calls onSelectLesson when a result is clicked
+- shows selected lesson name
+- debounces search input (does not fetch on every keystroke)
+```
+
+Mocks: `global.fetch` to mock `/api/lessons` responses
+
+#### Test 7.5: PdfSelector
+
+**File**: `tests/unit/components/pdf-conversion/PdfSelector.spec.tsx`
+
+```
+- shows loading state on mount
+- fetches lesson media and filters for PDFs
+- renders PDF filenames as selectable items
+- calls onSelectMedia when a PDF is clicked
+- shows "No PDFs" message when lesson has no PDF files
+- highlights selected PDF
+```
+
+Mocks: `global.fetch` to mock `/api/lessons/<id>` response with contentFiles
+
+#### Test 7.6: ConversionForm
+
+**File**: `tests/unit/components/pdf-conversion/ConversionForm.spec.tsx`
+
+```
+- renders all form sections (lesson, pdf, prompts, submit)
+- submit button is disabled when required fields are missing
+- submit button is disabled while submitting
+- calls onQueued after successful submission
+- shows error message on failed submission
+- shows success message after queueing
+- loads prompts when lesson is selected
+```
+
+Mocks:
+
+- `global.fetch` for `/api/prompts/for-conversion` and `/api/exercises/convert/queue`
+- Child components (LessonSelector, PdfSelector) mocked or rendered
+
+#### Test 7.7: JobHistory
+
+**File**: `tests/unit/components/pdf-conversion/JobHistory.spec.tsx`
+
+```
+- shows loading state initially
+- renders job cards after fetch
+- shows status badge with correct styling for each status
+- shows progress bar for running jobs
+- shows "Run Now" button for queued/failed jobs
+- calls onSelectJob when "View Exercises" is clicked
+- highlights selected job
+- re-fetches when refreshKey changes
+- shows empty state when no jobs exist
+```
+
+Mocks: `global.fetch` for `/api/exercises/convert/status` and `/api/media`
+
+#### Test 7.8: ExerciseReview
+
+**File**: `tests/unit/components/pdf-conversion/ExerciseReview.spec.tsx`
+
+```
+- shows loading state initially
+- renders exercise cards after fetch
+- shows exercise title, source pages, and status
+- renders "Open in Editor" link with correct href
+- shows empty state when no exercises found
+```
+
+Mocks: `global.fetch` for `/api/exercises` responses
+
+#### Test 7.9: Page Route (auth gating)
+
+**File**: `tests/unit/components/pdf-conversion/AdminPdfConversionPage.spec.tsx`
+
+```
+- shows loading state while auth is loading
+- shows login prompt when user is null
+- shows admin required message for non-admin users
+- renders PdfConversionPage for admin users
+```
+
+Mocks:
+
+- `vi.mock('@/client/hooks/useCurrentUser', ...)`
+- `vi.mock('@/ui/admin/PdfConversion/PdfConversionPage', ...)`
+
+---
+
+### Phase 8: Verification
+
+#### Step 8.1: TypeScript Check
+
+```bash
+pnpm tsc --noEmit
+```
+
+Must pass with zero errors.
+
+#### Step 8.2: Lint
+
+```bash
+pnpm lint
+```
+
+Must pass. Fix any auto-fixable issues with `pnpm lint --fix`.
+
+#### Step 8.3: Format
+
+```bash
+pnpm format:check
+```
+
+If fails, run `pnpm format` to fix.
+
+#### Step 8.4: Unit Tests
+
+```bash
+pnpm test:unit
+```
+
+All existing + new tests must pass.
+
+#### Step 8.5: Import Map
+
+Verify `src/app/(payload)/admin/importMap.js` was regenerated and includes the new component paths.
+
+#### Step 8.6: Manual Smoke Test Checklist
+
+- [ ] Navigate to `/admin` -- sidebar shows "PDF Conversion" link
+- [ ] Click link -- page loads, shows "PDF Conversion" title
+- [ ] Non-admin user sees "Admin access required"
+- [ ] Search for a lesson -- results appear, selecting one works
+- [ ] Selected lesson shows its PDF files
+- [ ] Selecting a PDF enables prompt dropdowns
+- [ ] Prompts load correctly for the lesson's tenant
+- [ ] Starting a conversion shows success, job appears in history
+- [ ] Job history shows correct status badges
+- [ ] Completed job "View Exercises" shows exercise cards
+- [ ] "Open in Editor" links open exercise edit page in new tab
+- [ ] Page is responsive -- stacks on narrow viewport
+
+---
+
+### Phase 9: Git & PR
+
+#### Step 9.1: Commit Strategy
+
+Single feature commit (or split if large):
+
+```
+feat: add dedicated PDF conversion admin page
+
+Replace the cramped inline conversion panel with a full admin page at
+/admin/pdf-conversion. Includes searchable lesson/PDF selection, prompt
+configuration, job history with status monitoring, and exercise review cards.
+```
+
+#### Step 9.2: Create PR
+
+```bash
+gh pr create \
+  --title "feat: dedicated PDF conversion admin page" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds a new admin page at `/admin/pdf-conversion` for PDF-to-exercise conversion
+- Searchable lesson selector, PDF file picker, and prompt configuration form
+- Job history panel with status badges, progress bars, and error details
+- Exercise review cards for completed conversions with links to exercise editor
+
+## Changes
+- **New page**: `src/app/(payload)/admin/pdf-conversion/page.tsx`
+- **New components**: `src/ui/admin/PdfConversion/` (9 components)
+- **Backend**: Made `lessonId`/`mediaId` optional in status endpoint schema (backward compatible)
+- **Config**: Added sidebar nav link in `payload.config.ts`
+
+## Testing
+- Unit tests for all new components and schema changes
+- Manual smoke test against dev environment
+
+## Screenshots
+(attach after implementation)
+EOF
+)"
+```
+
+---
+
+## Files Summary
+
+### Files to Create (11)
+
+| File                                                      | Purpose                    |
+| --------------------------------------------------------- | -------------------------- |
+| `src/app/(payload)/admin/pdf-conversion/page.tsx`         | Page route (auth-gated)    |
+| `src/ui/admin/PdfConversion/SidebarLink/index.tsx`        | Nav link                   |
+| `src/ui/admin/PdfConversion/PdfConversionPage/index.tsx`  | Main two-column layout     |
+| `src/ui/admin/PdfConversion/PdfConversionPage/index.scss` | Page styles                |
+| `src/ui/admin/PdfConversion/LessonSelector/index.tsx`     | Searchable lesson picker   |
+| `src/ui/admin/PdfConversion/PdfSelector/index.tsx`        | PDF file selector          |
+| `src/ui/admin/PdfConversion/ConversionForm/index.tsx`     | Prompt config + submit     |
+| `src/ui/admin/PdfConversion/JobHistory/index.tsx`         | Job list with status       |
+| `src/ui/admin/PdfConversion/ExerciseReview/index.tsx`     | Exercise review cards      |
+| `tests/unit/components/pdf-conversion/*.spec.tsx`         | 8 test files (see Phase 7) |
+
+### Files to Modify (2)
+
+| File                                    | Change                                                           |
+| --------------------------------------- | ---------------------------------------------------------------- |
+| `src/payload.config.ts`                 | Add `'@/ui/admin/PdfConversion/SidebarLink'` to `beforeNavLinks` |
+| `src/server/api/schemas/job-schemas.ts` | Make `lessonId`/`mediaId` optional, change default limit to 10   |
+
+### Files NOT Modified
+
+- `src/app/api/exercises/convert/status/route.ts` -- No code changes needed (schema change is sufficient)
+- `src/app/api/exercises/convert/queue/route.ts` -- Unchanged
+- `src/ui/admin/exercise-conversion/*` -- Existing inline panel stays as-is
+- `src/server/payload/services/job-service.ts` -- Already handles optional context fields
+
+## Not in Scope
+
+- PDF preview/viewer on this page (could be added later)
+- Standalone PDF conversion (no lesson)
+- Batch operations (convert multiple PDFs at once)
+- Changes to the conversion pipeline or prompts system
+- E2E tests (would require full app + DB; can be added as follow-up)

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -33,6 +33,7 @@ import { default as default_c259230fb9bab1a58b8cb0b2cc96501a } from '@/ui/admin/
 import { default as default_016129c5e178a72215a550b5b56f066c } from '@/ui/admin/AdminChat/DashboardWidget'
 import { default as default_e8db4fbd97550d4d717940b5cf0234f3 } from '@/ui/admin/BeforeLogin'
 import { default as default_164c9a24e274ad3cd69e6bbec59bbe86 } from '@/ui/admin/AdminChat/SidebarLink'
+import { default as default_7545204935b55fcf02b3be70dde90fc1 } from '@/ui/admin/PdfConversion/SidebarLink'
 import { VercelBlobClientUploadHandler as VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e } from '@payloadcms/storage-vercel-blob/client'
 import { CollectionCards as CollectionCards_ab83ff7e88da8d3530831f296ec4756a } from '@payloadcms/ui/rsc'
 
@@ -72,6 +73,7 @@ export const importMap = {
   "@/ui/admin/AdminChat/DashboardWidget#default": default_016129c5e178a72215a550b5b56f066c,
   "@/ui/admin/BeforeLogin#default": default_e8db4fbd97550d4d717940b5cf0234f3,
   "@/ui/admin/AdminChat/SidebarLink#default": default_164c9a24e274ad3cd69e6bbec59bbe86,
+  "@/ui/admin/PdfConversion/SidebarLink#default": default_7545204935b55fcf02b3be70dde90fc1,
   "@payloadcms/storage-vercel-blob/client#VercelBlobClientUploadHandler": VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e,
   "@payloadcms/ui/rsc#CollectionCards": CollectionCards_ab83ff7e88da8d3530831f296ec4756a
 }

--- a/src/app/(payload)/admin/pdf-conversion/page.tsx
+++ b/src/app/(payload)/admin/pdf-conversion/page.tsx
@@ -1,0 +1,35 @@
+/**
+ * PDF Conversion Admin Page
+ *
+ * @fileType page
+ * @domain admin
+ * @pattern admin-page
+ * @ai-summary Dedicated admin page for PDF-to-exercise conversion
+ *
+ * Access: Admins only (enforced by role check)
+ */
+'use client'
+
+import { useCurrentUser } from '@/client/hooks/useCurrentUser'
+import { PdfConversionPage } from '@/ui/admin/PdfConversion/PdfConversionPage'
+
+export default function AdminPdfConversionPage() {
+  const { user, isLoading } = useCurrentUser()
+
+  if (isLoading) {
+    return <div style={{ padding: 20 }}>Loading...</div>
+  }
+
+  if (!user) {
+    return <div style={{ padding: 20 }}>Please log in to access PDF conversion</div>
+  }
+
+  // Check for admin role (handles both string role and array role)
+  const isAdmin = Array.isArray(user.role) ? user.role.includes('admin') : user.role === 'admin'
+
+  if (!isAdmin) {
+    return <div style={{ padding: 20 }}>Admin access required</div>
+  }
+
+  return <PdfConversionPage />
+}

--- a/src/app/(payload)/admin/pdf-conversion/page.tsx
+++ b/src/app/(payload)/admin/pdf-conversion/page.tsx
@@ -13,22 +13,34 @@
 import { useCurrentUser } from '@/client/hooks/useCurrentUser'
 import { PdfConversionPage } from '@/ui/admin/PdfConversion/PdfConversionPage'
 
+const loadingStyle: React.CSSProperties = {
+  padding: 20,
+  color: 'var(--theme-elevation-500)',
+  fontSize: 13,
+}
+
+const errorStyle: React.CSSProperties = {
+  padding: 20,
+  color: 'var(--theme-error)',
+  fontSize: 13,
+}
+
 export default function AdminPdfConversionPage() {
   const { user, isLoading } = useCurrentUser()
 
   if (isLoading) {
-    return <div style={{ padding: 20 }}>Loading...</div>
+    return <div style={loadingStyle}>Loading...</div>
   }
 
   if (!user) {
-    return <div style={{ padding: 20 }}>Please log in to access PDF conversion</div>
+    return <div style={errorStyle}>Please log in to access PDF conversion</div>
   }
 
   // Check for admin role (handles both string role and array role)
   const isAdmin = Array.isArray(user.role) ? user.role.includes('admin') : user.role === 'admin'
 
   if (!isAdmin) {
-    return <div style={{ padding: 20 }}>Admin access required</div>
+    return <div style={errorStyle}>Admin access required</div>
   }
 
   return <PdfConversionPage />

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -78,7 +78,7 @@ export default buildConfig({
       // The `BeforeDashboard` component renders the 'welcome' block that you see after logging into your admin panel.
       // Feel free to delete this at any time. Simply remove the line below.
       beforeDashboard: ['@/ui/admin/BeforeDashboard', '@/ui/admin/AdminChat/DashboardWidget'],
-      beforeNavLinks: ['@/ui/admin/AdminChat/SidebarLink'],
+      beforeNavLinks: ['@/ui/admin/AdminChat/SidebarLink', '@/ui/admin/PdfConversion/SidebarLink'],
     },
     importMap: {
       baseDir: path.resolve(dirname),

--- a/src/server/api/schemas/job-schemas.ts
+++ b/src/server/api/schemas/job-schemas.ts
@@ -7,9 +7,9 @@ export const runJobSchema = z.object({
 })
 
 export const jobStatusQuerySchema = z.object({
-  lessonId: objectIdSchema,
-  mediaId: objectIdSchema,
-  limit: z.coerce.number().int().min(1).max(100).default(1),
+  lessonId: objectIdSchema.optional(),
+  mediaId: objectIdSchema.optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(10),
 })
 
 export const queueConversionSchema = z.object({
@@ -17,6 +17,7 @@ export const queueConversionSchema = z.object({
   mediaId: objectIdSchema,
   extractorPromptId: objectIdSchema,
   verifierPromptId: objectIdSchema,
+  diagramPromptId: objectIdSchema.optional(),
 })
 
 export type RunJobInput = z.infer<typeof runJobSchema>

--- a/src/ui/admin/PdfConversion/ConversionForm/index.tsx
+++ b/src/ui/admin/PdfConversion/ConversionForm/index.tsx
@@ -66,6 +66,21 @@ const submitButtonDisabledStyle: React.CSSProperties = {
   opacity: 0.6,
 }
 
+const emptyStateStyle: React.CSSProperties = {
+  padding: 12,
+  fontSize: 13,
+  color: 'var(--theme-elevation-600)',
+  backgroundColor: 'var(--theme-elevation-50)',
+  borderRadius: 4,
+  border: '1px dashed var(--theme-elevation-300)',
+}
+
+const helperTextStyle: React.CSSProperties = {
+  fontSize: 12,
+  color: 'var(--theme-elevation-500)',
+  marginTop: 4,
+}
+
 export function ConversionForm({ onQueued }: ConversionFormProps) {
   const [selectedLessonId, setSelectedLessonId] = useState<string | null>(null)
   const [selectedMediaId, setSelectedMediaId] = useState<string | null>(null)
@@ -96,6 +111,7 @@ export function ConversionForm({ onQueued }: ConversionFormProps) {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ lessonId: selectedLessonId }),
+          credentials: 'include',
         })
 
         if (!response.ok) {
@@ -207,11 +223,24 @@ export function ConversionForm({ onQueued }: ConversionFormProps) {
 
       {isLoadingPrompts ? (
         <div style={loadingStyle}>Loading prompts...</div>
+      ) : !selectedLessonId ? (
+        <div style={emptyStateStyle}>Select a lesson above to load available prompts</div>
+      ) : prompts.extractors.length === 0 && prompts.verifiers.length === 0 ? (
+        <div style={emptyStateStyle}>
+          <strong>No prompts found</strong>
+          <p style={{ margin: '4px 0 0 0' }}>
+            Create published prompts with usage types extractor and verifier for the selected lesson
+            tenant
+          </p>
+        </div>
       ) : (
         <>
           <div style={fieldGroupStyle}>
             <label htmlFor="extractor-prompt" style={labelStyle}>
               Extractor Prompt *
+              {prompts.extractors.length > 0 && (
+                <span style={helperTextStyle}>({prompts.extractors.length} available)</span>
+              )}
             </label>
             <select
               id="extractor-prompt"
@@ -232,6 +261,9 @@ export function ConversionForm({ onQueued }: ConversionFormProps) {
           <div style={fieldGroupStyle}>
             <label htmlFor="verifier-prompt" style={labelStyle}>
               Verifier Prompt *
+              {prompts.verifiers.length > 0 && (
+                <span style={helperTextStyle}>({prompts.verifiers.length} available)</span>
+              )}
             </label>
             <select
               id="verifier-prompt"
@@ -252,6 +284,9 @@ export function ConversionForm({ onQueued }: ConversionFormProps) {
           <div style={fieldGroupStyle}>
             <label htmlFor="diagram-prompt" style={labelStyle}>
               Diagram Generator (optional)
+              {prompts.diagramGenerators.length > 0 && (
+                <span style={helperTextStyle}>({prompts.diagramGenerators.length} available)</span>
+              )}
             </label>
             <select
               id="diagram-prompt"

--- a/src/ui/admin/PdfConversion/ConversionForm/index.tsx
+++ b/src/ui/admin/PdfConversion/ConversionForm/index.tsx
@@ -11,6 +11,15 @@
 import { useCallback, useEffect, useState } from 'react'
 import { LessonSelector } from '../LessonSelector'
 import { PdfSelector } from '../PdfSelector'
+import {
+  cardStyle,
+  errorBannerStyle,
+  fieldGroupStyle,
+  labelStyle,
+  sectionHeadingStyle,
+  selectStyle,
+  successBannerStyle,
+} from '../styles'
 
 interface PromptOption {
   id: string
@@ -29,6 +38,32 @@ interface LessonOption {
 
 interface ConversionFormProps {
   onQueued: () => void
+}
+
+const loadingStyle: React.CSSProperties = {
+  fontSize: 13,
+  color: 'var(--theme-elevation-500)',
+}
+
+const submitButtonStyle: React.CSSProperties = {
+  width: '100%',
+  height: 36,
+  padding: '0 16px',
+  fontSize: 13,
+  fontWeight: 500,
+  backgroundColor: 'var(--theme-elevation-800)',
+  color: 'white',
+  border: 'none',
+  borderRadius: 4,
+  cursor: 'pointer',
+  marginTop: 8,
+}
+
+const submitButtonDisabledStyle: React.CSSProperties = {
+  ...submitButtonStyle,
+  backgroundColor: 'var(--theme-elevation-400)',
+  cursor: 'not-allowed',
+  opacity: 0.6,
 }
 
 export function ConversionForm({ onQueued }: ConversionFormProps) {
@@ -150,44 +185,37 @@ export function ConversionForm({ onQueued }: ConversionFormProps) {
   const isFormValid = selectedLessonId && selectedMediaId && extractorPromptId && verifierPromptId
 
   return (
-    <form
-      className="bg-white rounded-lg border border-gray-200 p-4 space-y-4"
-      onSubmit={handleSubmit}
-    >
-      <h2 className="text-lg font-semibold">Convert PDF to Exercises</h2>
+    <form style={cardStyle} onSubmit={handleSubmit}>
+      <h2 style={sectionHeadingStyle}>Convert PDF to Exercises</h2>
 
-      {error && (
-        <div className="p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">
-          {error}
-        </div>
-      )}
-      {success && (
-        <div className="p-3 bg-green-50 border border-green-200 rounded text-green-700 text-sm">
-          Conversion job queued successfully!
-        </div>
-      )}
+      {error && <div style={errorBannerStyle}>{error}</div>}
+      {success && <div style={successBannerStyle}>Conversion job queued successfully!</div>}
 
-      <LessonSelector selectedLessonId={selectedLessonId} onSelectLesson={handleLessonSelect} />
+      <div style={fieldGroupStyle}>
+        <LessonSelector selectedLessonId={selectedLessonId} onSelectLesson={handleLessonSelect} />
+      </div>
 
       {selectedLessonId && (
-        <PdfSelector
-          lessonId={selectedLessonId}
-          selectedMediaId={selectedMediaId}
-          onSelectMedia={setSelectedMediaId}
-        />
+        <div style={fieldGroupStyle}>
+          <PdfSelector
+            lessonId={selectedLessonId}
+            selectedMediaId={selectedMediaId}
+            onSelectMedia={setSelectedMediaId}
+          />
+        </div>
       )}
 
       {isLoadingPrompts ? (
-        <div className="text-sm text-gray-500">Loading prompts...</div>
+        <div style={loadingStyle}>Loading prompts...</div>
       ) : (
         <>
-          <div className="space-y-1">
-            <label htmlFor="extractor-prompt" className="block text-sm font-medium text-gray-700">
+          <div style={fieldGroupStyle}>
+            <label htmlFor="extractor-prompt" style={labelStyle}>
               Extractor Prompt *
             </label>
             <select
               id="extractor-prompt"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+              style={selectStyle}
               value={extractorPromptId}
               onChange={(e) => setExtractorPromptId(e.target.value)}
               required
@@ -201,13 +229,13 @@ export function ConversionForm({ onQueued }: ConversionFormProps) {
             </select>
           </div>
 
-          <div className="space-y-1">
-            <label htmlFor="verifier-prompt" className="block text-sm font-medium text-gray-700">
+          <div style={fieldGroupStyle}>
+            <label htmlFor="verifier-prompt" style={labelStyle}>
               Verifier Prompt *
             </label>
             <select
               id="verifier-prompt"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+              style={selectStyle}
               value={verifierPromptId}
               onChange={(e) => setVerifierPromptId(e.target.value)}
               required
@@ -221,13 +249,13 @@ export function ConversionForm({ onQueued }: ConversionFormProps) {
             </select>
           </div>
 
-          <div className="space-y-1">
-            <label htmlFor="diagram-prompt" className="block text-sm font-medium text-gray-700">
+          <div style={fieldGroupStyle}>
+            <label htmlFor="diagram-prompt" style={labelStyle}>
               Diagram Generator (optional)
             </label>
             <select
               id="diagram-prompt"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+              style={selectStyle}
               value={diagramPromptId}
               onChange={(e) => setDiagramPromptId(e.target.value)}
             >
@@ -244,7 +272,7 @@ export function ConversionForm({ onQueued }: ConversionFormProps) {
 
       <button
         type="submit"
-        className="w-full px-4 py-2 bg-blue-600 text-white rounded-md text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed hover:bg-blue-700 transition-colors"
+        style={isFormValid && !isSubmitting ? submitButtonStyle : submitButtonDisabledStyle}
         disabled={!isFormValid || isSubmitting}
       >
         {isSubmitting ? 'Queuing...' : 'Start Conversion'}

--- a/src/ui/admin/PdfConversion/ConversionForm/index.tsx
+++ b/src/ui/admin/PdfConversion/ConversionForm/index.tsx
@@ -1,0 +1,254 @@
+/**
+ * Conversion Form Component
+ *
+ * @fileType component
+ * @domain admin
+ * @pattern form
+ * @ai-summary Form for configuring and starting PDF-to-exercise conversion
+ */
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { LessonSelector } from '../LessonSelector'
+import { PdfSelector } from '../PdfSelector'
+
+interface PromptOption {
+  id: string
+  title: string
+  key: string
+  type: string
+  usage: string
+  status: string
+}
+
+interface LessonOption {
+  id: string
+  title: string
+  chapterTitle?: string
+}
+
+interface ConversionFormProps {
+  onQueued: () => void
+}
+
+export function ConversionForm({ onQueued }: ConversionFormProps) {
+  const [selectedLessonId, setSelectedLessonId] = useState<string | null>(null)
+  const [selectedMediaId, setSelectedMediaId] = useState<string | null>(null)
+  const [extractorPromptId, setExtractorPromptId] = useState<string>('')
+  const [verifierPromptId, setVerifierPromptId] = useState<string>('')
+  const [diagramPromptId, setDiagramPromptId] = useState<string>('')
+  const [prompts, setPrompts] = useState<{
+    extractors: PromptOption[]
+    verifiers: PromptOption[]
+    diagramGenerators: PromptOption[]
+  }>({ extractors: [], verifiers: [], diagramGenerators: [] })
+  const [isLoadingPrompts, setIsLoadingPrompts] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  useEffect(() => {
+    if (!selectedLessonId) {
+      setPrompts({ extractors: [], verifiers: [], diagramGenerators: [] })
+      return
+    }
+
+    async function fetchPrompts() {
+      setIsLoadingPrompts(true)
+      setError(null)
+      try {
+        const response = await fetch('/api/prompts/for-conversion', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ lessonId: selectedLessonId }),
+        })
+
+        if (!response.ok) {
+          const errorData = await response.json()
+          throw new Error(errorData.error?.message || 'Failed to fetch prompts')
+        }
+
+        const data = await response.json()
+        setPrompts({
+          extractors: data.extractors || [],
+          verifiers: data.verifiers || [],
+          diagramGenerators: data.diagramGenerators || [],
+        })
+      } catch (err) {
+        console.error('Failed to fetch prompts:', err)
+        setError(err instanceof Error ? err.message : 'Failed to load prompts')
+      } finally {
+        setIsLoadingPrompts(false)
+      }
+    }
+
+    fetchPrompts()
+  }, [selectedLessonId])
+
+  const handleLessonSelect = useCallback((lessonId: string, _lesson: LessonOption) => {
+    setSelectedLessonId(lessonId)
+    setSelectedMediaId(null)
+    setExtractorPromptId('')
+    setVerifierPromptId('')
+    setDiagramPromptId('')
+  }, [])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setSuccess(false)
+
+    if (!selectedLessonId || !selectedMediaId || !extractorPromptId || !verifierPromptId) {
+      setError('Please fill in all required fields')
+      return
+    }
+
+    setIsSubmitting(true)
+
+    try {
+      const body: Record<string, string> = {
+        lessonId: selectedLessonId,
+        mediaId: selectedMediaId,
+        extractorPromptId,
+        verifierPromptId,
+      }
+
+      if (diagramPromptId) {
+        body.diagramPromptId = diagramPromptId
+      }
+
+      const response = await fetch('/api/exercises/convert/queue', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+
+      if (!response.ok) {
+        const errorData = await response.json()
+        throw new Error(errorData.error?.message || 'Failed to queue conversion')
+      }
+
+      setSuccess(true)
+      onQueued()
+
+      // Reset form after 2 seconds
+      setTimeout(() => {
+        setSuccess(false)
+        setSelectedLessonId(null)
+        setSelectedMediaId(null)
+        setExtractorPromptId('')
+        setVerifierPromptId('')
+        setDiagramPromptId('')
+      }, 2000)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to queue conversion')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const isFormValid = selectedLessonId && selectedMediaId && extractorPromptId && verifierPromptId
+
+  return (
+    <form
+      className="bg-white rounded-lg border border-gray-200 p-4 space-y-4"
+      onSubmit={handleSubmit}
+    >
+      <h2 className="text-lg font-semibold">Convert PDF to Exercises</h2>
+
+      {error && (
+        <div className="p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">
+          {error}
+        </div>
+      )}
+      {success && (
+        <div className="p-3 bg-green-50 border border-green-200 rounded text-green-700 text-sm">
+          Conversion job queued successfully!
+        </div>
+      )}
+
+      <LessonSelector selectedLessonId={selectedLessonId} onSelectLesson={handleLessonSelect} />
+
+      {selectedLessonId && (
+        <PdfSelector
+          lessonId={selectedLessonId}
+          selectedMediaId={selectedMediaId}
+          onSelectMedia={setSelectedMediaId}
+        />
+      )}
+
+      {isLoadingPrompts ? (
+        <div className="text-sm text-gray-500">Loading prompts...</div>
+      ) : (
+        <>
+          <div className="space-y-1">
+            <label htmlFor="extractor-prompt" className="block text-sm font-medium text-gray-700">
+              Extractor Prompt *
+            </label>
+            <select
+              id="extractor-prompt"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+              value={extractorPromptId}
+              onChange={(e) => setExtractorPromptId(e.target.value)}
+              required
+            >
+              <option value="">Select extractor prompt</option>
+              {prompts.extractors.map((prompt) => (
+                <option key={prompt.id} value={prompt.id}>
+                  {prompt.title}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="verifier-prompt" className="block text-sm font-medium text-gray-700">
+              Verifier Prompt *
+            </label>
+            <select
+              id="verifier-prompt"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+              value={verifierPromptId}
+              onChange={(e) => setVerifierPromptId(e.target.value)}
+              required
+            >
+              <option value="">Select verifier prompt</option>
+              {prompts.verifiers.map((prompt) => (
+                <option key={prompt.id} value={prompt.id}>
+                  {prompt.title}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="diagram-prompt" className="block text-sm font-medium text-gray-700">
+              Diagram Generator (optional)
+            </label>
+            <select
+              id="diagram-prompt"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm"
+              value={diagramPromptId}
+              onChange={(e) => setDiagramPromptId(e.target.value)}
+            >
+              <option value="">None</option>
+              {prompts.diagramGenerators.map((prompt) => (
+                <option key={prompt.id} value={prompt.id}>
+                  {prompt.title}
+                </option>
+              ))}
+            </select>
+          </div>
+        </>
+      )}
+
+      <button
+        type="submit"
+        className="w-full px-4 py-2 bg-blue-600 text-white rounded-md text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed hover:bg-blue-700 transition-colors"
+        disabled={!isFormValid || isSubmitting}
+      >
+        {isSubmitting ? 'Queuing...' : 'Start Conversion'}
+      </button>
+    </form>
+  )
+}

--- a/src/ui/admin/PdfConversion/ExerciseReview/index.tsx
+++ b/src/ui/admin/PdfConversion/ExerciseReview/index.tsx
@@ -9,6 +9,14 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import {
+  cardStyle,
+  exerciseCardStyle,
+  exerciseMetaStyle,
+  exerciseTitleStyle,
+  getBadgeStyle,
+  sectionHeadingStyle,
+} from '../styles'
 
 interface Exercise {
   id: string
@@ -19,6 +27,43 @@ interface Exercise {
 
 interface ExerciseReviewProps {
   jobId: string
+}
+
+const loadingStyle: React.CSSProperties = {
+  ...cardStyle,
+}
+
+const errorStyle: React.CSSProperties = {
+  ...cardStyle,
+}
+
+const emptyStyle: React.CSSProperties = {
+  ...cardStyle,
+}
+
+const listStyle: React.CSSProperties = {
+  listStyle: 'none',
+  padding: 0,
+  margin: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+}
+
+const exerciseContentStyle: React.CSSProperties = {
+  flex: 1,
+  minWidth: 0,
+}
+
+const openButtonStyle: React.CSSProperties = {
+  padding: '4px 12px',
+  fontSize: 13,
+  backgroundColor: 'var(--theme-elevation-200)',
+  color: 'var(--theme-elevation-800)',
+  border: 'none',
+  borderRadius: 3,
+  cursor: 'pointer',
+  whiteSpace: 'nowrap' as const,
 }
 
 export function ExerciseReview({ jobId }: ExerciseReviewProps) {
@@ -57,27 +102,31 @@ export function ExerciseReview({ jobId }: ExerciseReviewProps) {
 
   if (isLoading) {
     return (
-      <div className="bg-white rounded-lg border border-gray-200 p-4">
-        <h3 className="text-lg font-semibold mb-3">Exercises</h3>
-        <div className="text-sm text-gray-500">Loading exercises...</div>
+      <div style={loadingStyle}>
+        <h3 style={sectionHeadingStyle}>Exercises</h3>
+        <div style={{ fontSize: 13, color: 'var(--theme-elevation-500)' }}>
+          Loading exercises...
+        </div>
       </div>
     )
   }
 
   if (error) {
     return (
-      <div className="bg-white rounded-lg border border-gray-200 p-4">
-        <h3 className="text-lg font-semibold mb-3">Exercises</h3>
-        <div className="text-sm text-red-600">{error}</div>
+      <div style={errorStyle}>
+        <h3 style={sectionHeadingStyle}>Exercises</h3>
+        <div style={{ fontSize: 13, color: 'var(--theme-error)' }}>{error}</div>
       </div>
     )
   }
 
   if (exercises.length === 0) {
     return (
-      <div className="bg-white rounded-lg border border-gray-200 p-4">
-        <h3 className="text-lg font-semibold mb-3">Exercises</h3>
-        <div className="text-sm text-gray-500">No exercises found for this job</div>
+      <div style={emptyStyle}>
+        <h3 style={sectionHeadingStyle}>Exercises</h3>
+        <div style={{ fontSize: 13, color: 'var(--theme-elevation-500)' }}>
+          No exercises found for this job
+        </div>
       </div>
     )
   }
@@ -88,43 +137,28 @@ export function ExerciseReview({ jobId }: ExerciseReviewProps) {
   }
 
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-4">
-      <h3 className="text-lg font-semibold mb-3">Exercises ({exercises.length})</h3>
-      <ul className="space-y-2">
+    <div style={cardStyle}>
+      <h3 style={sectionHeadingStyle}>Exercises ({exercises.length})</h3>
+      <ul style={listStyle}>
         {exercises.map((exercise) => (
-          <li
-            key={exercise.id}
-            className="p-3 border border-gray-200 rounded-lg hover:border-gray-300"
-          >
-            <div className="flex items-start justify-between gap-2">
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-gray-900 truncate">
-                  {truncateTitle(exercise.title)}
-                </p>
-                {exercise.sourcePages && (
-                  <p className="text-xs text-gray-500">Pages {exercise.sourcePages}</p>
-                )}
-                {exercise._status && (
-                  <span
-                    className={`inline-block mt-1 px-2 py-0.5 text-xs rounded ${
-                      exercise._status === 'published'
-                        ? 'bg-green-100 text-green-800'
-                        : 'bg-gray-100 text-gray-800'
-                    }`}
-                  >
-                    {exercise._status}
-                  </span>
-                )}
-              </div>
-              <a
-                href={`/admin/collections/exercises/${exercise.id}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="px-3 py-1 text-sm bg-blue-100 hover:bg-blue-200 text-blue-800 rounded transition-colors whitespace-nowrap"
-              >
-                Open in Editor
-              </a>
+          <li key={exercise.id} style={exerciseCardStyle}>
+            <div style={exerciseContentStyle}>
+              <p style={exerciseTitleStyle}>{truncateTitle(exercise.title)}</p>
+              {exercise.sourcePages && (
+                <p style={exerciseMetaStyle}>Pages {exercise.sourcePages}</p>
+              )}
+              {exercise._status && (
+                <span style={getBadgeStyle(exercise._status)}>{exercise._status}</span>
+              )}
             </div>
+            <a
+              href={`/admin/collections/exercises/${exercise.id}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={openButtonStyle}
+            >
+              Open in Editor
+            </a>
           </li>
         ))}
       </ul>

--- a/src/ui/admin/PdfConversion/ExerciseReview/index.tsx
+++ b/src/ui/admin/PdfConversion/ExerciseReview/index.tsx
@@ -1,0 +1,133 @@
+/**
+ * Exercise Review Component
+ *
+ * @fileType component
+ * @domain admin
+ * @pattern exercise-list
+ * @ai-summary Displays exercises created by a conversion job with links to editor
+ */
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface Exercise {
+  id: string
+  title: string
+  sourcePages?: string
+  _status?: 'draft' | 'published'
+}
+
+interface ExerciseReviewProps {
+  jobId: string
+}
+
+export function ExerciseReview({ jobId }: ExerciseReviewProps) {
+  const [exercises, setExercises] = useState<Exercise[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function fetchExercises() {
+      setIsLoading(true)
+      setError(null)
+
+      try {
+        const response = await fetch(
+          `/api/exercises?where[conversionJobId][equals]=${jobId}&limit=100&sort=sourceOrderInSegment`,
+          { credentials: 'include' },
+        )
+
+        if (!response.ok) {
+          throw new Error('Failed to fetch exercises')
+        }
+
+        const json = await response.json()
+        const fetchedExercises: Exercise[] = json.data?.docs || json.docs || []
+        setExercises(fetchedExercises)
+      } catch (err) {
+        console.error('Failed to fetch exercises:', err)
+        setError('Failed to load exercises')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchExercises()
+  }, [jobId])
+
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <h3 className="text-lg font-semibold mb-3">Exercises</h3>
+        <div className="text-sm text-gray-500">Loading exercises...</div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <h3 className="text-lg font-semibold mb-3">Exercises</h3>
+        <div className="text-sm text-red-600">{error}</div>
+      </div>
+    )
+  }
+
+  if (exercises.length === 0) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <h3 className="text-lg font-semibold mb-3">Exercises</h3>
+        <div className="text-sm text-gray-500">No exercises found for this job</div>
+      </div>
+    )
+  }
+
+  const truncateTitle = (title: string, maxLength = 80): string => {
+    if (title.length <= maxLength) return title
+    return title.substring(0, maxLength) + '...'
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4">
+      <h3 className="text-lg font-semibold mb-3">Exercises ({exercises.length})</h3>
+      <ul className="space-y-2">
+        {exercises.map((exercise) => (
+          <li
+            key={exercise.id}
+            className="p-3 border border-gray-200 rounded-lg hover:border-gray-300"
+          >
+            <div className="flex items-start justify-between gap-2">
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-gray-900 truncate">
+                  {truncateTitle(exercise.title)}
+                </p>
+                {exercise.sourcePages && (
+                  <p className="text-xs text-gray-500">Pages {exercise.sourcePages}</p>
+                )}
+                {exercise._status && (
+                  <span
+                    className={`inline-block mt-1 px-2 py-0.5 text-xs rounded ${
+                      exercise._status === 'published'
+                        ? 'bg-green-100 text-green-800'
+                        : 'bg-gray-100 text-gray-800'
+                    }`}
+                  >
+                    {exercise._status}
+                  </span>
+                )}
+              </div>
+              <a
+                href={`/admin/collections/exercises/${exercise.id}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-3 py-1 text-sm bg-blue-100 hover:bg-blue-200 text-blue-800 rounded transition-colors whitespace-nowrap"
+              >
+                Open in Editor
+              </a>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/ui/admin/PdfConversion/JobHistory/index.tsx
+++ b/src/ui/admin/PdfConversion/JobHistory/index.tsx
@@ -9,6 +9,15 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
+import {
+  cardStyle,
+  getBadgeStyle,
+  jobCardSelectedStyle,
+  jobCardStyle,
+  progressBarContainerStyle,
+  progressBarFillStyle,
+  sectionHeadingStyle,
+} from '../styles'
 
 interface JobStatus {
   id: string
@@ -44,21 +53,127 @@ interface JobHistoryProps {
   onSelectJob: (jobId: string) => void
 }
 
-// Badge colors using Tailwind classes
-const getBadgeClasses = (status: string): string => {
-  switch (status) {
-    case 'queued':
-      return 'bg-amber-100 text-amber-800'
-    case 'running':
-      return 'bg-blue-100 text-blue-800'
-    case 'completed':
-      return 'bg-green-100 text-green-800'
-    case 'failed':
-      return 'bg-red-100 text-red-800'
-    default:
-      return 'bg-gray-100 text-gray-800'
-  }
+const loadingStyle: React.CSSProperties = {
+  ...cardStyle,
 }
+
+const errorStyle: React.CSSProperties = {
+  ...cardStyle,
+}
+
+const emptyStyle: React.CSSProperties = {
+  ...cardStyle,
+}
+
+const listStyle: React.CSSProperties = {
+  listStyle: 'none',
+  padding: 0,
+  margin: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+}
+
+const headerStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  marginBottom: 12,
+}
+
+const pollingStyle: React.CSSProperties = {
+  color: 'var(--theme-elevation-400)',
+  fontSize: 16,
+  animation: 'spin 1s linear infinite',
+}
+
+const jobCardHeaderStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  marginBottom: 8,
+}
+
+const jobNameStyle: React.CSSProperties = {
+  fontWeight: 500,
+  color: 'var(--theme-elevation-1000)',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+}
+
+const progressContainerStyle: React.CSSProperties = {
+  marginBottom: 8,
+}
+
+const progressTextStyle: React.CSSProperties = {
+  fontSize: 12,
+  color: 'var(--theme-elevation-600)',
+  marginTop: 4,
+}
+
+const statsStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: 16,
+  fontSize: 13,
+  color: 'var(--theme-elevation-600)',
+  marginBottom: 4,
+}
+
+const dateStyle: React.CSSProperties = {
+  fontSize: 12,
+  color: 'var(--theme-elevation-500)',
+  marginBottom: 8,
+}
+
+const errorSummaryStyle: React.CSSProperties = {
+  fontSize: 13,
+  color: 'var(--theme-error)',
+  cursor: 'pointer',
+  marginBottom: 8,
+}
+
+const errorListStyle: React.CSSProperties = {
+  fontSize: 12,
+  color: 'var(--theme-error)',
+  paddingLeft: 16,
+  marginTop: 4,
+}
+
+const buttonGroupStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: 8,
+}
+
+const runNowButtonStyle: React.CSSProperties = {
+  padding: '4px 12px',
+  fontSize: 13,
+  backgroundColor: 'var(--theme-elevation-200)',
+  color: 'var(--theme-elevation-800)',
+  border: 'none',
+  borderRadius: 3,
+  cursor: 'pointer',
+}
+
+const viewButtonStyle: React.CSSProperties = {
+  padding: '4px 12px',
+  fontSize: 13,
+  backgroundColor: 'var(--theme-elevation-100)',
+  color: 'var(--theme-info)',
+  border: 'none',
+  borderRadius: 3,
+  cursor: 'pointer',
+}
+
+// Add spin animation via style tag
+const spinAnimation = (
+  <style>{`
+    @keyframes spin {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
+    }
+  `}</style>
+)
 
 export function JobHistory({ refreshKey, selectedJobId, onSelectJob }: JobHistoryProps) {
   const [jobs, setJobs] = useState<JobStatus[]>([])
@@ -174,39 +289,43 @@ export function JobHistory({ refreshKey, selectedJobId, onSelectJob }: JobHistor
 
   if (isLoading) {
     return (
-      <div className="bg-white rounded-lg border border-gray-200 p-4">
-        <h3 className="text-lg font-semibold mb-3">Job History</h3>
-        <div className="text-sm text-gray-500">Loading...</div>
+      <div style={loadingStyle}>
+        <h3 style={sectionHeadingStyle}>Job History</h3>
+        <div style={{ fontSize: 13, color: 'var(--theme-elevation-500)' }}>Loading...</div>
       </div>
     )
   }
 
   if (error) {
     return (
-      <div className="bg-white rounded-lg border border-gray-200 p-4">
-        <h3 className="text-lg font-semibold mb-3">Job History</h3>
-        <div className="text-sm text-red-600">{error}</div>
+      <div style={errorStyle}>
+        <h3 style={sectionHeadingStyle}>Job History</h3>
+        <div style={{ fontSize: 13, color: 'var(--theme-error)' }}>{error}</div>
       </div>
     )
   }
 
   if (jobs.length === 0) {
     return (
-      <div className="bg-white rounded-lg border border-gray-200 p-4">
-        <h3 className="text-lg font-semibold mb-3">Job History</h3>
-        <div className="text-sm text-gray-500">No conversion jobs yet</div>
+      <div style={emptyStyle}>
+        <h3 style={sectionHeadingStyle}>Job History</h3>
+        <div style={{ fontSize: 13, color: 'var(--theme-elevation-500)' }}>
+          No conversion jobs yet
+        </div>
       </div>
     )
   }
 
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-4">
-      <h3 className="text-lg font-semibold mb-3">
-        Job History {isPolling && <span className="text-gray-400 animate-spin">↻</span>}
+    <div style={cardStyle}>
+      {spinAnimation}
+      <h3 style={headerStyle}>
+        <span style={sectionHeadingStyle}>Job History</span>
+        {isPolling && <span style={pollingStyle}>↻</span>}
       </h3>
-      <ul className="space-y-3">
+      <ul style={listStyle}>
         {jobs.map((job) => {
-          const badgeClasses = getBadgeClasses(job.status)
+          const badgeStyleObj = getBadgeStyle(job.status)
           const hasErrors = job.output?.errors && job.output.errors.length > 0
           const progress = job.output?.segmentsTotal
             ? Math.round(((job.output.segmentsDone || 0) / job.output.segmentsTotal) * 100)
@@ -215,53 +334,42 @@ export function JobHistory({ refreshKey, selectedJobId, onSelectJob }: JobHistor
           return (
             <li
               key={job.id}
-              className={`p-3 rounded-lg border cursor-pointer transition-colors ${
-                selectedJobId === job.id
-                  ? 'border-blue-500 bg-blue-50'
-                  : 'border-gray-200 hover:border-gray-300'
-              }`}
+              style={selectedJobId === job.id ? jobCardSelectedStyle : jobCardStyle}
               onClick={() => onSelectJob(job.id)}
             >
-              <div className="flex items-center justify-between mb-2">
-                <span className="font-medium text-gray-900 truncate">{getJobName(job)}</span>
-                <span className={`px-2 py-0.5 rounded text-xs font-medium ${badgeClasses}`}>
-                  {job.status.toUpperCase()}
-                </span>
+              <div style={jobCardHeaderStyle}>
+                <span style={jobNameStyle}>{getJobName(job)}</span>
+                <span style={badgeStyleObj}>{job.status.toUpperCase()}</span>
               </div>
 
               {job.status === 'running' && progress !== null && (
-                <div className="mb-2">
-                  <div className="w-full bg-gray-200 rounded-full h-2">
-                    <div
-                      className="bg-blue-600 h-2 rounded-full transition-all"
-                      style={{ width: `${progress}%` }}
-                    />
+                <div style={progressContainerStyle}>
+                  <div style={progressBarContainerStyle}>
+                    <div style={{ ...progressBarFillStyle, width: `${progress}%` }} />
                   </div>
-                  <span className="text-xs text-gray-600">{progress}%</span>
+                  <span style={progressTextStyle}>{progress}%</span>
                 </div>
               )}
 
-              <div className="flex items-center gap-4 text-sm text-gray-600 mb-1">
+              <div style={statsStyle}>
                 {job.output?.segmentsTotal !== undefined && (
                   <span>
                     {job.output.segmentsDone || 0}/{job.output.segmentsTotal} segments
                   </span>
                 )}
                 {job.output?.exercisesCreated !== undefined && (
-                  <span>{job.output.exercisesCreated} exercises</span>
+                  <span>· {job.output.exercisesCreated} exercises</span>
                 )}
               </div>
 
-              <div className="text-xs text-gray-500 mb-2">
-                {formatDate(job.updatedAt || job.createdAt)}
-              </div>
+              <div style={dateStyle}>{formatDate(job.updatedAt || job.createdAt)}</div>
 
               {hasErrors && (
-                <details className="mb-2">
-                  <summary className="text-sm text-red-600 cursor-pointer">
+                <details style={{ marginBottom: 8 }}>
+                  <summary style={errorSummaryStyle}>
                     Show errors ({job.output?.errors?.length})
                   </summary>
-                  <ul className="mt-1 text-xs text-red-700 pl-4">
+                  <ul style={errorListStyle}>
                     {job.output?.errors?.map((err, idx) => (
                       <li key={idx}>
                         {err.stage}: {err.message}
@@ -271,18 +379,15 @@ export function JobHistory({ refreshKey, selectedJobId, onSelectJob }: JobHistor
                 </details>
               )}
 
-              <div className="flex gap-2">
+              <div style={buttonGroupStyle}>
                 {(job.status === 'queued' || job.status === 'failed') && (
-                  <button
-                    className="px-3 py-1 text-sm bg-gray-100 hover:bg-gray-200 rounded transition-colors"
-                    onClick={(e) => handleRunNow(job.id, e)}
-                  >
+                  <button style={runNowButtonStyle} onClick={(e) => handleRunNow(job.id, e)}>
                     Run Now
                   </button>
                 )}
                 {job.status === 'completed' && (
                   <button
-                    className="px-3 py-1 text-sm bg-blue-100 hover:bg-blue-200 text-blue-800 rounded transition-colors"
+                    style={viewButtonStyle}
                     onClick={(e) => {
                       e.stopPropagation()
                       onSelectJob(job.id)

--- a/src/ui/admin/PdfConversion/JobHistory/index.tsx
+++ b/src/ui/admin/PdfConversion/JobHistory/index.tsx
@@ -1,0 +1,301 @@
+/**
+ * Job History Component
+ *
+ * @fileType component
+ * @domain admin
+ * @pattern job-list
+ * @ai-summary Displays list of PDF conversion jobs with status and actions
+ */
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+interface JobStatus {
+  id: string
+  status: 'queued' | 'running' | 'completed' | 'failed'
+  input?: {
+    ctx?: {
+      sourceDocId?: string
+    }
+  }
+  output?: {
+    segmentsTotal?: number
+    segmentsDone?: number
+    segmentsFailed?: number
+    exercisesCreated?: number
+    errors?: Array<{
+      stage: string
+      code: string
+      message: string
+    }>
+  }
+  updatedAt?: string
+  createdAt?: string
+}
+
+interface MediaInfo {
+  id: string
+  filename: string
+}
+
+interface JobHistoryProps {
+  refreshKey: number
+  selectedJobId: string | null
+  onSelectJob: (jobId: string) => void
+}
+
+// Badge colors using Tailwind classes
+const getBadgeClasses = (status: string): string => {
+  switch (status) {
+    case 'queued':
+      return 'bg-amber-100 text-amber-800'
+    case 'running':
+      return 'bg-blue-100 text-blue-800'
+    case 'completed':
+      return 'bg-green-100 text-green-800'
+    case 'failed':
+      return 'bg-red-100 text-red-800'
+    default:
+      return 'bg-gray-100 text-gray-800'
+  }
+}
+
+export function JobHistory({ refreshKey, selectedJobId, onSelectJob }: JobHistoryProps) {
+  const [jobs, setJobs] = useState<JobStatus[]>([])
+  const [mediaMap, setMediaMap] = useState<Record<string, MediaInfo>>({})
+  const [isLoading, setIsLoading] = useState(true)
+  const [isPolling, setIsPolling] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchJobs = useCallback(async () => {
+    try {
+      const response = await fetch('/api/exercises/convert/status?limit=20', {
+        credentials: 'include',
+      })
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch jobs')
+      }
+
+      const json = await response.json()
+      const fetchedJobs: JobStatus[] = json.data?.docs || json.docs || []
+      setJobs(fetchedJobs)
+
+      // Extract media IDs to fetch filenames
+      const mediaIds = fetchedJobs
+        .filter((job) => job.input?.ctx?.sourceDocId)
+        .map((job) => job.input!.ctx!.sourceDocId!)
+        .filter(Boolean)
+
+      if (mediaIds.length > 0) {
+        const uniqueIds = [...new Set(mediaIds)]
+        const mediaResponse = await fetch(
+          `/api/media?where[id][in]=${uniqueIds.join(',')}&select[filename]=true&limit=20`,
+          { credentials: 'include' },
+        )
+
+        if (mediaResponse.ok) {
+          const mediaJson = await mediaResponse.json()
+          const mediaDocs: MediaInfo[] = mediaJson.data?.docs || mediaJson.docs || []
+          const newMediaMap: Record<string, MediaInfo> = {}
+          mediaDocs.forEach((media) => {
+            newMediaMap[media.id] = media
+          })
+          setMediaMap(newMediaMap)
+        }
+      }
+    } catch (err) {
+      console.error('Failed to fetch jobs:', err)
+      setError('Failed to load job history')
+    } finally {
+      setIsLoading(false)
+      setIsPolling(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchJobs()
+  }, [fetchJobs, refreshKey])
+
+  // Polling: every 5s if any job is queued/running, otherwise every 30s
+  useEffect(() => {
+    const hasActiveJobs = jobs.some((job) => job.status === 'queued' || job.status === 'running')
+    const pollInterval = hasActiveJobs ? 5000 : 30000
+
+    const interval = setInterval(() => {
+      if (!isLoading) {
+        setIsPolling(true)
+        fetchJobs()
+      }
+    }, pollInterval)
+
+    return () => clearInterval(interval)
+  }, [jobs, isLoading, fetchJobs])
+
+  const handleRunNow = async (jobId: string, e: React.MouseEvent) => {
+    e.stopPropagation()
+
+    try {
+      const response = await fetch('/api/jobs/run-immediate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ jobId }),
+      })
+
+      if (!response.ok) {
+        throw new Error('Failed to run job')
+      }
+
+      // Refresh jobs after running
+      setIsPolling(true)
+      fetchJobs()
+    } catch (err) {
+      console.error('Failed to run job:', err)
+      alert(`Failed to run job: ${err instanceof Error ? err.message : 'Unknown error'}`)
+    }
+  }
+
+  const getJobName = (job: JobStatus): string => {
+    const mediaId = job.input?.ctx?.sourceDocId
+    const media = mediaId ? mediaMap[mediaId] : null
+    return media?.filename || mediaId?.substring(0, 8) || 'Unknown'
+  }
+
+  const formatDate = (dateStr?: string): string => {
+    if (!dateStr) return ''
+    const date = new Date(dateStr)
+    return (
+      date.toLocaleDateString() +
+      ' ' +
+      date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <h3 className="text-lg font-semibold mb-3">Job History</h3>
+        <div className="text-sm text-gray-500">Loading...</div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <h3 className="text-lg font-semibold mb-3">Job History</h3>
+        <div className="text-sm text-red-600">{error}</div>
+      </div>
+    )
+  }
+
+  if (jobs.length === 0) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <h3 className="text-lg font-semibold mb-3">Job History</h3>
+        <div className="text-sm text-gray-500">No conversion jobs yet</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4">
+      <h3 className="text-lg font-semibold mb-3">
+        Job History {isPolling && <span className="text-gray-400 animate-spin">↻</span>}
+      </h3>
+      <ul className="space-y-3">
+        {jobs.map((job) => {
+          const badgeClasses = getBadgeClasses(job.status)
+          const hasErrors = job.output?.errors && job.output.errors.length > 0
+          const progress = job.output?.segmentsTotal
+            ? Math.round(((job.output.segmentsDone || 0) / job.output.segmentsTotal) * 100)
+            : null
+
+          return (
+            <li
+              key={job.id}
+              className={`p-3 rounded-lg border cursor-pointer transition-colors ${
+                selectedJobId === job.id
+                  ? 'border-blue-500 bg-blue-50'
+                  : 'border-gray-200 hover:border-gray-300'
+              }`}
+              onClick={() => onSelectJob(job.id)}
+            >
+              <div className="flex items-center justify-between mb-2">
+                <span className="font-medium text-gray-900 truncate">{getJobName(job)}</span>
+                <span className={`px-2 py-0.5 rounded text-xs font-medium ${badgeClasses}`}>
+                  {job.status.toUpperCase()}
+                </span>
+              </div>
+
+              {job.status === 'running' && progress !== null && (
+                <div className="mb-2">
+                  <div className="w-full bg-gray-200 rounded-full h-2">
+                    <div
+                      className="bg-blue-600 h-2 rounded-full transition-all"
+                      style={{ width: `${progress}%` }}
+                    />
+                  </div>
+                  <span className="text-xs text-gray-600">{progress}%</span>
+                </div>
+              )}
+
+              <div className="flex items-center gap-4 text-sm text-gray-600 mb-1">
+                {job.output?.segmentsTotal !== undefined && (
+                  <span>
+                    {job.output.segmentsDone || 0}/{job.output.segmentsTotal} segments
+                  </span>
+                )}
+                {job.output?.exercisesCreated !== undefined && (
+                  <span>{job.output.exercisesCreated} exercises</span>
+                )}
+              </div>
+
+              <div className="text-xs text-gray-500 mb-2">
+                {formatDate(job.updatedAt || job.createdAt)}
+              </div>
+
+              {hasErrors && (
+                <details className="mb-2">
+                  <summary className="text-sm text-red-600 cursor-pointer">
+                    Show errors ({job.output?.errors?.length})
+                  </summary>
+                  <ul className="mt-1 text-xs text-red-700 pl-4">
+                    {job.output?.errors?.map((err, idx) => (
+                      <li key={idx}>
+                        {err.stage}: {err.message}
+                      </li>
+                    ))}
+                  </ul>
+                </details>
+              )}
+
+              <div className="flex gap-2">
+                {(job.status === 'queued' || job.status === 'failed') && (
+                  <button
+                    className="px-3 py-1 text-sm bg-gray-100 hover:bg-gray-200 rounded transition-colors"
+                    onClick={(e) => handleRunNow(job.id, e)}
+                  >
+                    Run Now
+                  </button>
+                )}
+                {job.status === 'completed' && (
+                  <button
+                    className="px-3 py-1 text-sm bg-blue-100 hover:bg-blue-200 text-blue-800 rounded transition-colors"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onSelectJob(job.id)
+                    }}
+                  >
+                    View Exercises
+                  </button>
+                )}
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/src/ui/admin/PdfConversion/LessonSelector/index.tsx
+++ b/src/ui/admin/PdfConversion/LessonSelector/index.tsx
@@ -1,0 +1,134 @@
+/**
+ * Lesson Selector Component
+ *
+ * @fileType component
+ * @domain admin
+ * @pattern searchable-select
+ * @ai-summary Searchable dropdown to select a lesson for PDF conversion
+ */
+'use client'
+
+import { useDebounce } from '@/client/hooks/useDebounce'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+interface LessonOption {
+  id: string
+  title: string
+  chapterTitle?: string
+}
+
+interface LessonSelectorProps {
+  selectedLessonId: string | null
+  onSelectLesson: (lessonId: string, lesson: LessonOption) => void
+}
+
+export function LessonSelector({ selectedLessonId, onSelectLesson }: LessonSelectorProps) {
+  const [searchQuery, setSearchQuery] = useState('')
+  const [results, setResults] = useState<LessonOption[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+  const debouncedQuery = useDebounce(searchQuery, 300)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (debouncedQuery.length < 2) {
+      setResults([])
+      setIsDropdownOpen(false)
+      return
+    }
+
+    async function fetchLessons() {
+      setIsLoading(true)
+      try {
+        const response = await fetch(
+          `/api/lessons?where[title][contains]=${encodeURIComponent(debouncedQuery)}&limit=10&depth=1`,
+        )
+        if (response.ok) {
+          const data = await response.json()
+          const lessons: LessonOption[] =
+            data.docs?.map((doc: { id: string; title: string; chapter?: { title: string } }) => ({
+              id: doc.id,
+              title: doc.title,
+              chapterTitle: doc.chapter?.title,
+            })) || []
+          setResults(lessons)
+          setIsDropdownOpen(lessons.length > 0)
+        }
+      } catch (error) {
+        console.error('Failed to fetch lessons:', error)
+        setResults([])
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchLessons()
+  }, [debouncedQuery])
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsDropdownOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const handleSelect = useCallback(
+    (lesson: LessonOption) => {
+      onSelectLesson(lesson.id, lesson)
+      setIsDropdownOpen(false)
+      setSearchQuery('')
+    },
+    [onSelectLesson],
+  )
+
+  const selectedLessonTitle = results.find((l) => l.id === selectedLessonId)?.title
+
+  return (
+    <div className="space-y-1" ref={containerRef}>
+      <label htmlFor="lesson-search" className="block text-sm font-medium text-gray-700">
+        Select Lesson
+      </label>
+      <input
+        id="lesson-search"
+        type="text"
+        className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm placeholder:text-gray-400"
+        placeholder="Search lessons..."
+        value={searchQuery}
+        onChange={(e) => {
+          setSearchQuery(e.target.value)
+          setIsDropdownOpen(true)
+        }}
+        onFocus={() => {
+          if (results.length > 0) setIsDropdownOpen(true)
+        }}
+        disabled={isLoading}
+      />
+      {isLoading && <div className="text-sm text-gray-500">Loading...</div>}
+      {isDropdownOpen && results.length > 0 && (
+        <ul className="absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-auto">
+          {results.map((lesson) => (
+            <li
+              key={lesson.id}
+              className="px-3 py-2 hover:bg-gray-100 cursor-pointer"
+              onClick={() => handleSelect(lesson)}
+            >
+              <div className="text-sm font-medium text-gray-900">{lesson.title}</div>
+              {lesson.chapterTitle && (
+                <div className="text-xs text-gray-500">{lesson.chapterTitle}</div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+      {selectedLessonId && (
+        <div className="text-sm text-gray-600">
+          Selected: <span className="font-medium">{selectedLessonTitle || selectedLessonId}</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/ui/admin/PdfConversion/LessonSelector/index.tsx
+++ b/src/ui/admin/PdfConversion/LessonSelector/index.tsx
@@ -10,6 +10,7 @@
 
 import { useDebounce } from '@/client/hooks/useDebounce'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { dropdownStyle, inputStyle, labelStyle } from '../styles'
 
 interface LessonOption {
   id: string
@@ -22,11 +23,50 @@ interface LessonSelectorProps {
   onSelectLesson: (lessonId: string, lesson: LessonOption) => void
 }
 
+const containerStyle: React.CSSProperties = {
+  position: 'relative',
+}
+
+const loadingStyle: React.CSSProperties = {
+  fontSize: 13,
+  color: 'var(--theme-elevation-500)',
+  marginTop: 4,
+}
+
+const selectedStyle: React.CSSProperties = {
+  fontSize: 13,
+  color: 'var(--theme-elevation-600)',
+  marginTop: 4,
+}
+
+const dropdownItemStyle: React.CSSProperties = {
+  padding: '8px 12px',
+  cursor: 'pointer',
+  fontSize: 13,
+}
+
+const dropdownItemHoverStyle: React.CSSProperties = {
+  ...dropdownItemStyle,
+  backgroundColor: 'var(--theme-elevation-100)',
+}
+
+const dropdownItemTitleStyle: React.CSSProperties = {
+  fontWeight: 500,
+  color: 'var(--theme-elevation-1000)',
+}
+
+const dropdownItemChapterStyle: React.CSSProperties = {
+  fontSize: 12,
+  color: 'var(--theme-elevation-500)',
+}
+
 export function LessonSelector({ selectedLessonId, onSelectLesson }: LessonSelectorProps) {
   const [searchQuery, setSearchQuery] = useState('')
   const [results, setResults] = useState<LessonOption[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+  const [hoveredIndex, setHoveredIndex] = useState<number>(-1)
+  const [selectedLessonName, setSelectedLessonName] = useState<string>('')
   const debouncedQuery = useDebounce(searchQuery, 300)
   const containerRef = useRef<HTMLDivElement>(null)
 
@@ -79,23 +119,22 @@ export function LessonSelector({ selectedLessonId, onSelectLesson }: LessonSelec
   const handleSelect = useCallback(
     (lesson: LessonOption) => {
       onSelectLesson(lesson.id, lesson)
+      setSelectedLessonName(lesson.title)
       setIsDropdownOpen(false)
       setSearchQuery('')
     },
     [onSelectLesson],
   )
 
-  const selectedLessonTitle = results.find((l) => l.id === selectedLessonId)?.title
-
   return (
-    <div className="space-y-1" ref={containerRef}>
-      <label htmlFor="lesson-search" className="block text-sm font-medium text-gray-700">
+    <div style={containerStyle} ref={containerRef}>
+      <label htmlFor="lesson-search" style={labelStyle}>
         Select Lesson
       </label>
       <input
         id="lesson-search"
         type="text"
-        className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm placeholder:text-gray-400"
+        style={inputStyle}
         placeholder="Search lessons..."
         value={searchQuery}
         onChange={(e) => {
@@ -107,26 +146,29 @@ export function LessonSelector({ selectedLessonId, onSelectLesson }: LessonSelec
         }}
         disabled={isLoading}
       />
-      {isLoading && <div className="text-sm text-gray-500">Loading...</div>}
+      {isLoading && <div style={loadingStyle}>Loading...</div>}
       {isDropdownOpen && results.length > 0 && (
-        <ul className="absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-auto">
-          {results.map((lesson) => (
+        <ul style={dropdownStyle}>
+          {results.map((lesson, index) => (
             <li
               key={lesson.id}
-              className="px-3 py-2 hover:bg-gray-100 cursor-pointer"
+              style={hoveredIndex === index ? dropdownItemHoverStyle : dropdownItemStyle}
               onClick={() => handleSelect(lesson)}
+              onMouseEnter={() => setHoveredIndex(index)}
+              onMouseLeave={() => setHoveredIndex(-1)}
             >
-              <div className="text-sm font-medium text-gray-900">{lesson.title}</div>
+              <div style={dropdownItemTitleStyle}>{lesson.title}</div>
               {lesson.chapterTitle && (
-                <div className="text-xs text-gray-500">{lesson.chapterTitle}</div>
+                <div style={dropdownItemChapterStyle}>{lesson.chapterTitle}</div>
               )}
             </li>
           ))}
         </ul>
       )}
       {selectedLessonId && (
-        <div className="text-sm text-gray-600">
-          Selected: <span className="font-medium">{selectedLessonTitle || selectedLessonId}</span>
+        <div style={selectedStyle}>
+          Selected:{' '}
+          <span style={{ fontWeight: 500 }}>{selectedLessonName || selectedLessonId}</span>
         </div>
       )}
     </div>

--- a/src/ui/admin/PdfConversion/PdfConversionPage/index.tsx
+++ b/src/ui/admin/PdfConversion/PdfConversionPage/index.tsx
@@ -8,10 +8,62 @@
  */
 'use client'
 
+import Link from 'next/link'
 import { useCallback, useState } from 'react'
 import { ConversionForm } from '../ConversionForm'
 import { ExerciseReview } from '../ExerciseReview'
 import { JobHistory } from '../JobHistory'
+
+const pageStyle: React.CSSProperties = {
+  padding: 'calc(var(--base) * 1.5)',
+  maxWidth: 1400,
+}
+
+const headerStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 'calc(var(--base) * 0.75)',
+  marginBottom: 'calc(var(--base) * 1.25)',
+  paddingBottom: 'calc(var(--base) * 1.25)',
+  borderBottom: '1px solid var(--theme-elevation-150)',
+}
+
+const backLinkStyle: React.CSSProperties = {
+  color: 'var(--theme-elevation-500)',
+  textDecoration: 'none',
+  fontSize: 13,
+}
+
+const headerSepStyle: React.CSSProperties = {
+  color: 'var(--theme-elevation-300)',
+  fontSize: 14,
+}
+
+const titleStyle: React.CSSProperties = {
+  fontSize: 22,
+  fontWeight: 600,
+  color: 'var(--theme-text)',
+  margin: 0,
+}
+
+const layoutStyle: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: '400px 1fr',
+  gap: 'calc(var(--base) * 1.5)',
+  alignItems: 'start',
+}
+
+const leftStyle: React.CSSProperties = {
+  position: 'sticky',
+  top: 'calc(var(--base) * 1.5)',
+}
+
+const rightStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 'calc(var(--base) * 1.5)',
+  minWidth: 0,
+}
 
 export function PdfConversionPage() {
   const [selectedJobId, setSelectedJobId] = useState<string | null>(null)
@@ -22,13 +74,19 @@ export function PdfConversionPage() {
   }, [])
 
   return (
-    <div className="flex flex-col gap-4 p-4 max-w-7xl mx-auto">
-      <h1 className="text-2xl font-semibold">PDF Conversion</h1>
-      <div className="grid grid-cols-1 lg:grid-cols-[380px_1fr] gap-4 items-start">
-        <div className="lg:sticky lg:top-4">
+    <div style={pageStyle}>
+      <div style={headerStyle}>
+        <Link href="/admin" style={backLinkStyle}>
+          Dashboard
+        </Link>
+        <span style={headerSepStyle}>/</span>
+        <h1 style={titleStyle}>PDF Conversion</h1>
+      </div>
+      <div style={layoutStyle}>
+        <div style={leftStyle}>
           <ConversionForm onQueued={handleConversionQueued} />
         </div>
-        <div className="flex flex-col gap-4">
+        <div style={rightStyle}>
           <JobHistory
             refreshKey={refreshKey}
             selectedJobId={selectedJobId}

--- a/src/ui/admin/PdfConversion/PdfConversionPage/index.tsx
+++ b/src/ui/admin/PdfConversion/PdfConversionPage/index.tsx
@@ -1,0 +1,42 @@
+/**
+ * PDF Conversion Page Layout
+ *
+ * @fileType component
+ * @domain admin
+ * @pattern admin-page-layout
+ * @ai-summary Main two-column layout for PDF conversion page
+ */
+'use client'
+
+import { useCallback, useState } from 'react'
+import { ConversionForm } from '../ConversionForm'
+import { ExerciseReview } from '../ExerciseReview'
+import { JobHistory } from '../JobHistory'
+
+export function PdfConversionPage() {
+  const [selectedJobId, setSelectedJobId] = useState<string | null>(null)
+  const [refreshKey, setRefreshKey] = useState(0)
+
+  const handleConversionQueued = useCallback(() => {
+    setRefreshKey((k) => k + 1)
+  }, [])
+
+  return (
+    <div className="flex flex-col gap-4 p-4 max-w-7xl mx-auto">
+      <h1 className="text-2xl font-semibold">PDF Conversion</h1>
+      <div className="grid grid-cols-1 lg:grid-cols-[380px_1fr] gap-4 items-start">
+        <div className="lg:sticky lg:top-4">
+          <ConversionForm onQueued={handleConversionQueued} />
+        </div>
+        <div className="flex flex-col gap-4">
+          <JobHistory
+            refreshKey={refreshKey}
+            selectedJobId={selectedJobId}
+            onSelectJob={setSelectedJobId}
+          />
+          {selectedJobId && <ExerciseReview jobId={selectedJobId} />}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/ui/admin/PdfConversion/PdfSelector/index.tsx
+++ b/src/ui/admin/PdfConversion/PdfSelector/index.tsx
@@ -9,6 +9,7 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
+import { labelStyle } from '../styles'
 
 interface PdfFile {
   id: string
@@ -20,6 +21,55 @@ interface PdfSelectorProps {
   lessonId: string
   selectedMediaId: string | null
   onSelectMedia: (mediaId: string) => void
+}
+
+const loadingStyle: React.CSSProperties = {
+  fontSize: 13,
+  color: 'var(--theme-elevation-500)',
+  marginTop: 4,
+}
+
+const errorStyle: React.CSSProperties = {
+  fontSize: 13,
+  color: 'var(--theme-error)',
+}
+
+const emptyStyle: React.CSSProperties = {
+  fontSize: 13,
+  color: 'var(--theme-elevation-500)',
+  marginTop: 4,
+}
+
+const fieldGroupStyle: React.CSSProperties = {
+  marginTop: 8,
+}
+
+const radioGroupStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+}
+
+const radioLabelStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '8px 12px',
+  borderRadius: 3,
+  cursor: 'pointer',
+  fontSize: 13,
+  color: 'var(--theme-elevation-1000)',
+}
+
+const radioLabelSelectedStyle: React.CSSProperties = {
+  ...radioLabelStyle,
+  backgroundColor: 'var(--theme-elevation-100)',
+  border: '1px solid var(--theme-elevation-400)',
+}
+
+const radioLabelUnselectedStyle: React.CSSProperties = {
+  ...radioLabelStyle,
+  border: '1px solid transparent',
 }
 
 export function PdfSelector({ lessonId, selectedMediaId, onSelectMedia }: PdfSelectorProps) {
@@ -43,14 +93,19 @@ export function PdfSelector({ lessonId, selectedMediaId, onSelectMedia }: PdfSel
         }
         const data = await response.json()
         const contentFiles = data.contentFiles || []
+
+        // Handle both shapes: flat media objects and nested media objects
         const pdfs: PdfFile[] = contentFiles
-          .filter(
-            (file: { media?: { mimeType: string } }) => file.media?.mimeType === 'application/pdf',
-          )
-          .map((file: { media: { id: string; filename: string; mimeType: string } }) => ({
-            id: file.media.id,
-            filename: file.media.filename,
-            mimeType: file.media.mimeType,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .filter((file: any) => {
+            const mime = file.mimeType || file.media?.mimeType
+            return mime === 'application/pdf'
+          })
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .map((file: any) => ({
+            id: file.id || file.media?.id,
+            filename: file.filename || file.media?.filename || 'Unknown',
+            mimeType: file.mimeType || file.media?.mimeType || 'application/pdf',
           }))
         setPdfFiles(pdfs)
       } catch (err) {
@@ -74,43 +129,39 @@ export function PdfSelector({ lessonId, selectedMediaId, onSelectMedia }: PdfSel
 
   if (isLoading) {
     return (
-      <div className="space-y-1">
-        <label className="block text-sm font-medium text-gray-700">Select PDF</label>
-        <div className="text-sm text-gray-500">Loading PDF files...</div>
-      </div>
+      <fieldset style={fieldGroupStyle}>
+        <legend style={labelStyle}>Select PDF</legend>
+        <div style={loadingStyle}>Loading PDF files...</div>
+      </fieldset>
     )
   }
 
   if (error) {
     return (
-      <div className="space-y-1">
-        <label className="block text-sm font-medium text-gray-700">Select PDF</label>
-        <div className="text-sm text-red-600">{error}</div>
-      </div>
+      <fieldset style={fieldGroupStyle}>
+        <legend style={labelStyle}>Select PDF</legend>
+        <div style={errorStyle}>{error}</div>
+      </fieldset>
     )
   }
 
   if (pdfFiles.length === 0) {
     return (
-      <div className="space-y-1">
-        <label className="block text-sm font-medium text-gray-700">Select PDF</label>
-        <div className="text-sm text-gray-500">No PDFs attached to this lesson</div>
-      </div>
+      <fieldset style={fieldGroupStyle}>
+        <legend style={labelStyle}>Select PDF</legend>
+        <div style={emptyStyle}>No PDFs attached to this lesson</div>
+      </fieldset>
     )
   }
 
   return (
-    <fieldset className="space-y-2">
-      <legend className="text-sm font-medium text-gray-700">Select PDF</legend>
-      <div className="space-y-1">
+    <fieldset style={fieldGroupStyle}>
+      <legend style={labelStyle}>Select PDF</legend>
+      <div style={radioGroupStyle}>
         {pdfFiles.map((pdf) => (
           <label
             key={pdf.id}
-            className={`flex items-center gap-2 p-2 rounded cursor-pointer ${
-              selectedMediaId === pdf.id
-                ? 'bg-blue-50 border border-blue-200'
-                : 'hover:bg-gray-50 border border-transparent'
-            }`}
+            style={selectedMediaId === pdf.id ? radioLabelSelectedStyle : radioLabelUnselectedStyle}
           >
             <input
               type="radio"
@@ -118,9 +169,9 @@ export function PdfSelector({ lessonId, selectedMediaId, onSelectMedia }: PdfSel
               value={pdf.id}
               checked={selectedMediaId === pdf.id}
               onChange={() => handleSelect(pdf.id)}
-              className="text-blue-600"
+              style={{ marginRight: 8 }}
             />
-            <span className="text-sm text-gray-900">{pdf.filename}</span>
+            <span style={{ fontSize: 13 }}>{pdf.filename}</span>
           </label>
         ))}
       </div>

--- a/src/ui/admin/PdfConversion/PdfSelector/index.tsx
+++ b/src/ui/admin/PdfConversion/PdfSelector/index.tsx
@@ -1,0 +1,129 @@
+/**
+ * PDF File Selector Component
+ *
+ * @fileType component
+ * @domain admin
+ * @pattern file-selector
+ * @ai-summary Dropdown to select a PDF file from a lesson's content files
+ */
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+interface PdfFile {
+  id: string
+  filename: string
+  mimeType: string
+}
+
+interface PdfSelectorProps {
+  lessonId: string
+  selectedMediaId: string | null
+  onSelectMedia: (mediaId: string) => void
+}
+
+export function PdfSelector({ lessonId, selectedMediaId, onSelectMedia }: PdfSelectorProps) {
+  const [pdfFiles, setPdfFiles] = useState<PdfFile[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!lessonId) {
+      setPdfFiles([])
+      return
+    }
+
+    async function fetchLessonFiles() {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const response = await fetch(`/api/lessons/${lessonId}?depth=1`)
+        if (!response.ok) {
+          throw new Error('Failed to fetch lesson')
+        }
+        const data = await response.json()
+        const contentFiles = data.contentFiles || []
+        const pdfs: PdfFile[] = contentFiles
+          .filter(
+            (file: { media?: { mimeType: string } }) => file.media?.mimeType === 'application/pdf',
+          )
+          .map((file: { media: { id: string; filename: string; mimeType: string } }) => ({
+            id: file.media.id,
+            filename: file.media.filename,
+            mimeType: file.media.mimeType,
+          }))
+        setPdfFiles(pdfs)
+      } catch (err) {
+        console.error('Failed to fetch lesson files:', err)
+        setError('Failed to load PDF files')
+        setPdfFiles([])
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchLessonFiles()
+  }, [lessonId])
+
+  const handleSelect = useCallback(
+    (mediaId: string) => {
+      onSelectMedia(mediaId)
+    },
+    [onSelectMedia],
+  )
+
+  if (isLoading) {
+    return (
+      <div className="space-y-1">
+        <label className="block text-sm font-medium text-gray-700">Select PDF</label>
+        <div className="text-sm text-gray-500">Loading PDF files...</div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-1">
+        <label className="block text-sm font-medium text-gray-700">Select PDF</label>
+        <div className="text-sm text-red-600">{error}</div>
+      </div>
+    )
+  }
+
+  if (pdfFiles.length === 0) {
+    return (
+      <div className="space-y-1">
+        <label className="block text-sm font-medium text-gray-700">Select PDF</label>
+        <div className="text-sm text-gray-500">No PDFs attached to this lesson</div>
+      </div>
+    )
+  }
+
+  return (
+    <fieldset className="space-y-2">
+      <legend className="text-sm font-medium text-gray-700">Select PDF</legend>
+      <div className="space-y-1">
+        {pdfFiles.map((pdf) => (
+          <label
+            key={pdf.id}
+            className={`flex items-center gap-2 p-2 rounded cursor-pointer ${
+              selectedMediaId === pdf.id
+                ? 'bg-blue-50 border border-blue-200'
+                : 'hover:bg-gray-50 border border-transparent'
+            }`}
+          >
+            <input
+              type="radio"
+              name="pdf-selection"
+              value={pdf.id}
+              checked={selectedMediaId === pdf.id}
+              onChange={() => handleSelect(pdf.id)}
+              className="text-blue-600"
+            />
+            <span className="text-sm text-gray-900">{pdf.filename}</span>
+          </label>
+        ))}
+      </div>
+    </fieldset>
+  )
+}

--- a/src/ui/admin/PdfConversion/SidebarLink/index.tsx
+++ b/src/ui/admin/PdfConversion/SidebarLink/index.tsx
@@ -1,0 +1,24 @@
+/**
+ * PDF Conversion Sidebar Link
+ *
+ * @fileType component
+ * @domain admin
+ * @pattern admin-sidebar-link
+ * @ai-summary Navigation link for PDF conversion in the admin sidebar
+ */
+'use client'
+
+import Link from 'next/link'
+import React from 'react'
+
+export const PdfConversionSidebarLink: React.FC = () => {
+  return (
+    <li className="nav__item">
+      <Link href="/admin/pdf-conversion" className="nav__link">
+        <span className="nav__label">PDF Conversion</span>
+      </Link>
+    </li>
+  )
+}
+
+export default PdfConversionSidebarLink

--- a/src/ui/admin/PdfConversion/styles.ts
+++ b/src/ui/admin/PdfConversion/styles.ts
@@ -1,0 +1,168 @@
+import type { CSSProperties } from 'react'
+
+export const cardStyle: CSSProperties = {
+  padding: 16,
+  backgroundColor: 'var(--theme-elevation-50)',
+  border: '1px solid var(--theme-elevation-200)',
+  borderRadius: 4,
+}
+
+export const labelStyle: CSSProperties = {
+  display: 'block',
+  fontSize: 13,
+  fontWeight: 500,
+  color: 'var(--theme-elevation-700)',
+  marginBottom: 4,
+}
+
+export const selectStyle: CSSProperties = {
+  width: '100%',
+  height: 36,
+  padding: '0 10px',
+  fontSize: 13,
+  border: '1px solid var(--theme-elevation-200)',
+  borderRadius: 4,
+  backgroundColor: 'var(--theme-elevation-0)',
+  color: 'var(--theme-elevation-1000)',
+  boxSizing: 'border-box' as const,
+}
+
+export const inputStyle: CSSProperties = {
+  width: '100%',
+  height: 36,
+  padding: '0 10px',
+  fontSize: 13,
+  border: '1px solid var(--theme-elevation-200)',
+  borderRadius: 4,
+  backgroundColor: 'var(--theme-elevation-0)',
+  color: 'var(--theme-elevation-1000)',
+  boxSizing: 'border-box' as const,
+}
+
+export const fieldGroupStyle: CSSProperties = {
+  marginBottom: 16,
+}
+
+export const sectionHeadingStyle: CSSProperties = {
+  fontSize: 16,
+  fontWeight: 600,
+  color: 'var(--theme-elevation-1000)',
+  margin: '0 0 16px 0',
+}
+
+export const errorBannerStyle: CSSProperties = {
+  padding: '8px 12px',
+  marginBottom: 12,
+  fontSize: 13,
+  color: 'var(--theme-error)',
+  backgroundColor: 'var(--theme-error-100)',
+  borderRadius: 4,
+}
+
+export const successBannerStyle: CSSProperties = {
+  padding: '8px 12px',
+  marginBottom: 12,
+  fontSize: 13,
+  color: 'var(--theme-success)',
+  backgroundColor: 'var(--theme-success-100)',
+  borderRadius: 4,
+}
+
+export const getBadgeStyle = (status: string): CSSProperties => {
+  const map: Record<string, CSSProperties> = {
+    queued: { backgroundColor: 'var(--theme-warning-100)', color: 'var(--theme-warning)' },
+    running: { backgroundColor: 'var(--theme-info-100)', color: 'var(--theme-info)' },
+    completed: { backgroundColor: 'var(--theme-success-100)', color: 'var(--theme-success)' },
+    failed: { backgroundColor: 'var(--theme-error-100)', color: 'var(--theme-error)' },
+    draft: { backgroundColor: 'var(--theme-elevation-200)', color: 'var(--theme-elevation-700)' },
+    published: { backgroundColor: 'var(--theme-success-100)', color: 'var(--theme-success)' },
+  }
+  return {
+    display: 'inline-block',
+    padding: '3px 8px',
+    borderRadius: 3,
+    fontSize: 11,
+    fontWeight: 600,
+    textTransform: 'uppercase' as const,
+    ...(map[status] || map.draft),
+  }
+}
+
+export const dropdownStyle: CSSProperties = {
+  position: 'absolute',
+  zIndex: 10,
+  top: '100%',
+  left: 0,
+  right: 0,
+  marginTop: 4,
+  backgroundColor: 'var(--theme-elevation-0)',
+  border: '1px solid var(--theme-elevation-200)',
+  borderRadius: 4,
+  boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+  maxHeight: 240,
+  overflowY: 'auto',
+  listStyle: 'none',
+  padding: 0,
+  margin: 0,
+}
+
+export const radioItemStyle: CSSProperties = {
+  padding: '8px 12px',
+  cursor: 'pointer',
+  borderRadius: 3,
+  fontSize: 13,
+  color: 'var(--theme-elevation-1000)',
+}
+
+export const radioItemSelectedStyle: CSSProperties = {
+  ...radioItemStyle,
+  backgroundColor: 'var(--theme-elevation-100)',
+  border: '2px solid var(--theme-elevation-800)',
+}
+
+export const jobCardStyle: CSSProperties = {
+  padding: 12,
+  border: '1px solid var(--theme-elevation-200)',
+  borderRadius: 4,
+  cursor: 'pointer',
+  backgroundColor: 'var(--theme-elevation-0)',
+}
+
+export const jobCardSelectedStyle: CSSProperties = {
+  ...jobCardStyle,
+  border: '2px solid var(--theme-elevation-800)',
+}
+
+export const progressBarContainerStyle: CSSProperties = {
+  width: '100%',
+  height: 4,
+  backgroundColor: 'var(--theme-elevation-200)',
+  borderRadius: 2,
+  overflow: 'hidden',
+  marginTop: 8,
+}
+
+export const progressBarFillStyle: CSSProperties = {
+  height: '100%',
+  backgroundColor: 'var(--theme-success)',
+  borderRadius: 2,
+}
+
+export const exerciseCardStyle: CSSProperties = {
+  padding: 12,
+  border: '1px solid var(--theme-elevation-200)',
+  borderRadius: 4,
+  backgroundColor: 'var(--theme-elevation-0)',
+}
+
+export const exerciseTitleStyle: CSSProperties = {
+  fontSize: 14,
+  fontWeight: 500,
+  color: 'var(--theme-elevation-1000)',
+  marginBottom: 4,
+}
+
+export const exerciseMetaStyle: CSSProperties = {
+  fontSize: 12,
+  color: 'var(--theme-elevation-500)',
+}

--- a/tests/unit/api/schemas/job-schemas.spec.ts
+++ b/tests/unit/api/schemas/job-schemas.spec.ts
@@ -42,7 +42,7 @@ describe('Job Schemas', () => {
         mediaId: '507f1f77bcf86cd799439012',
       })
       expect(result.success).toBe(true)
-      if (result.success) expect(result.data.limit).toBe(1)
+      if (result.success) expect(result.data.limit).toBe(10)
     })
 
     it('should reject limit below 1', () => {
@@ -59,6 +59,65 @@ describe('Job Schemas', () => {
         lessonId: '507f1f77bcf86cd799439011',
         mediaId: '507f1f77bcf86cd799439012',
         limit: '101',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    // Optional params tests (for PDF conversion page)
+    it('should accept empty query (all jobs)', () => {
+      const result = jobStatusQuerySchema.safeParse({})
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.lessonId).toBeUndefined()
+        expect(result.data.mediaId).toBeUndefined()
+        expect(result.data.limit).toBe(10)
+      }
+    })
+
+    it('should accept only lessonId', () => {
+      const result = jobStatusQuerySchema.safeParse({
+        lessonId: '507f1f77bcf86cd799439011',
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.lessonId).toBe('507f1f77bcf86cd799439011')
+        expect(result.data.mediaId).toBeUndefined()
+      }
+    })
+
+    it('should accept only mediaId', () => {
+      const result = jobStatusQuerySchema.safeParse({
+        mediaId: '507f1f77bcf86cd799439012',
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.mediaId).toBe('507f1f77bcf86cd799439012')
+        expect(result.data.lessonId).toBeUndefined()
+      }
+    })
+
+    it('should still accept both params (backward compat)', () => {
+      const result = jobStatusQuerySchema.safeParse({
+        lessonId: '507f1f77bcf86cd799439011',
+        mediaId: '507f1f77bcf86cd799439012',
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.lessonId).toBe('507f1f77bcf86cd799439011')
+        expect(result.data.mediaId).toBe('507f1f77bcf86cd799439012')
+      }
+    })
+
+    it('should reject invalid lessonId format', () => {
+      const result = jobStatusQuerySchema.safeParse({
+        lessonId: 'bad-id',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject invalid mediaId format', () => {
+      const result = jobStatusQuerySchema.safeParse({
+        mediaId: 'bad-id',
       })
       expect(result.success).toBe(false)
     })


### PR DESCRIPTION
Replace the cramped inline conversion panel with a full admin page at /admin/pdf-conversion. Includes searchable lesson/PDF selection, prompt configuration, job history with status monitoring, and exercise review cards.

Changes:
- Add new admin page at /admin/pdf-conversion with auth gating
- Add sidebar navigation link in payload.config.ts
- Create 6 new components (PdfConversionPage, LessonSelector, PdfSelector, ConversionForm, JobHistory, ExerciseReview)
- Update job status schema to support optional lessonId/mediaId params
- Add unit tests for schema changes
- Regenerate import map