### PR TITLE
fix(test): reduce MongoDB connection pool for integration tests

### DIFF
--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -112,6 +112,10 @@ export default buildConfig({
   editor: defaultLexical,
   db: mongooseAdapter({
     url: databaseUrl,
+    connectOptions: {
+      // Reduce pool size for tests to avoid exhausting Atlas connection limits
+      maxPoolSize: process.env.VITEST ? 5 : 100,
+    },
   }),
   collections: [
     Pages,

--- a/tests/int/agent-chat-streaming.int.spec.ts
+++ b/tests/int/agent-chat-streaming.int.spec.ts
@@ -264,6 +264,11 @@ describe.skipIf(!hasDatabaseUrl)('agentChatStream', () => {
     } catch (error) {
       console.error('Cleanup failed:', error)
     }
+
+    // Close DB connection to prevent connection leaks
+    if (payload.db?.destroy) {
+      await payload.db.destroy()
+    }
   }, 60000)
 
   it('returns 401 when user is not authenticated', async () => {

--- a/tests/int/agent-chat.int.spec.ts
+++ b/tests/int/agent-chat.int.spec.ts
@@ -246,6 +246,11 @@ afterAll(async () => {
       id: testUserId,
     })
   }
+
+  // Close DB connection to prevent connection leaks
+  if (payload.db?.destroy) {
+    await payload.db.destroy()
+  }
 }, 30000)
 
 describe.skipIf(!hasDatabaseUrl)('agentChat endpoint', () => {

--- a/tests/int/api.int.spec.ts
+++ b/tests/int/api.int.spec.ts
@@ -40,6 +40,11 @@ describe('API', () => {
       delete process.env.DATABASE_URL
     }
 
+    // Close DB connection before stopping container
+    if (payload?.db?.destroy) {
+      await payload.db.destroy()
+    }
+
     // Stop MongoDB container
     await stopMongoContainer()
   })

--- a/tests/int/auth-login.int.spec.ts
+++ b/tests/int/auth-login.int.spec.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { beforeAll, beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getPayload, type Payload } from 'payload'
 import config from '@payload-config'
 import { loginAction } from '@/app/(frontend)/login/login_authenticate-action'
@@ -40,6 +40,13 @@ describe('Login Action', () => {
       await payload.delete({ collection: 'users', id: testUser.id })
     } catch {
       // Ignore cleanup errors
+    }
+  })
+
+  afterAll(async () => {
+    // Close DB connection to prevent connection leaks
+    if (payload?.db?.destroy) {
+      await payload.db.destroy()
     }
   })
 

--- a/tests/int/auth-oauth-google.int.spec.ts
+++ b/tests/int/auth-oauth-google.int.spec.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { getPayload, type Payload } from 'payload'
 import config from '@payload-config'
 import { encrypt, decrypt, generateSecret } from '@/infra/auth/oauth_crypto'
@@ -310,5 +310,12 @@ describe('Google OAuth Integration', () => {
       // Cleanup
       await payload.delete({ collection: 'users', id: user.id })
     })
+  })
+
+  afterAll(async () => {
+    // Close DB connection to prevent connection leaks
+    if (payload?.db?.destroy) {
+      await payload.db.destroy()
+    }
   })
 })

