### PR TITLE
fix: Externalize require-in-the-middle for Vercel serverless

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,7 +11,7 @@ const NEXT_PUBLIC_SERVER_URL = process.env.VERCEL_PROJECT_PRODUCTION_URL
 const nextConfig = {
   // Externalize pdfjs-dist to avoid bundled worker path issues in server contexts
   // This allows pdfjs-dist to load from node_modules at runtime, where worker paths work correctly
-  serverExternalPackages: ['pdfjs-dist'],
+  serverExternalPackages: ['pdfjs-dist', 'require-in-the-middle', 'import-in-the-middle'],
   images: {
     remotePatterns: [
       ...[NEXT_PUBLIC_SERVER_URL /* 'https://example.com' */].map((item) => {


### PR DESCRIPTION
Vercel's serverless bundler cannot statically analyze require-in-the-middle and import-in-the-middle, transitive deps of @sentry/nextjs. Adding them to serverExternalPackages allows loading from node_modules at runtime.