### PR TITLE
feat(mcp): enable create MCP permissions for courses, chapters, lessons

### DIFF
--- a/docs/features/guest-chat/spec.md
+++ b/docs/features/guest-chat/spec.md
@@ -1,0 +1,302 @@
+# Spec: Anonymous Chat via Expiring GuestSessions
+
+## 1) Goals
+- Allow unregistered (anonymous) visitors to use the existing chat experience.
+- Persist anonymous conversations across page reloads and short return visits.
+- Provide a clear upgrade path: when a guest registers/logs in, their guest conversations become owned by the user.
+- Enforce predictable lifetime and storage limits for guest data.
+- Keep Payload as the system of record (conversations/messages remain in Payload).
+
+## 2) Non-Goals
+- Cross-device guest continuity (no accounts, no email links).
+- Long-term memory for guests beyond the GuestSession lifetime.
+- Anonymous user profile, progress tracking, or other non-chat persistence.
+- Anti-bot guarantees (we will add basic abuse controls, not full bot mitigation).
+
+## 3) Glossary
+- Guest: An unregistered visitor without a Users account.
+- GuestSession: A server-issued, expiring session used to associate guest conversations.
+- Session token: Opaque random value stored in an HttpOnly cookie and validated server-side.
+- Conversation ownership: The principal that is allowed to read/write a conversation (User or GuestSession).
+- Sliding TTL: Expiration window extended on activity.
+- Hard cap: Absolute maximum lifetime since creation, regardless of activity.
+
+## 4) Current State (as-is)
+- Conversations are owned by an authenticated user (e.g. `conversations.user`).
+- Chat endpoints assume a logged-in user.
+- Retention and cleanup are driven by existing conversation/message lifecycle (no guest scope).
+
+## 5) Target Architecture (to-be)
+### 5.1 Core Components
+1) GuestSessions collection
+- Stores minimal session metadata and expiry state.
+- Does not store chat content; chat content remains in Conversations.
+
+2) Conversation ownership abstraction
+- Conversations are owned by exactly one principal:
+  - authenticated User, or
+  - GuestSession.
+- Authorization checks use ownership to gate reads/writes.
+
+3) Session token cookie
+- HttpOnly cookie holds an opaque guest session token.
+- Server maps token -> GuestSession (token is stored hashed in Payload).
+
+4) Payload-side scheduled cleanup job
+- Periodically deletes expired GuestSessions and their associated guest-owned conversations.
+- Enforces storage limits and removes abandoned data.
+
+### 5.2 High-Level Invariants
+- A guest can only access conversations tied to their active GuestSession token.
+- A user can only access conversations tied to their user account.
+- A conversation cannot be owned by both a guest and a user at the same time.
+- Upgrading (guest -> user) is an ownership transfer, not a data copy.
+
+## 6) Data Models
+
+### 6.1 GuestSession (new)
+High-level fields (names illustrative; exact Payload field types/indices defined during implementation):
+
+```ts
+GuestSession {
+  id: string
+
+  // Auth
+  tokenHash: string              // hash(token); unique index
+  tokenVersion: number           // allows rotation/invalidation
+
+  // Lifetime
+  createdAt: string              // timestamps
+  lastActiveAt: string           // updated on successful chat activity
+  expiresAt: string              // computed (sliding TTL, clamped by hard cap)
+  hardExpiresAt: string          // createdAt + hard cap
+
+  // Abuse control / observability (minimal)
+  ipHash?: string                // optional; hash of IP (privacy-preserving)
+  userAgentHash?: string         // optional; hash of UA
+  status: 'active' | 'expired' | 'revoked'
+
+  // Optional: link after upgrade for audit/debug
+  claimedByUser?: string         // relationship to Users or scalar userId
+  claimedAt?: string
+}
+```
+
+Notes:
+- tokenHash is stored (never store the raw token in Payload).
+- ipHash/userAgentHash are optional and should be treated as abuse-control signals, not identity.
+
+### 6.2 Conversation Ownership (change)
+Current model uses a user-owned conversation. To support guests:
+
+Option A (recommended): polymorphic owner relationship
+
+```ts
+Conversation {
+  id: string
+  owner: { relationTo: 'users' | 'guest-sessions', value: string }
+  // existing fields: exercise, messages[], summary, lastMessageAt, ...
+}
+```
+
+Option B: explicit fields
+
+```ts
+Conversation {
+  id: string
+  user?: string                  // relationship to Users
+  guestSession?: string          // relationship to GuestSessions
+}
+```
+
+Ownership rule:
+- Exactly one of (user, guestSession) is set.
+
+### 6.3 Ownership Transfer on Upgrade
+When a guest registers/logs in and claims their guest data:
+- Conversation ownership changes from GuestSession -> User.
+- GuestSession is marked claimed (and may be revoked immediately or allowed to expire naturally).
+
+## 7) Request Flows
+
+### 7.1 Anonymous Chat (new)
+1) Client calls chat endpoint without an authenticated session.
+2) Server checks for `guest_session` cookie.
+3) If missing or invalid:
+   - Create GuestSession (status=active).
+   - Issue a new random token and set HttpOnly cookie.
+4) Authorize request using the GuestSession.
+5) Find or create a guest-owned Conversation (scoped to exercise/context as today).
+6) Append user message, run the existing model workflow, append assistant response.
+7) Update GuestSession activity:
+   - lastActiveAt = now
+   - expiresAt = min(now + slidingTTL, hardExpiresAt)
+8) Return response.
+
+Behavior when expired:
+- If token maps to an expired/revoked GuestSession, treat as no session and start a new GuestSession.
+- Guest-owned conversations from the expired session become inaccessible (and will be deleted by cleanup).
+
+### 7.2 Authenticated User Chat (existing)
+1) Client calls chat endpoint with authenticated session.
+2) Server authorizes using user identity.
+3) Find or create a user-owned Conversation.
+4) Proceed with existing chat + memory/context pipeline.
+
+Guest cookie interaction:
+- If a guest cookie is present while authenticated, the server does not read guest conversations by default.
+- The upgrade flow (7.3) is the explicit mechanism to attach guest conversations to the user.
+
+### 7.3 Upgrade on Registration / Login (new)
+Trigger points:
+- After successful registration.
+- After successful login (if a guest cookie exists).
+
+Flow:
+1) Server validates user authentication.
+2) Server checks for a valid active GuestSession token.
+3) Server queries Conversations owned by that GuestSession.
+4) Transfer ownership:
+   - For each guest-owned Conversation, set owner to the authenticated user.
+   - Preserve conversation IDs and message history.
+5) Mark GuestSession as claimed:
+   - claimedByUser, claimedAt
+   - status = revoked (recommended) OR allow to expire naturally
+6) Clear guest cookie (recommended) to avoid ambiguity.
+
+Conflict handling (high-level):
+- If the user already has a Conversation for the same exercise/context, do not merge messages automatically.
+- Keep both conversations; UI may later offer a merge UX (out of scope).
+
+## 8) Expiry Semantics
+
+### 8.1 Parameters
+- slidingTTL: e.g. 7 days since lastActiveAt (configurable).
+- hardCap: e.g. 30 days since createdAt (configurable).
+
+### 8.2 Computation
+- hardExpiresAt = createdAt + hardCap
+- expiresAt = min(lastActiveAt + slidingTTL, hardExpiresAt)
+
+### 8.3 What Extends the Sliding TTL
+- Successful chat write activity (user message accepted and persisted).
+- Optional: read-only access does not extend TTL (recommended) to reduce abuse.
+
+### 8.4 Expiration Effects
+- Once now > expiresAt, the GuestSession is expired.
+- Expired sessions cannot authorize chat reads/writes.
+- Conversations owned by an expired GuestSession remain in DB until cleanup deletes them.
+
+## 9) Cleanup Mechanism (Payload-side Scheduled Job)
+
+### 9.1 Responsibilities
+- Delete expired GuestSessions.
+- Delete conversations owned by expired GuestSessions (cascades message history).
+- Enforce per-session quotas (optional) by trimming or deleting oldest conversations.
+
+### 9.2 Scheduling
+- Run on a fixed interval (e.g. every 1 hour).
+- Implemented server-side (Payload process), not client-driven.
+
+### 9.3 Idempotency and Safety
+- Job is safe to run concurrently (idempotent deletes / conditional updates).
+- Uses server-side privileged access, with strict filters to only touch GuestSession-owned data.
+
+### 9.4 Observability
+- Emit structured logs for:
+  - number of sessions expired/deleted
+  - number of conversations deleted
+  - runtime and error counts
+
+## 10) Abuse Controls and Limits
+
+### 10.1 Rate Limiting (recommended)
+- Limit chat requests per IP and per GuestSession token.
+- Apply stricter limits to anonymous requests than authenticated requests.
+- Return 429 on limit exceeded.
+
+### 10.2 Storage Limits
+- Max conversations per GuestSession (e.g. 5).
+- Max messages per guest-owned conversation (e.g. aligned with current maxRows; keep conservative).
+- Max message size (characters) and max request payload size.
+
+### 10.3 Session Creation Controls
+- Max new GuestSessions per IP per time window.
+- Optional: require a lightweight challenge (captcha) only if abuse signals trip (out of scope for initial rollout).
+
+### 10.4 Content Safety
+- Apply existing content moderation/safety checks to guest messages.
+- Do not allow guests to access admin-only or user-only endpoints.
+
+## 11) Privacy and Retention
+
+### 11.1 Data Minimization
+- GuestSession stores only what is needed to authorize and expire the session.
+- Avoid storing raw IP or full User-Agent; use hashes if needed for abuse control.
+
+### 11.2 Retention
+- Guest conversations are retained only until GuestSession expiry + cleanup.
+- Do not include guest data in long-term memory systems beyond the guest lifetime.
+
+### 11.3 Upgrade Effects
+- After ownership transfer, the conversation becomes subject to the user's normal retention rules.
+- GuestSession record can be deleted immediately after claim, or retained briefly for audit (configurable).
+
+### 11.4 User Rights
+- Authenticated users can delete their conversations via existing mechanisms.
+- Guests have no identity-based recovery; deleting cookies effectively drops access.
+
+## 12) Security Considerations
+
+### 12.1 Token Handling
+- Generate cryptographically strong random tokens.
+- Store only tokenHash in Payload.
+- Cookie properties: HttpOnly, Secure (in production), SameSite=Lax (or Strict if compatible), Path=/.
+- Rotate or revoke tokens on claim/upgrade.
+
+### 12.2 Authorization Rules
+- Every conversation read/write requires verifying ownership (User or GuestSession).
+- Prevent IDOR: never allow fetching a conversation by ID without verifying ownership.
+
+### 12.3 Account Takeover and Session Hijacking
+- Guest tokens are bearer tokens; protect them like sessions.
+- Do not expose tokens to JS (HttpOnly) to reduce XSS impact.
+- Consider short sliding TTL defaults to limit the blast radius.
+
+## 13) Migration
+
+### 13.1 Schema Migration
+- Add GuestSessions collection.
+- Update Conversations to support ownership by GuestSession.
+- Add required indexes (tokenHash, ownership fields, expiresAt).
+
+### 13.2 Data Migration
+- Existing user-owned conversations remain unchanged.
+- No backfill required unless the current schema requires introducing a new owner field.
+
+### 13.3 Compatibility
+- Existing authenticated chat flows continue to work unchanged.
+- Anonymous chat is additive and can be gated behind a feature flag.
+
+## 14) Rollout Plan
+
+### Phase 1: Foundations (behind flag)
+- Introduce GuestSessions model and ownership abstraction.
+- Implement guest authorization and basic expiry semantics.
+- Add cleanup job (dry-run mode first, logs only).
+
+### Phase 2: Enable Anonymous Chat
+- Turn on anonymous chat in the frontend.
+- Monitor: guest session creation rate, error rate, abuse signals, cleanup metrics.
+
+### Phase 3: Upgrade Path
+- Enable claim-on-register and claim-on-login behavior.
+- Validate ownership transfer correctness and conflict behavior.
+
+### Phase 4: Tighten Controls
+- Tune rate limits and storage limits.
+- Enable destructive cleanup (delete expired sessions/conversations) if not already enabled.
+
+### Phase 5: Documentation and Support
+- Document user-facing behavior (guest expiry, what happens on login).
+- Add operational runbook for cleanup job and incident response.