--- a/tests/int/chat-config-values.int.spec.ts
+++ b/tests/int/chat-config-values.int.spec.ts
@@ -21,7 +21,7 @@ const TEST_TENANT_SLUG = 'chat-config-test-tenant'
 
 describe('ChatConfig Values', () => {
   let payload: Awaited<ReturnType<typeof getPayload>>
-  let adminUser: User
+  let _adminUser: User
   let tenant: Tenant
 
   beforeAll(async () => {
@@ -34,9 +34,9 @@ describe('ChatConfig Values', () => {
         where: { email: { equals: TEST_ADMIN_EMAIL } },
       })
       if (users.docs.length > 0) {
-        adminUser = users.docs[0]
+        _adminUser = users.docs[0]
       } else {
-        adminUser = await payload.create({
+        _adminUser = await payload.create({
           collection: 'users',
           data: {
             email: TEST_ADMIN_EMAIL,
@@ -50,7 +50,7 @@ describe('ChatConfig Values', () => {
         collection: 'users',
         where: { email: { equals: TEST_ADMIN_EMAIL } },
       })
-      adminUser = users.docs[0]
+      _adminUser = users.docs[0]
     }
 
     // Create or find test tenant
@@ -94,6 +94,11 @@ describe('ChatConfig Values', () => {
       })
     } catch {
       // Ignore cleanup errors
+    }
+
+    // Close DB connection to prevent connection leaks
+    if (payload.db?.destroy) {
+      await payload.db.destroy()
     }
   })
 

--- a/tests/int/chat-endpoint-validation.int.spec.ts
+++ b/tests/int/chat-endpoint-validation.int.spec.ts
@@ -115,6 +115,11 @@ afterAll(async () => {
     await payload.delete({ collection: 'users', id: testUserId, overrideAccess: true })
   }
 
+  // Close DB connection before stopping container
+  if (payload?.db?.destroy) {
+    await payload.db.destroy()
+  }
+
   await stopMongoContainer()
 
   if (originalDatabaseUrl !== undefined) {

--- a/tests/int/config-manager.int.test.ts
+++ b/tests/int/config-manager.int.test.ts
@@ -107,6 +107,11 @@ describe('Config Secrets (Tenant-Scoped)', () => {
     } catch {
       // Ignore cleanup errors
     }
+
+    // Close DB connection to prevent connection leaks
+    if (payload.db?.destroy) {
+      await payload.db.destroy()
+    }
   })
 
   describe('ConfigSecrets Collection (Tenant-Scoped)', () => {

--- a/tests/int/config-values.int.spec.ts
+++ b/tests/int/config-values.int.spec.ts
@@ -130,6 +130,11 @@ describe('ConfigValues (Domain-Scoped Config)', () => {
     } catch {
       // Ignore cleanup errors
     }
+
+    // Close DB connection to prevent connection leaks
+    if (payload.db?.destroy) {
+      await payload.db.destroy()
+    }
   })
 
   describe('ConfigValues Collection', () => {

--- a/tests/int/jobs-run-now.int.spec.ts
+++ b/tests/int/jobs-run-now.int.spec.ts
@@ -49,6 +49,11 @@ describe('Jobs Run Now', () => {
       delete process.env.DATABASE_URL
     }
 
+    // Close DB connection before stopping container
+    if (payload?.db?.destroy) {
+      await payload.db.destroy()
+    }
+
     // Stop MongoDB container
     await stopMongoContainer()
   })

--- a/tests/int/lesson-context-injection.int.spec.ts
+++ b/tests/int/lesson-context-injection.int.spec.ts
@@ -212,6 +212,11 @@ afterAll(async () => {
       id: testLessonIdB,
     })
   }
+
+  // Close DB connection to prevent connection leaks
+  if (payload.db?.destroy) {
+    await payload.db.destroy()
+  }
 }, 30000)
 
 describe.skipIf(!hasDatabaseUrl)('Lesson Context Injection', () => {

--- a/tests/int/llm-model-reply-validation.int.spec.ts
+++ b/tests/int/llm-model-reply-validation.int.spec.ts
@@ -41,6 +41,11 @@ describe('LLM Model Configuration Validation', () => {
   }, 180000)
 
   afterAll(async () => {
+    // Close DB connection before stopping container
+    if (payload?.db?.destroy) {
+      await payload.db.destroy()
+    }
+
     await stopMongoContainer()
   })
 

--- a/tests/int/media-cleanup.int.spec.ts
+++ b/tests/int/media-cleanup.int.spec.ts
@@ -84,6 +84,11 @@ afterAll(async () => {
     await payload.delete({ collection: 'users', id: testUserId, overrideAccess: true })
   }
 
+  // Close DB connection before stopping container
+  if (payload?.db?.destroy) {
+    await payload.db.destroy()
+  }
+
   await stopMongoContainer()
 
   if (originalDatabaseUrl !== undefined) {

--- a/tests/int/memory-prompt-wiring.int.spec.ts
+++ b/tests/int/memory-prompt-wiring.int.spec.ts
@@ -313,6 +313,11 @@ afterAll(async () => {
   for (const userId of testUsers.values()) {
     await payload.delete({ collection: 'users', id: userId }).catch(() => {})
   }
+
+  // Close DB connection to prevent connection leaks
+  if (payload.db?.destroy) {
+    await payload.db.destroy()
+  }
 }, 60000)
 
 describe.skipIf(!hasDatabaseUrl)('Memory Prompt Wiring Tests', () => {

--- a/tests/int/memory-retriever-contract.int.spec.ts
+++ b/tests/int/memory-retriever-contract.int.spec.ts
@@ -213,6 +213,11 @@ afterAll(async () => {
   for (const userId of testUsers.values()) {
     await payload.delete({ collection: 'users', id: userId }).catch(() => {})
   }
+
+  // Close DB connection to prevent connection leaks
+  if (payload.db?.destroy) {
+    await payload.db.destroy()
+  }
 }, 60000)
 
 describe.skipIf(!hasDatabaseUrl)('Retriever Contract Tests (Deterministic)', () => {

--- a/tests/int/memory-system.int.spec.ts
+++ b/tests/int/memory-system.int.spec.ts
@@ -128,6 +128,11 @@ describe.skipIf(!hasOpenAIKey)('Memory System Integration Tests', () => {
         id: testUserId,
       })
     }
+
+    // Close DB connection to prevent connection leaks
+    if (payload?.db?.destroy) {
+      await payload.db.destroy()
+    }
   }, 30000) // 30s timeout for cleanup
 
   describe('Embeddings Service', () => {

--- a/tests/int/pdf-conversion-observability.int.spec.ts
+++ b/tests/int/pdf-conversion-observability.int.spec.ts
@@ -10,7 +10,7 @@
 
 import config from '@payload-config'
 import { getPayload } from 'payload'
-import { beforeEach, describe, expect, test } from 'vitest'
+import { afterAll, beforeEach, describe, expect, test } from 'vitest'
 
 describe('PDF→Exercises Observability', () => {
   let _payload: any
@@ -106,5 +106,12 @@ describe('PDF→Exercises Observability', () => {
       expect(parts[4]).toBe('1')
       expect(parts[5]).toBe('v1')
     })
+  })
+
+  afterAll(async () => {
+    // Close DB connection to prevent connection leaks
+    if (typeof _payload?.db?.destroy === 'function') {
+      await _payload.db.destroy()
+    }
   })
 })

--- a/tests/int/reset-chat-endpoint.int.spec.ts
+++ b/tests/int/reset-chat-endpoint.int.spec.ts
@@ -107,6 +107,11 @@ afterAll(async () => {
     await payload.delete({ collection: 'users', id: testUserIdTwo, overrideAccess: true })
   }
 
+  // Close DB connection before stopping container
+  if (payload?.db?.destroy) {
+    await payload.db.destroy()
+  }
+
   await stopMongoContainer()
 
   if (originalDatabaseUrl !== undefined) {

--- a/tests/int/runtime-config.int.test.ts
+++ b/tests/int/runtime-config.int.test.ts
@@ -51,6 +51,11 @@ describe('Runtime Config Integration (Tenant-Scoped Secrets)', () => {
     } catch {
       // Ignore cleanup errors
     }
+
+    // Close DB connection to prevent connection leaks
+    if (payload.db?.destroy) {
+      await payload.db.destroy()
+    }
   })
 
   test('should load tenant-scoped secrets from real DB', async () => {

--- a/tests/int/summary-maintenance-detailed.int.spec.ts
+++ b/tests/int/summary-maintenance-detailed.int.spec.ts
@@ -80,6 +80,11 @@ afterAll(async () => {
     await payload.delete({ collection: 'users', id: testUserId, overrideAccess: true })
   }
 
+  // Close DB connection before stopping container
+  if (payload?.db?.destroy) {
+    await payload.db.destroy()
+  }
+
   await stopMongoContainer()
 
   if (originalDatabaseUrl !== undefined) {

--- a/tests/int/system-params.int.test.ts
+++ b/tests/int/system-params.int.test.ts
@@ -51,6 +51,11 @@ describe('SystemParams Integration (ConfigValues-based)', () => {
     } catch {
       // Ignore cleanup errors
     }
+
+    // Close DB connection to prevent connection leaks
+    if (payload.db?.destroy) {
+      await payload.db.destroy()
+    }
   })
 
   test('should return default values when config not seeded', async () => {

--- a/tests/int/vector-search-validation.int.spec.ts
+++ b/tests/int/vector-search-validation.int.spec.ts
@@ -159,6 +159,11 @@ describe.skipIf(!hasOpenAIKey || !hasAtlasUrl)('Vector Search Validation Integra
         id: testUserId,
       })
     }
+
+    // Close DB connection to prevent connection leaks
+    if (payload.db?.destroy) {
+      await payload.db.destroy()
+    }
   }, 30000)
 
   describe('Index Existence and Configuration', () => {

--- a/tests/setup/global-int-setup.ts
+++ b/tests/setup/global-int-setup.ts
@@ -1,0 +1,29 @@
+/**
+ * Global setup/teardown for integration tests
+ *
+ * This file manages the MongoDB connection lifecycle for all integration tests.
+ * The teardown function ensures all DB connections are properly closed,
+ * preventing connection leaks and test runner hangs.
+ */
+
+export async function setup() {
+  // Payload singleton will be initialized by individual test files
+  // This hook is a placeholder for future shared setup
+  console.log('[global-int-setup] Integration test suite starting')
+}
+
+export async function teardown() {
+  // Safety net: destroy any remaining DB connections
+  try {
+    const { getPayload } = await import('payload')
+    const config = await import('@payload-config')
+    const payload = await getPayload({ config: config.default })
+    if (payload?.db?.destroy) {
+      await payload.db.destroy()
+    }
+    console.log('[global-int-teardown] DB connection destroyed')
+  } catch {
+    // Fine — Payload may not have initialized (tests were skipped)
+    console.log('[global-int-teardown] No Payload instance to clean up')
+  }
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -9,6 +9,8 @@ loadEnv({ path: '.env.test', override: true })
 export default defineConfig({
   plugins: [tsconfigPaths(), react()],
   test: {
+    fileParallelism: false, // Run test files sequentially to avoid exhausting MongoDB connection pool
+    globalSetup: ['./tests/setup/global-int-setup.ts'],
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
     include: ['tests/int/**/*.int.spec.ts', 'tests/int/**/*.int.spec.tsx'],


### PR DESCRIPTION
Changes:
- Add fileParallelism: false to vitest.config.mts to serialize test file execution
- Add maxPoolSize: 5 for test environment in mongooseAdapter config
- Add payload.db.destroy() to 22 integration test files to prevent connection leaks
- Create global-int-setup.ts with setup/teardown functions for safety net
- Fix unused variable warning (adminUser -> _adminUser)

This fixes the 500-connection Atlas limit exhaustion by:
1. Running test files sequentially instead of in parallel workers
2. Reducing pool size from 100 to 5 connections per test process
3. Ensuring proper cleanup of DB connections after each test file
4. Adding a global safety net for connection cleanup

Expected result: Connections drop from ~500 (saturated) to ~10 (2%)