### PR TITLE
feat(admin): Add typed question block editors

### DIFF
--- a/.tasks/20261102-exercise-question-block-editors/LOW_LEVEL_PLAN.md
+++ b/.tasks/20261102-exercise-question-block-editors/LOW_LEVEL_PLAN.md
@@ -1,0 +1,301 @@
+# Low-Level Plan: Exercise Question Block Editors
+
+## File Map
+
+```
+src/ui/admin/ExerciseContentEditor/
+├── index.tsx                          # MODIFY — swap question block rendering
+├── index.css                          # MODIFY — add styles for typed editors
+├── editors/                           # NEW directory
+│   ├── InlineRichTextEditor.tsx       # NEW — shared prompt/hint editor
+│   ├── HintSolutionPanel.tsx          # NEW — shared collapsible hint/solution/fullSolution
+│   ├── TrueFalseEditor.tsx            # NEW — true/false question editor
+│   ├── McqEditor.tsx                  # NEW — MCQ question editor
+│   ├── FreeResponseEditor.tsx         # NEW — free response question editor
+│   ├── TableEditor.tsx                # NEW — table question editor (Stage 2)
+│   ├── QuestionBlockWrapper.tsx       # NEW — wrapper with badge + Advanced JSON toggle
+│   └── normalizers.ts                 # NEW — pure functions for MCQ/table normalization
+├── JSONInspector.tsx                  # NO CHANGE (reused inside Advanced JSON toggle)
+├── BlockTypeSelector.tsx              # NO CHANGE
+├── RichTextEditor.tsx                 # NO CHANGE
+├── MediaPicker.tsx                    # NO CHANGE
+```
+
+---
+
+## Stage 1: Steps (True/False + MCQ + Free Response)
+
+### Step 1: Create `InlineRichTextEditor.tsx`
+
+**File:** `src/ui/admin/ExerciseContentEditor/editors/InlineRichTextEditor.tsx`
+
+**What it does:** Edits an `InlineRichText` object (`{ type, format, value, mediaIds }`). Only `value` is user-editable. The rest are preserved silently.
+
+**Props:**
+
+```ts
+interface InlineRichTextEditorProps {
+  value: InlineRichText
+  onChange: (value: InlineRichText) => void
+  placeholder?: string
+  minHeight?: string // default '80px' — shorter than RichTextEditor's 200px
+}
+```
+
+**Implementation:**
+
+- Reuse the same toolbar pattern from `RichTextEditor.tsx` (Bold, Italic, Heading, Code, Math, Link buttons with `insertText` helper).
+- Render a `<textarea>` for `value.value`.
+- On change: call `onChange({ ...value, value: newText })` — preserving `type`, `format`, `mediaIds`.
+- Use CSS class `.inline-rich-text-editor` with a shorter default height than `.rich-text-textarea`.
+- Show character count footer.
+
+---
+
+### Step 2: Create `HintSolutionPanel.tsx`
+
+**File:** `src/ui/admin/ExerciseContentEditor/editors/HintSolutionPanel.tsx`
+
+**What it does:** Collapsible panel containing three optional `InlineRichText` fields: hint, solution, fullSolution.
+
+**Props:**
+
+```ts
+interface HintSolutionPanelProps {
+  hint?: InlineRichText
+  solution?: InlineRichText
+  fullSolution?: InlineRichText
+  onChange: (field: 'hint' | 'solution' | 'fullSolution', value: InlineRichText | undefined) => void
+}
+```
+
+**Implementation:**
+
+- Use `CollapsibleSection` from `src/ui/admin/shared/CollapsibleSection.tsx` with title "Hints & Solutions", default collapsed.
+- For each field (hint, solution, fullSolution):
+  - If `undefined`: show an "Enable" button. Clicking creates a default `InlineRichText`.
+  - If defined: show `InlineRichTextEditor` + a "Remove" button (sets to `undefined`).
+- Labels: "Hint", "Solution", "Full Solution".
+
+---
+
+### Step 3: Create `QuestionBlockWrapper.tsx`
+
+**File:** `src/ui/admin/ExerciseContentEditor/editors/QuestionBlockWrapper.tsx`
+
+**What it does:** Wraps any typed question editor with a type badge and an "Advanced JSON" toggle.
+
+**Props:**
+
+```ts
+interface QuestionBlockWrapperProps {
+  blockType: string // e.g. "True/False", "Multiple Choice", etc.
+  block: ContentBlock
+  onBlockChange: (block: ContentBlock) => void
+  children: React.ReactNode // the typed editor
+}
+```
+
+**Implementation:**
+
+- Render the `.question-block-type-badge` (already styled in CSS).
+- Render `children` (the typed editor).
+- Below children: render an `AdvancedJsonPanel` from `src/ui/admin/shared/AdvancedJsonPanel.tsx` with `value={block}` and `onChange`. Collapsed by default.
+- If the block fails to match the expected shape: show an error banner + force-open the Advanced JSON panel.
+
+---
+
+### Step 4: Create `normalizers.ts`
+
+**File:** `src/ui/admin/ExerciseContentEditor/editors/normalizers.ts`
+
+**What it does:** Pure functions that enforce invariants from R3.
+
+**Functions:**
+
+```ts
+// MCQ: sync multiSelect with selectionMode, trim correctOptionIds
+export function normalizeMcq(block: QuestionSelectMcqBlock): QuestionSelectMcqBlock
+
+// MCQ: when an option is removed, clean up correctOptionIds
+export function removeOptionAndNormalize(
+  block: QuestionSelectMcqBlock,
+  optionId: string,
+): QuestionSelectMcqBlock
+
+// MCQ: when selectionMode changes, reset correctOptionIds if needed
+export function changeSelectionMode(
+  block: QuestionSelectMcqBlock,
+  mode: 'single' | 'multiple',
+): QuestionSelectMcqBlock
+```
+
+**Key rules (MCQ):**
+
+- `selectionMode === 'single'` → `answer.multiSelect = false`, `correctOptionIds` trimmed to first item only.
+- `selectionMode === 'multiple'` → `answer.multiSelect = true`.
+- After deleting an option: `correctOptionIds` filtered to remove deleted option's id.
+
+---
+
+### Step 5: Create `TrueFalseEditor.tsx`
+
+**File:** `src/ui/admin/ExerciseContentEditor/editors/TrueFalseEditor.tsx`
+
+**Props:**
+
+```ts
+interface TrueFalseEditorProps {
+  block: QuestionSelectTrueFalseBlock
+  onChange: (block: QuestionSelectTrueFalseBlock) => void
+}
+```
+
+**UI Layout:**
+
+1. **Prompt** — `InlineRichTextEditor` editing `block.prompt`.
+2. **Correct Answer** — Two styled radio buttons: "True" and "False". Selected = `block.answer.correctOptionId`.
+3. **Hints & Solutions** — `HintSolutionPanel`.
+
+---
+
+### Step 6: Create `McqEditor.tsx`
+
+**File:** `src/ui/admin/ExerciseContentEditor/editors/McqEditor.tsx`
+
+**Props:**
+
+```ts
+interface McqEditorProps {
+  block: QuestionSelectMcqBlock
+  onChange: (block: QuestionSelectMcqBlock) => void
+}
+```
+
+**UI Layout:**
+
+1. **Prompt** — `InlineRichTextEditor`.
+2. **Selection Mode** — Two buttons/tabs: "Single Answer" | "Multiple Answers". Maps to `block.selectionMode`.
+3. **Options List** — For each option:
+   - Correct marker (Radio if single, Checkbox if multiple).
+   - Option content: `InlineRichTextEditor`.
+   - Move up/down buttons.
+   - Delete button (disabled if only 2 options remain).
+4. **Add Option** button.
+5. **Hints & Solutions** — `HintSolutionPanel`.
+
+---
+
+### Step 7: Create `FreeResponseEditor.tsx`
+
+**File:** `src/ui/admin/ExerciseContentEditor/editors/FreeResponseEditor.tsx`
+
+**Props:**
+
+```ts
+interface FreeResponseEditorProps {
+  block: QuestionFreeResponseBlock
+  onChange: (block: QuestionFreeResponseBlock) => void
+}
+```
+
+**UI Layout:**
+
+1. **Prompt** — `InlineRichTextEditor`.
+2. **Accepted Answers** — List of text inputs with "Add Answer" and delete buttons (disabled if only 1 answer).
+3. **Hints & Solutions** — `HintSolutionPanel`.
+
+---
+
+### Step 8: Modify `ExerciseContentEditor/index.tsx` — Wire Up Editors
+
+**File:** `src/ui/admin/ExerciseContentEditor/index.tsx`
+
+Replace lines 507-521 with:
+
+```tsx
+<QuestionBlockWrapper
+  blockType={getBlockTypeLabel(block)}
+  block={block}
+  onBlockChange={(updated) => onUpdateBlock(block.id, updated)}
+>
+  {renderQuestionEditor(block, (updated) => onUpdateBlock(block.id, updated))}
+</QuestionBlockWrapper>
+```
+
+Add `renderQuestionEditor` dispatcher function that returns the appropriate typed editor based on block type/variant.
+
+---
+
+### Step 9: Add CSS for Typed Editors
+
+**File:** `src/ui/admin/ExerciseContentEditor/index.css`
+
+Add sections for:
+
+- `.inline-rich-text-editor`
+- `.hint-solution-panel`
+- `.tf-radio-group`, `.tf-radio-option`, `.tf-radio-option--selected`
+- `.mcq-option-row`
+- `.mcq-selection-mode`
+- `.accepted-answers-list`, `.accepted-answer-row`
+- `.question-editor-section`
+- `.question-editor-label`
+
+---
+
+### Step 10: Verify & Test (Stage 1 Gate)
+
+1. Run `pnpm tsc --noEmit`
+2. Run `pnpm generate:importmap`
+3. Manual test in browser
+4. Run `pnpm lint`
+
+---
+
+## Stage 2: Table Editor
+
+### Step 11: Create `TableEditor.tsx`
+
+**File:** `src/ui/admin/ExerciseContentEditor/editors/TableEditor.tsx`
+
+**UI Layout:**
+
+1. **Prompt** — `InlineRichTextEditor`.
+2. **Table Config** — Checkboxes for `showBorders`, `showHeader`, `solutionFill`.
+3. **Headers** — Editable row of text inputs. "Add Column" / "Remove Column" buttons.
+4. **Column Alignment** — Per-column select: left/center/right.
+5. **Data Rows** — Grid of text inputs. "Add Row" / "Remove Row" buttons.
+6. **Solution Fill Mode** (when `solutionFill === true`):
+   - Empty cells get visual indicator.
+   - Below each empty cell: text input for correct answer.
+7. **Hints & Solutions** — `HintSolutionPanel`.
+
+### Step 12: Add table normalizers to `normalizers.ts`
+
+- `normalizeTableOnHeaderChange`: resize rows when header count changes.
+- `normalizeTableAnswers`: drop out-of-bounds answer keys.
+- `normalizeTableSolutionFill`: handle toggle on/off.
+
+### Step 13: Add table CSS + verify
+
+Same pattern as Step 9-10 for `.table-editor-*` classes.
+
+---
+
+## Summary: Files Created / Modified
+
+| File                               | Action                  | Stage |
+| ---------------------------------- | ----------------------- | ----- |
+| `editors/InlineRichTextEditor.tsx` | CREATE                  | 1     |
+| `editors/HintSolutionPanel.tsx`    | CREATE                  | 1     |
+| `editors/QuestionBlockWrapper.tsx` | CREATE                  | 1     |
+| `editors/normalizers.ts`           | CREATE                  | 1+2   |
+| `editors/TrueFalseEditor.tsx`      | CREATE                  | 1     |
+| `editors/McqEditor.tsx`            | CREATE                  | 1     |
+| `editors/FreeResponseEditor.tsx`   | CREATE                  | 1     |
+| `editors/TableEditor.tsx`          | CREATE                  | 2     |
+| `index.tsx`                        | MODIFY (lines ~507-521) | 1     |
+| `index.css`                        | MODIFY (append)         | 1+2   |
+
+**Zero changes to:** schemas, types, defaults, collection config, frontend rendering, grading.