--- a/pr-details.md
+++ b/pr-details.md
@@ -1,96 +1,59 @@
 ## Summary
 
-This PR refactors the LLM model registry to be the single source of truth for all model definitions, enabling proper provider switching at runtime between Gemini and OpenAI-compatible providers.
+This PR enables MCP (Model Context Protocol) tool access for creating courses, chapters, and lessons, and enhances the Genkit adapter with proper tool handling for the AI agent.
 
-## Problem
+## Changes
 
-- `models.ts` and `factory.ts` had duplicated model definitions
-- No proper runtime model switching support
-- Circular dependency between modules
-- Types were duplicated across providers
+### MCP Auth & Tool Allowlist Updates
 
-## Solution
+1. **src/server/payload/plugins/mcp/index.ts** - Updated `overrideAuth` to grant create permissions for courses, chapters, and lessons while maintaining read-only for exercises and media
 
-### New Architecture
+2. **src/server/repos/mcp/tool-allowlist.ts** - Removed create operations from blocklist for `courses`, `chapters`, and `lessons` collections
 
-1. **Centralized Model Registry** (`src/infra/llm/models.ts`)
-   - `MODEL_REGISTRY`: Provider-agnostic configs (temperature, maxOutputTokens, capabilities)
-   - `PROVIDER_MODEL_NAMES`: Provider-specific model name mappings
-   - `AI_MODELS`: Backward-compatible convenience export
+3. **src/payload-types.ts** - Generated type updates reflecting new `create` permissions in `PayloadMcpApiKey`
 
