### PR TITLE
feat: Update minimax model to M2.5 and add OpenCode workflow

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,33 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, ' /oc') ||
+      startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /opencode') ||
+      startsWith(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+        with:
+          model: minimax-coding-plan/MiniMax-M2.5

--- a/opencode.json
+++ b/opencode.json
@@ -3,7 +3,7 @@
   "instructions": [".ai-docs/BOOTSTRAP.md", ".ai-docs/quick-reference/CHEAT-SHEET.md"],
   "agent": {
     "build": {
-      "model": "minimax-coding-plan/MiniMax-M2.1",
+      "model": "minimax-coding-plan/MiniMax-M2.5",
       "description": "Building features, refactoring, implementing changes"
     },
     "plan": {
@@ -23,11 +23,11 @@
       "description": "Collects operator questions and answers"
     },
     "verify": {
-      "model": "minimax-coding-plan/MiniMax-M2.1",
+      "model": "minimax-coding-plan/MiniMax-M2.5",
       "description": "Runs tests, validates implementation passes all gates"
     },
     "test": {
-      "model": "minimax-coding-plan/MiniMax-M2.1",
+      "model": "minimax-coding-plan/MiniMax-M2.5",
       "description": "Writes E2E and integration tests using Playwright"
     },
     "advisor": {
@@ -35,11 +35,11 @@
       "description": "Code review, suggestions, best practices"
     },
     "auditor": {
-      "model": "minimax-coding-plan/MiniMax-M2.1",
+      "model": "minimax-coding-plan/MiniMax-M2.5",
       "description": "Process improvement analysis agent"
     },
     "pr": {
-      "model": "minimax-coding-plan/MiniMax-M2.1",
+      "model": "minimax-coding-plan/MiniMax-M2.5",
       "description": "Creates branch, commits changes, opens pull request"
     }
   },

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -597,9 +597,6 @@ export interface Media {
     | number
     | boolean
     | null;
-  folder?: (string | null) | FolderInterface;
-  updatedAt: string;
-  createdAt: string;
   url?: string | null;
   thumbnailURL?: string | null;
   filename?: string | null;
@@ -609,6 +606,9 @@ export interface Media {
   height?: number | null;
   focalX?: number | null;
   focalY?: number | null;
+  folder?: (string | null) | FolderInterface;
+  updatedAt: string;
+  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -2610,9 +2610,6 @@ export interface MediaSelect<T extends boolean = true> {
   retentionPolicy?: T;
   expiresAt?: T;
   sizes?: T;
-  folder?: T;
-  updatedAt?: T;
-  createdAt?: T;
   url?: T;
   thumbnailURL?: T;
   filename?: T;
@@ -2622,6 +2619,9 @@ export interface MediaSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
+  folder?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
- Update opencode.json to use MiniMax-M2.5 model across all agents
- Add .github/workflows/opencode.yml for GitHub integration with OpenCode
- Update payload-types.ts for schema changes