--- a/.tasks/20261102-exercise-question-block-editors/spec.md
+++ b/.tasks/20261102-exercise-question-block-editors/spec.md
@@ -1,0 +1,299 @@
+# Exercise Question Block Editors (Payload Admin)
+
+## Context
+
+The `exercises` collection stores its authoring surface as `content` (JSON) with a strict block stream (`content.blocks`). The admin currently uses `ExerciseContentEditor` for the field, but question blocks are still edited primarily as JSON via `JSONInspector`.
+
+This task adds type-specific editors for all _question_ blocks, matching the existing Zod schema and shared types, without replacing the overall `ExerciseContentEditor` experience (layout, block list, add/move/delete, rich text editing, JSON panel).
+
+Primary sources of truth:
+
+- `src/server/payload/collections/Exercises/schemas.ts` (Zod validation for `content.blocks`)
+- `src/shared/exercise-content/types.ts` (shared TS types consumed by admin UI)
+- `src/ui/admin/ExerciseContentEditor/index.tsx` (admin editor surface)
+
+## Goal
+
+Replace JSON-first editing for question blocks with form-based editors that:
+
+- Map 1:1 to the Zod schema shape for each question block type/variant.
+- Preserve existing data and remain compatible with server-side validation.
+- Keep an “Advanced JSON” escape hatch (read/edit) for power users and debugging.
+
+## Non-Goals
+
+- No changes to persisted schema for `exercises.content`.
+- No migration of existing data.
+- No rewrite/replacement of the `ExerciseContentEditor` container UI.
+- No changes to frontend exercise rendering/grading logic.
+
+## Definitions
+
+Question blocks in the current schema:
+
+- `question_select` with `variant: 'true_false'`
+- `question_select` with `variant: 'mcq'`
+- `question_free_response`
+- `question_table`
+
+Supporting blocks (not in scope for custom editors):
+
+- `rich_text` (already uses a dedicated editor)
+- `latex` (not a question block; can remain JSON or get a small editor later)
+
+## Requirements
+
+### R1: Type-Specific Editors (Per Block)
+
+For each question block type/variant, provide a dedicated editor UI that edits exactly the fields defined by the Zod schema:
+
+1. `question_select` / `variant: 'true_false'`
+
+- Editable:
+  - `prompt` (Inline rich text)
+  - `answer.correctOptionId` (one of `true`/`false`)
+  - `hint` / `solution` / `fullSolution` (optional Inline rich text)
+- Non-editable (fixed/derived, but must be preserved):
+  - `type`, `variant`, `selectionMode` (always `'single'`)
+  - `options` tuple with ids `true`/`false` and labels
+
+2. `question_select` / `variant: 'mcq'`
+
+- Editable:
+  - `prompt`
+  - `selectionMode` (`single` | `multiple`)
+  - `answer.options` list (add/remove/reorder; each option has `id` + `content`)
+  - `answer.correctOptionIds` selection UI aligned with `selectionMode`
+  - `hint` / `solution` / `fullSolution`
+- Must enforce invariants aligned with Zod superRefine:
+  - `correctOptionIds` is a subset of `options[].id`
+  - if single-select: exactly one correct option
+  - `answer.multiSelect` must remain consistent with `selectionMode` (see R3)
+
+3. `question_free_response`
+
+- Editable:
+  - `prompt`
+  - `answer.acceptedAnswers` (array of strings; min 1)
+  - `hint` / `solution` / `fullSolution`
+
+4. `question_table`
+
+- Editable:
+  - `prompt`
+  - `table.solutionFill`
+  - `table.headers` (array; min 1)
+  - `table.rowsData` (2D array; min 1 row; each row must match header column count)
+  - `table.answers` (map of `"rowIdx-colIdx" -> string`, optional)
+  - `table.showBorders`, `table.showHeader`
+  - `table.columnAlignment` (optional; length must match header count)
+- Must enforce invariants aligned with Zod superRefine when `solutionFill === true`:
+  - every empty cell in `rowsData` must have an entry in `answers`
+  - `answers` keys must be in bounds
+  - `answers` keys must point only to empty cells
+
+### R2: Keep Existing Editor Container
+
+No changes to the overall workflow:
+
+- Block list remains the primary editing surface.
+- Add/move/delete remains the same.
+- The right-side JSON panel remains available.
+
+Change only the rendering of question blocks from “JSON editor” to “typed editor”.
+
+### R3: Data Normalization Rules (In-Editor)
+
+The typed editors must normalize data as the user edits to prevent invalid states.
+
+Required normalizations:
+
+- MCQ:
+  - `selectionMode === 'single'` => force `answer.multiSelect = false` and `correctOptionIds = [oneOptionId]`.
+  - `selectionMode === 'multiple'` => force `answer.multiSelect = true` and allow 1+ `correctOptionIds`.
+  - When an option is deleted, remove its id from `correctOptionIds`.
+  - When option ids change (if editable), rewrite `correctOptionIds` accordingly.
+
+- Table:
+  - When header count changes, resize each row to match.
+  - When rows are added/removed, drop out-of-bounds `answers` keys.
+  - When toggling `solutionFill` on:
+    - Ensure `answers` exists (at least `{}` initially).
+    - Provide a guided UI to mark cells fillable + set their correct value, which translates into `rowsData[row][col] === ''` and `answers["row-col"] = <value>`.
+  - When toggling `solutionFill` off:
+    - Keep `answers` but hide it by default (no destructive delete).
+
+### R4: Validation + Error UX
+
+- Client-side validation should exist at two levels:
+  - Inline, per-editor guardrails (disable invalid actions; show immediate field errors for obvious issues like “no accepted answers”).
+  - Optional “Validate Block” action per block, using the same Zod schema bundle if feasible in the admin runtime.
+- If a block is structurally invalid (e.g. edited via JSON and no longer matches expected shape), the typed editor must:
+  - Show a clear error state (what is missing / what is wrong at a high level).
+  - Provide a single action: “Open Advanced JSON” to repair.
+
+Server-side validation remains authoritative via `ContentSchema` in the collection field validate.
+
+### R5: Advanced JSON Escape Hatch
+
+- JSON view/edit stays available.
+- For question blocks, JSON is hidden behind an explicit “Advanced JSON” toggle/button (to reduce accidental usage).
+- Applying JSON changes should re-render the typed editor if the block becomes valid.
+
+### R6: Backward Compatibility
+
+- Existing documents must remain editable.
+- No automatic data reshaping on load beyond safe normalization (R3) that preserves semantics.
+- Any unknown future block types should continue to render with the existing JSON inspector so the editor remains forward-compatible.
+
+## Proposed Admin UI Design (High-Level)
+
+### Shared Building Blocks
+
+1. `InlineRichTextEditor`
+
+- A small component that edits an `InlineRichText` object:
+  - primary control: markdown editor for `value` (reuse existing `RichTextEditor` behavior)
+  - optional controls: media ids management (Stage 2; see Stages)
+- Must preserve `type`, `format`, `mediaIds`.
+
+2. `HintSolutionPanel`
+
+- A collapsible panel for `hint`, `solution`, `fullSolution`.
+- Each field is optional; provide “Enable” toggles that add/remove the object (or set to `undefined`) without losing content accidentally.
+
+3. `QuestionBlockHeader`
+
+- Displays the block type badge and quick actions:
+  - Move up/down
+  - Delete
+  - Advanced JSON toggle
+
+### Per-Block Editors
+
+1. True/False (`question_select` + `variant: 'true_false'`)
+
+- Prompt editor
+- Correct answer radio group (True/False)
+- Hint/Solution panel
+- (Optional) edit labels for True/False options (if you want teacher-defined phrasing); if not, keep fixed but preserve existing.
+
+2. MCQ (`question_select` + `variant: 'mcq'`)
+
+- Prompt editor
+- Selection mode toggle:
+  - Single (radio)
+  - Multiple (checkbox)
+- Options list:
+  - Add option
+  - Remove option
+  - Reorder options
+  - Edit option content (Inline rich text)
+- Correct option selection UI aligned with selection mode
+- Hint/Solution panel
+
+3. Free Response (`question_free_response`)
+
+- Prompt editor
+- Accepted answers editor:
+  - Tag-style input or line-separated list
+  - Must enforce min 1
+- Hint/Solution panel
+
+4. Table (`question_table`)
+
+- Prompt editor
+- Table builder:
+  - Header row editor
+  - Row/column add/remove
+  - Cell editor grid
+- Solution-fill mode:
+  - When off: all cells are just text
+  - When on: each cell supports “fillable” toggle; fillable cells become empty in `rowsData` and store answer in `answers`
+- Table display options:
+  - borders, header visibility
+  - per-column alignment
+
+## Architecture Notes
+
+### Where This Fits
+
+- `Exercises` collection stays unchanged; the `content` field remains JSON.
+- `ExerciseContentEditor` continues managing localValue, Save Changes, block operations.
+- Only the “question block rendering” section changes: it should dispatch by block type/variant to typed editors instead of embedding `JSONInspector` as the primary UI.
+
+### Type + Schema Alignment
+
+- All editors must use `src/shared/exercise-content/types.ts` types as the UI contract.
+- Validation and edge-case rules must mirror `src/server/payload/collections/Exercises/schemas.ts`.
+- If discrepancies are found (e.g., a field exists in Zod but not in shared types), the spec requires resolving them before UI is considered done.
+
+## Stages (Single Path)
+
+### Stage 1 — Typed Editors for Select + Free Response
+
+Timebox: 1 day
+
+Deliverables:
+
+- True/False editor
+- MCQ editor (options + correct answer + selection mode normalization)
+- Free response editor (acceptedAnswers)
+- Advanced JSON remains accessible
+
+Guardrails:
+
+- No schema changes
+- No media editing inside inline rich text yet (preserve existing `mediaIds` silently)
+
+Gates:
+
+- Create/edit each question type without touching JSON and save successfully.
+- Server-side `ContentSchema` accepts edited content.
+
+### Stage 2 — Table Editor (solutionFill support)
+
+Timebox: 1–2 days
+
+Deliverables:
+
+- Table builder grid
+- solutionFill workflow that guarantees Zod invariants
+- Minimal inline validation messages
+
+Gates:
+
+- Can build a valid `question_table` with `solutionFill: true` without using JSON.
+
+### Stage 3 — Inline Rich Text MediaIds (Optional)
+
+Timebox: 0.5–1 day
+
+Deliverables:
+
+- Media picker support for `InlineRichText.mediaIds` inside prompt/options/hint/solution/fullSolution
+
+Gates:
+
+- mediaIds can be added/removed in question prompts/options and persists.
+
+## Testing Strategy (High-Level)
+
+- Unit tests for normalization functions (MCQ + table key behaviors).
+- Admin-component tests (lightweight): render editor, simulate edits, ensure resulting block JSON matches expected shape.
+- Integration test: create an exercise, edit each question block via typed UI, save, and verify server-side validation passes.
+
+## Acceptance Criteria
+
+- All question blocks are fully editable through typed UIs that map to the Zod schema.
+- Editors prevent common invalid states (especially MCQ correctness selection and table solutionFill constraints).
+- “Advanced JSON” remains available but is not the primary UI for question blocks.
+- No schema changes and no migrations.
+
+## Open Questions (Must Answer If You Want Them In V1)
+
+1. Should True/False option labels be editable (stored in `options[].label.value`) or fixed to “True/False”?
+   - Default: fixed labels, preserve any existing values.
+
+2. Is editing `InlineRichText.mediaIds` required in V1 for prompts/options/hints, or can it be Stage 3?
+   - Default: Stage 3.

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -594,6 +594,9 @@ export interface Media {
     | number
     | boolean
     | null;
+  folder?: (string | null) | FolderInterface;
+  updatedAt: string;
+  createdAt: string;
   url?: string | null;
   thumbnailURL?: string | null;
   filename?: string | null;
@@ -603,9 +606,6 @@ export interface Media {
   height?: number | null;
   focalX?: number | null;
   focalY?: number | null;
-  folder?: (string | null) | FolderInterface;
-  updatedAt: string;
-  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -2473,6 +2473,9 @@ export interface MediaSelect<T extends boolean = true> {
   retentionPolicy?: T;
   expiresAt?: T;
   sizes?: T;
+  folder?: T;
+  updatedAt?: T;
+  createdAt?: T;
   url?: T;
   thumbnailURL?: T;
   filename?: T;
@@ -2482,9 +2485,6 @@ export interface MediaSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
-  folder?: T;
-  updatedAt?: T;
-  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/ui/admin/ExerciseContentEditor/MediaPicker.tsx
+++ b/src/ui/admin/ExerciseContentEditor/MediaPicker.tsx
@@ -4,6 +4,7 @@ import type { Media } from '@/payload-types'
 import { useTranslation } from '@payloadcms/ui'
 import Image from 'next/image'
 import React from 'react'
+import { Upload } from 'lucide-react'
 
 interface MediaPickerProps {
   isOpen: boolean
@@ -11,6 +12,9 @@ interface MediaPickerProps {
   selectedMediaIds: string[]
   onSave: (mediaIds: string[]) => void
 }
+
+const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'application/pdf']
+const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB
 
 export const MediaPicker: React.FC<MediaPickerProps> = ({
   isOpen,
@@ -24,6 +28,9 @@ export const MediaPicker: React.FC<MediaPickerProps> = ({
   const [error, setError] = React.useState<string | null>(null)
   const [searchTerm, setSearchTerm] = React.useState('')
   const [localSelectedIds, setLocalSelectedIds] = React.useState<string[]>(selectedMediaIds)
+  const [uploading, setUploading] = React.useState(false)
+  const [uploadError, setUploadError] = React.useState<string | null>(null)
+  const fileInputRef = React.useRef<HTMLInputElement>(null)
 
   // Sync local selection with prop changes
   React.useEffect(() => {
@@ -79,6 +86,79 @@ export const MediaPicker: React.FC<MediaPickerProps> = ({
     onClose()
   }
 
+  const handleFileSelect = async (files: FileList | null) => {
+    if (!files || files.length === 0) return
+
+    setUploading(true)
+    setUploadError(null)
+
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i]
+
+      // Validate file type
+      if (!ALLOWED_MIME_TYPES.includes(file.type)) {
+        setUploadError('Invalid file type. Allowed: JPEG, PNG, WebP, PDF')
+        continue
+      }
+
+      // Validate file size
+      if (file.size > MAX_FILE_SIZE) {
+        setUploadError('File too large. Maximum size is 10MB')
+        continue
+      }
+
+      try {
+        const formData = new FormData()
+        formData.append('file', file)
+
+        const response = await fetch('/api/media', {
+          method: 'POST',
+          credentials: 'include',
+          body: formData,
+        })
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}))
+          throw new Error(errorData.message || errorData.error || 'Upload failed')
+        }
+
+        const doc = await response.json()
+        const newMediaId = doc.doc?.id || doc.id
+
+        // Add to local selection
+        setLocalSelectedIds((prev) => [...prev, newMediaId])
+
+        // Add to media list so it appears in grid
+        setMedia((prev) => [
+          {
+            id: newMediaId,
+            filename: doc.doc?.filename || doc.filename || file.name,
+            url: doc.doc?.url || doc.url,
+            alt: '',
+            type: file.type.startsWith('image/') ? 'image' : 'pdf',
+            filesize: file.size,
+            mimeType: file.type,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          } as Media,
+          ...prev,
+        ])
+      } catch (err) {
+        setUploadError(err instanceof Error ? err.message : 'Upload failed')
+      }
+    }
+
+    setUploading(false)
+    // Reset file input
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ''
+    }
+  }
+
+  const triggerFilePicker = () => {
+    fileInputRef.current?.click()
+  }
+
   if (!isOpen) return null
 
   return (
@@ -89,6 +169,29 @@ export const MediaPicker: React.FC<MediaPickerProps> = ({
           <button type="button" className="media-picker-close" onClick={handleCancel}>
             ×
           </button>
+        </div>
+
+        <input
+          type="file"
+          ref={fileInputRef}
+          style={{ display: 'none' }}
+          accept={ALLOWED_MIME_TYPES.join(',')}
+          multiple
+          onChange={(e) => handleFileSelect(e.target.files)}
+        />
+
+        <div className="media-picker-upload">
+          <button
+            type="button"
+            className="media-picker-upload-btn"
+            onClick={triggerFilePicker}
+            disabled={uploading}
+          >
+            <Upload size={16} />
+            <span>{uploading ? 'Uploading...' : 'Upload new file'}</span>
+          </button>
+          {uploading && <div className="media-picker-uploading">Uploading...</div>}
+          {uploadError && <div className="media-picker-upload-error">{uploadError}</div>}
         </div>
 
         <div className="media-picker-search">

--- a/src/ui/admin/ExerciseContentEditor/editors/FreeResponseEditor.tsx
+++ b/src/ui/admin/ExerciseContentEditor/editors/FreeResponseEditor.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import React from 'react'
+import type { QuestionFreeResponseBlock } from '@/shared/exercise-content/types'
+import { InlineRichTextEditor } from './InlineRichTextEditor'
+import { HintSolutionPanel } from './HintSolutionPanel'
+import { Plus, Trash2 } from 'lucide-react'
+
+interface FreeResponseEditorProps {
+  block: QuestionFreeResponseBlock
+  onChange: (block: QuestionFreeResponseBlock) => void
+}
+
+export const FreeResponseEditor: React.FC<FreeResponseEditorProps> = ({ block, onChange }) => {
+  const handleAnswerChange = (index: number, value: string) => {
+    const newAnswers = [...block.answer.acceptedAnswers]
+    newAnswers[index] = value
+    onChange({ ...block, answer: { ...block.answer, acceptedAnswers: newAnswers } })
+  }
+
+  const handleAddAnswer = () => {
+    onChange({
+      ...block,
+      answer: { ...block.answer, acceptedAnswers: [...block.answer.acceptedAnswers, ''] },
+    })
+  }
+
+  const handleRemoveAnswer = (index: number) => {
+    if (block.answer.acceptedAnswers.length <= 1) return
+    const newAnswers = block.answer.acceptedAnswers.filter((_, i) => i !== index)
+    onChange({ ...block, answer: { ...block.answer, acceptedAnswers: newAnswers } })
+  }
+
+  return (
+    <div className="free-response-editor">
+      <div className="question-editor-section">
+        <label className="question-editor-label">Prompt</label>
+        <InlineRichTextEditor
+          value={block.prompt}
+          onChange={(newPrompt) => onChange({ ...block, prompt: newPrompt })}
+          placeholder="Enter your free response question..."
+        />
+      </div>
+
+      <div className="question-editor-section">
+        <label className="question-editor-label">Accepted Answers</label>
+        <div className="accepted-answers-list">
+          {block.answer.acceptedAnswers.map((answer, index) => (
+            <div key={index} className="accepted-answer-row">
+              <input
+                type="text"
+                className="accepted-answer-input"
+                value={answer}
+                onChange={(e) => handleAnswerChange(index, e.target.value)}
+                placeholder={`Answer ${index + 1}`}
+              />
+              <button
+                type="button"
+                className="accepted-answer-remove-btn"
+                onClick={() => handleRemoveAnswer(index)}
+                disabled={block.answer.acceptedAnswers.length <= 1}
+                title="Remove answer"
+              >
+                <Trash2 size={14} />
+              </button>
+            </div>
+          ))}
+        </div>
+        <button type="button" className="accepted-answer-add-btn" onClick={handleAddAnswer}>
+          <Plus size={14} />
+          <span>Add Answer</span>
+        </button>
+      </div>
+
+      <div className="question-editor-section">
+        <HintSolutionPanel
+          hint={block.hint}
+          solution={block.solution}
+          fullSolution={block.fullSolution}
+          onChange={(field, value) => onChange({ ...block, [field]: value })}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/ui/admin/ExerciseContentEditor/editors/HintSolutionPanel.tsx
+++ b/src/ui/admin/ExerciseContentEditor/editors/HintSolutionPanel.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import React from 'react'
+import type { InlineRichText } from '@/shared/exercise-content/types'
+import { CollapsibleSection } from '../../shared/CollapsibleSection'
+import { InlineRichTextEditor } from './InlineRichTextEditor'
+import { Plus, X } from 'lucide-react'
+
+interface HintSolutionPanelProps {
+  hint?: InlineRichText
+  solution?: InlineRichText
+  fullSolution?: InlineRichText
+  onChange: (field: 'hint' | 'solution' | 'fullSolution', value: InlineRichText | undefined) => void
+}
+
+function createDefaultInlineRichText(): InlineRichText {
+  return {
+    type: 'rich_text',
+    format: 'md-math-v1',
+    value: '',
+    mediaIds: [],
+  }
+}
+
+export const HintSolutionPanel: React.FC<HintSolutionPanelProps> = ({
+  hint,
+  solution,
+  fullSolution,
+  onChange,
+}) => {
+  const [expanded, setExpanded] = React.useState(false)
+
+  return (
+    <CollapsibleSection
+      title="Hints & Solutions"
+      defaultExpanded={false}
+      isExpanded={expanded}
+      onToggle={setExpanded}
+    >
+      <div className="hint-solution-panel">
+        <HintSolutionField label="Hint" value={hint} onChange={(val) => onChange('hint', val)} />
+        <HintSolutionField
+          label="Solution"
+          value={solution}
+          onChange={(val) => onChange('solution', val)}
+        />
+        <HintSolutionField
+          label="Full Solution"
+          value={fullSolution}
+          onChange={(val) => onChange('fullSolution', val)}
+        />
+      </div>
+    </CollapsibleSection>
+  )
+}
+
+interface HintSolutionFieldProps {
+  label: string
+  value?: InlineRichText
+  onChange: (value: InlineRichText | undefined) => void
+}
+
+const HintSolutionField: React.FC<HintSolutionFieldProps> = ({ label, value, onChange }) => {
+  if (!value) {
+    return (
+      <div className="hint-solution-field-empty">
+        <button
+          type="button"
+          className="hint-solution-enable-btn"
+          onClick={() => onChange(createDefaultInlineRichText())}
+        >
+          <Plus size={14} />
+          <span>Add {label}</span>
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="hint-solution-field">
+      <div className="hint-solution-field-header">
+        <span className="hint-solution-field-label">{label}</span>
+        <button
+          type="button"
+          className="hint-solution-remove-btn"
+          onClick={() => onChange(undefined)}
+          title={`Remove ${label}`}
+        >
+          <X size={14} />
+        </button>
+      </div>
+      <InlineRichTextEditor
+        value={value}
+        onChange={onChange}
+        placeholder={`Enter ${label.toLowerCase()}...`}
+        minHeight="60px"
+      />
+    </div>
+  )
+}

--- a/src/ui/admin/ExerciseContentEditor/editors/InlineRichTextEditor.tsx
+++ b/src/ui/admin/ExerciseContentEditor/editors/InlineRichTextEditor.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import React from 'react'
+import type { InlineRichText } from '@/shared/exercise-content/types'
+import { Bold, Italic, Code, Sigma, Heading1, Link as LinkIcon } from 'lucide-react'
+
+interface InlineRichTextEditorProps {
+  value: InlineRichText
+  onChange: (value: InlineRichText) => void
+  placeholder?: string
+  minHeight?: string
+}
+
+export const InlineRichTextEditor: React.FC<InlineRichTextEditorProps> = ({
+  value,
+  onChange,
+  placeholder = 'Enter text...',
+  minHeight = '80px',
+}) => {
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null)
+
+  const insertText = (before: string, after: string = '') => {
+    const textarea = textareaRef.current
+    if (!textarea) return
+
+    const start = textarea.selectionStart
+    const end = textarea.selectionEnd
+    const text = textarea.value
+    const selection = text.substring(start, end)
+
+    const newValue = text.substring(0, start) + before + selection + after + text.substring(end)
+
+    onChange({ ...value, value: newValue })
+
+    setTimeout(() => {
+      textarea.focus()
+      textarea.setSelectionRange(start + before.length, end + before.length)
+    }, 0)
+  }
+
+  return (
+    <div className="inline-rich-text-editor">
+      <div className="inline-rich-text-toolbar">
+        <button className="toolbar-button" onClick={() => insertText('**', '**')} title="Bold">
+          <Bold size={14} />
+        </button>
+        <button className="toolbar-button" onClick={() => insertText('*', '*')} title="Italic">
+          <Italic size={14} />
+        </button>
+        <div className="toolbar-divider" />
+        <button className="toolbar-button" onClick={() => insertText('# ')} title="Heading">
+          <Heading1 size={14} />
+        </button>
+        <button className="toolbar-button" onClick={() => insertText('`', '`')} title="Code">
+          <Code size={14} />
+        </button>
+        <button
+          className="toolbar-button"
+          onClick={() => insertText('$', '$')}
+          title="Math (Inline)"
+        >
+          <Sigma size={14} />
+        </button>
+        <div className="toolbar-divider" />
+        <button className="toolbar-button" onClick={() => insertText('[', '](url)')} title="Link">
+          <LinkIcon size={14} />
+        </button>
+      </div>
+
+      <textarea
+        ref={textareaRef}
+        className="inline-rich-text-textarea"
+        style={{ minHeight }}
+        value={value.value}
+        onChange={(e) => onChange({ ...value, value: e.target.value })}
+        placeholder={placeholder}
+      />
+
+      <div className="inline-rich-text-footer">{value.value.length} characters</div>
+    </div>
+  )
+}

--- a/src/ui/admin/ExerciseContentEditor/editors/InlineRichTextEditor.tsx
+++ b/src/ui/admin/ExerciseContentEditor/editors/InlineRichTextEditor.tsx
@@ -2,7 +2,19 @@
 
 import React from 'react'
 import type { InlineRichText } from '@/shared/exercise-content/types'
-import { Bold, Italic, Code, Sigma, Heading1, Link as LinkIcon } from 'lucide-react'
+import type { Media } from '@/payload-types'
+import {
+  Bold,
+  Italic,
+  Code,
+  Sigma,
+  Heading1,
+  Link as LinkIcon,
+  Image as ImageIcon,
+  X,
+} from 'lucide-react'
+import Image from 'next/image'
+import { MediaPicker } from '../MediaPicker'
 
 interface InlineRichTextEditorProps {
   value: InlineRichText
@@ -18,6 +30,9 @@ export const InlineRichTextEditor: React.FC<InlineRichTextEditorProps> = ({
   minHeight = '80px',
 }) => {
   const textareaRef = React.useRef<HTMLTextAreaElement>(null)
+  const [mediaPickerOpen, setMediaPickerOpen] = React.useState(false)
+  const [mediaItems, setMediaItems] = React.useState<Media[]>([])
+  const [loadingMedia, setLoadingMedia] = React.useState(false)
 
   const insertText = (before: string, after: string = '') => {
     const textarea = textareaRef.current
@@ -36,6 +51,40 @@ export const InlineRichTextEditor: React.FC<InlineRichTextEditorProps> = ({
       textarea.focus()
       textarea.setSelectionRange(start + before.length, end + before.length)
     }, 0)
+  }
+
+  React.useEffect(() => {
+    const fetchMedia = async () => {
+      if (!value.mediaIds || value.mediaIds.length === 0) {
+        setMediaItems([])
+        return
+      }
+
+      setLoadingMedia(true)
+      try {
+        const fetchPromises = value.mediaIds.map((id) =>
+          fetch(`/api/media/${id}`).then((res) => (res.ok ? res.json() : null)),
+        )
+        const results = await Promise.all(fetchPromises)
+        setMediaItems(results.filter(Boolean) as Media[])
+      } catch {
+        setMediaItems([])
+      } finally {
+        setLoadingMedia(false)
+      }
+    }
+
+    fetchMedia()
+  }, [value.mediaIds])
+
+  const handleMediaSave = (mediaIds: string[]) => {
+    onChange({ ...value, mediaIds })
+    setMediaPickerOpen(false)
+  }
+
+  const handleRemoveMedia = (mediaId: string) => {
+    const newMediaIds = (value.mediaIds || []).filter((id) => id !== mediaId)
+    onChange({ ...value, mediaIds: newMediaIds })
   }
 
   return (
@@ -65,6 +114,13 @@ export const InlineRichTextEditor: React.FC<InlineRichTextEditorProps> = ({
         <button className="toolbar-button" onClick={() => insertText('[', '](url)')} title="Link">
           <LinkIcon size={14} />
         </button>
+        <button
+          className="toolbar-button toolbar-button--media"
+          onClick={() => setMediaPickerOpen(true)}
+          title="Attach media"
+        >
+          <ImageIcon size={14} />
+        </button>
       </div>
 
       <textarea
@@ -76,7 +132,57 @@ export const InlineRichTextEditor: React.FC<InlineRichTextEditorProps> = ({
         placeholder={placeholder}
       />
 
+      {value.mediaIds && value.mediaIds.length > 0 && (
+        <div className="inline-rich-text-media">
+          {loadingMedia && <div className="inline-rich-text-media-loading">Loading media...</div>}
+          {!loadingMedia && mediaItems.length > 0 && (
+            <div className="inline-rich-text-media-list">
+              {mediaItems.map((item) => {
+                const isImage = item.type === 'image'
+                const thumbnailUrl =
+                  (item as unknown as { sizes?: { thumbnail?: { url: string } } }).sizes?.thumbnail
+                    ?.url || item.url
+
+                return (
+                  <div key={item.id} className="inline-rich-text-media-item">
+                    {thumbnailUrl && isImage ? (
+                      <Image
+                        src={thumbnailUrl}
+                        alt={item.alt || item.filename || 'Media'}
+                        width={40}
+                        height={40}
+                        className="inline-rich-text-media-thumb"
+                      />
+                    ) : (
+                      <div className="inline-rich-text-media-icon">
+                        <ImageIcon size={16} />
+                      </div>
+                    )}
+                    <span className="inline-rich-text-media-name">{item.filename}</span>
+                    <button
+                      type="button"
+                      className="inline-rich-text-media-remove"
+                      onClick={() => handleRemoveMedia(item.id)}
+                      title="Remove media"
+                    >
+                      <X size={12} />
+                    </button>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      )}
+
       <div className="inline-rich-text-footer">{value.value.length} characters</div>
+
+      <MediaPicker
+        isOpen={mediaPickerOpen}
+        onClose={() => setMediaPickerOpen(false)}
+        selectedMediaIds={value.mediaIds || []}
+        onSave={handleMediaSave}
+      />
     </div>
   )
 }

--- a/src/ui/admin/ExerciseContentEditor/editors/McqEditor.tsx
+++ b/src/ui/admin/ExerciseContentEditor/editors/McqEditor.tsx
@@ -1,0 +1,178 @@
+'use client'
+
+import React from 'react'
+import type { QuestionSelectMcqBlock } from '@/shared/exercise-content/types'
+import { generateId } from '@/shared/exercise-content/types'
+import { InlineRichTextEditor } from './InlineRichTextEditor'
+import { HintSolutionPanel } from './HintSolutionPanel'
+import {
+  changeSelectionMode,
+  removeOptionAndNormalize,
+  toggleCorrectOption,
+  addOptionAndNormalize,
+  updateOptionAndNormalize,
+} from './normalizers'
+import { Plus, Trash2, MoveUp, MoveDown } from 'lucide-react'
+
+interface McqEditorProps {
+  block: QuestionSelectMcqBlock
+  onChange: (block: QuestionSelectMcqBlock) => void
+}
+
+export const McqEditor: React.FC<McqEditorProps> = ({ block, onChange }) => {
+  const handleSelectionModeChange = (mode: 'single' | 'multiple') => {
+    onChange(changeSelectionMode(block, mode))
+  }
+
+  const handleToggleCorrect = (optionId: string) => {
+    onChange(toggleCorrectOption(block, optionId))
+  }
+
+  const handleRemoveOption = (optionId: string) => {
+    onChange(removeOptionAndNormalize(block, optionId))
+  }
+
+  const handleAddOption = () => {
+    const newOption = {
+      id: generateId(),
+      content: {
+        type: 'rich_text' as const,
+        format: 'md-math-v1' as const,
+        value: '',
+        mediaIds: [],
+      },
+    }
+    onChange(addOptionAndNormalize(block, newOption))
+  }
+
+  const handleOptionContentChange = (
+    optionId: string,
+    content: { type: 'rich_text'; format: 'md-math-v1'; value: string; mediaIds: string[] },
+  ) => {
+    onChange(updateOptionAndNormalize(block, optionId, { content }))
+  }
+
+  const handleMoveOption = (index: number, direction: 'up' | 'down') => {
+    const newIndex = direction === 'up' ? index - 1 : index + 1
+    if (newIndex < 0 || newIndex >= block.answer.options.length) return
+
+    const newOptions = [...block.answer.options]
+    const [movedOption] = newOptions.splice(index, 1)
+    newOptions.splice(newIndex, 0, movedOption)
+
+    onChange({
+      ...block,
+      answer: {
+        ...block.answer,
+        options: newOptions,
+      },
+    })
+  }
+
+  return (
+    <div className="mcq-editor">
+      <div className="question-editor-section">
+        <label className="question-editor-label">Prompt</label>
+        <InlineRichTextEditor
+          value={block.prompt}
+          onChange={(newPrompt) => onChange({ ...block, prompt: newPrompt })}
+          placeholder="Enter your multiple choice question..."
+        />
+      </div>
+
+      <div className="question-editor-section">
+        <label className="question-editor-label">Selection Mode</label>
+        <div className="mcq-selection-mode">
+          <button
+            type="button"
+            className={`mcq-mode-btn ${block.selectionMode === 'single' ? 'mcq-mode-btn--selected' : ''}`}
+            onClick={() => handleSelectionModeChange('single')}
+          >
+            Single Answer
+          </button>
+          <button
+            type="button"
+            className={`mcq-mode-btn ${block.selectionMode === 'multiple' ? 'mcq-mode-btn--selected' : ''}`}
+            onClick={() => handleSelectionModeChange('multiple')}
+          >
+            Multiple Answers
+          </button>
+        </div>
+      </div>
+
+      <div className="question-editor-section">
+        <label className="question-editor-label">Options</label>
+        <div className="mcq-options-list">
+          {block.answer.options.map((option, index) => (
+            <div key={option.id} className="mcq-option-row">
+              <div className="mcq-option-correct">
+                <button
+                  type="button"
+                  className={`mcq-correct-marker ${block.answer.correctOptionIds.includes(option.id) ? 'mcq-correct-marker--checked' : ''}`}
+                  onClick={() => handleToggleCorrect(option.id)}
+                  title={
+                    block.selectionMode === 'single'
+                      ? 'Mark as correct answer'
+                      : 'Toggle correct answer'
+                  }
+                >
+                  <div className="mcq-correct-inner" />
+                </button>
+              </div>
+              <div className="mcq-option-content">
+                <InlineRichTextEditor
+                  value={option.content}
+                  onChange={(newContent) => handleOptionContentChange(option.id, newContent)}
+                  placeholder={`Option ${index + 1}...`}
+                  minHeight="50px"
+                />
+              </div>
+              <div className="mcq-option-actions">
+                <button
+                  type="button"
+                  className="mcq-option-action-btn"
+                  onClick={() => handleMoveOption(index, 'up')}
+                  disabled={index === 0}
+                  title="Move up"
+                >
+                  <MoveUp size={14} />
+                </button>
+                <button
+                  type="button"
+                  className="mcq-option-action-btn"
+                  onClick={() => handleMoveOption(index, 'down')}
+                  disabled={index === block.answer.options.length - 1}
+                  title="Move down"
+                >
+                  <MoveDown size={14} />
+                </button>
+                <button
+                  type="button"
+                  className="mcq-option-action-btn mcq-option-action-btn--delete"
+                  onClick={() => handleRemoveOption(option.id)}
+                  disabled={block.answer.options.length <= 2}
+                  title="Remove option"
+                >
+                  <Trash2 size={14} />
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+        <button type="button" className="mcq-add-option-btn" onClick={handleAddOption}>
+          <Plus size={14} />
+          <span>Add Option</span>
+        </button>
+      </div>
+
+      <div className="question-editor-section">
+        <HintSolutionPanel
+          hint={block.hint}
+          solution={block.solution}
+          fullSolution={block.fullSolution}
+          onChange={(field, value) => onChange({ ...block, [field]: value })}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/ui/admin/ExerciseContentEditor/editors/QuestionBlockWrapper.tsx
+++ b/src/ui/admin/ExerciseContentEditor/editors/QuestionBlockWrapper.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import React from 'react'
+import type { ContentBlock } from '@/shared/exercise-content/types'
+import { AdvancedJsonPanel } from '../../shared/AdvancedJsonPanel'
+
+interface QuestionBlockWrapperProps {
+  blockType: string
+  block: ContentBlock
+  onBlockChange: (block: ContentBlock) => void
+  children: React.ReactNode
+}
+
+export const QuestionBlockWrapper: React.FC<QuestionBlockWrapperProps> = ({
+  blockType,
+  block,
+  onBlockChange,
+  children,
+}) => {
+  return (
+    <div className="question-block-wrapper">
+      <div className="question-block-type-badge">{blockType}</div>
+      <div className="question-block-content">{children}</div>
+      <div className="question-block-json-toggle">
+        <AdvancedJsonPanel
+          value={block}
+          onChange={(value) => onBlockChange(value as ContentBlock)}
+          label="Advanced JSON"
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/ui/admin/ExerciseContentEditor/editors/QuestionBlockWrapper.tsx
+++ b/src/ui/admin/ExerciseContentEditor/editors/QuestionBlockWrapper.tsx
@@ -3,30 +3,83 @@
 import React from 'react'
 import type { ContentBlock } from '@/shared/exercise-content/types'
 import { AdvancedJsonPanel } from '../../shared/AdvancedJsonPanel'
+import { MoveUp, MoveDown, Plus, Trash2 } from 'lucide-react'
 
 interface QuestionBlockWrapperProps {
   blockType: string
   block: ContentBlock
   onBlockChange: (block: ContentBlock) => void
-  children: React.ReactNode
+  onMoveUp?: () => void
+  onMoveDown?: () => void
+  onAdd?: () => void
+  onDelete?: () => void
+  canMoveUp?: boolean
+  canMoveDown?: boolean
+  canDelete?: boolean
+  children?: React.ReactNode
 }
 
 export const QuestionBlockWrapper: React.FC<QuestionBlockWrapperProps> = ({
   blockType,
   block,
   onBlockChange,
+  onMoveUp,
+  onMoveDown,
+  onAdd,
+  onDelete,
+  canMoveUp = false,
+  canMoveDown = false,
+  canDelete = true,
   children,
 }) => {
   return (
-    <div className="question-block-wrapper">
-      <div className="question-block-type-badge">{blockType}</div>
-      <div className="question-block-content">{children}</div>
-      <div className="question-block-json-toggle">
-        <AdvancedJsonPanel
-          value={block}
-          onChange={(value) => onBlockChange(value as ContentBlock)}
-          label="Advanced JSON"
-        />
+    <div className="container-block container-block--level-0">
+      <div className="container-block__header">
+        <div className="container-block__header-left">
+          <span className="container-block__title">{blockType}</span>
+        </div>
+        <div className="container-block__actions">
+          <button
+            type="button"
+            className="icon-button"
+            onClick={onMoveUp}
+            disabled={!canMoveUp}
+            title="Move up"
+          >
+            <MoveUp size={14} />
+          </button>
+          <button
+            type="button"
+            className="icon-button"
+            onClick={onMoveDown}
+            disabled={!canMoveDown}
+            title="Move down"
+          >
+            <MoveDown size={14} />
+          </button>
+          <button type="button" className="icon-button" onClick={onAdd} title="Add block below">
+            <Plus size={14} />
+          </button>
+          <button
+            type="button"
+            className="icon-button icon-button--delete"
+            onClick={onDelete}
+            disabled={!canDelete}
+            title="Delete block"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
+      </div>
+      <div className="container-block__body">
+        <div className="question-block-content">{children}</div>
+        <div className="question-block-json-toggle">
+          <AdvancedJsonPanel
+            value={block}
+            onChange={(value) => onBlockChange(value as ContentBlock)}
+            label="Advanced JSON"
+          />
+        </div>
       </div>
     </div>
   )

--- a/src/ui/admin/ExerciseContentEditor/editors/QuestionBlockWrapper.tsx
+++ b/src/ui/admin/ExerciseContentEditor/editors/QuestionBlockWrapper.tsx
@@ -3,7 +3,7 @@
 import React from 'react'
 import type { ContentBlock } from '@/shared/exercise-content/types'
 import { AdvancedJsonPanel } from '../../shared/AdvancedJsonPanel'
-import { MoveUp, MoveDown, Plus, Trash2 } from 'lucide-react'
+import { MoveUp, MoveDown, Trash2 } from 'lucide-react'
 
 interface QuestionBlockWrapperProps {
   blockType: string
@@ -11,7 +11,6 @@ interface QuestionBlockWrapperProps {
   onBlockChange: (block: ContentBlock) => void
   onMoveUp?: () => void
   onMoveDown?: () => void
-  onAdd?: () => void
   onDelete?: () => void
   canMoveUp?: boolean
   canMoveDown?: boolean
@@ -25,7 +24,6 @@ export const QuestionBlockWrapper: React.FC<QuestionBlockWrapperProps> = ({
   onBlockChange,
   onMoveUp,
   onMoveDown,
-  onAdd,
   onDelete,
   canMoveUp = false,
   canMoveDown = false,
@@ -56,9 +54,6 @@ export const QuestionBlockWrapper: React.FC<QuestionBlockWrapperProps> = ({
             title="Move down"
           >
             <MoveDown size={14} />
-          </button>
-          <button type="button" className="icon-button" onClick={onAdd} title="Add block below">
-            <Plus size={14} />
           </button>
           <button
             type="button"

--- a/src/ui/admin/ExerciseContentEditor/editors/TableEditor.tsx
+++ b/src/ui/admin/ExerciseContentEditor/editors/TableEditor.tsx
@@ -1,0 +1,282 @@
+'use client'
+
+import React from 'react'
+import type { QuestionTableBlock } from '@/shared/exercise-content/types'
+import { InlineRichTextEditor } from './InlineRichTextEditor'
+import { HintSolutionPanel } from './HintSolutionPanel'
+import { Plus, Trash2 } from 'lucide-react'
+
+interface TableEditorProps {
+  block: QuestionTableBlock
+  onChange: (block: QuestionTableBlock) => void
+}
+
+export const TableEditor: React.FC<TableEditorProps> = ({ block, onChange }) => {
+  const { table } = block
+
+  const handleHeaderChange = (index: number, value: string) => {
+    const newHeaders = [...table.headers]
+    newHeaders[index] = value
+    onChange({
+      ...block,
+      table: { ...table, headers: newHeaders },
+    })
+  }
+
+  const handleAddHeader = () => {
+    onChange({
+      ...block,
+      table: {
+        ...table,
+        headers: [...table.headers, `Column ${table.headers.length + 1}`],
+        columnAlignment: [...(table.columnAlignment || []), 'left'],
+      },
+    })
+  }
+
+  const handleRemoveHeader = (index: number) => {
+    if (table.headers.length <= 1) return
+    const newHeaders = table.headers.filter((_, i) => i !== index)
+    const newAlignment = table.columnAlignment?.filter((_, i) => i !== index)
+    const newRowsData = table.rowsData.map((row) => row.filter((_, i) => i !== index))
+    const newAnswers: Record<string, string> = {}
+    Object.entries(table.answers || {}).forEach(([key, value]) => {
+      const [rowIdx, colIdx] = key.split('-').map(Number)
+      if (colIdx !== index) {
+        const newColIdx = colIdx > index ? colIdx - 1 : colIdx
+        newAnswers[`${rowIdx}-${newColIdx}`] = value
+      }
+    })
+    onChange({
+      ...block,
+      table: {
+        ...table,
+        headers: newHeaders,
+        columnAlignment: newAlignment,
+        rowsData: newRowsData,
+        answers: newAnswers,
+      },
+    })
+  }
+
+  const handleColumnAlignmentChange = (index: number, alignment: 'left' | 'center' | 'right') => {
+    const newAlignment = [...(table.columnAlignment || [])]
+    newAlignment[index] = alignment
+    onChange({
+      ...block,
+      table: { ...table, columnAlignment: newAlignment },
+    })
+  }
+
+  const handleCellChange = (rowIndex: number, colIndex: number, value: string) => {
+    const newRowsData = [...table.rowsData]
+    newRowsData[rowIndex] = [...newRowsData[rowIndex]]
+    newRowsData[rowIndex][colIndex] = value
+    onChange({
+      ...block,
+      table: { ...table, rowsData: newRowsData },
+    })
+  }
+
+  const handleAddRow = () => {
+    const newRow = Array(table.headers.length).fill('')
+    onChange({
+      ...block,
+      table: {
+        ...table,
+        rowsData: [...table.rowsData, newRow],
+      },
+    })
+  }
+
+  const handleRemoveRow = (rowIndex: number) => {
+    if (table.rowsData.length <= 1) return
+    const newRowsData = table.rowsData.filter((_, i) => i !== rowIndex)
+    const newAnswers: Record<string, string> = {}
+    Object.entries(table.answers || {}).forEach(([key, value]) => {
+      const [rowIdx, colIdx] = key.split('-').map(Number)
+      if (rowIdx !== rowIndex) {
+        const newRowIdx = rowIdx > rowIndex ? rowIdx - 1 : rowIdx
+        newAnswers[`${newRowIdx}-${colIdx}`] = value
+      }
+    })
+    onChange({
+      ...block,
+      table: {
+        ...table,
+        rowsData: newRowsData,
+        answers: newAnswers,
+      },
+    })
+  }
+
+  const handleToggleSolutionFill = () => {
+    if (table.solutionFill) {
+      onChange({
+        ...block,
+        table: { ...table, solutionFill: false },
+      })
+    } else {
+      onChange({
+        ...block,
+        table: { ...table, solutionFill: true, answers: table.answers || {} },
+      })
+    }
+  }
+
+  const handleAnswerChange = (rowIndex: number, colIndex: number, value: string) => {
+    const newAnswers = { ...(table.answers || {}) }
+    newAnswers[`${rowIndex}-${colIndex}`] = value
+    onChange({
+      ...block,
+      table: { ...table, answers: newAnswers },
+    })
+  }
+
+  const handleToggleBorders = () => {
+    onChange({
+      ...block,
+      table: { ...table, showBorders: !table.showBorders },
+    })
+  }
+
+  const handleToggleHeader = () => {
+    onChange({
+      ...block,
+      table: { ...table, showHeader: !table.showHeader },
+    })
+  }
+
+  return (
+    <div className="table-editor">
+      <div className="question-editor-section">
+        <label className="question-editor-label">Prompt</label>
+        <InlineRichTextEditor
+          value={block.prompt}
+          onChange={(newPrompt) => onChange({ ...block, prompt: newPrompt })}
+          placeholder="Enter your table question..."
+        />
+      </div>
+
+      <div className="question-editor-section">
+        <label className="question-editor-label">Table Configuration</label>
+        <div className="table-config-options">
+          <label className="table-config-option">
+            <input type="checkbox" checked={table.showBorders} onChange={handleToggleBorders} />
+            <span>Show Borders</span>
+          </label>
+          <label className="table-config-option">
+            <input type="checkbox" checked={table.showHeader} onChange={handleToggleHeader} />
+            <span>Show Header</span>
+          </label>
+          <label className="table-config-option table-config-option--highlight">
+            <input
+              type="checkbox"
+              checked={table.solutionFill}
+              onChange={handleToggleSolutionFill}
+            />
+            <span>Solution Fill Mode</span>
+          </label>
+        </div>
+      </div>
+
+      <div className="question-editor-section">
+        <label className="question-editor-label">Headers</label>
+        <div className="table-headers-editor">
+          {table.headers.map((header, index) => (
+            <div key={index} className="table-header-row">
+              <input
+                type="text"
+                className="table-header-input"
+                value={header}
+                onChange={(e) => handleHeaderChange(index, e.target.value)}
+                placeholder={`Column ${index + 1}`}
+              />
+              <select
+                className="table-align-select"
+                value={table.columnAlignment?.[index] || 'left'}
+                onChange={(e) =>
+                  handleColumnAlignmentChange(index, e.target.value as 'left' | 'center' | 'right')
+                }
+              >
+                <option value="left">Left</option>
+                <option value="center">Center</option>
+                <option value="right">Right</option>
+              </select>
+              <button
+                type="button"
+                className="table-header-remove-btn"
+                onClick={() => handleRemoveHeader(index)}
+                disabled={table.headers.length <= 1}
+                title="Remove column"
+              >
+                <Trash2 size={14} />
+              </button>
+            </div>
+          ))}
+          <button type="button" className="table-add-header-btn" onClick={handleAddHeader}>
+            <Plus size={14} />
+            <span>Add Column</span>
+          </button>
+        </div>
+      </div>
+
+      <div className="question-editor-section">
+        <label className="question-editor-label">Data Rows</label>
+        <div className="table-rows-container">
+          {table.rowsData.map((row, rowIndex) => (
+            <div key={rowIndex} className="table-row">
+              <div className="table-row-label">Row {rowIndex + 1}</div>
+              <div className="table-row-cells">
+                {row.map((cell, colIndex) => (
+                  <div key={colIndex} className="table-cell-wrapper">
+                    <input
+                      type="text"
+                      className="table-cell-input"
+                      style={{ textAlign: table.columnAlignment?.[colIndex] || 'left' }}
+                      value={cell}
+                      onChange={(e) => handleCellChange(rowIndex, colIndex, e.target.value)}
+                    />
+                    {table.solutionFill && (
+                      <div className="table-solution-input-wrapper">
+                        <input
+                          type="text"
+                          className="table-solution-input"
+                          placeholder="Answer"
+                          value={table.answers?.[`${rowIndex}-${colIndex}`] || ''}
+                          onChange={(e) => handleAnswerChange(rowIndex, colIndex, e.target.value)}
+                        />
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+              <button
+                type="button"
+                className="table-row-remove-btn"
+                onClick={() => handleRemoveRow(rowIndex)}
+                disabled={table.rowsData.length <= 1}
+                title="Remove row"
+              >
+                <Trash2 size={14} />
+              </button>
+            </div>
+          ))}
+        </div>
+        <button type="button" className="table-add-row-btn" onClick={handleAddRow}>
+          <Plus size={14} />
+          <span>Add Row</span>
+        </button>
+      </div>
+
+      <div className="question-editor-section">
+        <HintSolutionPanel
+          hint={block.hint}
+          solution={block.solution}
+          fullSolution={block.fullSolution}
+          onChange={(field, value) => onChange({ ...block, [field]: value })}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/ui/admin/ExerciseContentEditor/editors/TrueFalseEditor.tsx
+++ b/src/ui/admin/ExerciseContentEditor/editors/TrueFalseEditor.tsx
@@ -16,8 +16,8 @@ export const TrueFalseEditor: React.FC<TrueFalseEditorProps> = ({ block, onChang
   const trueOption = block.options?.[0]
   const falseOption = block.options?.[1]
 
-  const trueLabel = trueOption?.label?.value || 'True'
-  const falseLabel = falseOption?.label?.value || 'False'
+  const trueLabel = trueOption?.label?.value ?? 'True'
+  const falseLabel = falseOption?.label?.value ?? 'False'
 
   const updateOptionLabel = (optionIndex: number, newValue: string) => {
     if (!block.options) return

--- a/src/ui/admin/ExerciseContentEditor/editors/TrueFalseEditor.tsx
+++ b/src/ui/admin/ExerciseContentEditor/editors/TrueFalseEditor.tsx
@@ -13,6 +13,22 @@ interface TrueFalseEditorProps {
 export const TrueFalseEditor: React.FC<TrueFalseEditorProps> = ({ block, onChange }) => {
   const correctOptionId = block.answer.correctOptionId || 'true'
 
+  const trueOption = block.options?.[0]
+  const falseOption = block.options?.[1]
+
+  const trueLabel = trueOption?.label?.value || 'True'
+  const falseLabel = falseOption?.label?.value || 'False'
+
+  const updateOptionLabel = (optionIndex: number, newValue: string) => {
+    if (!block.options) return
+
+    const newOptions = block.options.map((opt, i) =>
+      i === optionIndex ? { ...opt, label: { ...opt.label, value: newValue } } : opt,
+    ) as typeof block.options
+
+    onChange({ ...block, options: newOptions })
+  }
+
   return (
     <div className="true-false-editor">
       <div className="question-editor-section">
@@ -25,21 +41,37 @@ export const TrueFalseEditor: React.FC<TrueFalseEditorProps> = ({ block, onChang
       </div>
 
       <div className="question-editor-section">
-        <label className="question-editor-label">Correct Answer</label>
-        <div className="tf-radio-group">
+        <label className="question-editor-label">Options</label>
+        <div className="tf-option-row">
           <button
             type="button"
             className={`tf-radio-option ${correctOptionId === 'true' ? 'tf-radio-option--selected' : ''}`}
             onClick={() => onChange({ ...block, answer: { correctOptionId: 'true' } })}
           >
-            True
+            <span className="tf-radio-indicator" />
+            <input
+              type="text"
+              className="tf-option-input"
+              value={trueLabel}
+              onChange={(e) => updateOptionLabel(0, e.target.value)}
+              onClick={(e) => e.stopPropagation()}
+              placeholder="Option label"
+            />
           </button>
           <button
             type="button"
             className={`tf-radio-option ${correctOptionId === 'false' ? 'tf-radio-option--selected' : ''}`}
             onClick={() => onChange({ ...block, answer: { correctOptionId: 'false' } })}
           >
-            False
+            <span className="tf-radio-indicator" />
+            <input
+              type="text"
+              className="tf-option-input"
+              value={falseLabel}
+              onChange={(e) => updateOptionLabel(1, e.target.value)}
+              onClick={(e) => e.stopPropagation()}
+              placeholder="Option label"
+            />
           </button>
         </div>
       </div>

--- a/src/ui/admin/ExerciseContentEditor/editors/TrueFalseEditor.tsx
+++ b/src/ui/admin/ExerciseContentEditor/editors/TrueFalseEditor.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import React from 'react'
+import type { QuestionSelectTrueFalseBlock } from '@/shared/exercise-content/types'
+import { InlineRichTextEditor } from './InlineRichTextEditor'
+import { HintSolutionPanel } from './HintSolutionPanel'
+
+interface TrueFalseEditorProps {
+  block: QuestionSelectTrueFalseBlock
+  onChange: (block: QuestionSelectTrueFalseBlock) => void
+}
+
+export const TrueFalseEditor: React.FC<TrueFalseEditorProps> = ({ block, onChange }) => {
+  const correctOptionId = block.answer.correctOptionId || 'true'
+
+  return (
+    <div className="true-false-editor">
+      <div className="question-editor-section">
+        <label className="question-editor-label">Prompt</label>
+        <InlineRichTextEditor
+          value={block.prompt}
+          onChange={(newPrompt) => onChange({ ...block, prompt: newPrompt })}
+          placeholder="Enter your True/False question..."
+        />
+      </div>
+
+      <div className="question-editor-section">
+        <label className="question-editor-label">Correct Answer</label>
+        <div className="tf-radio-group">
+          <button
+            type="button"
+            className={`tf-radio-option ${correctOptionId === 'true' ? 'tf-radio-option--selected' : ''}`}
+            onClick={() => onChange({ ...block, answer: { correctOptionId: 'true' } })}
+          >
+            True
+          </button>
+          <button
+            type="button"
+            className={`tf-radio-option ${correctOptionId === 'false' ? 'tf-radio-option--selected' : ''}`}
+            onClick={() => onChange({ ...block, answer: { correctOptionId: 'false' } })}
+          >
+            False
+          </button>
+        </div>
+      </div>
+
+      <div className="question-editor-section">
+        <HintSolutionPanel
+          hint={block.hint}
+          solution={block.solution}
+          fullSolution={block.fullSolution}
+          onChange={(field, value) => onChange({ ...block, [field]: value })}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/ui/admin/ExerciseContentEditor/editors/normalizers.ts
+++ b/src/ui/admin/ExerciseContentEditor/editors/normalizers.ts
@@ -1,0 +1,288 @@
+/**
+ * Normalization functions for question block editors.
+ * These functions enforce invariants to prevent invalid states.
+ */
+
+import type { QuestionSelectMcqBlock } from '@/shared/exercise-content/types'
+
+/**
+ * Normalize MCQ block: sync multiSelect with selectionMode.
+ * If selectionMode is 'single', ensure multiSelect is false and correctOptionIds has exactly 1.
+ * If selectionMode is 'multiple', ensure multiSelect is true.
+ */
+export function normalizeMcq(block: QuestionSelectMcqBlock): QuestionSelectMcqBlock {
+  const newBlock = { ...block }
+
+  if (newBlock.selectionMode === 'single') {
+    newBlock.answer.multiSelect = false
+    // Ensure exactly one correct option
+    if (newBlock.answer.correctOptionIds.length !== 1 && newBlock.answer.options.length > 0) {
+      newBlock.answer.correctOptionIds = [newBlock.answer.options[0].id]
+    }
+    // Trim to first if multiple
+    if (newBlock.answer.correctOptionIds.length > 1) {
+      newBlock.answer.correctOptionIds = [newBlock.answer.correctOptionIds[0]]
+    }
+  } else {
+    newBlock.answer.multiSelect = true
+  }
+
+  return newBlock
+}
+
+/**
+ * When an option is removed, clean up correctOptionIds.
+ * If the removed option was correct, auto-select the first remaining option if any.
+ */
+export function removeOptionAndNormalize(
+  block: QuestionSelectMcqBlock,
+  optionId: string,
+): QuestionSelectMcqBlock {
+  const newBlock = { ...block }
+  const optionIds = new Set(
+    newBlock.answer.options.map((o) => o.id).filter((id) => id !== optionId),
+  )
+
+  // Remove deleted option from correctOptionIds
+  newBlock.answer.correctOptionIds = newBlock.answer.correctOptionIds.filter((id) =>
+    optionIds.has(id),
+  )
+
+  // If no correct options remain but options still exist, auto-select first
+  if (newBlock.answer.correctOptionIds.length === 0 && optionIds.size > 0) {
+    newBlock.answer.correctOptionIds = [optionIds.values().next().value as string]
+  }
+
+  return normalizeMcq(newBlock)
+}
+
+/**
+ * When selectionMode changes, reset correctOptionIds if needed.
+ */
+export function changeSelectionMode(
+  block: QuestionSelectMcqBlock,
+  mode: 'single' | 'multiple',
+): QuestionSelectMcqBlock {
+  const newBlock = { ...block, selectionMode: mode }
+
+  if (mode === 'single' && newBlock.answer.correctOptionIds.length > 0) {
+    // Keep only first correct option
+    newBlock.answer.correctOptionIds = [newBlock.answer.correctOptionIds[0]]
+  }
+
+  return normalizeMcq(newBlock)
+}
+
+/**
+ * Add a new option and normalize.
+ */
+export function addOptionAndNormalize(
+  block: QuestionSelectMcqBlock,
+  newOption: {
+    id: string
+    content: { type: 'rich_text'; format: 'md-math-v1'; value: string; mediaIds: string[] }
+  },
+): QuestionSelectMcqBlock {
+  const newBlock: QuestionSelectMcqBlock = {
+    ...block,
+    answer: {
+      ...block.answer,
+      options: [...block.answer.options, { id: newOption.id, content: newOption.content }],
+    },
+  }
+
+  // If no correct option selected, select the new one
+  if (newBlock.answer.correctOptionIds.length === 0) {
+    newBlock.answer.correctOptionIds = [newOption.id]
+  }
+
+  return normalizeMcq(newBlock)
+}
+
+/**
+ * Update an option and normalize.
+ */
+export function updateOptionAndNormalize(
+  block: QuestionSelectMcqBlock,
+  optionId: string,
+  updates: Partial<{
+    content: { type: 'rich_text'; format: 'md-math-v1'; value: string; mediaIds: string[] }
+  }>,
+): QuestionSelectMcqBlock {
+  const newBlock: QuestionSelectMcqBlock = {
+    ...block,
+    answer: {
+      ...block.answer,
+      options: block.answer.options.map((opt) =>
+        opt.id === optionId ? { ...opt, ...updates } : opt,
+      ),
+    },
+  }
+
+  return newBlock
+}
+
+/**
+ * Toggle correct option and normalize.
+ */
+export function toggleCorrectOption(
+  block: QuestionSelectMcqBlock,
+  optionId: string,
+): QuestionSelectMcqBlock {
+  const newBlock: QuestionSelectMcqBlock = { ...block }
+
+  if (block.selectionMode === 'single') {
+    // Single mode: only this option can be correct
+    newBlock.answer.correctOptionIds = [optionId]
+  } else {
+    // Multiple mode: toggle
+    const isCorrect = newBlock.answer.correctOptionIds.includes(optionId)
+    if (isCorrect) {
+      newBlock.answer.correctOptionIds = newBlock.answer.correctOptionIds.filter(
+        (id) => id !== optionId,
+      )
+    } else {
+      newBlock.answer.correctOptionIds = [...newBlock.answer.correctOptionIds, optionId]
+    }
+  }
+
+  return normalizeMcq(newBlock)
+}
+
+/**
+ * Table normalizers - Stage 2
+ */
+
+import type { QuestionTableBlock } from '@/shared/exercise-content/types'
+
+/**
+ * When header count changes, resize each row and update columnAlignment.
+ */
+export function normalizeTableOnHeaderChange(
+  block: QuestionTableBlock,
+  newHeaders: string[],
+): QuestionTableBlock {
+  const oldHeaderCount = block.table.headers.length
+  const newHeaderCount = newHeaders.length
+  const newAlignment = [...(block.table.columnAlignment || [])]
+
+  // Adjust column alignment
+  if (newHeaderCount > oldHeaderCount) {
+    // Add left alignment for new columns
+    for (let i = oldHeaderCount; i < newHeaderCount; i++) {
+      newAlignment.push('left')
+    }
+  } else {
+    // Trim alignment array
+    newAlignment.length = newHeaderCount
+  }
+
+  // Resize each row to match new header count
+  const newRowsData = block.table.rowsData.map((row) => {
+    if (newHeaderCount > row.length) {
+      // Pad with empty strings
+      return [...row, ...Array(newHeaderCount - row.length).fill('')]
+    } else {
+      // Trim
+      return row.slice(0, newHeaderCount)
+    }
+  })
+
+  // Adjust answers keys for removed columns
+  const newAnswers: Record<string, string> = {}
+  if (block.table.answers) {
+    Object.entries(block.table.answers).forEach(([key, value]) => {
+      const [, colIdxStr] = key.split('-')
+      const colIdx = Number(colIdxStr)
+      if (colIdx < newHeaderCount) {
+        if (colIdx < oldHeaderCount) {
+          newAnswers[key] = value
+        }
+      }
+    })
+  }
+
+  return {
+    ...block,
+    table: {
+      ...block.table,
+      headers: newHeaders,
+      columnAlignment: newAlignment,
+      rowsData: newRowsData,
+      answers: newAnswers,
+    },
+  }
+}
+
+/**
+ * When rows are added/removed, drop out-of-bounds answer keys.
+ */
+export function normalizeTableAnswers(
+  block: QuestionTableBlock,
+  newRowsData: string[][],
+): QuestionTableBlock {
+  const newAnswers: Record<string, string> = {}
+  const rowCount = newRowsData.length
+  const colCount = block.table.headers.length
+
+  if (block.table.answers) {
+    Object.entries(block.table.answers).forEach(([key, value]) => {
+      const [rowIdx, colIdx] = key.split('-').map(Number)
+      if (rowIdx < rowCount && colIdx < colCount) {
+        newAnswers[key] = value
+      }
+    })
+  }
+
+  return {
+    ...block,
+    table: {
+      ...block.table,
+      rowsData: newRowsData,
+      answers: newAnswers,
+    },
+  }
+}
+
+/**
+ * When toggling solutionFill on, ensure answers object exists.
+ */
+export function normalizeTableSolutionFillOn(block: QuestionTableBlock): QuestionTableBlock {
+  return {
+    ...block,
+    table: {
+      ...block.table,
+      solutionFill: true,
+      answers: block.table.answers || {},
+    },
+  }
+}
+
+/**
+ * When toggling solutionFill off, keep answers but don't enforce.
+ */
+export function normalizeTableSolutionFillOff(block: QuestionTableBlock): QuestionTableBlock {
+  return {
+    ...block,
+    table: {
+      ...block.table,
+      solutionFill: false,
+    },
+  }
+}
+
+/**
+ * Add a row to the table.
+ */
+export function addTableRow(block: QuestionTableBlock): QuestionTableBlock {
+  const newRow = Array(block.table.headers.length).fill('')
+  return normalizeTableAnswers(block, [...block.table.rowsData, newRow])
+}
+
+/**
+ * Remove a row from the table.
+ */
+export function removeTableRow(block: QuestionTableBlock, rowIndex: number): QuestionTableBlock {
+  const newRowsData = block.table.rowsData.filter((_, i) => i !== rowIndex)
+  return normalizeTableAnswers(block, newRowsData)
+}

--- a/src/ui/admin/ExerciseContentEditor/editors/normalizers.ts
+++ b/src/ui/admin/ExerciseContentEditor/editors/normalizers.ts
@@ -39,9 +39,15 @@ export function removeOptionAndNormalize(
   optionId: string,
 ): QuestionSelectMcqBlock {
   const newBlock = { ...block }
-  const optionIds = new Set(
-    newBlock.answer.options.map((o) => o.id).filter((id) => id !== optionId),
-  )
+
+  // Actually remove the option from the options array
+  newBlock.answer = {
+    ...newBlock.answer,
+    options: newBlock.answer.options.filter((o) => o.id !== optionId),
+  }
+
+  // Get remaining option IDs from the filtered options
+  const optionIds = new Set(newBlock.answer.options.map((o) => o.id))
 
   // Remove deleted option from correctOptionIds
   newBlock.answer.correctOptionIds = newBlock.answer.correctOptionIds.filter((id) =>

--- a/src/ui/admin/ExerciseContentEditor/index.css
+++ b/src/ui/admin/ExerciseContentEditor/index.css
@@ -1783,7 +1783,7 @@
   cursor: pointer;
 }
 
-.table-config-option input[type="checkbox"] {
+.table-config-option input[type='checkbox'] {
   width: 16px;
   height: 16px;
   cursor: pointer;

--- a/src/ui/admin/ExerciseContentEditor/index.css
+++ b/src/ui/admin/ExerciseContentEditor/index.css
@@ -1369,3 +1369,625 @@
     padding: 1rem;
   }
 }
+
+/* Question Block Wrapper */
+.question-block-wrapper {
+  padding: 0.5rem 0;
+}
+
+.question-block-json-toggle {
+  margin-top: 1rem;
+}
+
+/* Inline Rich Text Editor (shorter variant) */
+.inline-rich-text-editor {
+  border: 1px solid var(--theme-elevation-200);
+  border-radius: 4px;
+  background: var(--theme-elevation-0);
+}
+
+.inline-rich-text-toolbar {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.375rem 0.5rem;
+  border-bottom: 1px solid var(--theme-elevation-150);
+  background: var(--theme-elevation-50);
+}
+
+.inline-rich-text-textarea {
+  width: 100%;
+  min-height: 80px;
+  padding: 0.75rem;
+  border: none;
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--theme-elevation-1000);
+  background: transparent;
+  resize: vertical;
+}
+
+.inline-rich-text-textarea:focus {
+  outline: none;
+}
+
+.inline-rich-text-footer {
+  padding: 0.375rem 0.75rem;
+  background: var(--theme-elevation-50);
+  border-top: 1px solid var(--theme-elevation-150);
+  font-size: 0.75rem;
+  color: var(--theme-elevation-600);
+  text-align: right;
+}
+
+/* Hint & Solution Panel */
+.hint-solution-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.hint-solution-field {
+  margin-bottom: 0.5rem;
+}
+
+.hint-solution-field-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.375rem;
+}
+
+.hint-solution-field-label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--theme-elevation-600);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.hint-solution-field-empty {
+  padding: 0.5rem 0;
+}
+
+.hint-solution-enable-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  border: 1px dashed var(--theme-elevation-300);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--theme-elevation-600);
+  font-size: 0.8125rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.hint-solution-enable-btn:hover {
+  border-color: var(--theme-info-500);
+  color: var(--theme-info-500);
+  background: var(--theme-info-50);
+}
+
+.hint-solution-remove-btn {
+  padding: 0.25rem;
+  border: none;
+  background: transparent;
+  color: var(--theme-elevation-500);
+  border-radius: 3px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.hint-solution-remove-btn:hover {
+  background: var(--theme-error-50);
+  color: var(--theme-error-500);
+}
+
+/* True/False Editor */
+.true-false-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.tf-radio-group {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.tf-radio-option {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  border: 2px solid var(--theme-elevation-200);
+  border-radius: 6px;
+  background: var(--theme-elevation-0);
+  color: var(--theme-elevation-700);
+  font-size: 0.9375rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.tf-radio-option:hover {
+  border-color: var(--theme-elevation-300);
+  background: var(--theme-elevation-50);
+}
+
+.tf-radio-option--selected {
+  border-color: var(--theme-success-500);
+  background: var(--theme-success-50);
+  color: var(--theme-success-700);
+}
+
+/* MCQ Editor */
+.mcq-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.mcq-selection-mode {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.mcq-mode-btn {
+  flex: 1;
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--theme-elevation-200);
+  border-radius: 4px;
+  background: var(--theme-elevation-0);
+  color: var(--theme-elevation-700);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.mcq-mode-btn:hover {
+  background: var(--theme-elevation-50);
+}
+
+.mcq-mode-btn--selected {
+  border-color: var(--theme-info-500);
+  background: var(--theme-info-50);
+  color: var(--theme-info-700);
+}
+
+.mcq-options-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.mcq-option-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid var(--theme-elevation-200);
+  border-radius: 6px;
+  background: var(--theme-elevation-0);
+}
+
+.mcq-option-correct {
+  flex-shrink: 0;
+  padding-top: 0.25rem;
+}
+
+.mcq-correct-marker {
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--theme-elevation-300);
+  border-radius: 50%;
+  background: var(--theme-elevation-0);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+}
+
+.mcq-correct-marker:hover {
+  border-color: var(--theme-success-400);
+}
+
+.mcq-correct-marker--checked {
+  border-color: var(--theme-success-500);
+  background: var(--theme-success-500);
+}
+
+.mcq-correct-inner {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: white;
+}
+
+.mcq-option-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.mcq-option-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.mcq-option-action-btn {
+  padding: 0.375rem;
+  border: none;
+  background: transparent;
+  border-radius: 3px;
+  color: var(--theme-elevation-500);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.mcq-option-action-btn:hover:not(:disabled) {
+  background: var(--theme-elevation-100);
+  color: var(--theme-elevation-700);
+}
+
+.mcq-option-action-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.mcq-option-action-btn--delete:hover:not(:disabled) {
+  background: var(--theme-error-50);
+  color: var(--theme-error-500);
+}
+
+.mcq-add-option-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  padding: 0.625rem 1rem;
+  border: 1px dashed var(--theme-elevation-300);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--theme-elevation-600);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+  margin-top: 0.5rem;
+}
+
+.mcq-add-option-btn:hover {
+  border-color: var(--theme-info-500);
+  color: var(--theme-info-500);
+  background: var(--theme-info-50);
+}
+
+/* Free Response Editor */
+.free-response-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.accepted-answers-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.accepted-answer-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.accepted-answer-input {
+  flex: 1;
+  padding: 0.625rem 0.875rem;
+  border: 1px solid var(--theme-elevation-200);
+  border-radius: 4px;
+  font-size: 0.875rem;
+  background: var(--theme-elevation-0);
+  color: var(--theme-elevation-1000);
+}
+
+.accepted-answer-input:focus {
+  outline: none;
+  border-color: var(--theme-elevation-400);
+}
+
+.accepted-answer-remove-btn {
+  padding: 0.5rem;
+  border: 1px solid var(--theme-elevation-200);
+  border-radius: 4px;
+  background: var(--theme-elevation-0);
+  color: var(--theme-elevation-500);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.accepted-answer-remove-btn:hover:not(:disabled) {
+  background: var(--theme-error-50);
+  border-color: var(--theme-error-200);
+  color: var(--theme-error-500);
+}
+
+.accepted-answer-remove-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.accepted-answer-add-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  padding: 0.625rem 1rem;
+  border: 1px dashed var(--theme-elevation-300);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--theme-elevation-600);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+  margin-top: 0.5rem;
+}
+
+.accepted-answer-add-btn:hover {
+  border-color: var(--theme-info-500);
+  color: var(--theme-info-500);
+  background: var(--theme-info-50);
+}
+
+/* Shared Question Editor Styles */
+.question-editor-section {
+  margin-bottom: 0.5rem;
+}
+
+.question-editor-label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--theme-elevation-600);
+  margin-bottom: 0.5rem;
+}
+
+/* Table Editor */
+.table-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.table-config-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 0.75rem;
+  background: var(--theme-elevation-50);
+  border-radius: 6px;
+  border: 1px solid var(--theme-elevation-150);
+}
+
+.table-config-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--theme-elevation-700);
+  cursor: pointer;
+}
+
+.table-config-option input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
+.table-config-option--highlight {
+  color: var(--theme-info-600);
+  font-weight: 500;
+}
+
+.table-headers-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.table-header-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.table-header-input {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--theme-elevation-200);
+  border-radius: 4px;
+  font-size: 0.875rem;
+  background: var(--theme-elevation-0);
+}
+
+.table-header-input:focus {
+  outline: none;
+  border-color: var(--theme-elevation-400);
+}
+
+.table-align-select {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--theme-elevation-200);
+  border-radius: 4px;
+  font-size: 0.8125rem;
+  background: var(--theme-elevation-0);
+  cursor: pointer;
+}
+
+.table-header-remove-btn {
+  padding: 0.5rem;
+  border: 1px solid var(--theme-elevation-200);
+  border-radius: 4px;
+  background: var(--theme-elevation-0);
+  color: var(--theme-elevation-500);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.table-header-remove-btn:hover:not(:disabled) {
+  background: var(--theme-error-50);
+  border-color: var(--theme-error-200);
+  color: var(--theme-error-500);
+}
+
+.table-header-remove-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.table-add-header-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  padding: 0.5rem 1rem;
+  border: 1px dashed var(--theme-elevation-300);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--theme-elevation-600);
+  font-size: 0.8125rem;
+  cursor: pointer;
+  transition: all 0.15s;
+  margin-top: 0.25rem;
+}
+
+.table-add-header-btn:hover {
+  border-color: var(--theme-info-500);
+  color: var(--theme-info-500);
+  background: var(--theme-info-50);
+}
+
+.table-rows-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border: 1px solid var(--theme-elevation-200);
+  border-radius: 6px;
+  padding: 1rem;
+  background: var(--theme-elevation-0);
+}
+
+.table-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.table-row-label {
+  flex-shrink: 0;
+  width: 50px;
+  padding: 0.5rem 0;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--theme-elevation-500);
+}
+
+.table-row-cells {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.table-cell-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.table-cell-input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--theme-elevation-200);
+  border-radius: 4px;
+  font-size: 0.875rem;
+  background: var(--theme-elevation-0);
+}
+
+.table-cell-input:focus {
+  outline: none;
+  border-color: var(--theme-elevation-400);
+}
+
+.table-solution-input-wrapper {
+  padding: 0.25rem 0;
+}
+
+.table-solution-input {
+  width: 100%;
+  padding: 0.375rem 0.75rem;
+  border: 1px dashed var(--theme-info-300);
+  border-radius: 4px;
+  font-size: 0.8125rem;
+  background: var(--theme-info-50);
+  color: var(--theme-info-700);
+}
+
+.table-solution-input:focus {
+  outline: none;
+  border-color: var(--theme-info-500);
+  background: var(--theme-info-100);
+}
+
+.table-solution-input::placeholder {
+  color: var(--theme-info-400);
+}
+
+.table-row-remove-btn {
+  padding: 0.5rem;
+  border: 1px solid var(--theme-elevation-200);
+  border-radius: 4px;
+  background: var(--theme-elevation-0);
+  color: var(--theme-elevation-500);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.table-row-remove-btn:hover:not(:disabled) {
+  background: var(--theme-error-50);
+  border-color: var(--theme-error-200);
+  color: var(--theme-error-500);
+}
+
+.table-row-remove-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.table-add-row-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  padding: 0.625rem 1rem;
+  border: 1px dashed var(--theme-elevation-300);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--theme-elevation-600);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+  margin-top: 0.75rem;
+}
+
+.table-add-row-btn:hover {
+  border-color: var(--theme-info-500);
+  color: var(--theme-info-500);
+  background: var(--theme-info-50);
+}

--- a/src/ui/admin/ExerciseContentEditor/index.css
+++ b/src/ui/admin/ExerciseContentEditor/index.css
@@ -191,6 +191,10 @@
   cursor: not-allowed;
 }
 
+.toolbar-button--media {
+  margin-left: auto;
+}
+
 .toolbar-divider {
   width: 1px;
   background: var(--theme-elevation-200);
@@ -1107,6 +1111,50 @@
   color: var(--theme-elevation-900);
 }
 
+.media-picker-upload {
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--theme-elevation-150);
+  background: var(--theme-elevation-50);
+}
+
+.media-picker-upload-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  border: 2px dashed var(--theme-elevation-300);
+  border-radius: 6px;
+  background: var(--theme-elevation-0);
+  color: var(--theme-elevation-700);
+  font-size: 0.9375rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.media-picker-upload-btn:hover:not(:disabled) {
+  border-color: var(--theme-primary-500);
+  color: var(--theme-primary-700);
+  background: var(--theme-primary-50);
+}
+
+.media-picker-upload-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.media-picker-uploading {
+  margin-top: 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--theme-elevation-600);
+}
+
+.media-picker-upload-error {
+  margin-top: 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--theme-error-700);
+}
+
 .media-picker-search {
   padding: 1rem 1.5rem;
   border-bottom: 1px solid var(--theme-elevation-150);
@@ -1418,6 +1466,81 @@
   font-size: 0.75rem;
   color: var(--theme-elevation-600);
   text-align: right;
+}
+
+.inline-rich-text-media {
+  padding: 0.5rem 0.75rem;
+  border-top: 1px solid var(--theme-elevation-150);
+  background: var(--theme-elevation-50);
+}
+
+.inline-rich-text-media-loading {
+  font-size: 0.75rem;
+  color: var(--theme-elevation-600);
+}
+
+.inline-rich-text-media-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.inline-rich-text-media-item {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.25rem 0.5rem 0.25rem 0.25rem;
+  background: var(--theme-elevation-0);
+  border: 1px solid var(--theme-elevation-200);
+  border-radius: 4px;
+  font-size: 0.75rem;
+}
+
+.inline-rich-text-media-thumb {
+  width: 32px;
+  height: 32px;
+  border-radius: 2px;
+  object-fit: cover;
+  border: 1px solid var(--theme-elevation-200);
+}
+
+.inline-rich-text-media-icon {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--theme-elevation-100);
+  border-radius: 2px;
+  color: var(--theme-elevation-600);
+}
+
+.inline-rich-text-media-name {
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--theme-elevation-800);
+}
+
+.inline-rich-text-media-remove {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--theme-elevation-500);
+  cursor: pointer;
+  border-radius: 2px;
+  transition: all 0.15s;
+}
+
+.inline-rich-text-media-remove:hover {
+  background: var(--theme-error-100);
+  color: var(--theme-error-700);
 }
 
 /* Hint & Solution Panel */

--- a/src/ui/admin/ExerciseContentEditor/index.css
+++ b/src/ui/admin/ExerciseContentEditor/index.css
@@ -1492,7 +1492,7 @@
   gap: 1rem;
 }
 
-.tf-radio-group {
+.tf-option-row {
   display: flex;
   gap: 0.75rem;
 }
@@ -1508,6 +1508,9 @@
   font-weight: 500;
   cursor: pointer;
   transition: all 0.15s;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .tf-radio-option:hover {
@@ -1519,6 +1522,48 @@
   border-color: var(--theme-success-500);
   background: var(--theme-success-50);
   color: var(--theme-success-700);
+}
+
+.tf-radio-indicator {
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--theme-elevation-300);
+  border-radius: 50%;
+  flex-shrink: 0;
+  position: relative;
+}
+
+.tf-radio-option--selected .tf-radio-indicator {
+  border-color: var(--theme-success-500);
+}
+
+.tf-radio-option--selected .tf-radio-indicator::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 8px;
+  height: 8px;
+  background: var(--theme-success-500);
+  border-radius: 50%;
+}
+
+.tf-option-input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: inherit;
+  outline: none;
+  min-width: 0;
+  padding: 0;
+}
+
+.tf-option-input:focus {
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 /* MCQ Editor */

--- a/src/ui/admin/ExerciseContentEditor/index.tsx
+++ b/src/ui/admin/ExerciseContentEditor/index.tsx
@@ -439,7 +439,6 @@ function renderQuestionEditor(
   blockCount: number,
   onMoveUp: () => void,
   onMoveDown: () => void,
-  onAdd: () => void,
   onDelete: () => void,
 ): React.ReactNode {
   if (block.type === 'question_select' && block.variant === 'true_false') {
@@ -450,7 +449,6 @@ function renderQuestionEditor(
         onBlockChange={onChange}
         onMoveUp={onMoveUp}
         onMoveDown={onMoveDown}
-        onAdd={onAdd}
         onDelete={onDelete}
         canMoveUp={blockIndex > 0}
         canMoveDown={blockIndex < blockCount - 1}
@@ -471,7 +469,6 @@ function renderQuestionEditor(
         onBlockChange={onChange}
         onMoveUp={onMoveUp}
         onMoveDown={onMoveDown}
-        onAdd={onAdd}
         onDelete={onDelete}
         canMoveUp={blockIndex > 0}
         canMoveDown={blockIndex < blockCount - 1}
@@ -492,7 +489,6 @@ function renderQuestionEditor(
         onBlockChange={onChange}
         onMoveUp={onMoveUp}
         onMoveDown={onMoveDown}
-        onAdd={onAdd}
         onDelete={onDelete}
         canMoveUp={blockIndex > 0}
         canMoveDown={blockIndex < blockCount - 1}
@@ -513,7 +509,6 @@ function renderQuestionEditor(
         onBlockChange={onChange}
         onMoveUp={onMoveUp}
         onMoveDown={onMoveDown}
-        onAdd={onAdd}
         onDelete={onDelete}
         canMoveUp={blockIndex > 0}
         canMoveDown={blockIndex < blockCount - 1}
@@ -588,14 +583,6 @@ function BlockList({
                       <MoveDown size={14} />
                     </button>
                     <button
-                      className="block-action-button"
-                      onClick={() => onAddBlock(index)}
-                      title="Add block below"
-                      type="button"
-                    >
-                      <Plus size={14} />
-                    </button>
-                    <button
                       className="block-action-button block-action-button--danger"
                       onClick={() => onDeleteBlock(block.id)}
                       disabled={blocks.length === 1}
@@ -647,7 +634,6 @@ function BlockList({
                   blocks.length,
                   () => onMoveBlock(block.id, 'up'),
                   () => onMoveBlock(block.id, 'down'),
-                  () => onAddBlock(index),
                   () => onDeleteBlock(block.id),
                 )}
               </div>
@@ -655,6 +641,11 @@ function BlockList({
           </div>
         )
       })}
+
+      <button className="add-block-button" onClick={() => onAddBlock()} type="button">
+        <Plus size={16} />
+        Add Block
+      </button>
 
       {blocks.length === 0 && (
         <div className="empty-state">

--- a/src/ui/admin/ExerciseContentEditor/index.tsx
+++ b/src/ui/admin/ExerciseContentEditor/index.tsx
@@ -12,6 +12,11 @@ import './index.css'
 import { JSONInspector } from './JSONInspector'
 import { MediaPicker } from './MediaPicker'
 import { RichTextEditor } from './RichTextEditor'
+import { QuestionBlockWrapper } from './editors/QuestionBlockWrapper'
+import { TrueFalseEditor } from './editors/TrueFalseEditor'
+import { McqEditor } from './editors/McqEditor'
+import { FreeResponseEditor } from './editors/FreeResponseEditor'
+import { TableEditor } from './editors/TableEditor'
 
 /**
  * Exercise Content Editor - Strict Flat Blocks
@@ -424,6 +429,77 @@ export const ExerciseContentEditor: React.FC<{ path: string }> = ({ path }) => {
   )
 }
 
+function getBlockTypeLabel(block: ContentBlock): string {
+  if (block.type === 'question_select' && block.variant === 'true_false') return 'True / False'
+  if (block.type === 'question_select' && block.variant === 'mcq') return 'Multiple Choice'
+  if (block.type === 'question_free_response') return 'Free Response'
+  if (block.type === 'question_table') return 'Table Question'
+  return block.type
+}
+
+function renderQuestionEditor(
+  block: ContentBlock,
+  onChange: (block: ContentBlock) => void,
+): React.ReactNode {
+  if (block.type === 'question_select' && block.variant === 'true_false') {
+    return (
+      <QuestionBlockWrapper
+        blockType={getBlockTypeLabel(block)}
+        block={block}
+        onBlockChange={onChange}
+      >
+        <TrueFalseEditor
+          block={block as import('@/shared/exercise-content/types').QuestionSelectTrueFalseBlock}
+          onChange={onChange}
+        />
+      </QuestionBlockWrapper>
+    )
+  }
+  if (block.type === 'question_select' && block.variant === 'mcq') {
+    return (
+      <QuestionBlockWrapper
+        blockType={getBlockTypeLabel(block)}
+        block={block}
+        onBlockChange={onChange}
+      >
+        <McqEditor
+          block={block as import('@/shared/exercise-content/types').QuestionSelectMcqBlock}
+          onChange={onChange}
+        />
+      </QuestionBlockWrapper>
+    )
+  }
+  if (block.type === 'question_free_response') {
+    return (
+      <QuestionBlockWrapper
+        blockType={getBlockTypeLabel(block)}
+        block={block}
+        onBlockChange={onChange}
+      >
+        <FreeResponseEditor
+          block={block as import('@/shared/exercise-content/types').QuestionFreeResponseBlock}
+          onChange={onChange}
+        />
+      </QuestionBlockWrapper>
+    )
+  }
+  if (block.type === 'question_table') {
+    return (
+      <QuestionBlockWrapper
+        blockType={getBlockTypeLabel(block)}
+        block={block}
+        onBlockChange={onChange}
+      >
+        <TableEditor
+          block={block as import('@/shared/exercise-content/types').QuestionTableBlock}
+          onChange={onChange}
+        />
+      </QuestionBlockWrapper>
+    )
+  }
+  return <JSONInspector block={block} mode="edit" onApply={onChange} />
+}
+
 interface BlockListProps {
   blocks: ContentBlock[]
   selectedBlockId: string | null
@@ -506,17 +582,9 @@ function BlockList({
               </div>
             ) : (
               <div className="question-block-json-editor">
-                <div className="question-block-type-badge">
-                  {block.type === 'question_select' &&
-                    (block.variant === 'mcq' ? 'Multiple Choice Question' : 'Select Question')}
-                  {block.type === 'question_free_response' && 'Free Response Question'}
-                  {block.type === 'question_table' && 'Table Question'}
-                </div>
-                <JSONInspector
-                  block={block}
-                  mode="edit"
-                  onApply={(updatedBlock) => onUpdateBlock(block.id, updatedBlock)}
-                />
+                {renderQuestionEditor(block, (updatedBlock) =>
+                  onUpdateBlock(block.id, updatedBlock),
+                )}
               </div>
             )}
           </div>

--- a/src/ui/admin/ExerciseContentEditor/index.tsx
+++ b/src/ui/admin/ExerciseContentEditor/index.tsx
@@ -440,6 +440,12 @@ function getBlockTypeLabel(block: ContentBlock): string {
 function renderQuestionEditor(
   block: ContentBlock,
   onChange: (block: ContentBlock) => void,
+  blockIndex: number,
+  blockCount: number,
+  onMoveUp: () => void,
+  onMoveDown: () => void,
+  onAdd: () => void,
+  onDelete: () => void,
 ): React.ReactNode {
   if (block.type === 'question_select' && block.variant === 'true_false') {
     return (
@@ -447,6 +453,13 @@ function renderQuestionEditor(
         blockType={getBlockTypeLabel(block)}
         block={block}
         onBlockChange={onChange}
+        onMoveUp={onMoveUp}
+        onMoveDown={onMoveDown}
+        onAdd={onAdd}
+        onDelete={onDelete}
+        canMoveUp={blockIndex > 0}
+        canMoveDown={blockIndex < blockCount - 1}
+        canDelete={blockCount > 1}
       >
         <TrueFalseEditor
           block={block as import('@/shared/exercise-content/types').QuestionSelectTrueFalseBlock}
@@ -461,6 +474,13 @@ function renderQuestionEditor(
         blockType={getBlockTypeLabel(block)}
         block={block}
         onBlockChange={onChange}
+        onMoveUp={onMoveUp}
+        onMoveDown={onMoveDown}
+        onAdd={onAdd}
+        onDelete={onDelete}
+        canMoveUp={blockIndex > 0}
+        canMoveDown={blockIndex < blockCount - 1}
+        canDelete={blockCount > 1}
       >
         <McqEditor
           block={block as import('@/shared/exercise-content/types').QuestionSelectMcqBlock}
@@ -475,6 +495,13 @@ function renderQuestionEditor(
         blockType={getBlockTypeLabel(block)}
         block={block}
         onBlockChange={onChange}
+        onMoveUp={onMoveUp}
+        onMoveDown={onMoveDown}
+        onAdd={onAdd}
+        onDelete={onDelete}
+        canMoveUp={blockIndex > 0}
+        canMoveDown={blockIndex < blockCount - 1}
+        canDelete={blockCount > 1}
       >
         <FreeResponseEditor
           block={block as import('@/shared/exercise-content/types').QuestionFreeResponseBlock}
@@ -489,6 +516,13 @@ function renderQuestionEditor(
         blockType={getBlockTypeLabel(block)}
         block={block}
         onBlockChange={onChange}
+        onMoveUp={onMoveUp}
+        onMoveDown={onMoveDown}
+        onAdd={onAdd}
+        onDelete={onDelete}
+        canMoveUp={blockIndex > 0}
+        canMoveDown={blockIndex < blockCount - 1}
+        canDelete={blockCount > 1}
       >
         <TableEditor
           block={block as import('@/shared/exercise-content/types').QuestionTableBlock}
@@ -525,97 +559,107 @@ function BlockList({
 }: BlockListProps) {
   return (
     <div className="block-list">
-      {blocks.map((block, index) => (
-        <div
-          key={block.id}
-          className={`block-item ${selectedBlockId === block.id ? 'block-item--selected' : ''}`}
-        >
-          <div className="block-header">
-            <div className="block-header-left">
-              <span className="block-number">Block {index + 1}</span>
-            </div>
-            <div className="block-actions">
-              <button
-                className="block-action-button"
-                onClick={() => onMoveBlock(block.id, 'up')}
-                disabled={index === 0}
-                title="Move up"
-                type="button"
-              >
-                <MoveUp size={14} />
-              </button>
-              <button
-                className="block-action-button"
-                onClick={() => onMoveBlock(block.id, 'down')}
-                disabled={index === blocks.length - 1}
-                title="Move down"
-                type="button"
-              >
-                <MoveDown size={14} />
-              </button>
-              <button
-                className="block-action-button"
-                onClick={() => onAddBlock(index)}
-                title="Add block below"
-                type="button"
-              >
-                <Plus size={14} />
-              </button>
-              <button
-                className="block-action-button block-action-button--danger"
-                onClick={() => onDeleteBlock(block.id)}
-                disabled={blocks.length === 1}
-                title="Delete block"
-                type="button"
-              >
-                <Trash2 size={14} />
-              </button>
-            </div>
-          </div>
-          <div className="block-content">
-            {block.type === 'rich_text' ? (
-              <div onClick={() => onSelect(block.id)} onFocus={() => onSelect(block.id)}>
-                <RichTextEditor
-                  value={block.value}
-                  onChange={(value) => onUpdateBlock(block.id, { value })}
-                />
-              </div>
+      {blocks.map((block, index) => {
+        const isRichText = block.type === 'rich_text'
+
+        return (
+          <div
+            key={block.id}
+            className={`block-item ${selectedBlockId === block.id ? 'block-item--selected' : ''}`}
+          >
+            {isRichText ? (
+              <>
+                <div className="block-header">
+                  <div className="block-header-left">
+                    <span className="block-number">Block {index + 1}</span>
+                  </div>
+                  <div className="block-actions">
+                    <button
+                      className="block-action-button"
+                      onClick={() => onMoveBlock(block.id, 'up')}
+                      disabled={index === 0}
+                      title="Move up"
+                      type="button"
+                    >
+                      <MoveUp size={14} />
+                    </button>
+                    <button
+                      className="block-action-button"
+                      onClick={() => onMoveBlock(block.id, 'down')}
+                      disabled={index === blocks.length - 1}
+                      title="Move down"
+                      type="button"
+                    >
+                      <MoveDown size={14} />
+                    </button>
+                    <button
+                      className="block-action-button"
+                      onClick={() => onAddBlock(index)}
+                      title="Add block below"
+                      type="button"
+                    >
+                      <Plus size={14} />
+                    </button>
+                    <button
+                      className="block-action-button block-action-button--danger"
+                      onClick={() => onDeleteBlock(block.id)}
+                      disabled={blocks.length === 1}
+                      title="Delete block"
+                      type="button"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  </div>
+                </div>
+                <div className="block-content">
+                  <div onClick={() => onSelect(block.id)} onFocus={() => onSelect(block.id)}>
+                    <RichTextEditor
+                      value={block.value}
+                      onChange={(value) => onUpdateBlock(block.id, { value })}
+                    />
+                  </div>
+                </div>
+                <div className="block-media-section">
+                  <button
+                    type="button"
+                    className="block-media-button"
+                    onClick={() => onOpenMediaPicker(block.id)}
+                    title="Attach media"
+                  >
+                    <ImageIcon size={14} />
+                    <span>
+                      {block.mediaIds && block.mediaIds.length > 0
+                        ? `${block.mediaIds.length} media attached`
+                        : 'Attach media'}
+                    </span>
+                  </button>
+
+                  {block.mediaIds && block.mediaIds.length > 0 && (
+                    <BlockMediaDisplay
+                      blockId={block.id}
+                      mediaIds={block.mediaIds}
+                      onRemoveMedia={onRemoveMedia}
+                    />
+                  )}
+                </div>
+              </>
             ) : (
               <div className="question-block-json-editor">
-                {renderQuestionEditor(block, (updatedBlock) =>
-                  onUpdateBlock(block.id, updatedBlock),
+                {renderQuestionEditor(
+                  block,
+                  (updatedBlock) => onUpdateBlock(block.id, updatedBlock),
+                  index,
+                  blocks.length,
+                  () => onMoveBlock(block.id, 'up'),
+                  () => onMoveBlock(block.id, 'down'),
+                  () => onAddBlock(index),
+                  () => onDeleteBlock(block.id),
                 )}
               </div>
             )}
           </div>
-
-          {block.type === 'rich_text' && (
-            <div className="block-media-section">
-              <button
-                type="button"
-                className="block-media-button"
-                onClick={() => onOpenMediaPicker(block.id)}
-                title="Attach media"
-              >
-                <ImageIcon size={14} />
-                <span>
-                  {block.mediaIds && block.mediaIds.length > 0
-                    ? `${block.mediaIds.length} media attached`
-                    : 'Attach media'}
-                </span>
-              </button>
-
-              {block.mediaIds && block.mediaIds.length > 0 && (
-                <BlockMediaDisplay
-                  blockId={block.id}
-                  mediaIds={block.mediaIds}
-                  onRemoveMedia={onRemoveMedia}
-                />
-              )}
-            </div>
-          )}
-        </div>
-      ))}
+        )
+      })}
 
       {blocks.length === 0 && (
         <div className="empty-state">

--- a/src/ui/admin/ExerciseContentEditor/index.tsx
+++ b/src/ui/admin/ExerciseContentEditor/index.tsx
@@ -146,11 +146,6 @@ export const ExerciseContentEditor: React.FC<{ path: string }> = ({ path }) => {
 
     updateLocalValue({ blocks: newBlocks })
     setSelectedBlockId(newBlock.id)
-
-    // Open JSON panel for question blocks
-    if (blockType !== 'rich_text') {
-      setIsJsonPanelOpen(true)
-    }
   }
 
   // Delete block


### PR DESCRIPTION
- InlineRichTextEditor for prompt/hint/solution fields
- HintSolutionPanel for optional hint/solution/fullSolution
- TrueFalseEditor with radio selection
- McqEditor with options list, selection mode, correct marking
- FreeResponseEditor with accepted answers list
- TableEditor with headers, rows, solutionFill mode
- QuestionBlockWrapper with Advanced JSON toggle
- Normalizers for MCQ and table data consistency
- Full CSS styling for all editors

Stage 1: True/False, MCQ, Free Response editors
Stage 2: Table editor with solutionFill support