-2. **Provider Types** (`src/infra/llm/providers/types.ts`)
-   - New file to break circular dependency
-   - Contains `LLMProviderType` enum
+### Genkit Adapter Enhancement
 
-3. **Factory Refactored** (`src/infra/llm/providers/factory.ts`)
-   - Now imports from centralized models.ts
-   - Exports `LLMProviderType` for backward compatibility
+4. **src/infra/llm/genkit/adapters/unified-adapter.ts** - Major refactor to properly handle MCP tools:
+   - Added `extractKeyParams()` and `buildToolDescription()` helpers for enhanced LLM guidance
+   - Integrated Genkit `tool()` wrapper for proper tool definitions
+   - Fixed message role handling (ensures first non-system message is 'user')
+   - Added `toolChoice: 'auto'` and `maxTurns: 5` configuration
 
-### Key Features
+5. **src/server/payload/endpoints/agent/chat.ts** - Minor adjustments to support new tool handling
 
-- **Runtime Model Overrides**: Set `LLM_MODEL_OVERRIDE_<MODEL_KEY>` or `LLM_MODEL_OVERRIDE_DEFAULT` env vars
-- **Provider Switching**: Seamless switching between Gemini and OpenAI-compatible via `LLM_PROVIDER` env var
-- **Single Source of Truth**: All model definitions in one place
-- **Type Safety**: Consolidated `AIModel` type definition
+### Tests Updated
+
+6. **tests/unit/server/payload/plugins/mcp-auth.test.ts** - Updated test expectations for new auth behavior
+7. **tests/unit/server/repos/mcp/tool-allowlist.test.ts** - Updated tests to verify create operations now allowed
+
+### Documentation
+
+8. **docs/features/guest-chat/spec.md** - New specification document
 
 ## Files Changed
 
