### PR TITLE
feat(chat): Add dedicated wrong-answer help endpoint bypassing chat p…

### DIFF
--- a/src/app/api/agent/wrong-answer-help/route.ts
+++ b/src/app/api/agent/wrong-answer-help/route.ts
@@ -1,0 +1,31 @@
+import '@/infra/config/server-init'
+
+import { logger } from '@/infra/utils/logger/logger'
+import { wrongAnswerHelp } from '@/server/payload/endpoints/agent/wrong-answer-help'
+import config from '@payload-config'
+import { NextRequest, NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+
+export async function POST(request: NextRequest) {
+  const requestId = crypto.randomUUID()
+
+  try {
+    const body = await request.json()
+
+    const payload = await getPayload({ config })
+    const { user } = await payload.auth({ headers: request.headers })
+
+    const payloadRequest = {
+      payload,
+      user,
+      url: request.url,
+      headers: request.headers,
+      json: async () => body,
+    } as Parameters<typeof wrongAnswerHelp>[0]
+
+    return await wrongAnswerHelp(payloadRequest)
+  } catch (error) {
+    logger.error({ err: error, requestId }, 'Wrong-answer help route error')
+    return NextResponse.json({ success: false, error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/server/payload/endpoints/agent/wrong-answer-help.ts
+++ b/src/server/payload/endpoints/agent/wrong-answer-help.ts
@@ -1,0 +1,70 @@
+/**
+ * Wrong Answer Help Endpoint
+ * Calls Gemini directly to help students who answered incorrectly.
+ * Bypasses the chat pipeline — no conversation persistence, no user message.
+ */
+import { getGenkitInstance } from '@/infra/llm/genkit/genkit-instance'
+import { resolveGenkitConfig } from '@/infra/llm/genkit/config-resolver'
+import { logger } from '@/infra/utils/logger'
+import { getDefaultTenantId } from '@/server/repos/tenant/get-default-tenant'
+import type { PayloadRequest } from 'payload'
+import { z } from 'zod'
+
+const requestSchema = z.object({
+  questionJson: z.string().min(1),
+  studentAnswer: z.string().min(1),
+})
+
+const SYSTEM_PROMPT = `You are a supportive and encouraging tutor helping a student who answered a question incorrectly.
+Your goal is to help them understand why their answer is wrong and guide them toward the correct solution.
+Do NOT give the answer directly. Instead, explain the concept, point out the mistake, and encourage them to try again.
+Be warm, patient, and brief (2-3 sentences max).`
+
+export async function wrongAnswerHelp(
+  req: PayloadRequest & { json?: () => Promise<unknown> },
+): Promise<Response> {
+  const requestId = crypto.randomUUID()
+  const reqLogger = logger.child({ requestId })
+
+  if (!req.user) {
+    return Response.json({ success: false, error: 'Authentication required' }, { status: 401 })
+  }
+
+  try {
+    const body = await req.json?.()
+    const parsed = requestSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return Response.json(
+        { success: false, error: 'Invalid request', details: parsed.error.issues },
+        { status: 400 },
+      )
+    }
+
+    const { questionJson, studentAnswer } = parsed.data
+
+    reqLogger.info({ userId: req.user.id }, 'Processing wrong-answer help request')
+
+    const tenantId = await getDefaultTenantId(req.payload)
+    const ai = await getGenkitInstance(req.payload, tenantId)
+    const config = await resolveGenkitConfig('EXERCISE_CHAT', tenantId, req.payload)
+
+    const userPrompt = `Question data: ${questionJson}\n\nStudent's answer: "${studentAnswer}"`
+
+    const result = await ai.generate({
+      model: config.model,
+      system: SYSTEM_PROMPT,
+      prompt: userPrompt,
+    })
+
+    reqLogger.info({ responseLength: result.text.length }, 'Wrong-answer help generated')
+
+    return Response.json({ success: true, response: result.text })
+  } catch (error) {
+    reqLogger.error({ err: error }, 'Wrong-answer help failed')
+    return Response.json(
+      { success: false, error: error instanceof Error ? error.message : 'Generation failed' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/server/payload/endpoints/agent/wrong-answer-help.ts
+++ b/src/server/payload/endpoints/agent/wrong-answer-help.ts
@@ -1,18 +1,25 @@
 /**
  * Wrong Answer Help Endpoint
  * Calls Gemini directly to help students who answered incorrectly.
- * Bypasses the chat pipeline — no conversation persistence, no user message.
+ * Bypasses the chat pipeline for the instruction (no user message persisted),
+ * but persists the AI response in the conversation so it sticks in history.
  */
 import { getGenkitInstance } from '@/infra/llm/genkit/genkit-instance'
 import { resolveGenkitConfig } from '@/infra/llm/genkit/config-resolver'
 import { logger } from '@/infra/utils/logger'
 import { getDefaultTenantId } from '@/server/repos/tenant/get-default-tenant'
+import { ConversationService } from '@/server/services/conversation-service'
 import type { PayloadRequest } from 'payload'
 import { z } from 'zod'
 
 const requestSchema = z.object({
   questionJson: z.string().min(1),
   studentAnswer: z.string().min(1),
+  // Context params for conversation persistence
+  exerciseId: z.string().optional(),
+  lessonId: z.string().optional(),
+  chapterId: z.string().optional(),
+  courseId: z.string().optional(),
 })
 
 const SYSTEM_PROMPT = `You are a supportive and encouraging tutor helping a student who answered a question incorrectly.
@@ -41,10 +48,11 @@ export async function wrongAnswerHelp(
       )
     }
 
-    const { questionJson, studentAnswer } = parsed.data
+    const { questionJson, studentAnswer, exerciseId, lessonId, chapterId, courseId } = parsed.data
 
     reqLogger.info({ userId: req.user.id }, 'Processing wrong-answer help request')
 
+    // Generate AI response via Genkit (bypasses chat pipeline)
     const tenantId = await getDefaultTenantId(req.payload)
     const ai = await getGenkitInstance(req.payload, tenantId)
     const config = await resolveGenkitConfig('EXERCISE_CHAT', tenantId, req.payload)
@@ -57,9 +65,70 @@ export async function wrongAnswerHelp(
       prompt: userPrompt,
     })
 
-    reqLogger.info({ responseLength: result.text.length }, 'Wrong-answer help generated')
+    const responseText = result.text
+    reqLogger.info({ responseLength: responseText.length }, 'Wrong-answer help generated')
 
-    return Response.json({ success: true, response: result.text })
+    // Persist the assistant response in the conversation (if context provided)
+    const hasContext = exerciseId || lessonId || chapterId || courseId
+    let conversationId: string | undefined
+    let contextKey: string | undefined
+
+    if (hasContext) {
+      try {
+        const conversationService = new ConversationService(req.payload)
+        const context = await conversationService.resolveContext({
+          exerciseId,
+          lessonId,
+          chapterId,
+          courseId,
+        })
+
+        contextKey = context.contextKey
+        const conversation = await conversationService.getOrCreateActiveConversation(req.user.id, {
+          relationTo: context.relationTo as 'courses' | 'chapters' | 'lessons' | 'exercises',
+          value: context.value,
+        })
+
+        conversationId = conversation.id
+
+        // Persist ONLY the assistant message (no user instruction)
+        const existingMessages = conversation.messages || []
+        const assistantMessage = {
+          role: 'assistant' as const,
+          content: responseText,
+          timestamp: new Date().toISOString(),
+        }
+
+        await req.payload.update({
+          collection: 'conversations',
+          id: conversationId,
+          data: {
+            messages: [...existingMessages, assistantMessage],
+            lastMessageAt: new Date().toISOString(),
+          },
+          user: req.user,
+          overrideAccess: true,
+        })
+
+        reqLogger.info(
+          { conversationId, contextKey },
+          'Persisted assistant message to conversation',
+        )
+      } catch (persistError) {
+        // Log but don't fail — the AI response was already generated
+        reqLogger.error(
+          { err: persistError },
+          'Failed to persist wrong-answer help to conversation',
+        )
+      }
+    }
+
+    return Response.json({
+      success: true,
+      response: responseText,
+      conversationId,
+      contextKey,
+    })
   } catch (error) {
     reqLogger.error({ err: error }, 'Wrong-answer help failed')
     return Response.json(

--- a/src/server/services/api/api-service.ts
+++ b/src/server/services/api/api-service.ts
@@ -238,6 +238,33 @@ export const apiService = {
   },
 
   /**
+   * Get AI help for a wrong answer (calls Gemini directly, bypasses chat pipeline)
+   */
+  async wrongAnswerHelp(
+    questionJson: string,
+    studentAnswer: string,
+  ): Promise<{ success: boolean; response?: string; error?: string }> {
+    try {
+      const response = await fetch('/api/agent/wrong-answer-help', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ questionJson, studentAnswer }),
+      })
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        return { success: false, error: data.error || 'Request failed' }
+      }
+
+      return { success: true, response: data.response }
+    } catch {
+      return { success: false, error: 'Network error' }
+    }
+  },
+
+  /**
    * Stream a chat response using SSE
    *
    * @param message - The user's message

--- a/src/server/services/api/api-service.ts
+++ b/src/server/services/api/api-service.ts
@@ -239,17 +239,24 @@ export const apiService = {
 
   /**
    * Get AI help for a wrong answer (calls Gemini directly, bypasses chat pipeline)
+   * The AI response is persisted in the conversation so it appears in history.
    */
   async wrongAnswerHelp(
     questionJson: string,
     studentAnswer: string,
+    context?: {
+      exerciseId?: string
+      lessonId?: string
+      chapterId?: string
+      courseId?: string
+    },
   ): Promise<{ success: boolean; response?: string; error?: string }> {
     try {
       const response = await fetch('/api/agent/wrong-answer-help', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ questionJson, studentAnswer }),
+        body: JSON.stringify({ questionJson, studentAnswer, ...context }),
       })
 
       const data = await response.json()

--- a/src/ui/web/chat/ChatInterface/index.tsx
+++ b/src/ui/web/chat/ChatInterface/index.tsx
@@ -153,7 +153,12 @@ export function ChatInterface({
     }
     onChatInteraction?.()
     setIsHelpLoading(true)
-    const result = await apiService.wrongAnswerHelp(questionJson, studentAnswer)
+    const result = await apiService.wrongAnswerHelp(questionJson, studentAnswer, {
+      exerciseId,
+      lessonId,
+      chapterId,
+      courseId,
+    })
     if (result.success && result.response) {
       addAssistantMessage(result.response)
     }

--- a/src/ui/web/chat/ChatInterface/index.tsx
+++ b/src/ui/web/chat/ChatInterface/index.tsx
@@ -2,6 +2,7 @@
 
 import { ChatMessageRole } from '@/infra/llm/chat-message-role'
 import { cn } from '@/infra/utils/ui'
+import { apiService } from '@/server/services/api/api-service'
 import { useTranslations } from '@/ui/web/providers/I18n'
 import {
   BookOpen,
@@ -114,8 +115,8 @@ export function ChatInterface({
     // Error handling
     chatError,
     dismissError,
-    // Programmatic contextual help
-    sendContextualHelp,
+    // Programmatic message injection
+    addAssistantMessage,
   } = useNotebookChat({
     initialMessage: t('chatWelcome'),
     authRequiredMessage: t('chatAuthRequired'),
@@ -142,17 +143,21 @@ export function ChatInterface({
     uploadFailedMessage: tCourses('chatUploadFailed'),
   })
 
-  // Auto-send contextual help on incorrect answer (ref pattern for stable listener)
+  // Wrong-answer help: call Gemini directly (bypasses chat pipeline)
+  const [isHelpLoading, setIsHelpLoading] = useState(false)
   const incorrectAnswerRef = useRef<(e: Event) => void>(() => {})
-  incorrectAnswerRef.current = (e: Event) => {
+  incorrectAnswerRef.current = async (e: Event) => {
     const { questionJson, studentAnswer } = (e as CustomEvent).detail as {
       questionJson: string
       studentAnswer: string
     }
     onChatInteraction?.()
-    sendContextualHelp(
-      `The student answered incorrectly. Here is the full question data:\n${questionJson}\n\nThe student's answer was: "${studentAnswer}"\n\nPlease help them understand why their answer is wrong and guide them toward the correct solution. Be encouraging and supportive.`,
-    )
+    setIsHelpLoading(true)
+    const result = await apiService.wrongAnswerHelp(questionJson, studentAnswer)
+    if (result.success && result.response) {
+      addAssistantMessage(result.response)
+    }
+    setIsHelpLoading(false)
   }
 
   useEffect(() => {
@@ -295,7 +300,7 @@ export function ChatInterface({
               <ChatMessageContent content={msg.content} />
             </div>
           ))}
-        {isLoading && (
+        {(isLoading || isHelpLoading) && (
           <div className="mr-auto bg-card text-foreground border border-border px-[18px] py-3.5 rounded-[20px] rounded-br-[4px] max-w-[85%] flex items-center gap-2 shadow-sm">
             <Loader2 className="w-4 h-4 animate-spin" />
             <span>{tCourses('chatThinking')}</span>

--- a/src/ui/web/chat/hooks/useNotebookChat.ts
+++ b/src/ui/web/chat/hooks/useNotebookChat.ts
@@ -625,17 +625,6 @@ export function useNotebookChat({
     setMessages((prev) => [...prev, { role: ChatRole.Assistant, content }])
   }, [])
 
-  /**
-   * Send a contextual help prompt to the AI without showing a user message bubble.
-   * Only the AI's streaming response appears in the chat.
-   */
-  const sendContextualHelp = async (prompt: string) => {
-    if (isLoading || isLoadingHistory) return
-    setIsLoading(true)
-    const context = { exerciseId, lessonId, chapterId, courseId, categoryId }
-    await streamMessage(prompt, acknowledgment, context)
-  }
-
   const dismissError = useCallback(() => {
     setChatError(null)
   }, [])
@@ -668,6 +657,5 @@ export function useNotebookChat({
     isGuestMode: _isGuestMode,
     // Programmatic message injection
     addAssistantMessage,
-    sendContextualHelp,
   }
 }


### PR DESCRIPTION
…ipeline

Calls Gemini directly via ai.generate() with proper system/prompt separation instead of routing through the streaming chat pipeline. This fixes two issues:
- Instruction prompt no longer visible to students (not persisted in conversation)
- Eliminates response doubling caused by flat prompt concatenation in unified-adapter