### PR TITLE
fix(cody): Prevent silent pipeline death when taskify writes invalid …

### DIFF
--- a/.tasks/260219-cody-pipeline-bugfix/plan.md
+++ b/.tasks/260219-cody-pipeline-bugfix/plan.md
@@ -1,0 +1,322 @@
+# Plan: Cody Pipeline Bugfix — "No Code in PR"
+
+## Root Cause Analysis
+
+After reviewing the Cody pipeline code (`scripts/cody/`) and three failing task runs (`260218-55`, `260219-my-task`, `260219-auto-34`), I identified **two compounding bugs**:
+
+### Bug 1 (PRIMARY): `taskify` agent writes inconsistent `pipeline` value in `task.json`
+The LLM-powered `taskify` stage writes valid enum values for `task_type` (e.g., `"fix_bug"`) but picks the **wrong** `pipeline` value. In the latest run:
+
+```json
+{
+  "task_type": "fix_bug",       // ✅ valid
+  "pipeline": "spec_only",      // ❌ WRONG — fix_bug requires "spec_execute_verify"
+  "confidence": 1.0,            // ✅ valid
+  ...
+}
+```
+
+The `PIPELINE_MAP` in `pipeline-utils.ts:62-70` enforces that `fix_bug → spec_execute_verify`, so this task.json fails the consistency check at line 136-143.
+
+### Bug 2 (FATAL): `readTask()` calls `process.exit(1)` on validation failure
+When `validateTask()` finds the pipeline inconsistency, `readTask()` (line 176) calls `process.exit(1)`. This:
+- **Kills the process silently** — no error thrown, no try/catch, no status update
+- **Bypasses all error handling** in `main()`, `runImplPipeline()`, and `runFullPipeline()`
+- **Leaves status.json in "running" state** forever (never updated to "failed")
+- **Leaves the PR with only spec files** because spec pipeline already committed them
+
+### Flow (what happens today)
+```
+1. /cody full → runFullPipeline()
+2. runSpecPipeline():
+   a. taskify → writes task.json with fix_bug + spec_only (inconsistent!) ← BUG 1
+   b. spec → creates spec.md ✅
+   c. clarify → creates questions.md/clarified.md ✅
+   d. commits all spec files to branch ✅
+3. runImplPipeline():
+   a. readTask() → validateTask() → "Pipeline inconsistency" error
+   b. process.exit(1) ← BUG 2 — silent death, no error handling
+4. Status stuck at "running". PR has only spec files. User sees "success" comment from spec phase.
+```
+
+### Why the user sees "success"
+The spec pipeline completes successfully and commits. The `commitTaskFilesCI()` pushes to the branch. If a PR was already created (or auto-created by a previous stage), it shows only spec files. The impl pipeline dies silently before it can produce any code.
+
+---
+
+## Assumptions
+
+- The `pipeline` field in task.json is **derivable** from `task_type` — there's a 1:1 mapping in `PIPELINE_MAP`. The agent doesn't need to guess it.
+- The `readTask()` `process.exit(1)` pattern was a development-time convenience that should be replaced with proper error handling.
+- Tests will be unit tests (pipeline-utils validation) and integration tests (pipeline flow).
+
+---
+
+## Step 1: Make `readTask()` throw instead of `process.exit(1)` (10 min)
+
+### Files
+- `scripts/cody/pipeline-utils.ts:148-182` (MODIFIED)
+
+### Exact Change
+Replace the two `process.exit(1)` calls in `readTask()` with `throw new Error(...)`:
+
+**JSON parse failure (line 161-171):**
+```
+// Before: process.exit(1)
+// After: throw new Error(`task.json is not valid JSON: ${preview}`)
+```
+
+**Validation failure (line 176-179):**
+```
+// Before: process.exit(1)  
+// After: throw new Error(`task.json validation failed:\n${result.errors.map(e => `  • ${e}`).join('\n')}`)
+```
+
+### Tests
+**File**: `tests/unit/cody/pipeline-utils.test.ts` (NEW)
+
+1. **Test: `readTask` throws on invalid JSON** — Create a temp dir with task.json containing `"not json {{"`. Call `readTask(tempDir)`. Expect it to throw with message matching `/not valid JSON/`.
+2. **Test: `readTask` throws on schema violation** — Create task.json with `{"task_type": "fix_bug", "pipeline": "spec_only", ...}` (inconsistent). Call `readTask(tempDir)`. Expect it to throw with message matching `/Pipeline inconsistency/`.
+
+### Acceptance Criteria
+- [ ] `readTask()` throws `Error` (not `process.exit`) on invalid JSON
+- [ ] `readTask()` throws `Error` (not `process.exit`) on validation failure
+- [ ] Error messages include the specific validation errors
+- [ ] `grep -r "process.exit" scripts/cody/pipeline-utils.ts` returns 0 matches
+
+---
+
+## Step 2: Auto-derive `pipeline` from `task_type` in `normalizeTask()` (15 min)
+
+### Files
+- `scripts/cody/pipeline-utils.ts` (MODIFIED — add `normalizeTask()`, export `PIPELINE_MAP`)
+
+### Exact Behavior
+Add a new function `normalizeTask(raw: Record<string, unknown>): Record<string, unknown>` that:
+
+1. **Always overrides `pipeline`** from `task_type` using `PIPELINE_MAP` — the agent should never choose this value; it's deterministic.
+2. **Wraps `scope` in array** if it's a string: `"foo"` → `["foo"]`
+3. **Converts string confidence** to number: `"high"` → `0.9`, `"medium"` → `0.7`, `"low"` → `0.5`
+4. **Maps common task_type aliases**: `"feature"` → `"implement_feature"`, `"bug"/"bugfix"` → `"fix_bug"`
+5. **Defaults missing arrays**: `missing_inputs` → `[]`, `assumptions` → `[]`
+
+Call `normalizeTask()` inside `readTask()` **before** `validateTask()`.
+
+The key insight: **`pipeline` should never be agent-determined**. It's a function of `task_type`. The normalization ensures this is always correct regardless of what the LLM writes.
+
+### Tests
+**File**: `tests/unit/cody/pipeline-utils.test.ts` (MODIFIED — add tests)
+
+1. **Test: `normalizeTask` fixes pipeline inconsistency** — Input: `{task_type: "fix_bug", pipeline: "spec_only"}`. Output: `pipeline` corrected to `"spec_execute_verify"`.
+2. **Test: `normalizeTask` maps common aliases** — Input: `{task_type: "feature", pipeline: "spec", confidence: "high", scope: "src/foo"}`. Output: `{task_type: "implement_feature", pipeline: "spec_execute_verify", confidence: 0.9, scope: ["src/foo"]}`.
+3. **Test: `normalizeTask` preserves valid values** — Input: fully valid task.json. Output: identical.
+4. **Test: `readTask` succeeds after normalization** — Create task.json with `{task_type: "fix_bug", pipeline: "spec_only", ...}` (the exact failing case). Call `readTask()`. Expect it to **succeed** and return `pipeline: "spec_execute_verify"`.
+
+### Acceptance Criteria
+- [ ] `normalizeTask()` always derives `pipeline` from `task_type` via `PIPELINE_MAP`
+- [ ] The exact `260219-auto-34` task.json (fix_bug + spec_only) would now pass validation
+- [ ] The exact `260218-55` task.json (feature + spec + "high") would now pass validation
+- [ ] Valid task.json passes through unchanged (except pipeline is re-derived — same value)
+
+---
+
+## Step 3: Handle `readTask()` errors gracefully in `runImplPipeline()` (10 min)
+
+### Files
+- `scripts/cody/cody.ts:435-439` (MODIFIED)
+
+### Exact Change
+Wrap the `readTask()` call in `runImplPipeline()` (line 436) in try/catch:
+
+```typescript
+let taskDef: TaskDefinition | null
+try {
+  taskDef = readTask(taskDir)
+} catch (error) {
+  const msg = error instanceof Error ? error.message : String(error)
+  console.error(`\n❌ Failed to read task definition: ${msg}`)
+  throw new Error(`Invalid task.json: ${msg}`)
+}
+```
+
+Also add a guard after line 439: if `taskDef.pipeline === 'spec_only'`, log a message and return early (don't attempt impl stages for spec-only tasks):
+
+```typescript
+if (taskDef.pipeline === 'spec_only') {
+  console.log('Task pipeline is spec_only — skipping implementation stages.')
+  return
+}
+```
+
+### Tests
+**File**: `tests/unit/cody/cody-impl-pipeline.test.ts` (NEW)
+
+1. **Test: `runImplPipeline` throws descriptive error on invalid task.json** — Create a task dir with invalid task.json (e.g., missing required fields that normalization can't fix). Mock backend. Call `runImplPipeline()`. Expect thrown error with descriptive message (not process.exit).
+2. **Test: `runImplPipeline` skips impl for spec_only pipeline** — Create a task dir with valid task.json where `task_type: "spec_only"`. Call `runImplPipeline()`. Expect it to return without running any stages.
+
+### Acceptance Criteria
+- [ ] Invalid task.json produces a thrown Error with clear message
+- [ ] Error propagates to `main()` which updates status to "failed" and posts GitHub comment
+- [ ] `spec_only` tasks return early from impl pipeline
+- [ ] No `process.exit` calls remain in the error path
+
+---
+
+## Step 4: Improve `taskify` prompt — remove `pipeline` field from agent output (10 min)
+
+### Files
+- `scripts/cody/stage-prompts.ts:45-58` (MODIFIED — `taskify` instruction)
+
+### Exact Change
+Since `pipeline` is now **always auto-derived** from `task_type` in `normalizeTask()`, the agent doesn't need to output it at all. Update the taskify prompt to:
+
+1. **Remove `pipeline` from the required fields list** — don't ask the agent to write it
+2. **Add an explicit JSON template** with example values
+3. **Add "WRONG → CORRECT" examples** for `task_type` to reduce hallucination
+4. Keep listing the valid `task_type` values explicitly
+
+New prompt excerpt:
+```
+Create a task.json. Write valid JSON only — no explanations, no code fences.
+
+Required fields:
+- task_type: One of: spec_only, implement_feature, fix_bug, refactor, docs, ops, research
+  Examples: "Add dark mode" → implement_feature, "Fix login crash" → fix_bug
+  WRONG: "feature", "bug", "bugfix" — use the exact values above
+- risk_level: One of: low, medium, high
+- confidence: Number 0.0-1.0 (e.g., 0.85)
+- primary_domain: One of: backend, frontend, infra, data, llm, devops, product
+- scope: Array of file paths affected (e.g., ["src/app/page.tsx"])
+- missing_inputs: Array of {field, question} or empty []
+- assumptions: Array of strings
+
+NOTE: Do NOT include a "pipeline" field — it is auto-derived from task_type.
+
+Example:
+{
+  "task_type": "fix_bug",
+  "risk_level": "low",
+  "confidence": 0.9,
+  "primary_domain": "frontend",
+  "scope": ["src/components/Login.tsx"],
+  "missing_inputs": [],
+  "assumptions": ["The bug is in the login form validation"]
+}
+```
+
+### Tests
+**File**: `tests/unit/cody/stage-prompts.test.ts` (NEW)
+
+1. **Test: taskify prompt lists all valid task_type values** — Call `buildStagePrompt({taskId: '260219-test'} as CodyInput, 'taskify')`. Verify returned string contains `implement_feature`, `fix_bug`, `refactor`, `spec_only`, `docs`, `ops`, `research`.
+2. **Test: taskify prompt does NOT ask for pipeline field** — Verify the prompt does NOT contain `"pipeline":` in the required fields section (it may mention "auto-derived").
+3. **Test: taskify prompt includes JSON example** — Verify the prompt contains a valid JSON example.
+
+### Acceptance Criteria
+- [ ] Prompt no longer asks agent to write `pipeline` field
+- [ ] Prompt includes explicit JSON example
+- [ ] Prompt lists all 7 valid `task_type` values
+- [ ] `normalizeTask()` handles missing `pipeline` field (derives from `task_type`)
+
+---
+
+## Step 5: Add post-taskify validation in spec pipeline (15 min)
+
+### Files
+- `scripts/cody/cody.ts:303-347` (MODIFIED — inside `runSpecPipeline`, after taskify stage completes)
+
+### Exact Change
+After the `taskify` stage loop iteration succeeds (the file watcher detected task.json), add an immediate validation step:
+
+```typescript
+// After taskify completes, validate task.json immediately
+if (stage === 'taskify' && fs.existsSync(outputFile)) {
+  try {
+    readTask(taskDir)  // This now normalizes + validates
+    console.log('✓ task.json validated successfully')
+  } catch (error) {
+    // Delete invalid file so retry can recreate it
+    fs.unlinkSync(outputFile)
+    updateStageStatus(input.taskId, stage, 'failed', { 
+      error: error instanceof Error ? error.message : 'Invalid task.json'
+    })
+    throw new Error(`Taskify produced invalid task.json: ${error instanceof Error ? error.message : error}`)
+  }
+}
+```
+
+This catches problems **early** — at spec time, not impl time. If normalization can't fix the task.json (e.g., completely garbled), the pipeline fails fast with a clear message.
+
+### Tests
+**File**: `tests/unit/cody/spec-pipeline.test.ts` (NEW)
+
+1. **Test: spec pipeline validates task.json after taskify** — Mock agent runner to produce task.json with `{task_type: "fix_bug", pipeline: "spec_only"}`. Run spec pipeline. Verify it succeeds (normalization fixes it).
+2. **Test: spec pipeline fails fast on unfixable task.json** — Mock agent runner to produce task.json with `{task_type: "banana"}`. Run spec pipeline. Verify it throws with "invalid task.json" message.
+
+### Acceptance Criteria
+- [ ] Valid-but-inconsistent task.json is auto-fixed and pipeline continues
+- [ ] Completely invalid task.json fails fast at taskify stage (not at impl time)
+- [ ] Error message is posted to GitHub issue
+
+---
+
+## Step 6: End-to-end dry-run regression test (15 min)
+
+### Files
+- `tests/unit/cody/full-pipeline-dryrun.test.ts` (NEW)
+
+### Behavior
+Test the complete `full` pipeline in dry-run mode, which exercises the real code paths but skips agent execution:
+
+1. **Happy path**: Create temp task dir with valid task.md. Run `full` pipeline in dry-run. Verify all output files exist and status is `completed`.
+2. **The exact bug scenario**: Create temp task dir, write task.json with `{task_type: "fix_bug", pipeline: "spec_only", ...}` (the exact failing values from `260219-auto-34`). Call `readTask()`. Verify it **succeeds** with `pipeline: "spec_execute_verify"`.
+3. **Silent death prevention**: Verify `pipeline-utils.ts` contains zero `process.exit` calls.
+
+### Tests
+
+1. **Test: readTask normalizes the exact 260219-auto-34 task.json** — Use the literal JSON from the user's report. Expect `readTask()` returns `{pipeline: "spec_execute_verify"}`.
+2. **Test: readTask normalizes the exact 260218-55 task.json** — Use the literal JSON from the earlier bug. Expect `readTask()` returns successfully with corrected values.
+3. **Test: no process.exit in pipeline-utils.ts** — Read the file contents and assert no `process.exit` calls exist.
+
+### Acceptance Criteria
+- [ ] Both real-world failing task.json inputs now parse successfully
+- [ ] Zero `process.exit` calls in `pipeline-utils.ts`
+- [ ] Full pipeline dry-run completes with all stages
+
+---
+
+## Files Summary
+
+| File | Action | Description |
+|---|---|---|
+| `scripts/cody/pipeline-utils.ts` | MODIFY | Replace `process.exit(1)` with `throw`, add `normalizeTask()`, export `PIPELINE_MAP` |
+| `scripts/cody/cody.ts` | MODIFY | Handle readTask errors in runImplPipeline, add post-taskify validation in spec pipeline |
+| `scripts/cody/stage-prompts.ts` | MODIFY | Remove `pipeline` from taskify prompt, add JSON template |
+| `tests/unit/cody/pipeline-utils.test.ts` | NEW | Tests for readTask, normalizeTask, validateTask |
+| `tests/unit/cody/stage-prompts.test.ts` | NEW | Tests for prompt content |
+| `tests/unit/cody/cody-impl-pipeline.test.ts` | NEW | Tests for impl pipeline error handling |
+| `tests/unit/cody/spec-pipeline.test.ts` | NEW | Tests for post-taskify validation |
+| `tests/unit/cody/full-pipeline-dryrun.test.ts` | NEW | Regression tests with real-world failing inputs |
+
+## Verification Commands
+
+```bash
+# Run all new tests
+pnpm vitest run tests/unit/cody/
+
+# TypeScript check
+pnpm -s tsc --noEmit
+
+# Lint check  
+pnpm -s lint
+
+# Verify no process.exit in pipeline-utils
+grep -c "process.exit" scripts/cody/pipeline-utils.ts  # should be 0
+
+# Manual smoke test (dry-run, no agent needed)
+pnpm cody:run --task-id=260219-test --mode=full --dry-run --local
+```
+
+## Risk Assessment
+- **Risk**: Low — changes are in pipeline tooling only, not production application code
+- **Blast radius**: Only affects Cody pipeline execution
+- **Rollback**: Revert the commit; no data migrations or schema changes

--- a/.tasks/260219-cody-pipeline-bugfix/task.md
+++ b/.tasks/260219-cody-pipeline-bugfix/task.md
@@ -1,0 +1,9 @@
+# Task
+
+Bug in Cody pipeline: it successfully creates a task, spec files, and PR, and reports success ("fixed"), but the PR contains only spec/task scaffolding files — no actual code fix.
+
+## Observed Evidence
+
+1. `260219-my-task`: Pipeline ran `spec_execute_verify` but only completed `taskify→spec→clarify` stages, then marked "completed". No impl stages ran. No `task.json` was created (taskify output missing).
+2. `260218-55`: `task.json` has invalid enum values (`"feature"` not `"implement_feature"`, `"spec"` not `"spec_execute_verify"`, `"high"` not a number for confidence, `scope` is a string not an array). The agent created its own branch `opencode/issue437-...` bypassing pipeline branch naming.
+3. User reports seeing PRs with only task/spec files and no actual code changes.

--- a/scripts/cody/cody.ts
+++ b/scripts/cody/cody.ts
@@ -343,6 +343,24 @@ async function runSpecPipeline(
       retries: result.retries,
       outputFile: path.basename(outputFile),
     })
+
+    // Validate task.json immediately after taskify to catch LLM mistakes early
+    if (stage === 'taskify' && fs.existsSync(outputFile)) {
+      try {
+        readTask(taskDir) // normalizes + validates; writes back corrected values
+        console.log('  ✓ task.json validated and normalized')
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error)
+        console.error(`  ❌ task.json invalid after normalization: ${msg}`)
+        // Delete invalid file so retry can recreate it
+        fs.unlinkSync(outputFile)
+        updateStageStatus(input.taskId, stage, 'failed', {
+          error: `Invalid task.json: ${msg}`,
+        })
+        throw new Error(`Taskify produced invalid task.json: ${msg}`)
+      }
+    }
+
     console.log(`✓ ${stage} complete`)
   }
 