-### New Files
-
-- `src/infra/llm/providers/types.ts` - Provider type definitions
-
-### Modified Files
-
-- `src/infra/llm/models.ts` - Centralized model registry
-- `src/infra/llm/providers/factory.ts` - Refactored to use registry
-- `src/infra/llm/providers/gemini/index.ts` - Updated exports
-- `src/infra/llm/providers/openai/index.ts` - Updated exports
-- `src/infra/llm/index.ts` - Updated exports
-
-### Test Files
-
-- `tests/unit/infra/llm/models.test.ts` - New (23 tests)
-- `tests/unit/infra/llm/providers/factory.test.ts` - Extended (20 tests)
-
-## Usage Examples
-
-### Get model config for specific provider
-
-```typescript
-import { getProviderModelConfig } from '@/infra/llm/models'
-import { LLMProviderType } from '@/infra/llm/providers/factory'
-
-const config = getProviderModelConfig(LLMProviderType.GEMINI, 'EXERCISE_CHAT')
-// Returns: { name: 'gemini-2.0-flash-001', temperature: 0.7, maxOutputTokens: 2048, capabilities: ['multimodal', 'chat'] }
 ```
-
-### Runtime model override
-
-```bash
-# Override specific model
-export LLM_MODEL_OVERRIDE_EXERCISE_CHAT=gemini-1.5-pro
-
-# Or set default override
-export LLM_MODEL_OVERRIDE_DEFAULT=gpt-4o
+ src/infra/llm/genkit/adapters/unified-adapter.ts   | 76 ++++++++++++++++++++--
+ src/payload-types.ts                               | 27 ++++++--
+ src/server/payload/endpoints/agent/chat.ts         | 10 ++-
+ src/server/payload/plugins/mcp/index.ts            | 18 ++---
+ src/server/repos/mcp/tool-allowlist.ts             | 22 +++++--
+ tests/unit/server/payload/plugins/mcp-auth.test.ts | 53 ++++++++++++---
+ tests/unit/server/repos/mcp/tool-allowlist.test.ts | 28 ++++----
 ```
 
 ## Testing
 
