### PR TITLE
fix(cody): Handle literal backslash-n in comment body parsing

### DIFF
--- a/scripts/cody/cody-utils.ts
+++ b/scripts/cody/cody-utils.ts
@@ -401,8 +401,15 @@ export function parseCommentBody(body: string, issueNumber?: number): ParseComme
     }
   }
 
-  // Remove /cody prefix and normalize whitespace
-  const cmd = decoded.replace(/^\/cody\s*/, '').trim()
+  // Normalize literal \n sequences to real newlines
+  // (double-escaping from the GitHub Actions → shell → pnpm → Node.js pipeline
+  //  can leave literal backslash-n instead of actual newlines)
+  decoded = decoded.replace(/\\n/g, '\n')
+
+  // Only parse the first line — /cody commands live on line 1;
+  // trailing lines are just whitespace or comment noise
+  const firstLine = decoded.split('\n')[0]
+  const cmd = firstLine.replace(/^\/cody\s*/, '').trim()
 
   // Extract subcommand (first word)
   const spaceIdx = cmd.indexOf(' ')


### PR DESCRIPTION
When a user comments just '/cody' on a GitHub issue, the newlines in the comment body get double-escaped through the GitHub Actions → shell → pnpm → Node.js pipeline. This causes literal \n sequences (backslash + n characters) to survive JSON.parse instead of being converted to real newlines. The parser then treats \n as an unknown subcommand and fails.

This fix normalizes literal \n to real newlines after JSON parsing, and only parses the first line of the comment body for robustness.