### PR TITLE
feat(chat): Add hidden message support for contextual help prompts

### DIFF
--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1046,6 +1046,10 @@ export interface Conversation {
         content: string;
         timestamp: string;
         /**
+         * Hidden messages are persisted for LLM context but excluded from client responses
+         */
+        hidden?: boolean | null;
+        /**
          * Media attachments for this message (max 5)
          */
         media?:
@@ -2302,6 +2306,7 @@ export interface ConversationsSelect<T extends boolean = true> {
         role?: T;
         content?: T;
         timestamp?: T;
+        hidden?: T;
         media?:
           | T
           | {

--- a/src/server/payload/collections/Conversations.ts
+++ b/src/server/payload/collections/Conversations.ts
@@ -178,6 +178,15 @@ export const Conversations: CollectionConfig = {
           },
         },
         {
+          name: 'hidden',
+          type: 'checkbox',
+          defaultValue: false,
+          admin: {
+            description:
+              'Hidden messages are persisted for LLM context but excluded from client responses',
+          },
+        },
+        {
           name: 'media',
           type: 'array',
           maxRows: 5,

--- a/src/server/payload/endpoints/agent/chat/pipeline.ts
+++ b/src/server/payload/endpoints/agent/chat/pipeline.ts
@@ -44,6 +44,7 @@ export function trimMessagesForUpdatePipeline(messages: Message[]): ChatMessage[
     content: m.content,
     timestamp: typeof m.timestamp === 'string' ? m.timestamp : m.timestamp.toISOString(),
     media: (m as unknown as { media?: Array<{ mediaId: string }> })?.media,
+    ...((m as unknown as { hidden?: boolean })?.hidden && { hidden: true }),
   }))
 }
 
@@ -173,12 +174,13 @@ export async function runChatPipeline(
 
   reqLogger.info({ conversationId, contextKey: context.contextKey }, 'Using conversation')
 
-  // Persist user message
+  // Persist user message (optionally hidden for contextual help prompts)
   const userMessage = {
     role: 'user' as const,
     content: validated.message,
     timestamp: new Date().toISOString(),
     media: validated.mediaIds?.map((id: string) => ({ mediaId: id })) || [],
+    ...(validated.hidden && { hidden: true }),
   }
 
   const conversationHistory = conversation.messages || []

--- a/src/server/payload/endpoints/agent/chat/request-validation.ts
+++ b/src/server/payload/endpoints/agent/chat/request-validation.ts
@@ -18,6 +18,8 @@ export const chatRequestSchema = z.object({
   mediaIds: z.array(z.string()).max(5).optional(),
   // Admin mode flag (for admin chat without context)
   adminMode: z.boolean().optional(),
+  // Hidden flag — message persisted for LLM context but excluded from client responses
+  hidden: z.boolean().optional(),
 })
 
 export type ChatRequest = z.infer<typeof chatRequestSchema>

--- a/src/server/payload/endpoints/agent/get-conversation.ts
+++ b/src/server/payload/endpoints/agent/get-conversation.ts
@@ -178,6 +178,8 @@ export async function getConversation(req: PayloadRequest & { json?: () => Promi
         if (!msg || !msg.role || !msg.content) return false
         if (typeof msg.content !== 'string' || msg.content.trim().length === 0) return false
         if (msg.role !== 'user' && msg.role !== 'assistant') return false
+        // Exclude hidden messages (contextual help prompts) from client responses
+        if (msg.hidden) return false
         return true
       })
       .map((msg) => {

--- a/src/server/services/api/api-service.ts
+++ b/src/server/services/api/api-service.ts
@@ -256,6 +256,7 @@ export const apiService = {
       courseId?: string
       categoryId?: string
     },
+    options?: { hidden?: boolean },
   ): AsyncGenerator<ChatStreamEvent, void, unknown> {
     const response = await fetch('/api/agent/chat/stream', {
       method: 'POST',
@@ -265,6 +266,7 @@ export const apiService = {
         message,
         acknowledgment,
         ...context,
+        ...(options?.hidden && { hidden: true }),
       }),
     })
 

--- a/src/ui/web/chat/hooks/useNotebookChat.ts
+++ b/src/ui/web/chat/hooks/useNotebookChat.ts
@@ -437,9 +437,10 @@ export function useNotebookChat({
       courseId?: string
       categoryId?: string
     },
+    options?: { hidden?: boolean },
   ) => {
     try {
-      const stream = apiService.chatStream(message, acknowledgment, context)
+      const stream = apiService.chatStream(message, acknowledgment, context, options)
 
       // Create placeholder assistant message for streaming
       const placeholderMessage: ChatMessage = {
@@ -627,13 +628,14 @@ export function useNotebookChat({
 
   /**
    * Send a contextual help prompt to the AI without showing a user message bubble.
+   * The prompt is persisted as hidden (for LLM context) but excluded from client responses.
    * Only the AI's streaming response appears in the chat.
    */
   const sendContextualHelp = async (prompt: string) => {
     if (isLoading || isLoadingHistory) return
     setIsLoading(true)
     const context = { exerciseId, lessonId, chapterId, courseId, categoryId }
-    await streamMessage(prompt, acknowledgment, context)
+    await streamMessage(prompt, acknowledgment, context, { hidden: true })
   }
 
   const dismissError = useCallback(() => {

--- a/tests/unit/hooks/useNotebookChat.test.ts
+++ b/tests/unit/hooks/useNotebookChat.test.ts
@@ -86,13 +86,18 @@ describe('useNotebookChat', () => {
     })
 
     await waitFor(() => expect(result.current.messages).toHaveLength(3))
-    expect(apiService.chatStream).toHaveBeenCalledWith('Hello', defaultProps.acknowledgment, {
-      exerciseId: defaultProps.exerciseId,
-      lessonId: defaultProps.lessonId,
-      chapterId: undefined,
-      courseId: undefined,
-      categoryId: undefined,
-    })
+    expect(apiService.chatStream).toHaveBeenCalledWith(
+      'Hello',
+      defaultProps.acknowledgment,
+      {
+        exerciseId: defaultProps.exerciseId,
+        lessonId: defaultProps.lessonId,
+        chapterId: undefined,
+        courseId: undefined,
+        categoryId: undefined,
+      },
+      undefined,
+    )
   })
 
   it('shows auth error when chat requires authentication', async () => {


### PR DESCRIPTION
Hidden messages are persisted in the conversation for LLM context but excluded from getConversation responses so they never appear in the client. sendContextualHelp now passes hidden: true through the existing streaming pipeline — no new endpoint needed.