### PR TITLE
fix(chat): Forward auth cookies for server-to-server media fetch

### DIFF
--- a/src/infra/llm/services/exercise-chat-service.ts
+++ b/src/infra/llm/services/exercise-chat-service.ts
@@ -229,38 +229,49 @@ async function sendMultimodalToGenkit(
   payload: Payload,
 ): Promise<ExerciseChatResult> {
   // Convert media parts to Genkit-compatible attachments
+  // Fetches the direct blob URL from the media document (no auth required)
+  // since the Payload file-serving endpoint requires authentication
   const attachments: Array<{ data: string; mimeType: string }> = []
 
   for (const mediaPart of mediaPartsWithPath) {
-    if (mediaPart.mediaId) {
-      try {
-        const mediaDoc = await payload.findByID({
-          collection: 'media',
-          id: mediaPart.mediaId,
-          depth: 0,
-        })
+    try {
+      // Get the media doc to access the direct blob URL
+      const mediaDoc = await payload.findByID({
+        collection: 'media',
+        id: mediaPart.mediaId,
+        depth: 0,
+        overrideAccess: true,
+      })
 
-        if (mediaDoc && 'url' in mediaDoc && mediaDoc.url) {
-          // Fetch the image and convert to base64
-          const imageUrl = mediaDoc.url.startsWith('/')
-            ? `${process.env.PAYLOAD_PUBLIC_SERVER_URL || 'http://localhost:3000'}${mediaDoc.url}`
-            : mediaDoc.url
-
-          const response = await fetch(imageUrl)
-          const arrayBuffer = await response.arrayBuffer()
-          const base64 = Buffer.from(arrayBuffer).toString('base64')
-
-          attachments.push({
-            data: base64,
-            mimeType: mediaDoc.mimeType || 'image/jpeg',
-          })
-        }
-      } catch (fetchError) {
+      const blobUrl = (mediaDoc as { url?: string }).url
+      if (!blobUrl) {
         logger.warn(
-          { err: fetchError, mediaId: mediaPart.mediaId },
-          '[ExerciseChat] Failed to fetch media',
+          { mediaId: mediaPart.mediaId },
+          '[ExerciseChat] Media document has no url field',
         )
+        continue
       }
+
+      const response = await fetch(blobUrl)
+      if (!response.ok) {
+        logger.warn(
+          { mediaId: mediaPart.mediaId, status: response.status, url: blobUrl },
+          '[ExerciseChat] Failed to fetch media from blob - non-OK response',
+        )
+        continue
+      }
+      const arrayBuffer = await response.arrayBuffer()
+      const base64 = Buffer.from(arrayBuffer).toString('base64')
+
+      attachments.push({
+        data: base64,
+        mimeType: mediaPart.mimeType || 'image/jpeg',
+      })
+    } catch (fetchError) {
+      logger.warn(
+        { err: fetchError, mediaId: mediaPart.mediaId },
+        '[ExerciseChat] Failed to fetch media',
+      )
     }
   }
 

--- a/src/infra/llm/services/exercise-chat-service.ts
+++ b/src/infra/llm/services/exercise-chat-service.ts
@@ -103,6 +103,7 @@ export async function chatWithExerciseHelper(
         input.mediaPartsWithPath,
         modelConfig,
         payload,
+        input.req,
       )
     }
 
@@ -219,7 +220,7 @@ async function resolveModelConfig(modelKey: AIModelKey): Promise<AIModel> {
 
 /**
  * Send multimodal content (text + media) using Genkit adapter
- * Uses unified adapter for multimodal generation
+ * Fetches media via publicUrl with forwarded auth cookies (serverless compatible)
  */
 async function sendMultimodalToGenkit(
   systemPrompt: string,
@@ -227,36 +228,35 @@ async function sendMultimodalToGenkit(
   mediaPartsWithPath: MediaPartWithPath[],
   model: AIModel,
   payload: Payload,
+  reqContext?: { headers: { authorization?: string; cookie?: string } },
 ): Promise<ExerciseChatResult> {
-  // Convert media parts to Genkit-compatible attachments
-  // Fetches the direct blob URL from the media document (no auth required)
-  // since the Payload file-serving endpoint requires authentication
+  // Convert media parts to Genkit-compatible base64 attachments
+  // Uses publicUrl (absolute URL built from request origin) with forwarded cookies
   const attachments: Array<{ data: string; mimeType: string }> = []
+
+  // Build fetch headers with forwarded auth cookies for server-to-server calls
+  const fetchHeaders: Record<string, string> = {}
+  if (reqContext?.headers.cookie) {
+    fetchHeaders.cookie = reqContext.headers.cookie
+  }
+  if (reqContext?.headers.authorization) {
+    fetchHeaders.authorization = reqContext.headers.authorization
+  }
 
   for (const mediaPart of mediaPartsWithPath) {
     try {
-      // Get the media doc to access the direct blob URL
-      const mediaDoc = await payload.findByID({
-        collection: 'media',
-        id: mediaPart.mediaId,
-        depth: 0,
-        overrideAccess: true,
-      })
-
-      const blobUrl = (mediaDoc as { url?: string }).url
-      if (!blobUrl) {
-        logger.warn(
-          { mediaId: mediaPart.mediaId },
-          '[ExerciseChat] Media document has no url field',
-        )
+      if (!mediaPart.publicUrl) {
+        logger.warn({ mediaId: mediaPart.mediaId }, '[ExerciseChat] Media part has no publicUrl')
         continue
       }
 
-      const response = await fetch(blobUrl)
+      const response = await fetch(mediaPart.publicUrl, {
+        headers: fetchHeaders,
+      })
       if (!response.ok) {
         logger.warn(
-          { mediaId: mediaPart.mediaId, status: response.status, url: blobUrl },
-          '[ExerciseChat] Failed to fetch media from blob - non-OK response',
+          { mediaId: mediaPart.mediaId, status: response.status, url: mediaPart.publicUrl },
+          '[ExerciseChat] Failed to fetch media - non-OK response',
         )
         continue
       }


### PR DESCRIPTION
## Summary
- `sendMultimodalToGenkit` fetches uploaded images server-side to convert them to base64 for Gemini
- On Vercel, the server-to-server `fetch()` to `/api/media/file/` had no auth cookies, causing 401 errors
- Now threads `input.req` (user's auth cookies) through to the fetch call, authenticating properly
- Uses `mediaPart.publicUrl` (absolute URL already built from request origin) instead of querying the DB

## What changed
- Removed `payload.findByID` with `overrideAccess: true` (security concern)
- Added `reqContext` parameter to `sendMultimodalToGenkit` for cookie forwarding
- Fetch to media endpoint now includes forwarded `cookie` and `authorization` headers

## Test plan
- [ ] Upload an image via chat's Plus button on Vercel deploy
- [ ] Send a message with the image attached — AI should see and respond about the image
- [ ] Verify no 401, ECONNREFUSED, or "Invalid URL" errors in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)