@@ -432,10 +450,23 @@ async function runImplPipeline(
     throw new Error(`clarified.md not found. Run spec pipeline first or create it.`)
   }
 
-  // Get task definition
-  const taskDef = readTask(taskDir)
+  // Get task definition (readTask now throws on invalid JSON/schema instead of process.exit)
+  let taskDef
+  try {
+    taskDef = readTask(taskDir)
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error)
+    console.error(`\n❌ Failed to read task definition: ${msg}`)
+    throw new Error(`Invalid task.json: ${msg}`)
+  }
   if (!taskDef) {
     throw new Error(`task.json not found. Run spec pipeline first.`)
+  }
+
+  // Skip impl stages for spec-only pipelines
+  if (taskDef.pipeline === 'spec_only') {
+    console.log('Task pipeline is spec_only — skipping implementation stages.')
+    return
   }
 
   // Determine stages based on task type

--- a/scripts/cody/pipeline-utils.ts
+++ b/scripts/cody/pipeline-utils.ts
@@ -59,7 +59,7 @@ export interface TaskDefinition {
 }
 
 // Pipeline consistency: task_type → allowed pipeline values
-const PIPELINE_MAP: Record<TaskType, Pipeline> = {
+export const PIPELINE_MAP: Record<TaskType, Pipeline> = {
   spec_only: 'spec_only',
   research: 'spec_only',
   docs: 'spec_only',
@@ -72,6 +72,92 @@ const PIPELINE_MAP: Record<TaskType, Pipeline> = {
 interface ValidationResult {
   valid: boolean
   errors: string[]
+}
+
+// --- Task type alias mapping (common LLM mistakes) ---
+
+const TASK_TYPE_ALIASES: Record<string, TaskType> = {
+  feature: 'implement_feature',
+  new_feature: 'implement_feature',
+  add_feature: 'implement_feature',
+  bug: 'fix_bug',
+  bugfix: 'fix_bug',
+  bug_fix: 'fix_bug',
+  hotfix: 'fix_bug',
+  refactoring: 'refactor',
+  cleanup: 'refactor',
+  documentation: 'docs',
+  doc: 'docs',
+  operations: 'ops',
+  devops: 'ops',
+  infra: 'ops',
+  spec: 'spec_only',
+  research_only: 'research',
+  investigate: 'research',
+}
+
+// --- Confidence string-to-number mapping ---
+
+const CONFIDENCE_MAP: Record<string, number> = {
+  high: 0.9,
+  medium: 0.7,
+  low: 0.5,
+  very_high: 0.95,
+  very_low: 0.3,
+}
+
+/**
+ * Normalize a raw task.json object, fixing common LLM mistakes:
+ * - Maps task_type aliases (e.g., "feature" → "implement_feature")
+ * - Always derives pipeline from task_type (agent should never set this)
+ * - Converts string confidence to number (e.g., "high" → 0.9)
+ * - Wraps scope in array if it's a string
+ * - Defaults missing arrays
+ */
+export function normalizeTask(raw: Record<string, unknown>): Record<string, unknown> {
+  const data = { ...raw }
+
+  // 1. Normalize task_type aliases
+  if (typeof data.task_type === 'string') {
+    const alias = TASK_TYPE_ALIASES[data.task_type.toLowerCase()]
+    if (alias) {
+      data.task_type = alias
+    }
+  }
+
+  // 2. Always derive pipeline from task_type (never trust agent's value)
+  if (VALID_TASK_TYPES.includes(data.task_type as TaskType)) {
+    data.pipeline = PIPELINE_MAP[data.task_type as TaskType]
+  }
+
+  // 3. Convert string confidence to number
+  if (typeof data.confidence === 'string') {
+    const mapped = CONFIDENCE_MAP[data.confidence.toLowerCase()]
+    if (mapped !== undefined) {
+      data.confidence = mapped
+    } else {
+      // Try parsing as number string (e.g., "0.9")
+      const parsed = parseFloat(data.confidence)
+      if (!isNaN(parsed) && parsed >= 0 && parsed <= 1) {
+        data.confidence = parsed
+      }
+    }
+  }
+
+  // 4. Wrap scope in array if string
+  if (typeof data.scope === 'string') {
+    data.scope = [data.scope]
+  }
+
+  // 5. Default missing arrays
+  if (!Array.isArray(data.missing_inputs)) {
+    data.missing_inputs = []
+  }
+  if (!Array.isArray(data.assumptions)) {
+    data.assumptions = []
+  }
+
+  return data
 }
 
 export function validateTask(raw: unknown): ValidationResult {
@@ -158,24 +244,33 @@ export function readTask(taskDir: string): TaskDefinition | null {
     raw = JSON.parse(content)
   } catch {
     const preview = content.slice(0, 200).replace(/\n/g, '\\n')
-    console.error(`\n❌ task.json is not valid JSON`)
-    console.error(`  File: ${taskFile}`)
-    console.error(`  Preview: ${preview}`)
-    console.error(`\n  Common causes:`)
-    console.error(`    • Agent wrapped JSON in markdown code fences`)
-    console.error(`    • Trailing comma in JSON`)
-    console.error(`    • Agent wrote commentary outside the JSON object`)
-    console.error(`\n  Fix task.json and re-run, or delete it to re-classify:`)
-    console.error(`    rm ${taskFile}`)
-    process.exit(1)
+    throw new Error(
+      `task.json is not valid JSON.\n` +
+        `  File: ${taskFile}\n` +
+        `  Preview: ${preview}\n` +
+        `  Common causes:\n` +
+        `    • Agent wrapped JSON in markdown code fences\n` +
+        `    • Trailing comma in JSON\n` +
+        `    • Agent wrote commentary outside the JSON object\n` +
+        `  Fix task.json and re-run, or delete it to re-classify:\n` +
+        `    rm ${taskFile}`,
+    )
+  }
+
+  // Normalize common LLM mistakes before validation
+  if (typeof raw === 'object' && raw !== null) {
+    raw = normalizeTask(raw as Record<string, unknown>)
+
+    // Write back normalized values so subsequent reads are consistent
+    fs.writeFileSync(taskFile, JSON.stringify(raw, null, 2) + '\n')
   }
 
   const result = validateTask(raw)
 
   if (!result.valid) {
-    console.error('\n❌ task.json validation failed:')
-    result.errors.forEach((err) => console.error(`  • ${err}`))
-    process.exit(1)
+    throw new Error(
+      `task.json validation failed:\n${result.errors.map((e) => `  • ${e}`).join('\n')}`,
+    )
   }
 
   return raw as TaskDefinition
@@ -209,7 +304,6 @@ const DRY_RUN_OUTPUTS: Record<string, (taskId: string) => string> = {
     JSON.stringify(
       {
         task_type: 'implement_feature',
-        pipeline: 'spec_execute_verify',
         risk_level: 'medium',
         confidence: 0.9,
         primary_domain: 'backend',

--- a/scripts/cody/stage-prompts.ts
+++ b/scripts/cody/stage-prompts.ts
@@ -47,15 +47,29 @@ export const stageInstructions: Record<Stage, (taskId: string) => string> = {
 Analyze the task description and create a task.json with these exact fields:
 
 - task_type: MUST be one of: spec_only, implement_feature, fix_bug, refactor, docs, ops, research
-- pipeline: MUST be one of: spec_only, spec_execute_verify
+  Examples: "Add dark mode" → implement_feature, "Fix login crash" → fix_bug, "Update README" → docs
+  WRONG values (do NOT use): "feature", "bug", "bugfix", "hotfix"
 - risk_level: MUST be one of: low, medium, high
-- confidence: MUST be a number between 0.0 and 1.0 (e.g., 0.9 for 90%)
+- confidence: MUST be a number between 0.0 and 1.0 (e.g., 0.85)
 - primary_domain: MUST be one of: backend, frontend, infra, data, llm, devops, product
-- scope: MUST be an array of strings (e.g., ["src/app", "src/components"])
-- missing_inputs: array of objects with "field" and "question" keys
+- scope: MUST be an array of file paths (e.g., ["src/app/page.tsx", "src/components/Login.tsx"])
+- missing_inputs: array of objects with "field" and "question" keys, or empty []
 - assumptions: array of strings
 
-Write valid JSON only - no explanations, no markdown code fences.`,
+NOTE: Do NOT include a "pipeline" field — it is auto-derived from task_type.
+
+Example output:
+{
+  "task_type": "fix_bug",
+  "risk_level": "low",
+  "confidence": 0.9,
+  "primary_domain": "frontend",
+  "scope": ["src/components/Login.tsx"],
+  "missing_inputs": [],
+  "assumptions": ["The bug is in the login form validation"]
+}
+
+Write valid JSON only — no explanations, no markdown code fences, no comments.`,
 
   spec: (taskId) => `${specOnlyInstructionTemplate.replace('{TASK_ID}', taskId)}
 

--- a/tests/unit/scripts/cody/pipeline-utils.test.ts
+++ b/tests/unit/scripts/cody/pipeline-utils.test.ts
@@ -1,0 +1,437 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+import {
+  validateTask,
+  readTask,
+  normalizeTask,
+  PIPELINE_MAP,
+} from '../../../../scripts/cody/pipeline-utils'
+
+// Helper: create a temp task directory with a task.json
+function createTempTaskDir(taskJson?: unknown): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cody-test-'))
+  if (taskJson !== undefined) {
+    const content = typeof taskJson === 'string' ? taskJson : JSON.stringify(taskJson, null, 2)
+    fs.writeFileSync(path.join(dir, 'task.json'), content)
+  }
+  return dir
+}
+
+// A valid task.json fixture
+const VALID_TASK: Record<string, unknown> = {
+  task_type: 'implement_feature',
+  pipeline: 'spec_execute_verify',
+  risk_level: 'medium',
+  confidence: 0.9,
+  primary_domain: 'backend',
+  scope: ['src/app'],
+  missing_inputs: [],
+  assumptions: ['Assumption 1'],
+}
+
+// The exact task.json from the 260219-auto-34 bug report
+const BUG_260219_AUTO_34: Record<string, unknown> = {
+  task_type: 'fix_bug',
+  pipeline: 'spec_only', // WRONG — should be spec_execute_verify
+  risk_level: 'low',
+  confidence: 1.0,
+  primary_domain: 'frontend',
+  scope: ['src/ui/web/homepage/GreetingFlow/index.tsx'],
+  missing_inputs: [],
+  assumptions: [
+    'The speed parameter in TypingAnimation represents milliseconds per character',
+    'Reducing speed by half means increasing the speed value from 100 to 200 (slower typing)',
+    'There are 3 occurrences of speed={100} in the GreetingFlow component that all need to be updated',
+  ],
+}
+
+// The exact task.json from the 260218-55 bug report
+const BUG_260218_55: Record<string, unknown> = {
+  task_type: 'feature',
+  pipeline: 'spec',
+  risk_level: 'low',
+  confidence: 'high',
+  primary_domain: 'frontend',
+  scope: 'Reduce home welcome typing text speed by half (from 50ms to 100ms per character)',
+  missing_inputs: [],
+  assumptions: [
+    'The current typing speed is 50ms per character in GreetingFlow component',
+    'Reducing speed by half means doubling the delay to 100ms per character',
+    'All three TypingAnimation usages in GreetingFlow need to be updated',
+  ],
+}
+
+describe('pipeline-utils', () => {
+  let tempDirs: string[] = []
+
+  afterEach(() => {
+    // Cleanup temp dirs
+    for (const dir of tempDirs) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true })
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+    tempDirs = []
+  })
+
+  function trackDir(dir: string): string {
+    tempDirs.push(dir)
+    return dir
+  }
+
+  // ==========================================================================
+  // validateTask
+  // ==========================================================================
+  describe('validateTask', () => {
+    it('should accept a fully valid task.json', () => {
+      const result = validateTask(VALID_TASK)
+      expect(result.valid).toBe(true)
+      expect(result.errors).toHaveLength(0)
+    })
+
+    it('should reject non-object input', () => {
+      const result = validateTask('not an object')
+      expect(result.valid).toBe(false)
+      expect(result.errors[0]).toContain('not a JSON object')
+    })
+
+    it('should reject null input', () => {
+      const result = validateTask(null)
+      expect(result.valid).toBe(false)
+    })
+
+    it('should reject invalid task_type', () => {
+      const result = validateTask({ ...VALID_TASK, task_type: 'banana' })
+      expect(result.valid).toBe(false)
+      expect(result.errors[0]).toContain('Invalid task_type')
+      expect(result.errors[0]).toContain('banana')
+    })
+
+    it('should reject invalid pipeline', () => {
+      const result = validateTask({ ...VALID_TASK, pipeline: 'banana' })
+      expect(result.valid).toBe(false)
+      expect(result.errors[0]).toContain('Invalid pipeline')
+    })
+
+    it('should reject pipeline inconsistency (fix_bug + spec_only)', () => {
+      const result = validateTask({
+        ...VALID_TASK,
+        task_type: 'fix_bug',
+        pipeline: 'spec_only',
+      })
+      expect(result.valid).toBe(false)
+      expect(result.errors[0]).toContain('Pipeline inconsistency')
+    })
+
+    it('should reject string confidence', () => {
+      const result = validateTask({ ...VALID_TASK, confidence: 'high' })
+      expect(result.valid).toBe(false)
+      expect(result.errors[0]).toContain('Invalid confidence')
+    })
+
+    it('should reject confidence out of range', () => {
+      expect(validateTask({ ...VALID_TASK, confidence: 1.5 }).valid).toBe(false)
+      expect(validateTask({ ...VALID_TASK, confidence: -0.1 }).valid).toBe(false)
+    })
+
+    it('should reject non-array scope', () => {
+      const result = validateTask({ ...VALID_TASK, scope: 'not-array' })
+      expect(result.valid).toBe(false)
+      expect(result.errors[0]).toContain('scope')
+    })
+
+    it('should reject non-array missing_inputs', () => {
+      const result = validateTask({ ...VALID_TASK, missing_inputs: 'not-array' })
+      expect(result.valid).toBe(false)
+    })
+
+    it('should reject non-array assumptions', () => {
+      const result = validateTask({ ...VALID_TASK, assumptions: 'not-array' })
+      expect(result.valid).toBe(false)
+    })
+
+    it('should collect multiple errors at once', () => {
+      const result = validateTask({
+        task_type: 'banana',
+        pipeline: 'cherry',
+        risk_level: 'extreme',
+        confidence: 'very_high',
+        primary_domain: 'magic',
+        scope: 'not-array',
+        missing_inputs: 'not-array',
+        assumptions: 'not-array',
+      })
+      expect(result.valid).toBe(false)
+      expect(result.errors.length).toBeGreaterThan(3)
+    })
+  })
+
+  // ==========================================================================
+  // normalizeTask
+  // ==========================================================================
+  describe('normalizeTask', () => {
+    it('should derive pipeline from task_type (fix_bug → spec_execute_verify)', () => {
+      const result = normalizeTask({
+        task_type: 'fix_bug',
+        pipeline: 'spec_only', // wrong value
+      })
+      expect(result.pipeline).toBe('spec_execute_verify')
+    })
+
+    it('should derive pipeline from task_type (spec_only → spec_only)', () => {
+      const result = normalizeTask({
+        task_type: 'spec_only',
+        pipeline: 'spec_execute_verify', // wrong value
+      })
+      expect(result.pipeline).toBe('spec_only')
+    })
+
+    it('should derive pipeline from task_type (implement_feature → spec_execute_verify)', () => {
+      const result = normalizeTask({ task_type: 'implement_feature' })
+      expect(result.pipeline).toBe('spec_execute_verify')
+    })
+
+    it('should derive pipeline even when pipeline field is missing', () => {
+      const result = normalizeTask({ task_type: 'fix_bug' })
+      expect(result.pipeline).toBe('spec_execute_verify')
+    })
+
+    it('should map task_type alias "feature" → "implement_feature"', () => {
+      const result = normalizeTask({ task_type: 'feature' })
+      expect(result.task_type).toBe('implement_feature')
+      expect(result.pipeline).toBe('spec_execute_verify')
+    })
+
+    it('should map task_type alias "bug" → "fix_bug"', () => {
+      const result = normalizeTask({ task_type: 'bug' })
+      expect(result.task_type).toBe('fix_bug')
+      expect(result.pipeline).toBe('spec_execute_verify')
+    })
+
+    it('should map task_type alias "bugfix" → "fix_bug"', () => {
+      const result = normalizeTask({ task_type: 'bugfix' })
+      expect(result.task_type).toBe('fix_bug')
+    })
+
+    it('should map task_type alias "hotfix" → "fix_bug"', () => {
+      const result = normalizeTask({ task_type: 'hotfix' })
+      expect(result.task_type).toBe('fix_bug')
+    })
+
+    it('should map task_type alias "doc" → "docs"', () => {
+      const result = normalizeTask({ task_type: 'doc' })
+      expect(result.task_type).toBe('docs')
+      expect(result.pipeline).toBe('spec_only')
+    })
+
+    it('should convert string confidence "high" → 0.9', () => {
+      const result = normalizeTask({ confidence: 'high' })
+      expect(result.confidence).toBe(0.9)
+    })
+
+    it('should convert string confidence "medium" → 0.7', () => {
+      const result = normalizeTask({ confidence: 'medium' })
+      expect(result.confidence).toBe(0.7)
+    })
+
+    it('should convert string confidence "low" → 0.5', () => {
+      const result = normalizeTask({ confidence: 'low' })
+      expect(result.confidence).toBe(0.5)
+    })
+
+    it('should parse numeric string confidence "0.85" → 0.85', () => {
+      const result = normalizeTask({ confidence: '0.85' })
+      expect(result.confidence).toBe(0.85)
+    })
+
+    it('should preserve valid numeric confidence', () => {
+      const result = normalizeTask({ confidence: 0.9 })
+      expect(result.confidence).toBe(0.9)
+    })
+
+    it('should wrap string scope in array', () => {
+      const result = normalizeTask({ scope: 'src/app/page.tsx' })
+      expect(result.scope).toEqual(['src/app/page.tsx'])
+    })
+
+    it('should preserve array scope', () => {
+      const result = normalizeTask({ scope: ['src/a', 'src/b'] })
+      expect(result.scope).toEqual(['src/a', 'src/b'])
+    })
+
+    it('should default missing missing_inputs to empty array', () => {
+      const result = normalizeTask({})
+      expect(result.missing_inputs).toEqual([])
+    })
+
+    it('should default missing assumptions to empty array', () => {
+      const result = normalizeTask({})
+      expect(result.assumptions).toEqual([])
+    })
+
+    it('should preserve already-valid task unchanged (except pipeline re-derived)', () => {
+      const result = normalizeTask({ ...VALID_TASK })
+      expect(result.task_type).toBe('implement_feature')
+      expect(result.pipeline).toBe('spec_execute_verify')
+      expect(result.risk_level).toBe('medium')
+      expect(result.confidence).toBe(0.9)
+      expect(result.primary_domain).toBe('backend')
+      expect(result.scope).toEqual(['src/app'])
+    })
+
+    it('should fix the exact 260219-auto-34 bug (fix_bug + spec_only)', () => {
+      const result = normalizeTask({ ...BUG_260219_AUTO_34 })
+      expect(result.task_type).toBe('fix_bug')
+      expect(result.pipeline).toBe('spec_execute_verify')
+      // After normalization, it should pass validation
+      const validation = validateTask(result)
+      expect(validation.valid).toBe(true)
+    })
+
+    it('should fix the exact 260218-55 bug (feature + spec + high + string scope)', () => {
+      const result = normalizeTask({ ...BUG_260218_55 })
+      expect(result.task_type).toBe('implement_feature')
+      expect(result.pipeline).toBe('spec_execute_verify')
+      expect(result.confidence).toBe(0.9)
+      expect(Array.isArray(result.scope)).toBe(true)
+      // After normalization, it should pass validation
+      const validation = validateTask(result)
+      expect(validation.valid).toBe(true)
+    })
+
+    it('should not mutate the original object', () => {
+      const original = { task_type: 'feature', pipeline: 'spec' }
+      normalizeTask(original)
+      expect(original.task_type).toBe('feature') // unchanged
+    })
+  })
+
+  // ==========================================================================
+  // PIPELINE_MAP
+  // ==========================================================================
+  describe('PIPELINE_MAP', () => {
+    it('should map fix_bug to spec_execute_verify', () => {
+      expect(PIPELINE_MAP.fix_bug).toBe('spec_execute_verify')
+    })
+
+    it('should map implement_feature to spec_execute_verify', () => {
+      expect(PIPELINE_MAP.implement_feature).toBe('spec_execute_verify')
+    })
+
+    it('should map spec_only to spec_only', () => {
+      expect(PIPELINE_MAP.spec_only).toBe('spec_only')
+    })
+
+    it('should map research to spec_only', () => {
+      expect(PIPELINE_MAP.research).toBe('spec_only')
+    })
+
+    it('should map docs to spec_only', () => {
+      expect(PIPELINE_MAP.docs).toBe('spec_only')
+    })
+  })
+
+  // ==========================================================================
+  // readTask
+  // ==========================================================================
+  describe('readTask', () => {
+    it('should return null when task.json does not exist', () => {
+      const dir = trackDir(createTempTaskDir())
+      const result = readTask(dir)
+      expect(result).toBeNull()
+    })
+
+    it('should throw on invalid JSON (not process.exit)', () => {
+      const dir = trackDir(createTempTaskDir('not valid json {{'))
+      expect(() => readTask(dir)).toThrow(/not valid JSON/)
+    })
+
+    it('should throw on empty file', () => {
+      const dir = trackDir(createTempTaskDir(''))
+      // Empty string is not valid JSON
+      expect(() => readTask(dir)).toThrow()
+    })
+
+    it('should throw on JSON wrapped in markdown code fences', () => {
+      const dir = trackDir(createTempTaskDir('```json\n{"task_type": "fix_bug"}\n```'))
+      expect(() => readTask(dir)).toThrow(/not valid JSON/)
+    })
+
+    it('should read and return a fully valid task.json', () => {
+      const dir = trackDir(createTempTaskDir(VALID_TASK))
+      const result = readTask(dir)
+      expect(result).not.toBeNull()
+      expect(result!.task_type).toBe('implement_feature')
+      expect(result!.pipeline).toBe('spec_execute_verify')
+    })
+
+    it('should normalize and succeed for the 260219-auto-34 bug case', () => {
+      const dir = trackDir(createTempTaskDir(BUG_260219_AUTO_34))
+      // This previously would have called process.exit(1)!
+      const result = readTask(dir)
+      expect(result).not.toBeNull()
+      expect(result!.task_type).toBe('fix_bug')
+      expect(result!.pipeline).toBe('spec_execute_verify') // fixed!
+    })
+
+    it('should normalize and succeed for the 260218-55 bug case', () => {
+      const dir = trackDir(createTempTaskDir(BUG_260218_55))
+      // This previously would have called process.exit(1)!
+      const result = readTask(dir)
+      expect(result).not.toBeNull()
+      expect(result!.task_type).toBe('implement_feature') // "feature" → "implement_feature"
+      expect(result!.pipeline).toBe('spec_execute_verify')
+      expect(result!.confidence).toBe(0.9) // "high" → 0.9
+      expect(Array.isArray(result!.scope)).toBe(true)
+    })
+
+    it('should write back normalized task.json to disk', () => {
+      const dir = trackDir(createTempTaskDir(BUG_260219_AUTO_34))
+      readTask(dir)
+
+      // Re-read the file from disk
+      const onDisk = JSON.parse(fs.readFileSync(path.join(dir, 'task.json'), 'utf-8'))
+      expect(onDisk.pipeline).toBe('spec_execute_verify')
+    })
+
+    it('should throw on completely unfixable task.json', () => {
+      const dir = trackDir(
+        createTempTaskDir({
+          task_type: 'banana', // not a valid type and not an alias
+          risk_level: 'extreme',
+          confidence: 'impossible',
+          primary_domain: 'magic',
+          scope: 42,
+        }),
+      )
+      expect(() => readTask(dir)).toThrow(/validation failed/)
+    })
+
+    it('should include specific error details in thrown error', () => {
+      const dir = trackDir(
+        createTempTaskDir({
+          task_type: 'banana',
+          pipeline: 'cherry',
+          risk_level: 'low',
+          confidence: 0.9,
+          primary_domain: 'frontend',
+          scope: ['src'],
+          missing_inputs: [],
+          assumptions: [],
+        }),
+      )
+      try {
+        readTask(dir)
+        expect.fail('Should have thrown')
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error)
+        expect((error as Error).message).toContain('Invalid task_type')
+        expect((error as Error).message).toContain('banana')
+      }
+    })
+  })
+})

--- a/tests/unit/scripts/cody/stage-prompts.test.ts
+++ b/tests/unit/scripts/cody/stage-prompts.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { buildStagePrompt, stageInstructions } from '../../../../scripts/cody/stage-prompts'
+import type { CodyInput } from '../../../../scripts/cody/cody-utils'
+
+const mockInput: CodyInput = {
+  mode: 'full',
+  taskId: '260219-test',
+  dryRun: false,
+}
+
+describe('stage-prompts', () => {
+  describe('taskify prompt', () => {
+    it('should list all valid task_type values', () => {
+      const prompt = buildStagePrompt(mockInput, 'taskify')
+      const validTypes = [
+        'spec_only',
+        'implement_feature',
+        'fix_bug',
+        'refactor',
+        'docs',
+        'ops',
+        'research',
+      ]
+      for (const type of validTypes) {
+        expect(prompt).toContain(type)
+      }
+    })
+
+    it('should NOT ask agent to write pipeline field', () => {
+      const prompt = buildStagePrompt(mockInput, 'taskify')
+      // The prompt should tell the agent NOT to include pipeline
+      expect(prompt).toContain('Do NOT include a "pipeline" field')
+    })
+
+    it('should include a JSON example', () => {
+      const prompt = buildStagePrompt(mockInput, 'taskify')
+      // Should contain a JSON example with valid task_type
+      expect(prompt).toContain('"task_type"')
+      expect(prompt).toContain('"fix_bug"')
+      expect(prompt).toContain('"scope"')
+    })
+
+    it('should warn about common WRONG values', () => {
+      const prompt = buildStagePrompt(mockInput, 'taskify')
+      expect(prompt).toContain('WRONG')
+      expect(prompt).toContain('"feature"')
+    })
+
+    it('should include the task ID and context path', () => {
+      const prompt = buildStagePrompt(mockInput, 'taskify')
+      expect(prompt).toContain('260219-test')
+      expect(prompt).toContain('.context.md')
+    })
+
+    it('should include spec-only instruction (no code changes)', () => {
+      const prompt = buildStagePrompt(mockInput, 'taskify')
+      expect(prompt).toContain('DO NOT create branches')
+      expect(prompt).toContain('DO NOT modify any code files')
+    })
+
+    it('should not include pipeline in the example JSON', () => {
+      // The example JSON should not have a pipeline field
+      const instruction = stageInstructions.taskify('260219-test')
+      // Find the JSON example block
+      const exampleMatch = instruction.match(/Example output:\s*\{[\s\S]*?\}/)
+      if (exampleMatch) {
+        expect(exampleMatch[0]).not.toContain('"pipeline"')
+      }
+    })
+  })
+
+  describe('other stage prompts', () => {
+    it('should build valid prompts for all stages', () => {
+      const stages = [
+        'taskify',
+        'spec',
+        'clarify',
+        'architect',
+        'build',
+        'test',
+        'verify',
+        'auditor',
+        'pr',
+      ]
+      for (const stage of stages) {
+        const prompt = buildStagePrompt(mockInput, stage)
+        expect(prompt.length).toBeGreaterThan(10)
+        expect(prompt).toContain('260219-test')
+      }
+    })
+  })
+})


### PR DESCRIPTION
…task.json

Root cause: LLM taskify agent writes inconsistent pipeline values in task.json (e.g., fix_bug + spec_only). readTask() called process.exit(1) on validation failure, silently killing the process. Spec files were already committed, so the PR contained only scaffolding — no code.

Changes:
- Replace process.exit(1) with throw in readTask() for proper error handling
- Add normalizeTask() that auto-derives pipeline from task_type via PIPELINE_MAP
- Map common LLM task_type aliases (feature→implement_feature, bug→fix_bug)
- Convert string confidence to numbers (high→0.9, medium→0.7, low→0.5)
- Wrap string scope in array, default missing arrays
- Handle readTask errors gracefully in runImplPipeline (try/catch, not death)
- Skip impl stages for spec_only pipelines
- Validate task.json immediately after taskify stage (fail fast)
- Remove pipeline from taskify prompt (auto-derived, agent shouldn't set it)
- Add 57 tests covering normalization, validation, and real-world bug cases