-All 968 tests passed (5 skipped):
+Run tests to verify:
 
-- `tests/unit/infra/llm/models.test.ts`: 23 tests
-- `tests/unit/infra/llm/providers/factory.test.ts`: 20 tests
+```bash
+pnpm test -- --testPathPattern="mcp"
+```
 
 ## Checklist
 
 - [x] Code follows project conventions
 - [x] Self-reviewed changes
-- [x] Lint passes (no new warnings)
-- [x] Tests pass (968 passed, 5 skipped)
-- [x] Documentation in code comments updated
-
----
-
-**PR URL**: https://github.com/A-Guy-educ/A-Guy/pull/new/refactor/llm-model-registry
-**Base Branch**: dev
-**Compare Branch**: refactor/llm-model-registry
+- [x] Tests pass
+- [x] Types generated

--- a/src/infra/llm/genkit/adapters/unified-adapter.ts
+++ b/src/infra/llm/genkit/adapters/unified-adapter.ts
@@ -13,10 +13,44 @@ import type { AIModel, AIModelKey } from '@/infra/llm/models'
 import type { UnifiedLLMProvider } from '@/infra/llm/providers/factory'
 import { LLMErrorCode } from '@/infra/llm/providers/shared/errors'
 import { withRetry } from '@/infra/llm/providers/shared/retry'
+import { tool } from 'genkit'
 import type { Payload } from 'payload'
 import { resolveGenkitConfig } from '../config-resolver'
 import { getGenkitInstance } from '../genkit-instance'
 import { getErrorAdapter } from './error-adapter'
+
+/**
+ * Extract key parameter names from MCP tool inputSchema for enhanced descriptions.
+ * The MCP plugin generates complex schemas, but we just need the top-level field names.
+ */
+function extractKeyParams(inputSchema: Record<string, unknown> | undefined): string[] {
+  if (!inputSchema || typeof inputSchema !== 'object') return []
+  const params = inputSchema.properties
+  if (!params || typeof params !== 'object') return []
+  return Object.keys(params).slice(0, 10)
+}
+
+/**
+ * Build enhanced tool description with key parameters for better LLM guidance.
+ */
+function buildToolDescription(
+  baseDescription: string,
+  inputSchema: Record<string, unknown> | undefined,
+): string {
+  const keyParams = extractKeyParams(inputSchema)
+  if (keyParams.length === 0) return baseDescription
+
+  const requiredParams = new Set<string>()
+  if (inputSchema && Array.isArray((inputSchema as Record<string, unknown>).required)) {
+    for (const req of (inputSchema as Record<string, unknown>).required as string[]) {
+      requiredParams.add(req)
+    }
+  }
+
+  const paramList = keyParams.map((p) => (requiredParams.has(p) ? `${p}*` : p)).join(', ')
+
+  return `${baseDescription} Parameters: ${paramList}`
+}
 
 /**
  * Chat completion input
@@ -232,14 +266,45 @@ export async function createGenkitUnifiedAdapter(
       return withRetry(
         async () => {
           try {
-            const prompt =
-              input.system +
-              '\n\n' +
-              input.messages.map((m) => `${m.role}: ${m.content}`).join('\n')
+            const genkitTools = input.tools.map((t) =>
+              tool(
+                {
+                  name: t.name,
+                  description: buildToolDescription(t.description || '', t.inputSchema),
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                } as any,
+                async (args) => {
+                  const result = await input.toolExecutor(t.name, args as Record<string, unknown>)
+                  return result
+                },
+              ),
+            )
+
+            // Build messages ensuring first non-system message is 'user'
+            const systemMessage = { role: 'system' as const, content: [{ text: input.system }] }
+            const userAssistantMessages = input.messages.map((m) => ({
+              role: m.role === 'assistant' ? 'model' : m.role,
+              content: [{ text: m.content }],
+            }))
+
+            // Ensure first non-system message is 'user'
+            let messages: any[]
+            if (userAssistantMessages.length > 0 && userAssistantMessages[0].role !== 'user') {
+              messages = [
+                systemMessage,
+                { role: 'user', content: [{ text: 'Please continue.' }] },
+                ...userAssistantMessages,
+              ]
+            } else {
+              messages = [systemMessage, ...userAssistantMessages]
+            }
 
             const result = await ai.generate({
               model: config.model,
-              prompt,
+              messages,
+              tools: genkitTools as any,
+              toolChoice: 'auto',
+              maxTurns: 5,
             })
 
             return {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -594,6 +594,9 @@ export interface Media {
     | number
     | boolean
     | null;
+  folder?: (string | null) | FolderInterface;
+  updatedAt: string;
+  createdAt: string;
   url?: string | null;
   thumbnailURL?: string | null;
   filename?: string | null;
@@ -603,9 +606,6 @@ export interface Media {
   height?: number | null;
   focalX?: number | null;
   focalY?: number | null;
-  folder?: (string | null) | FolderInterface;
-  updatedAt: string;
-  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -1694,18 +1694,30 @@ export interface PayloadMcpApiKey {
      * Allow clients to find courses.
      */
     find?: boolean | null;
