### PR TITLE
fix(e2e): Add fast HEAD health endpoint and increase timeout

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -53,9 +53,9 @@ export default defineConfig({
   ],
   webServer: {
     command: 'rm -rf .next && pnpm build && test -d .next && pnpm start',
-    reuseExistingServer: true, // Reuse existing server if available
-    url: 'http://localhost:3000/api/health', // Use dedicated health endpoint (fast, no blocking operations)
-    timeout: 300000, // 5 minutes for build + server start (MongoDB connection can be slow, static generation may take time)
+    reuseExistingServer: true,
+    url: 'http://localhost:3000/api/health', // Uses HEAD request (faster, no body)
+    timeout: 600000, // 10 minutes for build + server start (MongoDB connection can be slow, static generation may take time)
     stdout: 'pipe',
     stderr: 'pipe',
     env: {

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -66,3 +66,8 @@ export async function GET(): Promise<
     return NextResponse.json({ error: 'Health check failed' }, { status: 500 })
   }
 }
+
+// Simple ping endpoint for load balancers and health checks - no expensive operations
+export async function HEAD(): Promise<NextResponse> {
+  return new NextResponse(null, { status: 200 })
+}


### PR DESCRIPTION
- Add HEAD() endpoint to /api/health for fast load balancer health checks
- Increase webServer timeout from 5min to 10min for slow builds