### PR TITLE
fix(media): Allow External media type to save without file upload

### DIFF
--- a/.tasks/media-external-fix/build.md
+++ b/.tasks/media-external-fix/build.md
@@ -1,0 +1,58 @@
+# Build Agent Report: media-external-fix
+
+## Changes
+
+- **Modified** `src/server/payload/collections/Media/index.ts` - Changed adminThumbnail from string `'thumbnail'` to a function that:
+  - Returns YouTube thumbnail URL for External YouTube media (`https://img.youtube.com/vi/{id}/mqdefault.jpg`)
+  - Returns null for other External media
+  - Returns doc.url for uploaded files
+  - Imported `extractYouTubeVideoId` and `isYouTubeUrl` from `@/infra/media/youtube`
+
+- **Modified** `src/server/payload/collections/Media/hooks/validateMediaUpload.ts` - Added filename auto-population for External media:
+  - Sets filename from URL hostname (e.g., 'youtube.com', 'vimeo.com')
+  - Falls back to 'External' for invalid URLs
+  - Preserves pre-existing filename if provided
+
+- **Modified** `src/ui/admin/ExerciseContentEditor/MediaPicker.tsx` - Updated thumbnail URL logic:
+  - Changed from `itemAny.sizes?.thumbnail?.url || item.url` to `item.thumbnailURL || itemAny.sizes?.thumbnail?.url || item.url`
+  - Added fallback display text for External media: `item.filename || 'External'`
+
+- **Modified** `src/ui/admin/ExerciseContentEditor/index.tsx` - Updated BlockMediaDisplay:
+  - Changed thumbnail URL logic to use `thumbnailURL` first, then fall back to sizes
+
+- **Modified** `src/ui/admin/ExerciseContentEditor/editors/InlineRichTextEditor.tsx` - Updated inline media display:
+  - Changed thumbnail URL logic to use `thumbnailURL` first
+  - Fixed condition to show thumbnail for external type when thumbnailUrl exists (was only showing for image type)
+
+- **Modified** `next.config.js` - Added `img.youtube.com` to `remotePatterns`:
+  - Added `{ protocol: 'https', hostname: 'img.youtube.com' }` to allow Next.js Image optimization to load YouTube thumbnails
+
+## Tests Written
+
+- `tests/unit/hooks/validateMediaUpload.test.ts` - Added 4 tests for filename auto-population:
+  - External media with YouTube URL gets youtube.com as filename
+  - External media with custom URL gets that hostname
+  - External media with invalid URL gets 'External' as fallback
+  - External media with pre-existing filename is not overwritten
+
+- `tests/unit/admin-thumbnail.test.ts` - Added 24 tests for YouTube thumbnail generation:
+  - isYouTubeUrl: recognizes all YouTube URL formats (watch, short, embed, shorts, live, mobile)
+  - extractYouTubeVideoId: extracts video IDs from all YouTube URL formats
+  - YouTube thumbnail URL generation
+  - adminThumbnail behavior simulation for various media types
+
+## Quality
+
+- TypeScript: PASS
+- Lint: PASS (pre-existing warnings unrelated to changes)
+- Unit Tests: PASS (1974 tests passed, including 28 new tests)
+
+## Summary
+
+Fixed 4 issues with External Media (YouTube/videos without uploaded files):
+1. **Media list view thumbnail** - YouTube External media now shows YouTube thumbnail
+2. **Media list view filename** - Shows hostname (youtube.com) instead of "undefined" for new External media
+3. **Exercise media picker** - Shows YouTube thumbnail in grid (after adding img.youtube.com to next.config.js remotePatterns)
+4. **Exercise block/inline media** - Shows YouTube thumbnail in previews
+
+The thumbnailURL virtual field is computed once on the server via adminThumbnail function, eliminating the need to duplicate YouTube detection logic in client components.

--- a/next.config.js
+++ b/next.config.js
@@ -41,6 +41,11 @@ const nextConfig = {
         protocol: 'https',
         hostname: '*.blob.vercel-storage.com',
       },
+      // Allow YouTube thumbnails for External media
+      {
+        protocol: 'https',
+        hostname: 'img.youtube.com',
+      },
     ],
   },
   outputFileTracingExcludes: {

--- a/src/infra/media/youtube.ts
+++ b/src/infra/media/youtube.ts
@@ -1,0 +1,67 @@
+/**
+ * @fileType utility
+ * @domain media
+ * @pattern youtube-detection
+ * @ai-summary Client-side YouTube URL detection and embed URL generation (no API calls)
+ */
+
+/**
+ * YouTube URL patterns supported:
+ * - https://www.youtube.com/watch?v=VIDEO_ID
+ * - https://youtu.be/VIDEO_ID
+ * - https://www.youtube.com/embed/VIDEO_ID
+ * - https://www.youtube.com/shorts/VIDEO_ID
+ * - https://www.youtube.com/live/VIDEO_ID
+ * - https://m.youtube.com/watch?v=VIDEO_ID
+ * - With extra query params (t=, list=, si=, etc.)
+ */
+
+const YOUTUBE_PATTERNS = [
+  // Standard watch URL: youtube.com/watch?v=ID
+  /(?:https?:\/\/)?(?:www\.|m\.)?youtube\.com\/watch\?.*v=([a-zA-Z0-9_-]{11})/,
+  // Short URL: youtu.be/ID
+  /(?:https?:\/\/)?youtu\.be\/([a-zA-Z0-9_-]{11})/,
+  // Embed URL: youtube.com/embed/ID
+  /(?:https?:\/\/)?(?:www\.)?youtube(?:-nocookie)?\.com\/embed\/([a-zA-Z0-9_-]{11})/,
+  // Shorts URL: youtube.com/shorts/ID
+  /(?:https?:\/\/)?(?:www\.)?youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})/,
+  // Live URL: youtube.com/live/ID
+  /(?:https?:\/\/)?(?:www\.)?youtube\.com\/live\/([a-zA-Z0-9_-]{11})/,
+]
+
+/**
+ * Check if a URL is a YouTube video URL.
+ */
+export function isYouTubeUrl(url: string): boolean {
+  if (!url) return false
+  return YOUTUBE_PATTERNS.some((pattern) => pattern.test(url))
+}
+
+/**
+ * Extract the 11-character video ID from a YouTube URL.
+ * Returns null if the URL is not a recognized YouTube format.
+ */
+export function extractYouTubeVideoId(url: string): string | null {
+  if (!url) return null
+
+  for (const pattern of YOUTUBE_PATTERNS) {
+    const match = url.match(pattern)
+    if (match?.[1]) {
+      return match[1]
+    }
+  }
+
+  return null
+}
+
+/**
+ * Get a privacy-enhanced embed URL for a YouTube video.
+ * Uses youtube-nocookie.com to avoid tracking cookies.
+ * Returns null if the URL is not a YouTube video.
+ */
+export function getYouTubeEmbedUrl(url: string): string | null {
+  const videoId = extractYouTubeVideoId(url)
+  if (!videoId) return null
+
+  return `https://www.youtube-nocookie.com/embed/${videoId}`
+}

