### PR TITLE
fix(ci): Replace broken OpenCode CLI install with proven cache+PATH p…

### DIFF
--- a/.github/workflows/pipeline-orchestrated.yml
+++ b/.github/workflows/pipeline-orchestrated.yml
@@ -263,11 +263,30 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install OpenCode CLI
+      # OpenCode CLI setup — replicated from anomalyco/opencode/github@latest action.yml
+      # We don't use the Action directly because the orchestrator spawns
+      # `opencode github run` multiple times (once per pipeline stage).
+      - name: Get opencode version
+        id: oc-version
         run: |
-          curl -fsSL https://opencode.ai/install | bash
+          VERSION=$(curl -sf https://api.github.com/repos/anomalyco/opencode/releases/latest | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
+          echo "version=${VERSION:-latest}" >> $GITHUB_OUTPUT
+
+      - name: Cache opencode
+        uses: actions/cache@v4
+        id: oc-cache
+        with:
+          path: ~/.opencode/bin
+          key: opencode-${{ runner.os }}-${{ runner.arch }}-${{ steps.oc-version.outputs.version }}
+
+      - name: Install opencode
+        if: steps.oc-cache.outputs.cache-hit != 'true'
+        run: curl -fsSL https://opencode.ai/install | bash
+
+      - name: Add opencode to PATH
+        run: |
           echo "$HOME/.opencode/bin" >> $GITHUB_PATH
-          opencode --version
+          $HOME/.opencode/bin/opencode --version
 
       - name: Run orchestrated pipeline
         env:


### PR DESCRIPTION
…attern

- Replace single-step install with 4-step pattern from anomalyco/opencode/github@latest
- Fixes 'opencode: command not found' error caused by PATH not updating in same step
- Adds caching for faster subsequent runs
- Add comment explaining why we don't use the Action directly