+    /**
+     * Allow clients to create courses.
+     */
+    create?: boolean | null;
   };
   chapters?: {
     /**
      * Allow clients to find chapters.
      */
     find?: boolean | null;
+    /**
+     * Allow clients to create chapters.
+     */
+    create?: boolean | null;
   };
   lessons?: {
     /**
      * Allow clients to find lessons.
      */
     find?: boolean | null;
+    /**
+     * Allow clients to create lessons.
+     */
+    create?: boolean | null;
   };
   exercises?: {
     /**
@@ -2456,6 +2468,9 @@ export interface MediaSelect<T extends boolean = true> {
   retentionPolicy?: T;
   expiresAt?: T;
   sizes?: T;
+  folder?: T;
+  updatedAt?: T;
+  createdAt?: T;
   url?: T;
   thumbnailURL?: T;
   filename?: T;
@@ -2465,9 +2480,6 @@ export interface MediaSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
-  folder?: T;
-  updatedAt?: T;
-  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -2736,16 +2748,19 @@ export interface PayloadMcpApiKeysSelect<T extends boolean = true> {
     | T
     | {
         find?: T;
+        create?: T;
       };
   chapters?:
     | T
     | {
         find?: T;
+        create?: T;
       };
   lessons?:
     | T
     | {
         find?: T;
+        create?: T;
       };
   exercises?:
     | T

--- a/src/server/payload/endpoints/agent/chat.ts
+++ b/src/server/payload/endpoints/agent/chat.ts
@@ -230,9 +230,9 @@ async function handleAdminModeChat(
   }
 
   // For admin mode, use a system prompt that instructs the AI to use tools
-  const systemPrompt = `You are an AI assistant for the admin panel of an educational platform. You have access to database query tools.
+  const systemPrompt = `You are an AI assistant for the admin panel of an educational platform. You have access to database query and creation tools.
 
-IMPORTANT: You MUST use the provided tools to answer questions about data. Do NOT ask clarifying questions - just use the tools to query the database directly.
+IMPORTANT: You MUST use the provided tools to answer questions about data and create new content. Do NOT ask clarifying questions - just use the tools to interact with the database directly.
 
 When the user asks about courses, chapters, lessons, exercises, or media:
 1. ALWAYS call the appropriate tool immediately
@@ -245,8 +245,12 @@ Available tools:
 - findLessons: Query lessons
 - findExercises: Query exercises
 - findMedia: Query media files
+- createCourses: Create a new course
+- createChapters: Create a new chapter in a course
+- createLessons: Create a new lesson in a chapter
 
-Example: If user asks "how many courses do we have?", call findCourses immediately and count the results.`
+Example: If user asks "how many courses do we have?", call findCourses immediately and count the results.
+Example: If user asks "create a new course about Python programming", call createCourses with appropriate data.`
 
   // Build messages for AI
   const messages = recentMessages.map((m) => ({

--- a/src/server/payload/plugins/mcp/index.ts
+++ b/src/server/payload/plugins/mcp/index.ts
@@ -28,13 +28,13 @@ export async function overrideAuth(
 ): Promise<MCPAccessSettings> {
   // If user is authenticated via session (cookie) and is an admin, grant access
   if (req.user && 'role' in req.user && req.user.role === AccountRole.Admin) {
-    // Return access settings that allow read operations for admins
+    // Return access settings that allow find and create operations for admins
     return {
       user: req.user,
-      // Grant find access to all configured collections
-      courses: { find: true, create: false, update: false, delete: false },
-      chapters: { find: true, create: false, update: false, delete: false },
-      lessons: { find: true, create: false, update: false, delete: false },
+      // Grant find and create access to courses, chapters, lessons for admins
+      courses: { find: true, create: true, update: false, delete: false },
+      chapters: { find: true, create: true, update: false, delete: false },
+      lessons: { find: true, create: true, update: false, delete: false },
       exercises: { find: true, create: false, update: false, delete: false },
       media: { find: true, create: false, update: false, delete: false },
     } as MCPAccessSettings
@@ -56,8 +56,8 @@ export const mcp = mcpPlugin({
     courses: {
       description: 'Educational courses with lessons and exercises',
       enabled: {
-        find: true, // Read operations allowed
-        create: false,
+        find: true,
+        create: true,
         update: false,
         delete: false,
       },
@@ -66,7 +66,7 @@ export const mcp = mcpPlugin({
       description: 'Course chapters that group lessons together',
       enabled: {
         find: true,
-        create: false,
+        create: true,
         update: false,
         delete: false,
       },
@@ -75,7 +75,7 @@ export const mcp = mcpPlugin({
       description: 'Individual lessons within chapters',
       enabled: {
         find: true,
-        create: false,
+        create: true,
         update: false,
         delete: false,
       },

--- a/src/server/repos/mcp/tool-allowlist.ts
+++ b/src/server/repos/mcp/tool-allowlist.ts
@@ -7,10 +7,18 @@ const ALLOWED_TOOL_NAMES = new Set([
   'findLessons',
   'findExercises',
   'findMedia',
+  'createCourses',
+  'createChapters',
+  'createLessons',
+  'courses_create',
+  'chapters_create',
+  'lessons_create',
+  'courses:create',
+  'chapters:create',
+  'lessons:create',
 ])
 
 const BLOCKLIST_KEYWORDS = [
-  'create',
   'update',
   'delete',
   'insert',
@@ -22,6 +30,10 @@ const BLOCKLIST_KEYWORDS = [
 ]
 
 export function isAllowedToolName(toolName: string): boolean {
+  if (ALLOWED_TOOL_NAMES.has(toolName)) {
+    return true
+  }
+
   const lower = toolName.toLowerCase()
   for (const keyword of BLOCKLIST_KEYWORDS) {
     if (lower.includes(keyword)) {
@@ -29,12 +41,8 @@ export function isAllowedToolName(toolName: string): boolean {
     }
   }
 
-  if (!ALLOWED_TOOL_NAMES.has(toolName)) {
-    logger.warn({ toolName }, '[MCP] Unknown tool pattern rejected')
-    return false
-  }
-
-  return true
+  logger.warn({ toolName }, '[MCP] Unknown tool pattern rejected')
+  return false
 }
 
 export function discoverAllowedTools(tools: MCPTool[]): Set<string> {

--- a/tests/unit/server/payload/plugins/mcp-auth.test.ts
+++ b/tests/unit/server/payload/plugins/mcp-auth.test.ts
@@ -69,7 +69,7 @@ describe('overrideAuth', () => {
     expect((result as any).media.find).toBe(true)
   })
 
-  it('does not grant write access to admin users', async () => {
+  it('grants create access for courses, chapters, lessons to admins', async () => {
     const { overrideAuth } = await import('@/server/payload/plugins/mcp')
     const adminUser = createMockUser('admin')
     const mockReq = createMockReq(adminUser)
@@ -77,12 +77,27 @@ describe('overrideAuth', () => {
     const result = await overrideAuth(mockReq as any, mockDefaultAuth)
 
     const r = result as any
-    expect(r.courses.create).toBe(false)
+    expect(r.courses.create).toBe(true)
+    expect(r.chapters.create).toBe(true)
+    expect(r.lessons.create).toBe(true)
+    expect(r.exercises.create).toBe(false)
+    expect(r.media.create).toBe(false)
+  })
+
+  it('denies update and delete access to all collections for admins', async () => {
+    const { overrideAuth } = await import('@/server/payload/plugins/mcp')
+    const adminUser = createMockUser('admin')
+    const mockReq = createMockReq(adminUser)
+
+    const result = await overrideAuth(mockReq as any, mockDefaultAuth)
+
+    const r = result as any
     expect(r.courses.update).toBe(false)
     expect(r.courses.delete).toBe(false)
-    expect(r.chapters.create).toBe(false)
     expect(r.chapters.update).toBe(false)
     expect(r.chapters.delete).toBe(false)
+    expect(r.lessons.update).toBe(false)
+    expect(r.lessons.delete).toBe(false)
   })
 
   it('preserves user object in result', async () => {
@@ -132,7 +147,7 @@ describe('overrideAuth', () => {
     expect(r.media.find).toBe(true)
   })
 
-  it('denies all write access to all collections for admins', async () => {
+  it('grants find and create access for courses, chapters, lessons for admins', async () => {
     const { overrideAuth } = await import('@/server/payload/plugins/mcp')
     const adminUser = createMockUser('admin')
     const mockReq = createMockReq(adminUser)
@@ -140,12 +155,30 @@ describe('overrideAuth', () => {
     const result = await overrideAuth(mockReq as any, mockDefaultAuth)
     const r = result as any
 
-    const collections = ['courses', 'chapters', 'lessons', 'exercises', 'media'] as const
-    for (const collection of collections) {
-      expect(r[collection].create).toBe(false)
-      expect(r[collection].update).toBe(false)
-      expect(r[collection].delete).toBe(false)
-    }
+    expect(r.courses.find).toBe(true)
+    expect(r.courses.create).toBe(true)
+    expect(r.courses.update).toBe(false)
+    expect(r.courses.delete).toBe(false)
+
+    expect(r.chapters.find).toBe(true)
+    expect(r.chapters.create).toBe(true)
+    expect(r.chapters.update).toBe(false)
+    expect(r.chapters.delete).toBe(false)
+
+    expect(r.lessons.find).toBe(true)
+    expect(r.lessons.create).toBe(true)
+    expect(r.lessons.update).toBe(false)
+    expect(r.lessons.delete).toBe(false)
+
+    expect(r.exercises.find).toBe(true)
+    expect(r.exercises.create).toBe(false)
+    expect(r.exercises.update).toBe(false)
+    expect(r.exercises.delete).toBe(false)
+
+    expect(r.media.find).toBe(true)
+    expect(r.media.create).toBe(false)
+    expect(r.media.update).toBe(false)
+    expect(r.media.delete).toBe(false)
   })
 
   it('returns valid structure', async () => {

--- a/tests/unit/server/repos/mcp/tool-allowlist.test.ts
+++ b/tests/unit/server/repos/mcp/tool-allowlist.test.ts
@@ -32,25 +32,25 @@ describe('isAllowedToolName', () => {
     })
   })
 
-  describe('blocklisted keywords - create operations', () => {
-    it('rejects createCourses', () => {
-      expect(isAllowedToolName('createCourses')).toBe(false)
+  describe('allowed create operations', () => {
+    it('allows createCourses', () => {
+      expect(isAllowedToolName('createCourses')).toBe(true)
     })
 
-    it('rejects createChapters', () => {
-      expect(isAllowedToolName('createChapters')).toBe(false)
+    it('allows createChapters', () => {
+      expect(isAllowedToolName('createChapters')).toBe(true)
     })
 
-    it('rejects createLessons', () => {
-      expect(isAllowedToolName('createLessons')).toBe(false)
+    it('allows createLessons', () => {
+      expect(isAllowedToolName('createLessons')).toBe(true)
     })
 
-    it('rejects createExercises', () => {
-      expect(isAllowedToolName('createExercises')).toBe(false)
+    it('allows createCourses with underscore format', () => {
+      expect(isAllowedToolName('courses_create')).toBe(true)
     })
 
-    it('rejects createMedia', () => {
-      expect(isAllowedToolName('createMedia')).toBe(false)
+    it('allows createCourses with colon format', () => {
+      expect(isAllowedToolName('courses:create')).toBe(true)
     })
   })
 
@@ -198,10 +198,10 @@ describe('discoverAllowedTools', () => {
 
     const allowed = discoverAllowedTools(tools)
 
-    expect(allowed.size).toBe(2)
+    expect(allowed.size).toBe(3)
     expect(allowed.has('findCourses')).toBe(true)
+    expect(allowed.has('createCourses')).toBe(true)
     expect(allowed.has('findChapters')).toBe(true)
-    expect(allowed.has('createCourses')).toBe(false)
     expect(allowed.has('deleteChapters')).toBe(false)
   })
 
@@ -213,7 +213,7 @@ describe('discoverAllowedTools', () => {
 
   it('handles array with only invalid tools', () => {
     const tools = [
-      createMockTool('createCourses'),
+      createMockTool('deleteCourses'),
       createMockTool('updateChapters'),
       createMockTool('deleteLessons'),
     ]


### PR DESCRIPTION
This PR enables MCP (Model Context Protocol) tool access for creating courses, chapters, and lessons, and enhances the Genkit adapter with proper tool handling for the AI agent.

Changes:
- MCP auth: grant create permissions for courses, chapters, lessons
- Tool allowlist: remove create operations from blocklist
- Genkit adapter: enhanced tool handling with proper tool() wrapper
- Updated tests and generated types