--- a/src/server/payload/collections/Media/hooks/inferMediaType.ts
+++ b/src/server/payload/collections/Media/hooks/inferMediaType.ts
@@ -22,6 +22,11 @@ export const inferMediaTypeHook: FieldHook = ({ data, operation, value, req }) =
     return value
   }
 
+  // External type is user-selected (no file to infer from) — preserve it
+  if (value === MediaType.External) {
+    return value
+  }
+
   // Auto-infer from MIME type
   const inferredType = inferMediaType(mimeType, filename)
 

--- a/src/server/payload/collections/Media/hooks/validateMediaUpload.ts
+++ b/src/server/payload/collections/Media/hooks/validateMediaUpload.ts
@@ -23,6 +23,11 @@ export const validateMediaUploadHook: CollectionBeforeValidateHook = async ({
     return data
   }
 
+  // Non-external types require a file (safety net since filesRequiredOnCreate is false)
+  if (!mimeType && !filename) {
+    throw new Error('A file is required for non-external media types')
+  }
+
   // Validate MIME type against allowlist
   if (mimeType && type !== MediaType.Other) {
     if (!validateMimeType(mimeType, type)) {

--- a/src/server/payload/collections/Media/hooks/validateMediaUpload.ts
+++ b/src/server/payload/collections/Media/hooks/validateMediaUpload.ts
@@ -20,6 +20,14 @@ export const validateMediaUploadHook: CollectionBeforeValidateHook = async ({
     if (!data?.externalUrl) {
       throw new Error('External media requires an external URL')
     }
+    // Set filename from URL hostname if not provided
+    if (!data.filename) {
+      try {
+        data.filename = new URL(data.externalUrl).hostname
+      } catch {
+        data.filename = 'External'
+      }
+    }
     return data
   }
 

--- a/src/server/payload/collections/Media/index.ts
+++ b/src/server/payload/collections/Media/index.ts
@@ -6,6 +6,7 @@ import {
   lexicalEditor,
 } from '@payloadcms/richtext-lexical'
 
+import { extractYouTubeVideoId, isYouTubeUrl } from '@/infra/media/youtube'
 import { MediaType } from '@/infra/media/types'
 import { isUsersCollectionUser } from '@/server/payload/access/isUsersCollectionUser'
 import { AccountRole } from '@/server/payload/collections/Users/roles'
@@ -26,7 +27,29 @@ export const Media: CollectionConfig = {
     filesRequiredOnCreate: false,
     // Vercel Blob storage plugin handles actual file storage
     // Plugin injects disableLocalStorage: true and adapter handlers
-    adminThumbnail: 'thumbnail', // Show thumbnail in admin list view
+    // Show thumbnail in admin list view - uses function to handle External media
+    adminThumbnail: ({ doc }) => {
+      // Cast doc to access typed properties
+      const docData = doc as { type?: string; externalUrl?: string; url?: string }
+      // YouTube External media: return YouTube thumbnail
+      if (
+        docData.type === MediaType.External &&
+        docData.externalUrl &&
+        isYouTubeUrl(docData.externalUrl)
+      ) {
+        const videoId = extractYouTubeVideoId(docData.externalUrl)
+        if (videoId) {
+          return `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`
+        }
+        return null
+      }
+      // Other External media: no thumbnail
+      if (docData.type === MediaType.External) {
+        return null
+      }
+      // Uploaded files: return the main URL (false to disable if url is undefined)
+      return docData.url || false
+    },
     mimeTypes: [
       'image/*',
       'video/*',

--- a/src/server/payload/collections/Media/index.ts
+++ b/src/server/payload/collections/Media/index.ts
@@ -21,6 +21,9 @@ export const Media: CollectionConfig = {
   slug: 'media',
   // folders: true, // Disabled - conflicts with Vercel Blob plugin
   upload: {
+    // Allow External media type to be saved without a file upload.
+    // Our validateMediaUploadHook enforces file presence for non-External types.
+    filesRequiredOnCreate: false,
     // Vercel Blob storage plugin handles actual file storage
     // Plugin injects disableLocalStorage: true and adapter handlers
     adminThumbnail: 'thumbnail', // Show thumbnail in admin list view

--- a/src/ui/admin/ExerciseContentEditor/MediaPicker.tsx
+++ b/src/ui/admin/ExerciseContentEditor/MediaPicker.tsx
@@ -239,7 +239,8 @@ export const MediaPicker: React.FC<MediaPickerProps> = ({
                 // Cast to any to bypass strict type checking for blob storage sizes
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 const itemAny = item as any
-                const thumbnailUrl = itemAny.sizes?.thumbnail?.url || item.url
+                // Use thumbnailURL (set by adminThumbnail) first, then fall back to sizes.thumbnail.url
+                const thumbnailUrl = item.thumbnailURL || itemAny.sizes?.thumbnail?.url || item.url
 
                 return (
                   <div
@@ -266,7 +267,7 @@ export const MediaPicker: React.FC<MediaPickerProps> = ({
                       />
                     )}
                     <div className="media-grid-info">
-                      <div className="media-grid-filename">{item.filename}</div>
+                      <div className="media-grid-filename">{item.filename || 'External'}</div>
                       {item.alt && <div className="media-grid-alt">{item.alt}</div>}
                     </div>
                   </div>

--- a/src/ui/admin/ExerciseContentEditor/editors/InlineRichTextEditor.tsx
+++ b/src/ui/admin/ExerciseContentEditor/editors/InlineRichTextEditor.tsx
@@ -139,13 +139,14 @@ export const InlineRichTextEditor: React.FC<InlineRichTextEditorProps> = ({
             <div className="inline-rich-text-media-list">
               {mediaItems.map((item) => {
                 const isImage = item.type === 'image'
-                const thumbnailUrl =
-                  (item as unknown as { sizes?: { thumbnail?: { url: string } } }).sizes?.thumbnail
-                    ?.url || item.url
-
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const itemAny = item as any
+                // Use thumbnailURL (set by adminThumbnail) first, then fall back to sizes.thumbnail.url
+                const thumbnailUrl = item.thumbnailURL || itemAny.sizes?.thumbnail?.url || item.url
                 return (
                   <div key={item.id} className="inline-rich-text-media-item">
-                    {thumbnailUrl && isImage ? (
+                    {/* Show thumbnail for images OR for external media with thumbnailUrl */}
+                    {thumbnailUrl && (isImage || item.type === 'external') ? (
                       <Image
                         src={thumbnailUrl}
                         alt={item.alt || item.filename || 'Media'}

--- a/src/ui/admin/ExerciseContentEditor/index.tsx
+++ b/src/ui/admin/ExerciseContentEditor/index.tsx
@@ -745,7 +745,8 @@ function BlockMediaDisplay({ blockId, mediaIds, onRemoveMedia }: BlockMediaDispl
         // Cast to any to bypass strict type checking for blob storage sizes
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const mediaAny = media as any
-        const thumbnailUrl = mediaAny.sizes?.thumbnail?.url || media.url
+        // Use thumbnailURL (set by adminThumbnail) first, then fall back to sizes.thumbnail.url
+        const thumbnailUrl = media.thumbnailURL || mediaAny.sizes?.thumbnail?.url || media.url
         return (
           <div key={media.id} className="media-thumbnail-preview">
             {thumbnailUrl && (

--- a/src/ui/admin/MediaPreview/ExternalPreview.tsx
+++ b/src/ui/admin/MediaPreview/ExternalPreview.tsx
@@ -3,6 +3,8 @@
 import React from 'react'
 import { useFormFields } from '@payloadcms/ui'
 
+import { getYouTubeEmbedUrl, isYouTubeUrl } from '@/infra/media/youtube'
+
 export const ExternalPreview: React.FC = () => {
   const externalUrlField = useFormFields(([fields]) => fields.externalUrl)
 
@@ -16,10 +18,19 @@ export const ExternalPreview: React.FC = () => {
     )
   }
 
+  const youTubeEmbedUrl = getYouTubeEmbedUrl(externalUrl)
+
   return (
     <div className="p-4">
-      <h3 className="mb-2">External Media</h3>
-      <p className="mb-4 break-all">
+      <div className="mb-2 flex items-center gap-2">
+        <h3 className="m-0">External Media</h3>
+        {isYouTubeUrl(externalUrl) && (
+          <span className="inline-block rounded bg-red-600 px-2 py-0.5 text-xs font-semibold text-white">
+            YouTube
+          </span>
+        )}
+      </div>
+      <p className="mb-4 break-all text-sm">
         <strong>URL:</strong> {externalUrl}
       </p>
       <div className="mb-4">
@@ -27,16 +38,30 @@ export const ExternalPreview: React.FC = () => {
           href={externalUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-block px-4 py-2 bg-[var(--theme-elevation-300)] rounded no-underline"
+          className="inline-block rounded bg-[var(--theme-elevation-300)] px-4 py-2 no-underline"
         >
-          🔗 Open Link
+          Open Link
         </a>
       </div>
-      <iframe
-        src={externalUrl}
-        className="w-full h-[400px] border border-[var(--theme-elevation-300)] rounded"
-        title="External content"
-      />
+      {youTubeEmbedUrl ? (
+        <div className="relative w-full overflow-hidden rounded" style={{ paddingTop: '56.25%' }}>
+          <iframe
+            src={youTubeEmbedUrl}
+            className="absolute inset-0 h-full w-full border-0"
+            title="YouTube video"
+            loading="lazy"
+            allowFullScreen
+            referrerPolicy="strict-origin-when-cross-origin"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          />
+        </div>
+      ) : (
+        <iframe
+          src={externalUrl}
+          className="h-[400px] w-full rounded border border-[var(--theme-elevation-300)]"
+          title="External content"
+        />
+      )}
     </div>
   )
 }

--- a/src/ui/web/exerciserenderer/components/MediaAttachments/index.tsx
+++ b/src/ui/web/exerciserenderer/components/MediaAttachments/index.tsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import { cn } from '@/infra/utils/ui'
 import { getMediaUrl } from '@/infra/utils/getMediaUrl'
+import { getYouTubeEmbedUrl } from '@/infra/media/youtube'
 import type { Media } from '@/payload-types'
 import { useMediaMap } from '../../context/MediaMapContext'
 
@@ -19,11 +20,43 @@ function isVideoType(media: Media): boolean {
   return media.type === 'video'
 }
 
+function isExternalType(media: Media): boolean {
+  return media.type === 'external'
+}
+
 /**
  * Renders a single media item.
  * Uses plain <img> / <video> to avoid Next.js Image optimization domain issues.
  */
 function MediaItem({ media }: { media: Media }) {
+  // External media has no uploaded file — handle before getMediaUrl
+  if (isExternalType(media)) {
+    const externalUrl = media.externalUrl
+    if (!externalUrl) return null
+
+    const youTubeEmbedUrl = getYouTubeEmbedUrl(externalUrl)
+
+    if (youTubeEmbedUrl) {
+      return (
+        <div className="relative w-full overflow-hidden" style={{ paddingTop: '56.25%' }}>
+          <iframe
+            src={youTubeEmbedUrl}
+            className="absolute inset-0 h-full w-full border-0"
+            title="YouTube video"
+            loading="lazy"
+            allowFullScreen
+            referrerPolicy="strict-origin-when-cross-origin"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          />
+        </div>
+      )
+    }
+
+    return (
+      <iframe src={externalUrl} className="h-[400px] w-full border-0" title="External content" />
+    )
+  }
+
   const src = getMediaUrl(media.url, media.updatedAt)
 
   if (!src) return null

--- a/src/ui/web/media/ExternalMedia/index.tsx
+++ b/src/ui/web/media/ExternalMedia/index.tsx
@@ -3,8 +3,9 @@
 import { cn } from '@/infra/utils/ui'
 import React from 'react'
 
-import type { Props as MediaProps } from '../types'
+import { getYouTubeEmbedUrl } from '@/infra/media/youtube'
 import type { Media } from '@/payload-types'
+import type { Props as MediaProps } from '../types'
 
 interface ExternalMediaResource extends Media {
   externalUrl?: string
@@ -20,12 +21,31 @@ export const ExternalMedia: React.FC<MediaProps> = (props) => {
       return <p className={cn('external-media-error', className)}>No external URL provided</p>
     }
 
-    // Simple iframe embed (could be enhanced to detect URL type)
+    const youTubeEmbedUrl = getYouTubeEmbedUrl(externalUrl)
+
+    if (youTubeEmbedUrl) {
+      return (
+        <div className={cn('external-media', className)}>
+          <div className="relative w-full overflow-hidden rounded" style={{ paddingTop: '56.25%' }}>
+            <iframe
+              src={youTubeEmbedUrl}
+              className="absolute inset-0 h-full w-full border-0"
+              title="YouTube video"
+              loading="lazy"
+              allowFullScreen
+              referrerPolicy="strict-origin-when-cross-origin"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            />
+          </div>
+        </div>
+      )
+    }
+
     return (
       <div className={cn('external-media', className)}>
         <iframe
           src={externalUrl}
-          className="w-full h-[400px] border border-border rounded"
+          className="h-[400px] w-full rounded border border-border"
           title="External content"
         />
       </div>

--- a/tests/unit/admin-thumbnail.test.ts
+++ b/tests/unit/admin-thumbnail.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from 'vitest'
+
+import { MediaType } from '@/infra/media/types'
+import { isYouTubeUrl, extractYouTubeVideoId } from '@/infra/media/youtube'
+
+describe('adminThumbnail logic (YouTube thumbnail generation)', () => {
+  /**
+   * This test file validates the thumbnail URL generation logic
+   * that is used in the adminThumbnail function in Media/index.ts
+   *
+   * The actual adminThumbnail function is:
+   *   adminThumbnail: ({ doc }) => {
+   *     const docData = doc as { type?: string; externalUrl?: string; url?: string }
+   *     if (docData.type === MediaType.External && docData.externalUrl && isYouTubeUrl(docData.externalUrl)) {
+   *       const videoId = extractYouTubeVideoId(docData.externalUrl)
+   *       if (videoId) {
+   *         return `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`
+   *       }
+   *       return null
+   *     }
+   *     if (docData.type === MediaType.External) {
+   *       return null
+   *     }
+   *     return docData.url || false
+   *   }
+   */
+
+  describe('isYouTubeUrl', () => {
+    it('should recognize standard YouTube watch URLs', () => {
+      expect(isYouTubeUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe(true)
+      expect(isYouTubeUrl('http://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe(true)
+      expect(isYouTubeUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PL123')).toBe(true)
+    })
+
+    it('should recognize YouTube short URLs', () => {
+      expect(isYouTubeUrl('https://youtu.be/dQw4w9WgXcQ')).toBe(true)
+      expect(isYouTubeUrl('http://youtu.be/dQw4w9WgXcQ')).toBe(true)
+    })
+
+    it('should recognize YouTube embed URLs', () => {
+      expect(isYouTubeUrl('https://www.youtube.com/embed/dQw4w9WgXcQ')).toBe(true)
+      expect(isYouTubeUrl('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ')).toBe(true)
+    })
+
+    it('should recognize YouTube shorts URLs', () => {
+      expect(isYouTubeUrl('https://www.youtube.com/shorts/dQw4w9WgXcQ')).toBe(true)
+    })
+
+    it('should recognize YouTube live URLs', () => {
+      expect(isYouTubeUrl('https://www.youtube.com/live/dQw4w9WgXcQ')).toBe(true)
+    })
+
+    it('should recognize mobile YouTube URLs', () => {
+      expect(isYouTubeUrl('https://m.youtube.com/watch?v=dQw4w9WgXcQ')).toBe(true)
+    })
+
+    it('should reject non-YouTube URLs', () => {
+      expect(isYouTubeUrl('https://vimeo.com/123456789')).toBe(false)
+      expect(isYouTubeUrl('https://example.com/video')).toBe(false)
+      expect(isYouTubeUrl('')).toBe(false)
+      expect(isYouTubeUrl('not-a-url')).toBe(false)
+    })
+  })
+
+  describe('extractYouTubeVideoId', () => {
+    it('should extract video ID from standard watch URL', () => {
+      expect(extractYouTubeVideoId('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe(
+        'dQw4w9WgXcQ',
+      )
+    })
+
+    it('should extract video ID from short URL', () => {
+      expect(extractYouTubeVideoId('https://youtu.be/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
+    })
+
+    it('should extract video ID from embed URL', () => {
+      expect(extractYouTubeVideoId('https://www.youtube.com/embed/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
+    })
+
+    it('should extract video ID from shorts URL', () => {
+      expect(extractYouTubeVideoId('https://www.youtube.com/shorts/dQw4w9WgXcQ')).toBe(
+        'dQw4w9WgXcQ',
+      )
+    })
+
+    it('should extract video ID from live URL', () => {
+      expect(extractYouTubeVideoId('https://www.youtube.com/live/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
+    })
+
+    it('should handle URLs with extra parameters', () => {
+      expect(
+        extractYouTubeVideoId('https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PL123&index=1'),
+      ).toBe('dQw4w9WgXcQ')
+    })
+
+    it('should return null for non-YouTube URLs', () => {
+      expect(extractYouTubeVideoId('https://vimeo.com/123456789')).toBe(null)
+      expect(extractYouTubeVideoId('https://example.com/video')).toBe(null)
+      expect(extractYouTubeVideoId('')).toBe(null)
+    })
+  })
+
+  describe('YouTube thumbnail URL generation', () => {
+    it('should generate correct mqdefault thumbnail URL', () => {
+      const videoId = extractYouTubeVideoId('https://www.youtube.com/watch?v=dQw4w9WgXcQ')
+      expect(videoId).toBe('dQw4w9WgXcQ')
+      const thumbnailUrl = `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`
+      expect(thumbnailUrl).toBe('https://img.youtube.com/vi/dQw4w9WgXcQ/mqdefault.jpg')
+    })
+
+    it('should generate correct thumbnail for shorts URL', () => {
+      const videoId = extractYouTubeVideoId('https://www.youtube.com/shorts/abc123xyz99')
+      const thumbnailUrl = `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`
+      expect(thumbnailUrl).toBe('https://img.youtube.com/vi/abc123xyz99/mqdefault.jpg')
+    })
+  })
+
+  describe('adminThumbnail behavior simulation', () => {
+    /**
+     * Simulates the adminThumbnail function logic
+     */
+    function getAdminThumbnailUrl(doc: {
+      type?: string
+      externalUrl?: string | null
+      url?: string | null
+    }): string | null | false {
+      const docData = doc as { type?: string; externalUrl?: string | null; url?: string | null }
+
+      // YouTube External media: return YouTube thumbnail
+      if (
+        docData.type === MediaType.External &&
+        docData.externalUrl &&
+        isYouTubeUrl(docData.externalUrl)
+      ) {
+        const videoId = extractYouTubeVideoId(docData.externalUrl)
+        if (videoId) {
+          return `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`
+        }
+        return null
+      }
+
+      // Other External media: no thumbnail
+      if (docData.type === MediaType.External) {
+        return null
+      }
+
+      // Uploaded files: return the main URL (false to disable if url is undefined)
+      return docData.url || false
+    }
+
+    it('should return YouTube thumbnail URL for YouTube External media', () => {
+      const doc = {
+        type: MediaType.External,
+        externalUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        url: null,
+      }
+      expect(getAdminThumbnailUrl(doc)).toBe('https://img.youtube.com/vi/dQw4w9WgXcQ/mqdefault.jpg')
+    })
+
+    it('should return null for non-YouTube External media', () => {
+      const doc = {
+        type: MediaType.External,
+        externalUrl: 'https://vimeo.com/123456789',
+        url: null,
+      }
+      expect(getAdminThumbnailUrl(doc)).toBe(null)
+    })
+
+    it('should return null for External media with no externalUrl', () => {
+      const doc = {
+        type: MediaType.External,
+        externalUrl: null,
+        url: null,
+      }
+      expect(getAdminThumbnailUrl(doc)).toBe(null)
+    })
+
+    it('should return url for uploaded image files', () => {
+      const doc = {
+        type: MediaType.Image,
+        externalUrl: null,
+        url: 'https://example.blob.vercel-storage.com/image.jpg',
+      }
+      expect(getAdminThumbnailUrl(doc)).toBe('https://example.blob.vercel-storage.com/image.jpg')
+    })
+
+    it('should return false for uploaded file with no URL', () => {
+      const doc = {
+        type: MediaType.Image,
+        externalUrl: null,
+        url: null,
+      }
+      expect(getAdminThumbnailUrl(doc)).toBe(false)
+    })
+
+    it('should handle YouTube shorts URL', () => {
+      const doc = {
+        type: MediaType.External,
+        externalUrl: 'https://www.youtube.com/shorts/abc123xyz99',
+        url: null,
+      }
+      expect(getAdminThumbnailUrl(doc)).toBe('https://img.youtube.com/vi/abc123xyz99/mqdefault.jpg')
+    })
+
+    it('should handle YouTube embed URL', () => {
+      const doc = {
+        type: MediaType.External,
+        externalUrl: 'https://www.youtube.com/embed/dQw4w9WgXcQ',
+        url: null,
+      }
+      expect(getAdminThumbnailUrl(doc)).toBe('https://img.youtube.com/vi/dQw4w9WgXcQ/mqdefault.jpg')
+    })
+
+    it('should handle youtu.be short URL', () => {
+      const doc = {
+        type: MediaType.External,
+        externalUrl: 'https://youtu.be/dQw4w9WgXcQ',
+        url: null,
+      }
+      expect(getAdminThumbnailUrl(doc)).toBe('https://img.youtube.com/vi/dQw4w9WgXcQ/mqdefault.jpg')
+    })
+  })
+})

--- a/tests/unit/hooks/inferMediaType.test.ts
+++ b/tests/unit/hooks/inferMediaType.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { MediaType } from '@/infra/media/types'
+import { inferMediaTypeHook } from '@/server/payload/collections/Media/hooks/inferMediaType'
+
+// Helper to create a mock Payload req
+function createMockReq(user?: Record<string, unknown>) {
+  return {
+    user: user ?? null,
+    payload: {
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    },
+  } as unknown as Parameters<typeof inferMediaTypeHook>[0]['req']
+}
+
+// Helper to call the hook with minimal args
+function callHook({
+  data = {},
+  operation = 'create',
+  value,
+  user,
+}: {
+  data?: Record<string, unknown>
+  operation?: string
+  value?: string
+  user?: Record<string, unknown>
+}) {
+  return inferMediaTypeHook({
+    data,
+    operation,
+    value,
+    req: createMockReq(user),
+    field: {} as unknown as Parameters<typeof inferMediaTypeHook>[0]['field'],
+    collection: {} as unknown as Parameters<typeof inferMediaTypeHook>[0]['collection'],
+    context: {},
+    blockData: undefined,
+    fullData: data,
+    fullOriginalDoc: undefined,
+    indexPath: '',
+    overrideAccess: false,
+    path: '' as unknown as Parameters<typeof inferMediaTypeHook>[0]['path'],
+    previousDoc: undefined,
+    previousSiblingDoc: undefined,
+    previousValue: undefined,
+    schemaPath: '' as unknown as Parameters<typeof inferMediaTypeHook>[0]['schemaPath'],
+    siblingData: data,
+    siblingDocWithLocales: undefined,
+    siblingFields: [],
+    originalDoc: undefined,
+  } as unknown as Parameters<typeof inferMediaTypeHook>[0])
+}
+
+describe('inferMediaTypeHook', () => {
+  describe('External type preservation', () => {
+    it('should preserve External type when user selects it (no file)', () => {
+      const result = callHook({
+        data: {},
+        value: MediaType.External,
+        operation: 'create',
+      })
+
+      expect(result).toBe(MediaType.External)
+    })
+
+    it('should preserve External type on update', () => {
+      const result = callHook({
+        data: {},
+        value: MediaType.External,
+        operation: 'update',
+      })
+
+      expect(result).toBe(MediaType.External)
+    })
+
+    it('should preserve External type even when non-admin user', () => {
+      const result = callHook({
+        data: {},
+        value: MediaType.External,
+        operation: 'create',
+        user: { id: '1', role: 'student', collection: 'users' },
+      })
+
+      expect(result).toBe(MediaType.External)
+    })
+  })
+
+  describe('auto-inference from MIME type', () => {
+    it('should infer Image from image/jpeg MIME type', () => {
+      const result = callHook({
+        data: { mimeType: 'image/jpeg', filename: 'photo.jpg' },
+        operation: 'create',
+      })
+
+      expect(result).toBe(MediaType.Image)
+    })
+
+    it('should infer Video from video/mp4 MIME type', () => {
+      const result = callHook({
+        data: { mimeType: 'video/mp4', filename: 'clip.mp4' },
+        operation: 'create',
+      })
+
+      expect(result).toBe(MediaType.Video)
+    })
+
+    it('should infer PDF from application/pdf MIME type', () => {
+      const result = callHook({
+        data: { mimeType: 'application/pdf', filename: 'doc.pdf' },
+        operation: 'create',
+      })
+
+      expect(result).toBe(MediaType.PDF)
+    })
+
+    it('should return Other for no MIME type and no file', () => {
+      const result = callHook({
+        data: {},
+        operation: 'create',
+      })
+
+      expect(result).toBe(MediaType.Other)
+    })
+
+    it('should return Other and log warning for unrecognized MIME type', () => {
+      const req = createMockReq()
+      const result = inferMediaTypeHook({
+        data: { mimeType: 'application/x-custom-bizarre' },
+        operation: 'create',
+        value: undefined,
+        req,
+        field: {} as unknown as Parameters<typeof inferMediaTypeHook>[0]['field'],
+        collection: {} as unknown as Parameters<typeof inferMediaTypeHook>[0]['collection'],
+        context: {},
+      } as unknown as Parameters<typeof inferMediaTypeHook>[0])
+
+      expect(result).toBe(MediaType.Other)
+      expect(
+        (req as unknown as { payload: { logger: { warn: ReturnType<typeof vi.fn> } } }).payload
+          .logger.warn,
+      ).toHaveBeenCalledWith(expect.stringContaining('Unrecognized MIME type'))
+    })
+  })
+
+  describe('admin override on update', () => {
+    const adminUser = { id: '1', role: 'admin', collection: 'users' }
+
+    it('should allow admin to override type on update', () => {
+      const result = callHook({
+        data: { mimeType: 'image/jpeg' },
+        value: MediaType.Video,
+        operation: 'update',
+        user: adminUser,
+      })
+
+      // Admin chose Video even though MIME is image — should be respected
+      expect(result).toBe(MediaType.Video)
+    })
+
+    it('should log warning when admin override does not match MIME', () => {
+      const req = createMockReq(adminUser)
+      inferMediaTypeHook({
+        data: { mimeType: 'image/jpeg' },
+        operation: 'update',
+        value: MediaType.Video,
+        req,
+        field: {} as unknown as Parameters<typeof inferMediaTypeHook>[0]['field'],
+        collection: {} as unknown as Parameters<typeof inferMediaTypeHook>[0]['collection'],
+        context: {},
+      } as unknown as Parameters<typeof inferMediaTypeHook>[0])
+
+      expect(
+        (req as unknown as { payload: { logger: { warn: ReturnType<typeof vi.fn> } } }).payload
+          .logger.warn,
+      ).toHaveBeenCalledWith(
+        expect.stringContaining("Admin override type 'video' doesn't match MIME 'image/jpeg'"),
+      )
+    })
+
+    it('should NOT allow non-admin to override type on update', () => {
+      const result = callHook({
+        data: { mimeType: 'image/jpeg' },
+        value: MediaType.Video,
+        operation: 'update',
+        user: { id: '1', role: 'student', collection: 'users' },
+      })
+
+      // Non-admin tried to set Video, but MIME is image — should infer Image
+      expect(result).toBe(MediaType.Image)
+    })
+  })
+})

--- a/tests/unit/hooks/validateMediaUpload.test.ts
+++ b/tests/unit/hooks/validateMediaUpload.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { MediaType } from '@/infra/media/types'
+import { validateMediaUploadHook } from '@/server/payload/collections/Media/hooks/validateMediaUpload'
+
+// Helper to create a mock Payload req
+function createMockReq() {
+  return {
+    payload: {
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    },
+  } as unknown as Parameters<typeof validateMediaUploadHook>[0]['req']
+}
+
+// Helper to call the hook with minimal args
+async function callHook({
+  data = {},
+  operation = 'create' as string,
+}: {
+  data?: Record<string, unknown>
+  operation?: string
+}) {
+  return validateMediaUploadHook({
+    data,
+    operation,
+    req: createMockReq(),
+    collection: {} as unknown as Parameters<typeof validateMediaUploadHook>[0]['collection'],
+    context: {},
+    originalDoc: undefined,
+  } as unknown as Parameters<typeof validateMediaUploadHook>[0])
+}
+
+describe('validateMediaUploadHook', () => {
+  describe('External media (no file required)', () => {
+    it('should allow External type with externalUrl and no file', async () => {
+      const result = await callHook({
+        data: {
+          type: MediaType.External,
+          externalUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        },
+      })
+
+      expect(result).toEqual({
+        type: MediaType.External,
+        externalUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      })
+    })
+
+    it('should reject External type without externalUrl', async () => {
+      await expect(
+        callHook({
+          data: {
+            type: MediaType.External,
+          },
+        }),
+      ).rejects.toThrow('External media requires an external URL')
+    })
+
+    it('should reject External type with empty externalUrl', async () => {
+      await expect(
+        callHook({
+          data: {
+            type: MediaType.External,
+            externalUrl: '',
+          },
+        }),
+      ).rejects.toThrow('External media requires an external URL')
+    })
+  })
+
+  describe('Non-external media (file required)', () => {
+    it('should reject non-external type without a file', async () => {
+      await expect(
+        callHook({
+          data: {
+            type: MediaType.Image,
+          },
+        }),
+      ).rejects.toThrow('A file is required for non-external media types')
+    })
+
+    it('should reject Other type without a file', async () => {
+      await expect(
+        callHook({
+          data: {
+            type: MediaType.Other,
+          },
+        }),
+      ).rejects.toThrow('A file is required for non-external media types')
+    })
+
+    it('should allow Image type with mimeType and filename', async () => {
+      const result = await callHook({
+        data: {
+          type: MediaType.Image,
+          mimeType: 'image/jpeg',
+          filename: 'photo.jpg',
+          filesize: 1024,
+        },
+      })
+
+      expect(result).toBeDefined()
+      expect(result?.type).toBe(MediaType.Image)
+    })
+
+    it('should allow file with only mimeType (no filename)', async () => {
+      const result = await callHook({
+        data: {
+          type: MediaType.Image,
+          mimeType: 'image/jpeg',
+          filesize: 1024,
+        },
+      })
+
+      expect(result).toBeDefined()
+    })
+
+    it('should allow file with only filename (no mimeType)', async () => {
+      const result = await callHook({
+        data: {
+          type: MediaType.Image,
+          filename: 'photo.jpg',
+          filesize: 1024,
+        },
+      })
+
+      expect(result).toBeDefined()
+    })
+  })
+
+  describe('MIME type validation', () => {
+    it('should downgrade type to Other when MIME does not match', async () => {
+      const result = await callHook({
+        data: {
+          type: MediaType.Image,
+          mimeType: 'video/mp4',
+          filename: 'clip.mp4',
+          filesize: 1024,
+        },
+      })
+
+      expect(result?.type).toBe(MediaType.Other)
+    })
+
+    it('should keep type when MIME matches', async () => {
+      const result = await callHook({
+        data: {
+          type: MediaType.Image,
+          mimeType: 'image/jpeg',
+          filename: 'photo.jpg',
+          filesize: 1024,
+        },
+      })
+
+      expect(result?.type).toBe(MediaType.Image)
+    })
+  })
+
+  describe('size limit enforcement', () => {
+    it('should reject files exceeding size limit', async () => {
+      await expect(
+        callHook({
+          data: {
+            type: MediaType.Image,
+            mimeType: 'image/jpeg',
+            filename: 'huge.jpg',
+            filesize: 50 * 1024 * 1024, // 50MB, limit is 10MB
+          },
+        }),
+      ).rejects.toThrow(/exceeds maximum/)
+    })
+
+    it('should allow files within size limit', async () => {
+      const result = await callHook({
+        data: {
+          type: MediaType.Image,
+          mimeType: 'image/jpeg',
+          filename: 'small.jpg',
+          filesize: 5 * 1024 * 1024, // 5MB, limit is 10MB
+        },
+      })
+
+      expect(result).toBeDefined()
+    })
+  })
+
+  describe('operation handling', () => {
+    it('should skip validation on update operations', async () => {
+      const result = await callHook({
+        data: {},
+        operation: 'update',
+      })
+
+      // Should return data unchanged — no validation on update
+      expect(result).toEqual({})
+    })
+
+    it('should skip validation on delete operations', async () => {
+      const result = await callHook({
+        data: {},
+        operation: 'delete',
+      })
+
+      expect(result).toEqual({})
+    })
+  })
+})

--- a/tests/unit/hooks/validateMediaUpload.test.ts
+++ b/tests/unit/hooks/validateMediaUpload.test.ts
@@ -47,6 +47,7 @@ describe('validateMediaUploadHook', () => {
       expect(result).toEqual({
         type: MediaType.External,
         externalUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        filename: 'www.youtube.com',
       })
     })
 
@@ -69,6 +70,51 @@ describe('validateMediaUploadHook', () => {
           },
         }),
       ).rejects.toThrow('External media requires an external URL')
+    })
+
+    it('should set filename from YouTube URL hostname', async () => {
+      const result = await callHook({
+        data: {
+          type: MediaType.External,
+          externalUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        },
+      })
+
+      expect(result.filename).toBe('www.youtube.com')
+    })
+
+    it('should set filename from custom URL hostname', async () => {
+      const result = await callHook({
+        data: {
+          type: MediaType.External,
+          externalUrl: 'https://vimeo.com/123456789',
+        },
+      })
+
+      expect(result.filename).toBe('vimeo.com')
+    })
+
+    it('should set filename to "External" for invalid URL', async () => {
+      const result = await callHook({
+        data: {
+          type: MediaType.External,
+          externalUrl: 'not-a-valid-url',
+        },
+      })
+
+      expect(result.filename).toBe('External')
+    })
+
+    it('should not overwrite pre-existing filename', async () => {
+      const result = await callHook({
+        data: {
+          type: MediaType.External,
+          externalUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+          filename: 'My Custom Video',
+        },
+      })
+
+      expect(result.filename).toBe('My Custom Video')
     })
   })
 

--- a/tests/unit/infra/media/youtube.test.ts
+++ b/tests/unit/infra/media/youtube.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+
+import { isYouTubeUrl, extractYouTubeVideoId, getYouTubeEmbedUrl } from '@/infra/media/youtube'
+
+describe('YouTube URL utilities', () => {
+  describe('isYouTubeUrl', () => {
+    it.each([
+      ['https://www.youtube.com/watch?v=dQw4w9WgXcQ', 'standard watch'],
+      ['https://youtube.com/watch?v=dQw4w9WgXcQ', 'without www'],
+      ['http://www.youtube.com/watch?v=dQw4w9WgXcQ', 'http'],
+      ['https://m.youtube.com/watch?v=dQw4w9WgXcQ', 'mobile'],
+      ['https://youtu.be/dQw4w9WgXcQ', 'short URL'],
+      ['https://www.youtube.com/embed/dQw4w9WgXcQ', 'embed URL'],
+      ['https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ', 'privacy-enhanced embed'],
+      ['https://www.youtube.com/shorts/dQw4w9WgXcQ', 'shorts'],
+      ['https://www.youtube.com/live/dQw4w9WgXcQ', 'live'],
+      ['https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=120', 'with timestamp'],
+      [
+        'https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf',
+        'with playlist',
+      ],
+      ['https://youtu.be/dQw4w9WgXcQ?si=abc123', 'short with share param'],
+    ])('should detect %s (%s)', (url) => {
+      expect(isYouTubeUrl(url)).toBe(true)
+    })
+
+    it.each([
+      ['https://www.google.com', 'Google'],
+      ['https://vimeo.com/12345', 'Vimeo'],
+      ['https://www.dailymotion.com/video/x12345', 'Dailymotion'],
+      ['https://www.youtube.com/channel/UC12345', 'YouTube channel (no video)'],
+      ['https://www.youtube.com/', 'YouTube homepage'],
+      ['not-a-url', 'random string'],
+      ['', 'empty string'],
+    ])('should reject %s (%s)', (url) => {
+      expect(isYouTubeUrl(url)).toBe(false)
+    })
+  })
+
+  describe('extractYouTubeVideoId', () => {
+    it.each([
+      ['https://www.youtube.com/watch?v=dQw4w9WgXcQ', 'dQw4w9WgXcQ', 'standard watch'],
+      ['https://youtu.be/dQw4w9WgXcQ', 'dQw4w9WgXcQ', 'short URL'],
+      ['https://www.youtube.com/embed/dQw4w9WgXcQ', 'dQw4w9WgXcQ', 'embed'],
+      ['https://www.youtube.com/shorts/dQw4w9WgXcQ', 'dQw4w9WgXcQ', 'shorts'],
+      ['https://www.youtube.com/live/dQw4w9WgXcQ', 'dQw4w9WgXcQ', 'live'],
+      ['https://www.youtube.com/watch?v=Ab_Cd-Ef_12', 'Ab_Cd-Ef_12', 'hyphens and underscores'],
+      [
+        'https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=120&list=PLtest',
+        'dQw4w9WgXcQ',
+        'with extra params',
+      ],
+      ['https://m.youtube.com/watch?v=dQw4w9WgXcQ', 'dQw4w9WgXcQ', 'mobile'],
+    ])('should extract %s from %s (%s)', (url, expectedId) => {
+      expect(extractYouTubeVideoId(url)).toBe(expectedId)
+    })
+
+    it.each([
+      ['https://www.google.com', 'non-YouTube'],
+      ['https://vimeo.com/12345', 'Vimeo'],
+      ['', 'empty string'],
+    ])('should return null for %s (%s)', (url) => {
+      expect(extractYouTubeVideoId(url)).toBeNull()
+    })
+  })
+
+  describe('getYouTubeEmbedUrl', () => {
+    it('should return privacy-enhanced embed URL for YouTube', () => {
+      expect(getYouTubeEmbedUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe(
+        'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ',
+      )
+    })
+
+    it('should return privacy-enhanced embed URL for short URL', () => {
+      expect(getYouTubeEmbedUrl('https://youtu.be/dQw4w9WgXcQ')).toBe(
+        'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ',
+      )
+    })
+
+    it('should return null for non-YouTube URL', () => {
+      expect(getYouTubeEmbedUrl('https://www.google.com')).toBeNull()
+    })
+
+    it('should return null for empty string', () => {
+      expect(getYouTubeEmbedUrl('')).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
Payload's upload pipeline rejects documents without a file before custom hooks run. This adds filesRequiredOnCreate: false so External media (YouTube URLs etc.) can be created without uploading a file.

Changes:
- Set filesRequiredOnCreate: false on Media upload config
- Preserve user-selected External type in inferMediaTypeHook (prevents auto-inference from overwriting to Other when no file present)
- Add safety net in validateMediaUploadHook to still require files for non-External types
- Add 25 unit tests covering both hooks