### PR TITLE
feat(exercises): Render media attachments inside interactive lessons

### DIFF
--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/ExercisesPager/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/ExercisesPager/index.tsx
@@ -23,6 +23,7 @@ interface ExercisesPagerProps {
   lessonId: string
   introDescription?: string | null
   introMedia?: MediaType | string | number | null
+  mediaMap?: Record<string, MediaType>
 }
 
 export function ExercisesPager({
@@ -35,6 +36,7 @@ export function ExercisesPager({
   lessonId,
   introDescription,
   introMedia,
+  mediaMap,
 }: ExercisesPagerProps) {
   const t = useTranslations('courses')
   const hasAboutPage = Boolean(introDescription || (introMedia && typeof introMedia === 'object'))
@@ -91,6 +93,7 @@ export function ExercisesPager({
                     content={currentExercise.content as unknown as ExerciseContentData}
                     mode="student"
                     showCheckAnswer={true}
+                    mediaMap={mediaMap}
                   />
                 </div>
               </div>

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/page.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/page.tsx
@@ -6,6 +6,8 @@ import {
   queryExerciseBySlug,
   queryExercisesByLesson,
 } from '@/server/repos/queries/exercises'
+import { queryMediaByIds } from '@/server/repos/queries/media'
+import { extractAllMediaIds } from '@/ui/web/exerciserenderer/utils/extractMediaIds'
 import { ExercisesPager } from '../../_components/ExercisesPager'
 
 const OBJECT_ID_REGEX = /^[0-9a-fA-F]{24}$/
@@ -91,6 +93,8 @@ export default async function ExercisePage({ params }: ExercisePageProps) {
 
   const backUrl = `/courses/${courseSlug}/chapters/${chapterSlug}/lessons/${lessonSlug}`
 
+  const mediaMap = await queryMediaByIds(extractAllMediaIds(exercises))
+
   return (
     <ExercisesPager
       exercises={exercises}
@@ -100,6 +104,7 @@ export default async function ExercisePage({ params }: ExercisePageProps) {
       chapterSlug={chapterSlug}
       lessonSlug={lessonSlug}
       lessonId={lesson.id}
+      mediaMap={mediaMap}
     />
   )
 }

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/page.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/page.tsx
@@ -1,6 +1,8 @@
 import { queryCourseBySlug } from '@/server/repos/queries/courses'
 import { queryLessonBySlug } from '@/server/repos/queries/lessons'
 import { queryExercisesByLesson } from '@/server/repos/queries/exercises'
+import { queryMediaByIds } from '@/server/repos/queries/media'
+import { extractAllMediaIds } from '@/ui/web/exerciserenderer/utils/extractMediaIds'
 import type { Media } from '@/payload-types'
 import { Media as MediaComponent } from '@/ui/web/media'
 import { notFound } from 'next/navigation'
@@ -59,6 +61,9 @@ export default async function LessonPage({ params }: LessonPageProps) {
   const hasContent = validFiles.length > 0
   const hasExercises = exercises.length > 0
 
+  // Batch-fetch all media referenced inside exercise content blocks
+  const mediaMap = hasExercises ? await queryMediaByIds(extractAllMediaIds(exercises)) : {}
+
   // Case 1: No document attached -> Show exercises pager if exercises exist
   if (!hasContent) {
     return (
@@ -75,6 +80,7 @@ export default async function LessonPage({ params }: LessonPageProps) {
             lessonId={lesson.id}
             introDescription={lesson.introEnabled ? lesson.introDescription : null}
             introMedia={lesson.introEnabled ? lesson.introMedia : null}
+            mediaMap={mediaMap}
           />
         ) : (
           // Empty state: no document and no exercises

--- a/src/server/repos/queries/media.ts
+++ b/src/server/repos/queries/media.ts
@@ -1,0 +1,30 @@
+import { cache } from 'react'
+import { getPayload } from 'payload'
+import configPromise from '@payload-config'
+import type { Media } from '@/payload-types'
+
+/**
+ * Fetch multiple media documents by their IDs.
+ * Returns a map of id -> Media for efficient lookup.
+ */
+export const queryMediaByIds = cache(async (ids: string[]): Promise<Record<string, Media>> => {
+  if (ids.length === 0) return {}
+
+  const payload = await getPayload({ config: configPromise })
+
+  const result = await payload.find({
+    collection: 'media',
+    where: {
+      id: { in: ids },
+    },
+    limit: ids.length,
+    pagination: false,
+    depth: 0,
+  })
+
+  const map: Record<string, Media> = {}
+  for (const doc of result.docs) {
+    map[doc.id] = doc
+  }
+  return map
+})

--- a/src/ui/admin/ExerciseContentEditor/MediaPicker.tsx
+++ b/src/ui/admin/ExerciseContentEditor/MediaPicker.tsx
@@ -13,8 +13,18 @@ interface MediaPickerProps {
   onSave: (mediaIds: string[]) => void
 }
 
-const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'application/pdf']
-const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB
+const ALLOWED_MIME_TYPES = [
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+  'image/svg+xml',
+  'video/mp4',
+  'video/webm',
+  'application/pdf',
+]
+const MAX_FILE_SIZE = 100 * 1024 * 1024 // 100MB (videos can be large)
 
 export const MediaPicker: React.FC<MediaPickerProps> = ({
   isOpen,
@@ -97,13 +107,13 @@ export const MediaPicker: React.FC<MediaPickerProps> = ({
 
       // Validate file type
       if (!ALLOWED_MIME_TYPES.includes(file.type)) {
-        setUploadError('Invalid file type. Allowed: JPEG, PNG, WebP, PDF')
+        setUploadError('Invalid file type. Allowed: JPEG, PNG, WebP, GIF, SVG, MP4, WebM, PDF')
         continue
       }
 
       // Validate file size
       if (file.size > MAX_FILE_SIZE) {
-        setUploadError('File too large. Maximum size is 10MB')
+        setUploadError('File too large. Maximum size is 100MB')
         continue
       }
 
@@ -135,7 +145,14 @@ export const MediaPicker: React.FC<MediaPickerProps> = ({
             filename: doc.doc?.filename || doc.filename || file.name,
             url: doc.doc?.url || doc.url,
             alt: '',
-            type: file.type.startsWith('image/') ? 'image' : 'pdf',
+            type:
+              file.type === 'image/svg+xml'
+                ? 'svg'
+                : file.type.startsWith('video/')
+                  ? 'video'
+                  : file.type.startsWith('image/')
+                    ? 'image'
+                    : 'pdf',
             filesize: file.size,
             mimeType: file.type,
             createdAt: new Date().toISOString(),

--- a/src/ui/web/exerciserenderer/ExerciseRenderer/index.tsx
+++ b/src/ui/web/exerciserenderer/ExerciseRenderer/index.tsx
@@ -26,6 +26,7 @@ import { McqQuestion } from '../questions/McqQuestion'
 import { FreeResponseQuestion } from '../questions/FreeResponseQuestion'
 import { QuestionCard } from '../components/QuestionCard'
 import { checkQuestionAnswer, getInitialAnswer } from '../utils/answerChecking'
+import { MediaMapProvider } from '../context/MediaMapContext'
 
 /**
  * Format student's answer as readable text for AI context
@@ -47,11 +48,14 @@ function formatStudentAnswer(question: QuestionBlock, answer: UserAnswer): strin
 /**
  * Main Exercise Renderer Component
  */
+const EMPTY_MEDIA_MAP = {} as const
+
 export function ExerciseRenderer({
   content,
   mode: _mode = 'student',
   showCheckAnswer = true,
   className = '',
+  mediaMap = EMPTY_MEDIA_MAP,
 }: ExerciseRendererProps) {
   const t = useTranslations('courses')
 
@@ -147,79 +151,81 @@ export function ExerciseRenderer({
   }
 
   return (
-    <div className={cn('w-full max-w-3xl mx-auto', className)}>
-      <div className="flex flex-col gap-6">
-        {content.blocks.map((block) => {
-          // Rich text block - just render content
-          if (block.type === 'rich_text') {
+    <MediaMapProvider value={mediaMap}>
+      <div className={cn('w-full max-w-3xl mx-auto', className)}>
+        <div className="flex flex-col gap-6">
+          {content.blocks.map((block) => {
+            // Rich text block - just render content
+            if (block.type === 'rich_text') {
+              return (
+                <div
+                  key={block.id}
+                  className="prose prose-slate dark:prose-invert max-w-none text-foreground leading-relaxed"
+                >
+                  <RichTextRenderer block={block} />
+                </div>
+              )
+            }
+
+            // Question blocks - render with answer UI
+            const question = block as QuestionBlock
+            const answer = answers[question.id] ?? getInitialAnswer(question)
+            const checkResult = checkResults[question.id] || null
+            const checked = hasChecked[question.id] || false
+            const disabled = checked && checkResult?.isCorrect
+
+            // True/False questions don't show check button (immediate feedback)
+            const showCheckButton =
+              showCheckAnswer &&
+              !(question.type === 'question_select' && question.variant === 'true_false')
+
             return (
-              <div
-                key={block.id}
-                className="prose prose-slate dark:prose-invert max-w-none text-foreground leading-relaxed"
+              <QuestionCard
+                key={question.id}
+                showCheckButton={showCheckButton}
+                onCheckAnswer={() => handleCheckAnswer(question.id)}
+                disabled={!!disabled}
+                checked={checked}
+                checkResult={checkResult}
+                checkAnswerText={t('checkAnswer')}
+                correctText={t('correct')}
+                incorrectText={t('incorrect')}
               >
-                <RichTextRenderer block={block} />
-              </div>
+                {/* Render appropriate question component based on type */}
+                {question.type === 'question_select' && question.variant === 'true_false' && (
+                  <TrueFalseQuestion
+                    question={question as QuestionSelectTrueFalseBlock}
+                    answer={answer}
+                    onChange={(ans) => handleAnswerChange(question.id, ans)}
+                    disabled={!!disabled}
+                    checkResult={checkResult}
+                  />
+                )}
+                {question.type === 'question_select' && question.variant === 'mcq' && (
+                  <McqQuestion
+                    question={question as QuestionSelectMcqBlock}
+                    answer={answer}
+                    onChange={(ans) => handleAnswerChange(question.id, ans)}
+                    disabled={!!disabled}
+                    checkResult={checkResult}
+                    t={t}
+                  />
+                )}
+                {question.type === 'question_free_response' && (
+                  <FreeResponseQuestion
+                    question={question as QuestionFreeResponseBlock}
+                    answer={answer}
+                    onChange={(ans) => handleAnswerChange(question.id, ans)}
+                    disabled={!!disabled}
+                    checkResult={checkResult}
+                    t={t}
+                  />
+                )}
+              </QuestionCard>
             )
-          }
-
-          // Question blocks - render with answer UI
-          const question = block as QuestionBlock
-          const answer = answers[question.id] ?? getInitialAnswer(question)
-          const checkResult = checkResults[question.id] || null
-          const checked = hasChecked[question.id] || false
-          const disabled = checked && checkResult?.isCorrect
-
-          // True/False questions don't show check button (immediate feedback)
-          const showCheckButton =
-            showCheckAnswer &&
-            !(question.type === 'question_select' && question.variant === 'true_false')
-
-          return (
-            <QuestionCard
-              key={question.id}
-              showCheckButton={showCheckButton}
-              onCheckAnswer={() => handleCheckAnswer(question.id)}
-              disabled={!!disabled}
-              checked={checked}
-              checkResult={checkResult}
-              checkAnswerText={t('checkAnswer')}
-              correctText={t('correct')}
-              incorrectText={t('incorrect')}
-            >
-              {/* Render appropriate question component based on type */}
-              {question.type === 'question_select' && question.variant === 'true_false' && (
-                <TrueFalseQuestion
-                  question={question as QuestionSelectTrueFalseBlock}
-                  answer={answer}
-                  onChange={(ans) => handleAnswerChange(question.id, ans)}
-                  disabled={!!disabled}
-                  checkResult={checkResult}
-                />
-              )}
-              {question.type === 'question_select' && question.variant === 'mcq' && (
-                <McqQuestion
-                  question={question as QuestionSelectMcqBlock}
-                  answer={answer}
-                  onChange={(ans) => handleAnswerChange(question.id, ans)}
-                  disabled={!!disabled}
-                  checkResult={checkResult}
-                  t={t}
-                />
-              )}
-              {question.type === 'question_free_response' && (
-                <FreeResponseQuestion
-                  question={question as QuestionFreeResponseBlock}
-                  answer={answer}
-                  onChange={(ans) => handleAnswerChange(question.id, ans)}
-                  disabled={!!disabled}
-                  checkResult={checkResult}
-                  t={t}
-                />
-              )}
-            </QuestionCard>
-          )
-        })}
+          })}
+        </div>
       </div>
-    </div>
+    </MediaMapProvider>
   )
 }

--- a/src/ui/web/exerciserenderer/blocks/RichTextRenderer/index.tsx
+++ b/src/ui/web/exerciserenderer/blocks/RichTextRenderer/index.tsx
@@ -1,10 +1,12 @@
 /**
  * Rich Text Renderer
- * Renders markdown with math support (KaTeX) using the shared MathMarkdown component.
+ * Renders markdown with math support (KaTeX) using the shared MathMarkdown component,
+ * plus any attached media.
  */
 
 import { MathMarkdown } from '@/ui/web/shared/MathMarkdown'
 import { preprocessNewlines } from '@/infra/utils/textPreprocessing'
+import { MediaAttachments } from '../../components/MediaAttachments'
 
 interface RichTextRendererProps {
   block: {
@@ -19,9 +21,12 @@ export function RichTextRenderer({ block }: RichTextRendererProps) {
   const processedValue = preprocessNewlines(block.value)
 
   return (
-    <MathMarkdown
-      content={processedValue}
-      className="rich-text-content leading-relaxed text-foreground"
-    />
+    <>
+      <MathMarkdown
+        content={processedValue}
+        className="rich-text-content leading-relaxed text-foreground"
+      />
+      <MediaAttachments mediaIds={block.mediaIds} />
+    </>
   )
 }

--- a/src/ui/web/exerciserenderer/components/MediaAttachments/index.tsx
+++ b/src/ui/web/exerciserenderer/components/MediaAttachments/index.tsx
@@ -2,12 +2,56 @@
 
 import React from 'react'
 import { cn } from '@/infra/utils/ui'
-import { Media } from '@/ui/web/media'
+import { getMediaUrl } from '@/infra/utils/getMediaUrl'
+import type { Media } from '@/payload-types'
 import { useMediaMap } from '../../context/MediaMapContext'
 
 interface MediaAttachmentsProps {
   mediaIds: string[] | undefined
   className?: string
+}
+
+function isImageType(media: Media): boolean {
+  return media.type === 'image' || media.type === 'svg'
+}
+
+function isVideoType(media: Media): boolean {
+  return media.type === 'video'
+}
+
+/**
+ * Renders a single media item.
+ * Uses plain <img> / <video> to avoid Next.js Image optimization domain issues.
+ */
+function MediaItem({ media }: { media: Media }) {
+  const src = getMediaUrl(media.url, media.updatedAt)
+
+  if (!src) return null
+
+  if (isVideoType(media)) {
+    return (
+      <video controls playsInline className="w-full max-h-96">
+        <source src={src} type={media.mimeType || undefined} />
+      </video>
+    )
+  }
+
+  if (isImageType(media)) {
+    return (
+      /* eslint-disable-next-line @next/next/no-img-element */
+      <img src={src} alt={media.alt || ''} className="w-full h-auto max-h-96 object-contain" />
+    )
+  }
+
+  // Fallback for other types — render as image if URL exists
+  return (
+    /* eslint-disable-next-line @next/next/no-img-element */
+    <img
+      src={src}
+      alt={media.alt || media.filename || ''}
+      className="w-full h-auto max-h-96 object-contain"
+    />
+  )
 }
 
 /**
@@ -30,15 +74,9 @@ export function MediaAttachments({ mediaIds, className }: MediaAttachmentsProps)
       {resolved.map((media) => (
         <div
           key={media.id}
-          className="rounded-xl overflow-hidden border border-border/60 bg-muted/30"
+          className="rounded-xl overflow-hidden border border-border/60 bg-muted/30 flex items-center justify-center"
         >
-          <Media
-            resource={media}
-            imgClassName="w-full h-auto max-h-96 object-contain"
-            videoClassName="w-full max-h-96"
-            htmlElement="div"
-            className="flex items-center justify-center"
-          />
+          <MediaItem media={media} />
         </div>
       ))}
     </div>

--- a/src/ui/web/exerciserenderer/components/MediaAttachments/index.tsx
+++ b/src/ui/web/exerciserenderer/components/MediaAttachments/index.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import React from 'react'
+import { cn } from '@/infra/utils/ui'
+import { Media } from '@/ui/web/media'
+import { useMediaMap } from '../../context/MediaMapContext'
+
+interface MediaAttachmentsProps {
+  mediaIds: string[] | undefined
+  className?: string
+}
+
+/**
+ * Renders media items attached to a content block via mediaIds.
+ * Resolves IDs from the MediaMapContext provided at the ExerciseRenderer level.
+ */
+export function MediaAttachments({ mediaIds, className }: MediaAttachmentsProps) {
+  const mediaMap = useMediaMap()
+
+  if (!mediaIds || mediaIds.length === 0) return null
+
+  const resolved = mediaIds
+    .map((id) => mediaMap[id])
+    .filter((m): m is NonNullable<typeof m> => Boolean(m))
+
+  if (resolved.length === 0) return null
+
+  return (
+    <div className={cn('flex flex-col gap-3 mt-3', className)}>
+      {resolved.map((media) => (
+        <div
+          key={media.id}
+          className="rounded-xl overflow-hidden border border-border/60 bg-muted/30"
+        >
+          <Media
+            resource={media}
+            imgClassName="w-full h-auto max-h-96 object-contain"
+            videoClassName="w-full max-h-96"
+            htmlElement="div"
+            className="flex items-center justify-center"
+          />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/ui/web/exerciserenderer/context/MediaMapContext.tsx
+++ b/src/ui/web/exerciserenderer/context/MediaMapContext.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { createContext, useContext } from 'react'
+import type { Media } from '@/payload-types'
+
+export type MediaMap = Record<string, Media>
+
+const MediaMapContext = createContext<MediaMap>({})
+
+export const MediaMapProvider = MediaMapContext.Provider
+
+export function useMediaMap(): MediaMap {
+  return useContext(MediaMapContext)
+}

--- a/src/ui/web/exerciserenderer/types.ts
+++ b/src/ui/web/exerciserenderer/types.ts
@@ -129,4 +129,6 @@ export interface ExerciseRendererProps {
   mode?: PreviewMode
   showCheckAnswer?: boolean
   className?: string
+  /** Pre-resolved media objects keyed by ID, for rendering mediaIds in blocks */
+  mediaMap?: Record<string, import('@/payload-types').Media>
 }

--- a/src/ui/web/exerciserenderer/utils/extractMediaIds.ts
+++ b/src/ui/web/exerciserenderer/utils/extractMediaIds.ts
@@ -1,0 +1,73 @@
+/**
+ * Extract all unique mediaIds from exercise content blocks.
+ * Scans prompts, options, hints, solutions, and standalone rich text blocks.
+ *
+ * Uses loose typing to handle block types beyond the renderer's ContentBlock union
+ * (e.g. question_table, latex) that may exist in exercise data.
+ */
+
+interface LooseRichText {
+  mediaIds?: string[]
+}
+
+interface LooseBlock {
+  type: string
+  variant?: string
+  mediaIds?: string[]
+  prompt?: LooseRichText
+  hint?: LooseRichText
+  solution?: LooseRichText
+  fullSolution?: LooseRichText
+  options?: Array<{ label?: LooseRichText }>
+  answer?: {
+    options?: Array<{ content?: LooseRichText }>
+  }
+}
+
+export function extractMediaIds(content: { blocks: LooseBlock[] }): string[] {
+  const ids = new Set<string>()
+
+  const collect = (rt: LooseRichText | undefined) => {
+    if (!rt?.mediaIds) return
+    for (const id of rt.mediaIds) {
+      if (id) ids.add(id)
+    }
+  }
+
+  for (const block of content.blocks) {
+    collect(block)
+    collect(block.prompt)
+    collect(block.hint)
+    collect(block.solution)
+    collect(block.fullSolution)
+
+    if (block.options) {
+      for (const opt of block.options) {
+        collect(opt.label)
+      }
+    }
+
+    if (block.answer?.options) {
+      for (const opt of block.answer.options) {
+        collect(opt.content)
+      }
+    }
+  }
+
+  return Array.from(ids)
+}
+
+/**
+ * Extract all unique mediaIds from multiple exercises.
+ */
+export function extractAllMediaIds(exercises: { content: unknown }[]): string[] {
+  const ids = new Set<string>()
+  for (const ex of exercises) {
+    const content = ex.content as { blocks: LooseBlock[] }
+    if (!content?.blocks) continue
+    for (const id of extractMediaIds(content)) {
+      ids.add(id)
+    }
+  }
+  return Array.from(ids)
+}

--- a/tests/unit/exerciserenderer/MediaAttachments.test.tsx
+++ b/tests/unit/exerciserenderer/MediaAttachments.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { MediaAttachments } from '@/ui/web/exerciserenderer/components/MediaAttachments'
+import { MediaMapProvider } from '@/ui/web/exerciserenderer/context/MediaMapContext'
+import type { Media } from '@/payload-types'
+
+function createMedia(overrides: Partial<Media> & { id: string }): Media {
+  return {
+    filename: 'test.png',
+    url: '/media/test.png',
+    alt: '',
+    mimeType: 'image/png',
+    type: 'image',
+    filesize: 1000,
+    width: 100,
+    height: 100,
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+    retentionPolicy: 'persistent',
+    ...overrides,
+  } as Media
+}
+
+function renderWithMediaMap(ui: React.ReactElement, mediaMap: Record<string, Media>) {
+  return render(<MediaMapProvider value={mediaMap}>{ui}</MediaMapProvider>)
+}
+
+describe('MediaAttachments', () => {
+  it('renders nothing when mediaIds is undefined', () => {
+    const { container } = renderWithMediaMap(<MediaAttachments mediaIds={undefined} />, {})
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders nothing when mediaIds is empty', () => {
+    const { container } = renderWithMediaMap(<MediaAttachments mediaIds={[]} />, {})
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders nothing when media IDs are not in the map', () => {
+    const { container } = renderWithMediaMap(<MediaAttachments mediaIds={['nonexistent']} />, {})
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders an image for image type media', () => {
+    const media = createMedia({
+      id: 'img1',
+      type: 'image',
+      url: '/media/photo.png',
+      alt: 'A photo',
+    })
+
+    renderWithMediaMap(<MediaAttachments mediaIds={['img1']} />, { img1: media })
+
+    const img = screen.getByAltText('A photo')
+    expect(img).toBeTruthy()
+    expect(img.tagName).toBe('IMG')
+  })
+
+  it('renders an image for svg type media', () => {
+    const media = createMedia({
+      id: 'svg1',
+      type: 'svg',
+      url: '/media/diagram.svg',
+      alt: 'A diagram',
+      mimeType: 'image/svg+xml',
+    })
+
+    renderWithMediaMap(<MediaAttachments mediaIds={['svg1']} />, { svg1: media })
+
+    const img = screen.getByAltText('A diagram')
+    expect(img).toBeTruthy()
+    expect(img.tagName).toBe('IMG')
+  })
+
+  it('renders a video element for video type media', () => {
+    const media = createMedia({
+      id: 'vid1',
+      type: 'video',
+      url: '/media/clip.mp4',
+      mimeType: 'video/mp4',
+    })
+
+    const { container } = renderWithMediaMap(<MediaAttachments mediaIds={['vid1']} />, {
+      vid1: media,
+    })
+
+    const video = container.querySelector('video')
+    expect(video).toBeTruthy()
+    expect(video?.getAttribute('controls')).not.toBeNull()
+
+    const source = container.querySelector('source')
+    expect(source?.getAttribute('type')).toBe('video/mp4')
+  })
+
+  it('renders multiple media items', () => {
+    const img = createMedia({ id: 'img1', type: 'image', url: '/media/a.png', alt: 'Image A' })
+    const svg = createMedia({ id: 'svg1', type: 'svg', url: '/media/b.svg', alt: 'SVG B' })
+
+    renderWithMediaMap(<MediaAttachments mediaIds={['img1', 'svg1']} />, { img1: img, svg1: svg })
+
+    expect(screen.getByAltText('Image A')).toBeTruthy()
+    expect(screen.getByAltText('SVG B')).toBeTruthy()
+  })
+
+  it('applies custom className', () => {
+    const media = createMedia({ id: 'img1', type: 'image', url: '/media/a.png', alt: 'test' })
+
+    const { container } = renderWithMediaMap(
+      <MediaAttachments mediaIds={['img1']} className="custom-class" />,
+      { img1: media },
+    )
+
+    const wrapper = container.firstElementChild
+    expect(wrapper?.className).toContain('custom-class')
+  })
+})

--- a/tests/unit/exerciserenderer/extractMediaIds.test.ts
+++ b/tests/unit/exerciserenderer/extractMediaIds.test.ts
@@ -1,0 +1,131 @@
+import {
+  extractMediaIds,
+  extractAllMediaIds,
+} from '@/ui/web/exerciserenderer/utils/extractMediaIds'
+import { describe, expect, it } from 'vitest'
+
+describe('extractMediaIds', () => {
+  it('returns empty array when blocks have no mediaIds', () => {
+    const result = extractMediaIds({
+      blocks: [{ type: 'rich_text' }, { type: 'question_select' }],
+    })
+    expect(result).toEqual([])
+  })
+
+  it('extracts mediaIds from block-level mediaIds', () => {
+    const result = extractMediaIds({
+      blocks: [{ type: 'rich_text', mediaIds: ['m1', 'm2'] }],
+    })
+    expect(result).toEqual(['m1', 'm2'])
+  })
+
+  it('extracts mediaIds from prompt field', () => {
+    const result = extractMediaIds({
+      blocks: [{ type: 'question_select', prompt: { mediaIds: ['m3'] } }],
+    })
+    expect(result).toEqual(['m3'])
+  })
+
+  it('extracts mediaIds from hint and solution fields', () => {
+    const result = extractMediaIds({
+      blocks: [
+        {
+          type: 'question_free_response',
+          hint: { mediaIds: ['h1'] },
+          solution: { mediaIds: ['s1'] },
+          fullSolution: { mediaIds: ['fs1'] },
+        },
+      ],
+    })
+    expect(result).toEqual(['h1', 's1', 'fs1'])
+  })
+
+  it('extracts mediaIds from options labels', () => {
+    const result = extractMediaIds({
+      blocks: [
+        {
+          type: 'question_select',
+          options: [{ label: { mediaIds: ['ol1'] } }, { label: { mediaIds: ['ol2'] } }],
+        },
+      ],
+    })
+    expect(result).toEqual(['ol1', 'ol2'])
+  })
+
+  it('extracts mediaIds from answer options content', () => {
+    const result = extractMediaIds({
+      blocks: [
+        {
+          type: 'question_select',
+          answer: {
+            options: [{ content: { mediaIds: ['ac1'] } }, { content: { mediaIds: ['ac2'] } }],
+          },
+        },
+      ],
+    })
+    expect(result).toEqual(['ac1', 'ac2'])
+  })
+
+  it('deduplicates mediaIds across all fields', () => {
+    const result = extractMediaIds({
+      blocks: [
+        {
+          type: 'rich_text',
+          mediaIds: ['shared'],
+          prompt: { mediaIds: ['shared'] },
+          hint: { mediaIds: ['shared', 'unique'] },
+        },
+      ],
+    })
+    expect(result).toEqual(['shared', 'unique'])
+  })
+
+  it('skips falsy ids', () => {
+    const result = extractMediaIds({
+      blocks: [{ type: 'rich_text', mediaIds: ['m1', '', 'm2'] }],
+    })
+    expect(result).toEqual(['m1', 'm2'])
+  })
+
+  it('handles multiple blocks', () => {
+    const result = extractMediaIds({
+      blocks: [
+        { type: 'rich_text', mediaIds: ['a'] },
+        { type: 'question_select', prompt: { mediaIds: ['b'] } },
+        { type: 'latex', mediaIds: ['c'] },
+      ],
+    })
+    expect(result).toEqual(['a', 'b', 'c'])
+  })
+})
+
+describe('extractAllMediaIds', () => {
+  it('returns empty array for empty exercises list', () => {
+    expect(extractAllMediaIds([])).toEqual([])
+  })
+
+  it('extracts mediaIds across multiple exercises', () => {
+    const exercises = [
+      { content: { blocks: [{ type: 'rich_text', mediaIds: ['e1m1'] }] } },
+      { content: { blocks: [{ type: 'rich_text', mediaIds: ['e2m1', 'e2m2'] }] } },
+    ]
+    const result = extractAllMediaIds(exercises)
+    expect(result).toEqual(['e1m1', 'e2m1', 'e2m2'])
+  })
+
+  it('deduplicates across exercises', () => {
+    const exercises = [
+      { content: { blocks: [{ type: 'rich_text', mediaIds: ['shared'] }] } },
+      { content: { blocks: [{ type: 'rich_text', mediaIds: ['shared', 'unique'] }] } },
+    ]
+    const result = extractAllMediaIds(exercises)
+    expect(result).toEqual(['shared', 'unique'])
+  })
+
+  it('handles exercises with no blocks', () => {
+    const exercises = [{ content: {} }, { content: null }]
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = extractAllMediaIds(exercises as any)
+    expect(result).toEqual([])
+  })
+})


### PR DESCRIPTION
Add frontend rendering for media (images, SVGs, videos) attached to exercise content blocks via mediaIds. The admin editor already supports attaching media — this wires up the student-facing display.

- Extract all mediaIds from exercise content blocks server-side
- Batch-fetch media documents in a single query
- Provide media map via React context to avoid prop drilling
- RichTextRenderer now displays attached media below markdown text
- Works across all block types: prompts, MCQ options, rich text