### PR TITLE
feat(media): Add Vimeo video support

### DIFF
--- a/.tasks/260219-youtube-embed-integration/spec.md
+++ b/.tasks/260219-youtube-embed-integration/spec.md
@@ -11,6 +11,36 @@ High-level flow:
 3. Embed metadata is stored on the Media doc (`embedProvider`, `embedVideoId`, `embedUrl`, `embedTitle`, `embedThumbnailUrl`).
 4. Frontend renderers read stored embed fields and choose the appropriate embed UI (YouTube vs generic iframe), with a legacy fallback to `externalUrl`.
 
+## Gap Analysis
+
+### Current State (Observed In Repo)
+
+- `src/server/payload/collections/Media/index.ts` defines `type` (includes `external`) and `externalUrl`, but has no embed metadata fields (`embedProvider`, `embedVideoId`, `embedUrl`, `embedTitle`, `embedThumbnailUrl`).
+- Media collection hooks run `validateMediaUploadHook` in `beforeValidate` (requires `externalUrl` when `type === external`) and `enforceRetentionPolicyHook` in `beforeChange`; there is no hook that parses `externalUrl` or populates derived embed fields.
+- `src/ui/web/media/ExternalMedia/index.tsx` renders a generic iframe using `externalUrl` only; it does not detect YouTube, does not use `youtube-nocookie.com`, and does not use a responsive 16:9 player.
+- `src/ui/admin/MediaPreview/ExternalPreview.tsx` previews `externalUrl` only and renders a generic iframe; it does not show provider, title, thumbnail, or resolved embed URL.
+- `src/ui/web/exerciserenderer/components/MediaAttachments/index.tsx` only supports `video` and `image/svg`. External media attachments are effectively not rendered because they do not have a file `url` and `getMediaUrl(media.url, ...)` yields no `src`.
+- No embed/provider utilities or tests exist under `src/infra/media/embed/` or `tests/unit/infra/media/embed/`.
+
+### Target State (Per Task)
+
+- Persist resolved embed metadata on Media documents for `type === external` so all consumers can render embeds without re-parsing URLs.
+- Resolve YouTube URLs into `youtube-nocookie.com` embed URLs, video IDs, and best-effort title/thumbnail via the public oEmbed endpoint.
+- Render a first-class responsive YouTube embed everywhere external media is used, plus a generic iframe fallback for non-YouTube URLs and legacy data.
+- Upgrade admin preview for external media to show provider + title + thumbnail (YouTube) and use embedUrl where available.
+- Ensure exercise renderer attachments also support external media (YouTube + generic).
+- Add unit tests for URL parsing/resolution and the Media hook behavior (with mocked `fetch`).
+
+### Primary Gaps (Work Items)
+
+- **Schema gap**: Add 5 read-only, external-only embed fields to `src/server/payload/collections/Media/index.ts` and regenerate Payload types.
+- **Hook gap**: Create and register a Media `beforeChange` hook to resolve `externalUrl` on create/update and clear embed fields when leaving `external`.
+- **Infra gap**: Implement provider resolution utilities under `src/infra/media/embed/` (types, YouTube resolver, resolver router, barrel export).
+- **Web UI gap**: Update `src/ui/web/media/ExternalMedia/index.tsx` to render YouTube embeds responsively (16:9) when embed fields exist.
+- **Admin UI gap**: Update `src/ui/admin/MediaPreview/ExternalPreview.tsx` to preview provider metadata (YouTube thumbnail preferred over iframe).
+- **Exercise gap**: Update `src/ui/web/exerciserenderer/components/MediaAttachments/index.tsx` to render external media attachments.
+- **Test gap**: Add unit tests for embed utilities, resolver routing, and the Media hook.
+
 ## Requirements
 
 ### FR-001: Embed Provider Resolution Utilities
@@ -220,3 +250,177 @@ Expected locations (new):
 - Rich provider-specific UI beyond a standard responsive iframe and thumbnail preview.
 - Migration/backfill job for existing external media documents (legacy fallback is sufficient).
 - E2E tests and production monitoring/metrics for embed resolution (unit + manual verification only).
+
+## Implementation Plan (TDD)
+
+This plan maps directly to the requirements above (FR-001..FR-007, NFR-001..NFR-004). Each step is intended to be done in a tight TDD loop (write failing test(s) → implement → pass → run typecheck).
+
+### Step 1: Embed Types + YouTube URL Parsing (FR-001)
+
+**Create**:
+
+- `src/infra/media/embed/types.ts`
+- `src/infra/media/embed/youtube.ts` (sync parsing/build helpers only)
+- `tests/unit/infra/media/embed/youtube.test.ts`
+
+**Implement**:
+
+- `EmbedProvider = 'youtube' | 'generic'`
+- `EmbedMetadata` + `YouTubeOEmbedResponse` types
+- `isYouTubeUrl(url)`
+- `extractYouTubeVideoId(url)`
+- `buildYouTubeEmbedUrl(videoId)` (must use `youtube-nocookie.com`)
+
+**Run**:
+
+```bash
+pnpm test:unit -- tests/unit/infra/media/embed/youtube.test.ts
+pnpm -s tsc --noEmit
+```
+
+### Step 2: oEmbed Fetch + Provider Router (FR-001, NFR-002)
+
+**Create**:
+
+- `src/infra/media/embed/resolve.ts`
+- `src/infra/media/embed/index.ts`
+- `tests/unit/infra/media/embed/resolve.test.ts`
+
+**Modify**:
+
+- `src/infra/media/embed/youtube.ts` (add async metadata resolver)
+- `tests/unit/infra/media/embed/youtube.test.ts` (mock `fetch`)
+
+**Implement**:
+
+- `fetchYouTubeMetadata(videoId)` using `AbortSignal.timeout(5000)` and graceful failure (no throw)
+- `resolveYouTube(url)` → returns `null` if non-YouTube; otherwise returns `EmbedMetadata`
+- `resolveEmbedUrl(url)` → tries YouTube first, otherwise returns `generic` metadata
+
+**Run**:
+
+```bash
+pnpm test:unit -- tests/unit/infra/media/embed/
+pnpm -s tsc --noEmit
+```
+
+### Step 3: Media Schema Extensions (FR-002)
+
+**Modify**:
+
+- `src/server/payload/collections/Media/index.ts`
+
+**Add fields (after `externalUrl`)**:
+
+- `embedProvider` (select: youtube|generic, readOnly, sidebar, condition external)
+- `embedVideoId` (text, readOnly, sidebar, condition external)
+- `embedUrl` (text, readOnly, sidebar, condition external)
+- `embedTitle` (text, readOnly, condition external)
+- `embedThumbnailUrl` (text, readOnly, condition external)
+
+**Run**:
+
+```bash
+pnpm generate:types
+pnpm -s tsc --noEmit
+pnpm generate:importmap
+```
+
+### Step 4: Media `resolveEmbed` Hook (FR-003, NFR-002, NFR-004)
+
+**Create**:
+
+- `src/server/payload/collections/Media/hooks/resolveEmbed.ts`
+- `tests/unit/hooks/resolveEmbed.test.ts`
+
+**Modify**:
+
+- `src/server/payload/collections/Media/index.ts` (import + register hook)
+
+**Hook behavior**:
+
+- Create + external + URL present → resolve
+- Update + external + URL changed → resolve
+- Update + external + URL unchanged → no-op (performance)
+- Update + type changed away from external → clear embed fields (set to `null`)
+- Any resolver failure → log error, do not fail save
+
+**Run**:
+
+```bash
+pnpm test:unit -- tests/unit/hooks/resolveEmbed.test.ts
+pnpm -s tsc --noEmit
+```
+
+### Step 5: Web External Rendering (FR-004, NFR-001, NFR-003)
+
+**Modify (full update)**:
+
+- `src/ui/web/media/ExternalMedia/index.tsx`
+
+**Implement**:
+
+- If `embedProvider === 'youtube'` and `embedVideoId` + `embedUrl` exist → responsive 16:9 iframe with:
+  - `loading="lazy"`
+  - `allowFullScreen`
+  - `referrerPolicy="strict-origin-when-cross-origin"`
+  - explicit `allow` list
+- Else if `embedUrl` exists → generic iframe
+- Else if `externalUrl` exists → legacy iframe fallback (backward compatibility)
+
+**Run**:
+
+```bash
+pnpm -s tsc --noEmit
+```
+
+### Step 6: Admin External Preview (FR-005)
+
+**Modify (full update)**:
+
+- `src/ui/admin/MediaPreview/ExternalPreview.tsx`
+
+**Implement**:
+
+- Read form fields via `useFormFields`: `externalUrl`, `embedProvider`, `embedUrl`, `embedTitle`, `embedThumbnailUrl`, `embedVideoId`
+- Show provider badge + title + URL + open link
+- Prefer thumbnail (YouTube) over iframe in sidebar
+- Use inline styles (Payload admin)
+
+**Run**:
+
+```bash
+pnpm -s tsc --noEmit
+pnpm generate:importmap
+```
+
+### Step 7: Exercise Renderer Support + Test Updates (FR-006, FR-007)
+
+**Modify**:
+
+- `src/ui/web/exerciserenderer/components/MediaAttachments/index.tsx`
+- `tests/unit/exerciserenderer/MediaAttachments.test.tsx`
+
+**Implement**:
+
+- Add `external` media branch:
+  - YouTube (embed fields present) → responsive 16:9 iframe with same key attrs as web renderer
+  - Generic → iframe using `embedUrl` or fallback `externalUrl`
+
+**Run**:
+
+```bash
+pnpm test:unit -- tests/unit/exerciserenderer/MediaAttachments.test.tsx
+pnpm -s tsc --noEmit
+```
+
+### Final Verification
+
+```bash
+pnpm test:unit
+pnpm -s tsc --noEmit
+pnpm -s lint
+pnpm -s format
+pnpm generate:types
+pnpm generate:importmap
+```

--- a/src/infra/media/embed/index.ts
+++ b/src/infra/media/embed/index.ts
@@ -1,3 +1,4 @@
 export { resolveEmbedUrl } from './resolve'
 export { isYouTubeUrl, extractYouTubeVideoId, buildYouTubeEmbedUrl } from './youtube'
+export { isVimeoUrl, extractVimeoVideoId, buildVimeoEmbedUrl } from './vimeo'
 export type { EmbedProvider, EmbedMetadata } from './types'

--- a/src/infra/media/embed/index.ts
+++ b/src/infra/media/embed/index.ts
@@ -1,0 +1,3 @@
+export { resolveEmbedUrl } from './resolve'
+export { isYouTubeUrl, extractYouTubeVideoId, buildYouTubeEmbedUrl } from './youtube'
+export type { EmbedProvider, EmbedMetadata } from './types'

--- a/src/infra/media/embed/resolve.ts
+++ b/src/infra/media/embed/resolve.ts
@@ -1,0 +1,47 @@
+/**
+ * @fileType utility
+ * @domain media
+ * @pattern embed-provider
+ * @ai-summary Main entry point for resolving external URLs to embed metadata.
+ *             Tries each provider in order, falls back to generic.
+ */
+
+import type { EmbedMetadata } from './types'
+import { resolveYouTube } from './youtube'
+
+/**
+ * Resolve an external URL into embed metadata.
+ *
+ * How it works:
+ * 1. Try each supported provider in order (YouTube first)
+ * 2. If a provider matches, return its metadata
+ * 3. If no provider matches, return generic metadata (plain iframe)
+ *
+ * To add a new provider (e.g., Vimeo):
+ * 1. Create src/infra/media/embed/vimeo.ts with resolveVimeo()
+ * 2. Add 'vimeo' to the EmbedProvider type in types.ts
+ * 3. Add resolveVimeo to the providers array below
+ *
+ * @param url - The external URL to resolve
+ * @returns EmbedMetadata with provider info, embed URL, and optional title/thumbnail
+ */
+export async function resolveEmbedUrl(url: string): Promise<EmbedMetadata> {
+  // Try each provider in order. First match wins.
+  // Each resolver returns null if the URL doesn't match its pattern.
+  const providers = [resolveYouTube]
+
+  for (const resolve of providers) {
+    const result = await resolve(url)
+    if (result) return result
+  }
+
+  // No provider matched — return generic metadata.
+  // The URL will be used directly as an iframe src.
+  return {
+    provider: 'generic',
+    videoId: null,
+    embedUrl: url,
+    thumbnailUrl: null,
+    title: null,
+  }
+}

--- a/src/infra/media/embed/resolve.ts
+++ b/src/infra/media/embed/resolve.ts
@@ -8,6 +8,7 @@
 
 import type { EmbedMetadata } from './types'
 import { resolveYouTube } from './youtube'
+import { resolveVimeo } from './vimeo'
 
 /**
  * Resolve an external URL into embed metadata.
@@ -17,10 +18,10 @@ import { resolveYouTube } from './youtube'
  * 2. If a provider matches, return its metadata
  * 3. If no provider matches, return generic metadata (plain iframe)
  *
- * To add a new provider (e.g., Vimeo):
- * 1. Create src/infra/media/embed/vimeo.ts with resolveVimeo()
- * 2. Add 'vimeo' to the EmbedProvider type in types.ts
- * 3. Add resolveVimeo to the providers array below
+ * To add a new provider:
+ * 1. Create src/infra/media/embed/<provider>.ts with resolve<Provider>()
+ * 2. Add the provider name to the EmbedProvider type in types.ts
+ * 3. Add resolve<Provider> to the providers array below
  *
  * @param url - The external URL to resolve
  * @returns EmbedMetadata with provider info, embed URL, and optional title/thumbnail
@@ -28,7 +29,7 @@ import { resolveYouTube } from './youtube'
 export async function resolveEmbedUrl(url: string): Promise<EmbedMetadata> {
   // Try each provider in order. First match wins.
   // Each resolver returns null if the URL doesn't match its pattern.
-  const providers = [resolveYouTube]
+  const providers = [resolveYouTube, resolveVimeo]
 
   for (const resolve of providers) {
     const result = await resolve(url)

--- a/src/infra/media/embed/types.ts
+++ b/src/infra/media/embed/types.ts
@@ -1,0 +1,34 @@
+/**
+ * @fileType utility
+ * @domain media
+ * @pattern embed-provider
+ * @ai-summary Type definitions for external media embed providers
+ */
+
+/** Supported embed providers. Add new providers here. */
+export type EmbedProvider = 'youtube' | 'generic'
+
+/** Result of resolving an external URL to embed metadata */
+export interface EmbedMetadata {
+  /** Which provider was detected */
+  provider: EmbedProvider
+  /** Provider-specific video/content ID (e.g., YouTube video ID) */
+  videoId: string | null
+  /** The iframe-ready embed URL (e.g., https://www.youtube-nocookie.com/embed/xxx) */
+  embedUrl: string
+  /** Thumbnail image URL fetched from the provider */
+  thumbnailUrl: string | null
+  /** Content title fetched from the provider */
+  title: string | null
+}
+
+/** Response from YouTube's oEmbed API */
+export interface YouTubeOEmbedResponse {
+  title: string
+  author_name: string
+  author_url: string
+  thumbnail_url: string
+  thumbnail_width: number
+  thumbnail_height: number
+  html: string
+}

--- a/src/infra/media/embed/types.ts
+++ b/src/infra/media/embed/types.ts
@@ -6,7 +6,7 @@
  */
 
 /** Supported embed providers. Add new providers here. */
-export type EmbedProvider = 'youtube' | 'generic'
+export type EmbedProvider = 'youtube' | 'vimeo' | 'generic'
 
 /** Result of resolving an external URL to embed metadata */
 export interface EmbedMetadata {

--- a/src/infra/media/embed/vimeo.ts
+++ b/src/infra/media/embed/vimeo.ts
@@ -1,0 +1,138 @@
+/**
+ * @fileType utility
+ * @domain media
+ * @pattern embed-provider
+ * @ai-summary Vimeo URL detection, video ID extraction, and oEmbed metadata fetching
+ */
+
+import type { EmbedMetadata } from './types'
+
+/**
+ * Vimeo URL patterns supported:
+ *   - https://vimeo.com/VIDEO_ID
+ *   - https://www.vimeo.com/VIDEO_ID
+ *   - https://player.vimeo.com/video/VIDEO_ID
+ *   - https://vimeo.com/channels/CHANNEL/VIDEO_ID
+ *   - https://vimeo.com/groups/GROUP/videos/VIDEO_ID
+ *   - https://vimeo.com/VIDEO_ID?h=HASH (private video with hash)
+ */
+const VIMEO_PATTERNS: RegExp[] = [
+  // Standard: vimeo.com/ID
+  /(?:https?:\/\/)?(?:www\.)?vimeo\.com\/(\d+)/,
+  // Player embed: player.vimeo.com/video/ID
+  /(?:https?:\/\/)?player\.vimeo\.com\/video\/(\d+)/,
+  // Channel: vimeo.com/channels/CHANNEL/ID
+  /(?:https?:\/\/)?(?:www\.)?vimeo\.com\/channels\/[^/]+\/(\d+)/,
+  // Group: vimeo.com/groups/GROUP/videos/ID
+  /(?:https?:\/\/)?(?:www\.)?vimeo\.com\/groups\/[^/]+\/videos\/(\d+)/,
+]
+
+/**
+ * Check if a URL is a Vimeo URL.
+ */
+export function isVimeoUrl(url: string): boolean {
+  return VIMEO_PATTERNS.some((pattern) => pattern.test(url))
+}
+
+/**
+ * Extract the numeric video ID from a Vimeo URL.
+ * Returns null if the URL is not a recognized Vimeo format.
+ */
+export function extractVimeoVideoId(url: string): string | null {
+  for (const pattern of VIMEO_PATTERNS) {
+    const match = url.match(pattern)
+    if (match?.[1]) {
+      return match[1]
+    }
+  }
+  return null
+}
+
+/**
+ * Build the Vimeo player embed URL.
+ * Preserves the ?h= hash parameter required for private videos.
+ */
+export function buildVimeoEmbedUrl(videoId: string, privateHash?: string | null): string {
+  const base = `https://player.vimeo.com/video/${videoId}`
+  return privateHash ? `${base}?h=${privateHash}` : base
+}
+
+/** Response shape from Vimeo's public oEmbed API */
+interface VimeoOEmbedResponse {
+  title: string
+  thumbnail_url: string
+  thumbnail_url_with_play_button?: string
+  author_name: string
+  author_url: string
+  html: string
+}
+
+/**
+ * Fetch metadata (title, thumbnail) from Vimeo's public oEmbed endpoint.
+ *
+ * Does NOT require a Vimeo API key. Called once per media save (in the
+ * resolveEmbed beforeChange hook), so rate limits are not a concern.
+ *
+ * @param videoId - The Vimeo numeric video ID
+ * @param privateHash - Optional private hash (?h=...) for password-protected/private videos
+ */
+export async function fetchVimeoMetadata(
+  videoId: string,
+  privateHash?: string | null,
+): Promise<EmbedMetadata> {
+  const embedUrl = buildVimeoEmbedUrl(videoId, privateHash)
+
+  const metadata: EmbedMetadata = {
+    provider: 'vimeo',
+    videoId,
+    embedUrl,
+    thumbnailUrl: null,
+    title: null,
+  }
+
+  try {
+    const videoUrl = `https://vimeo.com/${videoId}`
+    const oEmbedUrl = `https://vimeo.com/api/oembed.json?url=${encodeURIComponent(videoUrl)}&width=1280`
+
+    const response = await fetch(oEmbedUrl, {
+      signal: AbortSignal.timeout(5000),
+    })
+
+    if (!response.ok) {
+      // Private or deleted video — embed may still work with the hash
+      return metadata
+    }
+
+    const data = (await response.json()) as VimeoOEmbedResponse
+
+    metadata.title = data.title || null
+    metadata.thumbnailUrl = data.thumbnail_url || null
+  } catch {
+    // Network error, timeout, or parse failure
+    // Graceful degradation — the embed URL still works
+  }
+
+  return metadata
+}
+
+/**
+ * Full Vimeo resolver: detect, extract, fetch metadata.
+ * Returns null if the URL is not a Vimeo URL.
+ *
+ * @param url - Any URL to check
+ */
+export async function resolveVimeo(url: string): Promise<EmbedMetadata | null> {
+  const videoId = extractVimeoVideoId(url)
+  if (!videoId) return null
+
+  // Extract private hash if present (?h=HASH)
+  let privateHash: string | null = null
+  try {
+    const parsed = new URL(url.startsWith('http') ? url : `https://${url}`)
+    privateHash = parsed.searchParams.get('h')
+  } catch {
+    // Ignore malformed URLs
+  }
+
+  return fetchVimeoMetadata(videoId, privateHash)
+}

--- a/src/infra/media/embed/youtube.ts
+++ b/src/infra/media/embed/youtube.ts
@@ -1,0 +1,145 @@
+/**
+ * @fileType utility
+ * @domain media
+ * @pattern embed-provider
+ * @ai-summary YouTube URL detection, video ID extraction, and oEmbed metadata fetching
+ */
+
+import type { EmbedMetadata, YouTubeOEmbedResponse } from './types'
+
+/**
+ * All the URL patterns YouTube uses.
+ * Each regex has a capture group for the video ID.
+ *
+ * Why so many? YouTube has many URL formats:
+ *   - https://www.youtube.com/watch?v=VIDEO_ID
+ *   - https://youtu.be/VIDEO_ID
+ *   - https://www.youtube.com/embed/VIDEO_ID
+ *   - https://www.youtube.com/shorts/VIDEO_ID
+ *   - https://www.youtube.com/live/VIDEO_ID
+ *   - https://m.youtube.com/watch?v=VIDEO_ID (mobile)
+ */
+const YOUTUBE_PATTERNS: RegExp[] = [
+  /(?:https?:\/\/)?(?:www\.)?youtube\.com\/watch\?.*v=([a-zA-Z0-9_-]{11})/,
+  /(?:https?:\/\/)?youtu\.be\/([a-zA-Z0-9_-]{11})/,
+  /(?:https?:\/\/)?(?:www\.)?youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/,
+  /(?:https?:\/\/)?(?:www\.)?youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})/,
+  /(?:https?:\/\/)?(?:www\.)?youtube\.com\/live\/([a-zA-Z0-9_-]{11})/,
+  /(?:https?:\/\/)?m\.youtube\.com\/watch\?.*v=([a-zA-Z0-9_-]{11})/,
+]
+
+/**
+ * Check if a URL is a YouTube URL.
+ *
+ * @param url - The URL to check (e.g., "https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+ * @returns true if the URL matches any YouTube pattern
+ */
+export function isYouTubeUrl(url: string): boolean {
+  return YOUTUBE_PATTERNS.some((pattern) => pattern.test(url))
+}
+
+/**
+ * Extract the 11-character video ID from a YouTube URL.
+ *
+ * YouTube video IDs are always exactly 11 characters containing:
+ * letters (a-z, A-Z), numbers (0-9), hyphens (-), and underscores (_).
+ *
+ * @param url - A YouTube URL in any supported format
+ * @returns The 11-character video ID, or null if not found
+ *
+ * @example
+ * extractYouTubeVideoId('https://www.youtube.com/watch?v=dQw4w9WgXcQ') // 'dQw4w9WgXcQ'
+ * extractYouTubeVideoId('https://youtu.be/dQw4w9WgXcQ')                // 'dQw4w9WgXcQ'
+ * extractYouTubeVideoId('https://example.com')                          // null
+ */
+export function extractYouTubeVideoId(url: string): string | null {
+  for (const pattern of YOUTUBE_PATTERNS) {
+    const match = url.match(pattern)
+    if (match?.[1]) {
+      return match[1]
+    }
+  }
+  return null
+}
+
+/**
+ * Convert a YouTube video ID into a privacy-enhanced embed URL.
+ *
+ * Uses youtube-nocookie.com instead of youtube.com to avoid
+ * setting tracking cookies on the user's browser.
+ *
+ * @param videoId - The 11-character YouTube video ID
+ * @returns A full embed URL ready for use in an <iframe> src attribute
+ */
+export function buildYouTubeEmbedUrl(videoId: string): string {
+  return `https://www.youtube-nocookie.com/embed/${videoId}`
+}
+
+/**
+ * Fetch metadata (title, thumbnail) from YouTube's public oEmbed endpoint.
+ *
+ * This does NOT require a YouTube API key. The oEmbed endpoint is public
+ * and rate-limited but sufficient for our use case (called once per media save).
+ *
+ * @param videoId - The YouTube video ID
+ * @returns EmbedMetadata with title and thumbnail, or null fields on failure
+ *
+ * How oEmbed works:
+ * 1. We send a GET request to YouTube's oEmbed URL with the video URL
+ * 2. YouTube responds with JSON containing title, author, thumbnail, etc.
+ * 3. We extract what we need and return it in our EmbedMetadata format
+ */
+export async function fetchYouTubeMetadata(videoId: string): Promise<EmbedMetadata> {
+  const embedUrl = buildYouTubeEmbedUrl(videoId)
+
+  // Base metadata (always available since we have the video ID)
+  const metadata: EmbedMetadata = {
+    provider: 'youtube',
+    videoId,
+    embedUrl,
+    thumbnailUrl: null,
+    title: null,
+  }
+
+  try {
+    // YouTube's public oEmbed endpoint — no API key needed
+    const oEmbedUrl = `https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${videoId}&format=json`
+
+    const response = await fetch(oEmbedUrl, {
+      // Timeout after 5 seconds — don't block the save if YouTube is slow
+      signal: AbortSignal.timeout(5000),
+    })
+
+    if (!response.ok) {
+      // Video might be private or deleted — embed will still work, just no metadata
+      return metadata
+    }
+
+    const data = (await response.json()) as YouTubeOEmbedResponse
+
+    metadata.title = data.title || null
+    metadata.thumbnailUrl = data.thumbnail_url || null
+  } catch {
+    // Network error, timeout, or parsing error
+    // This is fine — we still have the embed URL and video ID
+    // The embed will work, just without title/thumbnail
+  }
+
+  return metadata
+}
+
+/**
+ * Full YouTube resolver: detect, extract, fetch metadata.
+ *
+ * This is the main entry point for YouTube URL processing.
+ * Returns null if the URL is not a YouTube URL.
+ *
+ * @param url - Any URL to check
+ * @returns Full EmbedMetadata if YouTube URL, or null if not YouTube
+ */
+export async function resolveYouTube(url: string): Promise<EmbedMetadata | null> {
+  const videoId = extractYouTubeVideoId(url)
+  if (!videoId) return null
+
+  return fetchYouTubeMetadata(videoId)
+}

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -566,7 +566,7 @@ export interface Media {
   /**
    * Auto-detected from URL. Do not change manually.
    */
-  embedProvider?: ('youtube' | 'generic') | null;
+  embedProvider?: ('youtube' | 'vimeo' | 'generic') | null;
   /**
    * Provider-specific video/content ID
    */

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -564,6 +564,26 @@ export interface Media {
    */
   externalUrl?: string | null;
   /**
+   * Auto-detected from URL. Do not change manually.
+   */
+  embedProvider?: ('youtube' | 'generic') | null;
+  /**
+   * Provider-specific video/content ID
+   */
+  embedVideoId?: string | null;
+  /**
+   * Embed-ready URL for iframe (auto-generated)
+   */
+  embedUrl?: string | null;
+  /**
+   * Title fetched from provider (auto-populated)
+   */
+  embedTitle?: string | null;
+  /**
+   * Thumbnail URL fetched from provider (auto-populated)
+   */
+  embedThumbnailUrl?: string | null;
+  /**
    * Alternative text for images and SVGs (required for accessibility)
    */
   alt?: string | null;
@@ -2694,6 +2714,11 @@ export interface MediaSelect<T extends boolean = true> {
   tenant?: T;
   type?: T;
   externalUrl?: T;
+  embedProvider?: T;
+  embedVideoId?: T;
+  embedUrl?: T;
+  embedTitle?: T;
+  embedThumbnailUrl?: T;
   alt?: T;
   caption?: T;
   createdBy?: T;

--- a/src/server/payload/collections/Media/hooks/resolveEmbed.ts
+++ b/src/server/payload/collections/Media/hooks/resolveEmbed.ts
@@ -1,0 +1,85 @@
+/**
+ * @fileType hook
+ * @domain media
+ * @pattern embed-provider
+ * @ai-summary beforeChange hook that resolves external URLs to embed metadata.
+ *             Called on create and update when type is 'external'.
+ */
+
+import type { CollectionBeforeChangeHook } from 'payload'
+
+import { resolveEmbedUrl } from '@/infra/media/embed'
+import { MediaType } from '@/infra/media/types'
+
+/**
+ * Resolves external URLs to embed metadata.
+ *
+ * When this hook runs:
+ * - On CREATE with type === 'external': Always resolve
+ * - On UPDATE with type === 'external' AND externalUrl changed: Re-resolve
+ * - On UPDATE with type !== 'external': Clear embed fields (type was changed away from external)
+ * - Everything else: Skip (no-op)
+ *
+ * What it does:
+ * 1. Calls resolveEmbedUrl() which tries each provider (YouTube first)
+ * 2. Populates embedProvider, embedVideoId, embedUrl, embedTitle, embedThumbnailUrl
+ * 3. If the oEmbed fetch fails, the embed fields still get populated with what we have
+ *    (at minimum: provider and embedUrl)
+ */
+export const resolveEmbedHook: CollectionBeforeChangeHook = async ({
+  data,
+  operation,
+  originalDoc,
+  req,
+}) => {
+  const type = data?.type
+  const externalUrl = data?.externalUrl
+
+  // --- Case 1: Not an external type ---
+  // If the type was changed AWAY from external, clear embed fields
+  if (type !== MediaType.External) {
+    if (originalDoc?.embedProvider) {
+      // Was external before, now it's not — clear embed data
+      data.embedProvider = null
+      data.embedVideoId = null
+      data.embedUrl = null
+      data.embedTitle = null
+      data.embedThumbnailUrl = null
+    }
+    return data
+  }
+
+  // --- Case 2: External type, but no URL ---
+  if (!externalUrl) {
+    return data
+  }
+
+  // --- Case 3: Update, but URL hasn't changed ---
+  if (operation === 'update' && originalDoc?.externalUrl === externalUrl) {
+    // URL didn't change, keep existing embed data
+    return data
+  }
+
+  // --- Case 4: External type with a new/changed URL — resolve it ---
+  try {
+    req.payload.logger.info(`[Media] Resolving embed URL: ${externalUrl}`)
+
+    const metadata = await resolveEmbedUrl(externalUrl)
+
+    data.embedProvider = metadata.provider
+    data.embedVideoId = metadata.videoId
+    data.embedUrl = metadata.embedUrl
+    data.embedTitle = metadata.title
+    data.embedThumbnailUrl = metadata.thumbnailUrl
+
+    req.payload.logger.info(
+      `[Media] Resolved embed: provider=${metadata.provider}, videoId=${metadata.videoId}`,
+    )
+  } catch (error: unknown) {
+    // Don't fail the save — just log and leave embed fields empty
+    const message = error instanceof Error ? error.message : String(error)
+    req.payload.logger.error(`[Media] Failed to resolve embed URL: ${externalUrl} — ${message}`)
+  }
+
+  return data
+}

--- a/src/server/payload/collections/Media/index.ts
+++ b/src/server/payload/collections/Media/index.ts
@@ -140,6 +140,7 @@ export const Media: CollectionConfig = {
       type: 'select',
       options: [
         { label: 'YouTube', value: 'youtube' },
+        { label: 'Vimeo', value: 'vimeo' },
         { label: 'Generic', value: 'generic' },
       ],
       admin: {

--- a/src/server/payload/collections/Media/index.ts
+++ b/src/server/payload/collections/Media/index.ts
@@ -31,29 +31,44 @@ export const Media: CollectionConfig = {
     // Show thumbnail in admin list view - uses function to handle External media
     adminThumbnail: ({ doc }) => {
       // Cast doc to access typed properties
-      const docData = doc as { type?: string; externalUrl?: string; url?: string }
-      // YouTube External media: return YouTube thumbnail
-      if (
-        docData.type === MediaType.External &&
-        docData.externalUrl &&
-        isYouTubeUrl(docData.externalUrl)
-      ) {
-        const videoId = extractYouTubeVideoId(docData.externalUrl)
-        if (videoId) {
-          return `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`
-        }
-        return null
+      const docData = doc as {
+        type?: string
+        externalUrl?: string
+        url?: string
+        embedThumbnailUrl?: string | null
       }
-      // Other External media: no thumbnail
       if (docData.type === MediaType.External) {
+        // YouTube: use YouTube's CDN thumbnail directly (no API needed)
+        if (docData.externalUrl && isYouTubeUrl(docData.externalUrl)) {
+          const videoId = extractYouTubeVideoId(docData.externalUrl)
+          if (videoId) {
+            return `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`
+          }
+        }
+        // Vimeo (and other providers): use the thumbnail fetched by resolveEmbedHook
+        if (docData.embedThumbnailUrl) {
+          return docData.embedThumbnailUrl
+        }
         return null
       }
       // Uploaded files: return the main URL (false to disable if url is undefined)
       return docData.url || false
     },
+    // Skip Payload's buffer-based checkFileRestrictions.
+    // With clientUploads=true, Payload re-fetches the entire file from Vercel Blob into
+    // server memory before running restrictions — causing OOM/timeouts for large video files.
+    // Our validateMediaUploadHook already handles MIME type and size validation server-side.
+    allowRestrictedFileTypes: true,
     mimeTypes: [
       'image/*',
+      // Explicit video MIME types + extensions for browser file-picker compatibility.
+      // macOS Safari requires 'video/quicktime' or '.mov' explicitly — 'video/*' alone
+      // does not show .mov files in the file picker on all browsers.
       'video/*',
+      'video/mp4',
+      'video/quicktime',
+      '.mp4',
+      '.mov',
       'audio/*',
       'application/pdf',
       'application/msword',

--- a/src/server/payload/collections/Media/index.ts
+++ b/src/server/payload/collections/Media/index.ts
@@ -15,6 +15,7 @@ import { authenticated } from '../../access/authenticated'
 import { createdByField } from '../../fields/createdBy'
 import { enforceRetentionPolicyHook } from './hooks/enforceRetentionPolicy'
 import { inferMediaTypeHook } from './hooks/inferMediaType'
+import { resolveEmbedHook } from './hooks/resolveEmbed'
 import { validateMediaUploadHook } from './hooks/validateMediaUpload'
 
 export const Media: CollectionConfig = {
@@ -90,6 +91,63 @@ export const Media: CollectionConfig = {
       admin: {
         condition: (data) => data?.type === MediaType.External,
         description: 'URL for external embed or link',
+      },
+      required: false,
+    },
+    {
+      name: 'embedProvider',
+      type: 'select',
+      options: [
+        { label: 'YouTube', value: 'youtube' },
+        { label: 'Generic', value: 'generic' },
+      ],
+      admin: {
+        condition: (data) => data?.type === MediaType.External,
+        position: 'sidebar',
+        description: 'Auto-detected from URL. Do not change manually.',
+        readOnly: true,
+      },
+      required: false,
+    },
+    {
+      name: 'embedVideoId',
+      type: 'text',
+      admin: {
+        condition: (data) => data?.type === MediaType.External,
+        position: 'sidebar',
+        description: 'Provider-specific video/content ID',
+        readOnly: true,
+      },
+      required: false,
+    },
+    {
+      name: 'embedUrl',
+      type: 'text',
+      admin: {
+        condition: (data) => data?.type === MediaType.External,
+        position: 'sidebar',
+        description: 'Embed-ready URL for iframe (auto-generated)',
+        readOnly: true,
+      },
+      required: false,
+    },
+    {
+      name: 'embedTitle',
+      type: 'text',
+      admin: {
+        condition: (data) => data?.type === MediaType.External,
+        description: 'Title fetched from provider (auto-populated)',
+        readOnly: true,
+      },
+      required: false,
+    },
+    {
+      name: 'embedThumbnailUrl',
+      type: 'text',
+      admin: {
+        condition: (data) => data?.type === MediaType.External,
+        description: 'Thumbnail URL fetched from provider (auto-populated)',
+        readOnly: true,
       },
       required: false,
     },
@@ -171,7 +229,7 @@ export const Media: CollectionConfig = {
   ],
   hooks: {
     beforeValidate: [validateMediaUploadHook],
-    beforeChange: [enforceRetentionPolicyHook],
+    beforeChange: [resolveEmbedHook, enforceRetentionPolicyHook],
   },
   // File storage is handled by @payloadcms/storage-vercel-blob plugin
   // The plugin adds disableLocalStorage: true and adapter handlers to this collection

--- a/src/ui/admin/MediaPreview/ExternalPreview.tsx
+++ b/src/ui/admin/MediaPreview/ExternalPreview.tsx
@@ -3,40 +3,174 @@
 import React from 'react'
 import { useFormFields } from '@payloadcms/ui'
 
+/**
+ * Admin preview for External media type.
+ *
+ * Reads form fields reactively via useFormFields so the preview
+ * updates live as the editor changes values.
+ *
+ * Shows:
+ * - The detected provider (e.g., "YouTube") as a badge
+ * - The original URL with an "Open Link" button
+ * - The fetched title (if available)
+ * - A thumbnail image (if available) OR an iframe preview
+ */
 export const ExternalPreview: React.FC = () => {
+  // Read form field values reactively
   const externalUrlField = useFormFields(([fields]) => fields.externalUrl)
+  const embedProviderField = useFormFields(([fields]) => fields.embedProvider)
+  const embedUrlField = useFormFields(([fields]) => fields.embedUrl)
+  const embedTitleField = useFormFields(([fields]) => fields.embedTitle)
+  const embedThumbnailUrlField = useFormFields(([fields]) => fields.embedThumbnailUrl)
+  const embedVideoIdField = useFormFields(([fields]) => fields.embedVideoId)
 
   const externalUrl = externalUrlField?.value as string | undefined
+  const embedProvider = embedProviderField?.value as string | undefined
+  const embedUrl = embedUrlField?.value as string | undefined
+  const embedTitle = embedTitleField?.value as string | undefined
+  const embedThumbnailUrl = embedThumbnailUrlField?.value as string | undefined
+  const embedVideoId = embedVideoIdField?.value as string | undefined
 
   if (!externalUrl) {
     return (
-      <div className="p-4">
-        <p>No external URL provided</p>
+      <div style={{ padding: '16px' }}>
+        <p>Paste an external URL (e.g., YouTube link) and save to see a preview.</p>
       </div>
     )
   }
 
   return (
-    <div className="p-4">
-      <h3 className="mb-2">External Media</h3>
-      <p className="mb-4 break-all">
-        <strong>URL:</strong> {externalUrl}
+    <div style={{ padding: '16px' }}>
+      {/* Provider badge */}
+      {embedProvider && embedProvider !== 'generic' && (
+        <div
+          style={{
+            display: 'inline-block',
+            padding: '2px 8px',
+            marginBottom: '8px',
+            borderRadius: '4px',
+            backgroundColor: embedProvider === 'youtube' ? '#FF0000' : 'var(--theme-elevation-300)',
+            color: embedProvider === 'youtube' ? '#fff' : 'inherit',
+            fontSize: '12px',
+            fontWeight: 600,
+            textTransform: 'uppercase',
+          }}
+        >
+          {embedProvider}
+        </div>
+      )}
+
+      {/* Title */}
+      {embedTitle && <h4 style={{ margin: '0 0 8px 0', fontSize: '14px' }}>{embedTitle}</h4>}
+
+      {/* Original URL */}
+      <p
+        style={{
+          margin: '0 0 8px 0',
+          wordBreak: 'break-all',
+          fontSize: '12px',
+          opacity: 0.7,
+        }}
+      >
+        {externalUrl}
       </p>
-      <div className="mb-4">
+
+      {/* Open Link button */}
+      <div style={{ marginBottom: '12px' }}>
         <a
           href={externalUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-block px-4 py-2 bg-[var(--theme-elevation-300)] rounded no-underline"
+          style={{
+            display: 'inline-block',
+            padding: '4px 12px',
+            backgroundColor: 'var(--theme-elevation-300)',
+            borderRadius: '4px',
+            textDecoration: 'none',
+            fontSize: '13px',
+          }}
         >
-          🔗 Open Link
+          Open Link
         </a>
       </div>
-      <iframe
-        src={externalUrl}
-        className="w-full h-[400px] border border-[var(--theme-elevation-300)] rounded"
-        title="External content"
-      />
+
+      {/* Preview: thumbnail for YouTube, iframe for others */}
+      {embedProvider === 'youtube' && embedThumbnailUrl ? (
+        <div style={{ position: 'relative' }}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={embedThumbnailUrl}
+            alt={embedTitle || 'YouTube thumbnail'}
+            style={{
+              width: '100%',
+              borderRadius: '4px',
+              display: 'block',
+            }}
+          />
+          {/* Play button overlay */}
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              pointerEvents: 'none',
+            }}
+          >
+            <div
+              style={{
+                width: '48px',
+                height: '48px',
+                borderRadius: '50%',
+                backgroundColor: 'rgba(0,0,0,0.7)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              {/* CSS triangle play icon */}
+              <div
+                style={{
+                  width: 0,
+                  height: 0,
+                  borderTop: '10px solid transparent',
+                  borderBottom: '10px solid transparent',
+                  borderLeft: '16px solid white',
+                  marginLeft: '3px',
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      ) : embedUrl ? (
+        <iframe
+          src={embedUrl}
+          style={{
+            width: '100%',
+            height: '200px',
+            border: '1px solid var(--theme-elevation-300)',
+            borderRadius: '4px',
+          }}
+          title={embedTitle || 'External content preview'}
+        />
+      ) : (
+        <iframe
+          src={externalUrl}
+          style={{
+            width: '100%',
+            height: '200px',
+            border: '1px solid var(--theme-elevation-300)',
+            borderRadius: '4px',
+          }}
+          title="External content preview"
+        />
+      )}
+
+      {/* Video ID (debug info) */}
+      {embedVideoId && (
+        <p style={{ margin: '8px 0 0 0', fontSize: '11px', opacity: 0.5 }}>ID: {embedVideoId}</p>
+      )}
     </div>
   )
 }

--- a/src/ui/admin/MediaPreview/ExternalPreview.tsx
+++ b/src/ui/admin/MediaPreview/ExternalPreview.tsx
@@ -49,8 +49,13 @@ export const ExternalPreview: React.FC = () => {
             padding: '2px 8px',
             marginBottom: '8px',
             borderRadius: '4px',
-            backgroundColor: embedProvider === 'youtube' ? '#FF0000' : 'var(--theme-elevation-300)',
-            color: embedProvider === 'youtube' ? '#fff' : 'inherit',
+            backgroundColor:
+              embedProvider === 'youtube'
+                ? '#FF0000'
+                : embedProvider === 'vimeo'
+                  ? '#1ab7ea'
+                  : 'var(--theme-elevation-300)',
+            color: embedProvider === 'youtube' || embedProvider === 'vimeo' ? '#fff' : 'inherit',
             fontSize: '12px',
             fontWeight: 600,
             textTransform: 'uppercase',
@@ -94,13 +99,13 @@ export const ExternalPreview: React.FC = () => {
         </a>
       </div>
 
-      {/* Preview: thumbnail for YouTube, iframe for others */}
-      {embedProvider === 'youtube' && embedThumbnailUrl ? (
+      {/* Preview: thumbnail (with play overlay) for YouTube/Vimeo, iframe for others */}
+      {(embedProvider === 'youtube' || embedProvider === 'vimeo') && embedThumbnailUrl ? (
         <div style={{ position: 'relative' }}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={embedThumbnailUrl}
-            alt={embedTitle || 'YouTube thumbnail'}
+            alt={embedTitle || `${embedProvider} thumbnail`}
             style={{
               width: '100%',
               borderRadius: '4px',

--- a/src/ui/web/exerciserenderer/components/MediaAttachments/index.tsx
+++ b/src/ui/web/exerciserenderer/components/MediaAttachments/index.tsx
@@ -19,13 +19,62 @@ function isVideoType(media: Media): boolean {
   return media.type === 'video'
 }
 
+function isExternalType(media: Media): boolean {
+  return media.type === 'external'
+}
+
 /**
  * Renders a single media item.
  * Uses plain <img> / <video> to avoid Next.js Image optimization domain issues.
  */
 function MediaItem({ media }: { media: Media }) {
-  const src = getMediaUrl(media.url, media.updatedAt)
+  // External media has no file URL — handle before the src check
+  if (isExternalType(media)) {
+    const embedMedia = media as Media & {
+      embedProvider?: string | null
+      embedVideoId?: string | null
+      embedUrl?: string | null
+      embedTitle?: string | null
+      externalUrl?: string | null
+    }
 
+    // YouTube embed
+    if (embedMedia.embedProvider === 'youtube' && embedMedia.embedVideoId && embedMedia.embedUrl) {
+      return (
+        <div
+          className="relative w-full overflow-hidden rounded-lg"
+          style={{ aspectRatio: '16 / 9' }}
+        >
+          <iframe
+            src={embedMedia.embedUrl}
+            title={embedMedia.embedTitle || `YouTube video ${embedMedia.embedVideoId}`}
+            className="absolute inset-0 h-full w-full"
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowFullScreen
+            referrerPolicy="strict-origin-when-cross-origin"
+          />
+        </div>
+      )
+    }
+
+    // Generic external embed
+    const embedUrl = embedMedia.embedUrl || embedMedia.externalUrl
+    if (embedUrl) {
+      return (
+        <iframe
+          src={embedUrl}
+          title={embedMedia.embedTitle || 'External content'}
+          className="w-full h-[400px] border border-border rounded"
+          loading="lazy"
+        />
+      )
+    }
+
+    return null
+  }
+
+  const src = getMediaUrl(media.url, media.updatedAt)
   if (!src) return null
 
   if (isVideoType(media)) {

--- a/src/ui/web/exerciserenderer/components/MediaAttachments/index.tsx
+++ b/src/ui/web/exerciserenderer/components/MediaAttachments/index.tsx
@@ -38,8 +38,12 @@ function MediaItem({ media }: { media: Media }) {
       externalUrl?: string | null
     }
 
-    // YouTube embed
-    if (embedMedia.embedProvider === 'youtube' && embedMedia.embedVideoId && embedMedia.embedUrl) {
+    // YouTube / Vimeo embed — 16:9 responsive iframe
+    if (
+      (embedMedia.embedProvider === 'youtube' || embedMedia.embedProvider === 'vimeo') &&
+      embedMedia.embedVideoId &&
+      embedMedia.embedUrl
+    ) {
       return (
         <div
           className="relative w-full overflow-hidden rounded-lg"
@@ -47,7 +51,7 @@ function MediaItem({ media }: { media: Media }) {
         >
           <iframe
             src={embedMedia.embedUrl}
-            title={embedMedia.embedTitle || `YouTube video ${embedMedia.embedVideoId}`}
+            title={embedMedia.embedTitle || `Video ${embedMedia.embedVideoId}`}
             className="absolute inset-0 h-full w-full"
             loading="lazy"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"

--- a/src/ui/web/media/ExternalMedia/index.tsx
+++ b/src/ui/web/media/ExternalMedia/index.tsx
@@ -6,31 +6,123 @@ import React from 'react'
 import type { Props as MediaProps } from '../types'
 import type { Media } from '@/payload-types'
 
+/**
+ * Extended Media type with embed fields.
+ * These fields are populated by the resolveEmbed hook when type === 'external'.
+ */
 interface ExternalMediaResource extends Media {
-  externalUrl?: string
+  externalUrl?: string | null
+  embedProvider?: 'youtube' | 'generic' | null
+  embedVideoId?: string | null
+  embedUrl?: string | null
+  embedTitle?: string | null
+  embedThumbnailUrl?: string | null
 }
 
+/**
+ * Renders a YouTube embed with proper 16:9 aspect ratio.
+ *
+ * Key attributes:
+ * - youtube-nocookie.com: Privacy-enhanced mode (no tracking cookies)
+ * - loading="lazy": Don't load the iframe until it's near the viewport
+ * - allowFullScreen: Users can go fullscreen
+ * - allow="...": Permissions for the iframe (autoplay, clipboard, etc.)
+ */
+function YouTubeEmbed({
+  videoId,
+  embedUrl,
+  title,
+  className,
+}: {
+  videoId: string
+  embedUrl: string
+  title: string | null | undefined
+  className?: string
+}) {
+  return (
+    <div
+      className={cn('relative w-full overflow-hidden rounded-lg', className)}
+      style={{ aspectRatio: '16 / 9' }}
+    >
+      <iframe
+        src={embedUrl}
+        title={title || `YouTube video ${videoId}`}
+        className="absolute inset-0 h-full w-full"
+        loading="lazy"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allowFullScreen
+        referrerPolicy="strict-origin-when-cross-origin"
+      />
+    </div>
+  )
+}
+
+/**
+ * Generic iframe embed for non-YouTube URLs.
+ * Falls back to the original behavior: a plain iframe with the URL.
+ */
+function GenericEmbed({
+  url,
+  title,
+  className,
+}: {
+  url: string
+  title: string | null | undefined
+  className?: string
+}) {
+  return (
+    <div className={cn('external-media', className)}>
+      <iframe
+        src={url}
+        title={title || 'External content'}
+        className="w-full h-[400px] border border-border rounded"
+        loading="lazy"
+      />
+    </div>
+  )
+}
+
+/**
+ * Main ExternalMedia component.
+ *
+ * Routes to the correct renderer based on embedProvider:
+ * - 'youtube' -> YouTubeEmbed (proper 16:9 responsive player)
+ * - 'generic' or missing -> GenericEmbed (plain iframe, like before)
+ *
+ * This component is used by the main <Media> component (src/ui/web/media/index.tsx)
+ * when the media document has type === 'external'. It receives the full media
+ * document as props.resource, which includes the embed fields set by the hook.
+ */
 export const ExternalMedia: React.FC<MediaProps> = (props) => {
   const { resource, className } = props
 
-  if (resource && typeof resource === 'object') {
-    const externalUrl = (resource as ExternalMediaResource).externalUrl
+  if (!resource || typeof resource !== 'object') {
+    return null
+  }
 
-    if (!externalUrl) {
-      return <p className={cn('external-media-error', className)}>No external URL provided</p>
-    }
+  const media = resource as ExternalMediaResource
 
-    // Simple iframe embed (could be enhanced to detect URL type)
+  // If we have an embed URL from the hook, use the provider-specific renderer
+  if (media.embedProvider === 'youtube' && media.embedVideoId && media.embedUrl) {
     return (
-      <div className={cn('external-media', className)}>
-        <iframe
-          src={externalUrl}
-          className="w-full h-[400px] border border-border rounded"
-          title="External content"
-        />
-      </div>
+      <YouTubeEmbed
+        videoId={media.embedVideoId}
+        embedUrl={media.embedUrl}
+        title={media.embedTitle}
+        className={className}
+      />
     )
   }
 
-  return null
+  // If we have an embedUrl but not YouTube, use generic embed with the resolved URL
+  if (media.embedUrl) {
+    return <GenericEmbed url={media.embedUrl} title={media.embedTitle} className={className} />
+  }
+
+  // Fallback: use the raw externalUrl (for legacy data without embed fields)
+  if (media.externalUrl) {
+    return <GenericEmbed url={media.externalUrl} title={null} className={className} />
+  }
+
+  return <p className={cn('text-muted-foreground', className)}>No external URL provided</p>
 }

--- a/src/ui/web/media/ExternalMedia/index.tsx
+++ b/src/ui/web/media/ExternalMedia/index.tsx
@@ -12,7 +12,7 @@ import type { Props as MediaProps } from '../types'
  */
 interface ExternalMediaResource extends Media {
   externalUrl?: string | null
-  embedProvider?: 'youtube' | 'generic' | null
+  embedProvider?: 'youtube' | 'vimeo' | 'generic' | null
   embedVideoId?: string | null
   embedUrl?: string | null
   embedTitle?: string | null
@@ -20,15 +20,14 @@ interface ExternalMediaResource extends Media {
 }
 
 /**
- * Renders a YouTube embed with proper 16:9 aspect ratio.
+ * Renders a video embed (YouTube or Vimeo) with proper 16:9 aspect ratio.
  *
  * Key attributes:
- * - youtube-nocookie.com: Privacy-enhanced mode (no tracking cookies)
  * - loading="lazy": Don't load the iframe until it's near the viewport
  * - allowFullScreen: Users can go fullscreen
  * - allow="...": Permissions for the iframe (autoplay, clipboard, etc.)
  */
-function YouTubeEmbed({
+function VideoEmbed({
   videoId,
   embedUrl,
   title,
@@ -46,7 +45,7 @@ function YouTubeEmbed({
     >
       <iframe
         src={embedUrl}
-        title={title || `YouTube video ${videoId}`}
+        title={title || `Video ${videoId}`}
         className="absolute inset-0 h-full w-full"
         loading="lazy"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
@@ -86,7 +85,7 @@ function GenericEmbed({
  * Main ExternalMedia component.
  *
  * Routes to the correct renderer based on embedProvider:
- * - 'youtube' -> YouTubeEmbed (proper 16:9 responsive player)
+ * - 'youtube' | 'vimeo' -> VideoEmbed (proper 16:9 responsive player)
  * - 'generic' or missing -> GenericEmbed (plain iframe, like before)
  *
  * This component is used by the main <Media> component (src/ui/web/media/index.tsx)
@@ -103,9 +102,13 @@ export const ExternalMedia: React.FC<MediaProps> = (props) => {
   const media = resource as ExternalMediaResource
 
   // If we have an embed URL from the hook, use the provider-specific renderer
-  if (media.embedProvider === 'youtube' && media.embedVideoId && media.embedUrl) {
+  if (
+    (media.embedProvider === 'youtube' || media.embedProvider === 'vimeo') &&
+    media.embedVideoId &&
+    media.embedUrl
+  ) {
     return (
-      <YouTubeEmbed
+      <VideoEmbed
         videoId={media.embedVideoId}
         embedUrl={media.embedUrl}
         title={media.embedTitle}

--- a/tests/unit/exerciserenderer/MediaAttachments.test.tsx
+++ b/tests/unit/exerciserenderer/MediaAttachments.test.tsx
@@ -115,4 +115,46 @@ describe('MediaAttachments', () => {
     const wrapper = container.firstElementChild
     expect(wrapper?.className).toContain('custom-class')
   })
+
+  it('renders a YouTube iframe for external media with embed fields', () => {
+    const media = createMedia({
+      id: 'yt1',
+      type: 'external',
+      url: undefined as unknown as string,
+      embedProvider: 'youtube',
+      embedVideoId: 'dQw4w9WgXcQ',
+      embedUrl: 'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ',
+      embedTitle: 'Test Video',
+      externalUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    } as Partial<Media> & { id: string })
+
+    const { container } = renderWithMediaMap(<MediaAttachments mediaIds={['yt1']} />, {
+      yt1: media,
+    })
+
+    const iframe = container.querySelector('iframe')
+    expect(iframe).toBeTruthy()
+    expect(iframe?.getAttribute('src')).toBe('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ')
+    expect(iframe?.getAttribute('title')).toBe('Test Video')
+    expect(iframe?.getAttribute('allowfullscreen')).not.toBeNull()
+  })
+
+  it('renders a generic iframe for external media without YouTube', () => {
+    const media = createMedia({
+      id: 'ext1',
+      type: 'external',
+      url: undefined as unknown as string,
+      embedProvider: 'generic',
+      embedUrl: 'https://example.com/widget',
+      externalUrl: 'https://example.com/widget',
+    } as Partial<Media> & { id: string })
+
+    const { container } = renderWithMediaMap(<MediaAttachments mediaIds={['ext1']} />, {
+      ext1: media,
+    })
+
+    const iframe = container.querySelector('iframe')
+    expect(iframe).toBeTruthy()
+    expect(iframe?.getAttribute('src')).toBe('https://example.com/widget')
+  })
 })

--- a/tests/unit/hooks/resolveEmbed.test.ts
+++ b/tests/unit/hooks/resolveEmbed.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { CollectionBeforeChangeHook } from 'payload'
+import { resolveEmbedHook } from '@/server/payload/collections/Media/hooks/resolveEmbed'
+import { MediaType } from '@/infra/media/types'
+
+// Mock the embed resolver so we don't make real HTTP requests
+vi.mock('@/infra/media/embed', () => ({
+  resolveEmbedUrl: vi.fn(),
+}))
+
+import { resolveEmbedUrl } from '@/infra/media/embed'
+
+// Helper to create a mock Payload req object
+function createMockReq() {
+  return {
+    payload: {
+      logger: {
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+      },
+    },
+  } as unknown as Parameters<CollectionBeforeChangeHook>[0]['req']
+}
+
+// Helper to call the hook with partial args
+function callHook(args: {
+  data: Record<string, unknown>
+  operation: 'create' | 'update'
+  originalDoc?: Record<string, unknown>
+}) {
+  return resolveEmbedHook({
+    data: args.data,
+    operation: args.operation,
+    originalDoc: args.originalDoc ?? {},
+    req: createMockReq(),
+    collection: {
+      slug: 'media',
+    } as unknown as Parameters<CollectionBeforeChangeHook>[0]['collection'],
+    context: {},
+  } as Parameters<CollectionBeforeChangeHook>[0])
+}
+
+describe('resolveEmbedHook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should resolve YouTube URL on create', async () => {
+    vi.mocked(resolveEmbedUrl).mockResolvedValue({
+      provider: 'youtube',
+      videoId: 'dQw4w9WgXcQ',
+      embedUrl: 'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ',
+      title: 'Rick Astley - Never Gonna Give You Up',
+      thumbnailUrl: 'https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg',
+    })
+
+    const result = await callHook({
+      data: {
+        type: MediaType.External,
+        externalUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      },
+      operation: 'create',
+    })
+
+    expect(result.embedProvider).toBe('youtube')
+    expect(result.embedVideoId).toBe('dQw4w9WgXcQ')
+    expect(result.embedUrl).toBe('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ')
+    expect(result.embedTitle).toBe('Rick Astley - Never Gonna Give You Up')
+    expect(result.embedThumbnailUrl).toBe('https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg')
+  })
+
+  it('should skip resolution on update when URL has not changed', async () => {
+    const data = {
+      type: MediaType.External,
+      externalUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    }
+
+    const result = await callHook({
+      data,
+      operation: 'update',
+      originalDoc: {
+        externalUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        embedProvider: 'youtube',
+      },
+    })
+
+    // Should NOT have called the resolver
+    expect(resolveEmbedUrl).not.toHaveBeenCalled()
+    expect(result).toEqual(data) // data unchanged
+  })
+
+  it('should re-resolve on update when URL has changed', async () => {
+    vi.mocked(resolveEmbedUrl).mockResolvedValue({
+      provider: 'youtube',
+      videoId: 'newVideoIdxx',
+      embedUrl: 'https://www.youtube-nocookie.com/embed/newVideoIdxx',
+      title: 'New Video',
+      thumbnailUrl: 'https://thumb.jpg',
+    })
+
+    const result = await callHook({
+      data: {
+        type: MediaType.External,
+        externalUrl: 'https://www.youtube.com/watch?v=newVideoIdxx',
+      },
+      operation: 'update',
+      originalDoc: {
+        externalUrl: 'https://www.youtube.com/watch?v=oldVideoIdxx',
+        embedProvider: 'youtube',
+      },
+    })
+
+    expect(resolveEmbedUrl).toHaveBeenCalledWith('https://www.youtube.com/watch?v=newVideoIdxx')
+    expect(result.embedVideoId).toBe('newVideoIdxx')
+  })
+
+  it('should clear embed fields when type changes away from external', async () => {
+    const result = await callHook({
+      data: {
+        type: MediaType.Image,
+      },
+      operation: 'update',
+      originalDoc: {
+        embedProvider: 'youtube',
+        embedVideoId: 'oldId',
+        embedUrl: 'https://old-url',
+        embedTitle: 'Old Title',
+        embedThumbnailUrl: 'https://old-thumb',
+      },
+    })
+
+    expect(result.embedProvider).toBeNull()
+    expect(result.embedVideoId).toBeNull()
+    expect(result.embedUrl).toBeNull()
+    expect(result.embedTitle).toBeNull()
+    expect(result.embedThumbnailUrl).toBeNull()
+  })
+
+  it('should not fail the save if embed resolution throws', async () => {
+    vi.mocked(resolveEmbedUrl).mockRejectedValue(new Error('Network failure'))
+
+    const data = {
+      type: MediaType.External,
+      externalUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    }
+
+    // Should NOT throw — the save continues without embed metadata
+    const result = await callHook({
+      data,
+      operation: 'create',
+    })
+
+    // Data should be returned unchanged (no embed fields added)
+    expect(result.embedProvider).toBeUndefined()
+  })
+
+  it('should skip when type is external but no URL provided', async () => {
+    const data = {
+      type: MediaType.External,
+      externalUrl: null,
+    }
+
+    const result = await callHook({
+      data,
+      operation: 'create',
+    })
+
+    expect(resolveEmbedUrl).not.toHaveBeenCalled()
+    expect(result).toEqual(data)
+  })
+
+  it('should handle generic (non-YouTube) URL', async () => {
+    vi.mocked(resolveEmbedUrl).mockResolvedValue({
+      provider: 'generic',
+      videoId: null,
+      embedUrl: 'https://example.com/widget',
+      title: null,
+      thumbnailUrl: null,
+    })
+
+    const result = await callHook({
+      data: {
+        type: MediaType.External,
+        externalUrl: 'https://example.com/widget',
+      },
+      operation: 'create',
+    })
+
+    expect(result.embedProvider).toBe('generic')
+    expect(result.embedVideoId).toBeNull()
+    expect(result.embedUrl).toBe('https://example.com/widget')
+  })
+})

--- a/tests/unit/infra/media/embed/resolve.test.ts
+++ b/tests/unit/infra/media/embed/resolve.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { resolveEmbedUrl } from '@/infra/media/embed/resolve'
+
+// Mock the YouTube resolver so we test the routing logic, not YouTube parsing
+vi.mock('@/infra/media/embed/youtube', () => ({
+  resolveYouTube: vi.fn(),
+}))
+
+import { resolveYouTube } from '@/infra/media/embed/youtube'
+
+describe('resolveEmbedUrl', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should return YouTube metadata when URL is a YouTube URL', async () => {
+    const mockMetadata = {
+      provider: 'youtube' as const,
+      videoId: 'abc123xxxxx',
+      embedUrl: 'https://www.youtube-nocookie.com/embed/abc123xxxxx',
+      title: 'Test',
+      thumbnailUrl: 'https://thumb.jpg',
+    }
+    vi.mocked(resolveYouTube).mockResolvedValue(mockMetadata)
+
+    const result = await resolveEmbedUrl('https://youtube.com/watch?v=abc123xxxxx')
+
+    expect(result).toEqual(mockMetadata)
+  })
+
+  it('should return generic metadata when no provider matches', async () => {
+    vi.mocked(resolveYouTube).mockResolvedValue(null)
+
+    const result = await resolveEmbedUrl('https://example.com/some-page')
+
+    expect(result).toEqual({
+      provider: 'generic',
+      videoId: null,
+      embedUrl: 'https://example.com/some-page',
+      thumbnailUrl: null,
+      title: null,
+    })
+  })
+})

--- a/tests/unit/infra/media/embed/resolve.test.ts
+++ b/tests/unit/infra/media/embed/resolve.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { resolveEmbedUrl } from '@/infra/media/embed/resolve'
 
-// Mock the YouTube resolver so we test the routing logic, not YouTube parsing
+// Mock resolvers so we test the routing logic, not provider-specific parsing
 vi.mock('@/infra/media/embed/youtube', () => ({
   resolveYouTube: vi.fn(),
 }))
 
+vi.mock('@/infra/media/embed/vimeo', () => ({
+  resolveVimeo: vi.fn(),
+}))
+
 import { resolveYouTube } from '@/infra/media/embed/youtube'
+import { resolveVimeo } from '@/infra/media/embed/vimeo'
 
 describe('resolveEmbedUrl', () => {
   afterEach(() => {
@@ -22,14 +27,49 @@ describe('resolveEmbedUrl', () => {
       thumbnailUrl: 'https://thumb.jpg',
     }
     vi.mocked(resolveYouTube).mockResolvedValue(mockMetadata)
+    vi.mocked(resolveVimeo).mockResolvedValue(null)
 
     const result = await resolveEmbedUrl('https://youtube.com/watch?v=abc123xxxxx')
 
     expect(result).toEqual(mockMetadata)
   })
 
+  it('should return Vimeo metadata when URL is a Vimeo URL', async () => {
+    const mockMetadata = {
+      provider: 'vimeo' as const,
+      videoId: '123456789',
+      embedUrl: 'https://player.vimeo.com/video/123456789',
+      title: 'My Vimeo Video',
+      thumbnailUrl: 'https://i.vimeocdn.com/video/123_1280x720.jpg',
+    }
+    vi.mocked(resolveYouTube).mockResolvedValue(null)
+    vi.mocked(resolveVimeo).mockResolvedValue(mockMetadata)
+
+    const result = await resolveEmbedUrl('https://vimeo.com/123456789')
+
+    expect(result).toEqual(mockMetadata)
+  })
+
+  it('should return YouTube result without falling through to Vimeo when YouTube matches', async () => {
+    const youtubeMetadata = {
+      provider: 'youtube' as const,
+      videoId: 'abc123xxxxx',
+      embedUrl: 'https://www.youtube-nocookie.com/embed/abc123xxxxx',
+      title: 'YouTube',
+      thumbnailUrl: null,
+    }
+    vi.mocked(resolveYouTube).mockResolvedValue(youtubeMetadata)
+    vi.mocked(resolveVimeo).mockResolvedValue(null)
+
+    const result = await resolveEmbedUrl('https://youtube.com/watch?v=abc123xxxxx')
+
+    expect(result).toEqual(youtubeMetadata)
+    expect(result.provider).toBe('youtube')
+  })
+
   it('should return generic metadata when no provider matches', async () => {
     vi.mocked(resolveYouTube).mockResolvedValue(null)
+    vi.mocked(resolveVimeo).mockResolvedValue(null)
 
     const result = await resolveEmbedUrl('https://example.com/some-page')
 

--- a/tests/unit/infra/media/embed/vimeo.test.ts
+++ b/tests/unit/infra/media/embed/vimeo.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  isVimeoUrl,
+  extractVimeoVideoId,
+  buildVimeoEmbedUrl,
+  fetchVimeoMetadata,
+  resolveVimeo,
+} from '@/infra/media/embed/vimeo'
+
+describe('Vimeo embed utilities', () => {
+  // ----------------------------------------------------------
+  // isVimeoUrl
+  // ----------------------------------------------------------
+  describe('isVimeoUrl', () => {
+    it('should detect standard vimeo.com URL', () => {
+      expect(isVimeoUrl('https://vimeo.com/123456789')).toBe(true)
+    })
+
+    it('should detect www.vimeo.com URL', () => {
+      expect(isVimeoUrl('https://www.vimeo.com/123456789')).toBe(true)
+    })
+
+    it('should detect player.vimeo.com URL', () => {
+      expect(isVimeoUrl('https://player.vimeo.com/video/123456789')).toBe(true)
+    })
+
+    it('should detect channel URL', () => {
+      expect(isVimeoUrl('https://vimeo.com/channels/mychannel/123456789')).toBe(true)
+    })
+
+    it('should detect group URL', () => {
+      expect(isVimeoUrl('https://vimeo.com/groups/mygroup/videos/123456789')).toBe(true)
+    })
+
+    it('should detect URL without https://', () => {
+      expect(isVimeoUrl('vimeo.com/123456789')).toBe(true)
+    })
+
+    it('should detect private video URL with hash', () => {
+      expect(isVimeoUrl('https://vimeo.com/123456789?h=abc123')).toBe(true)
+    })
+
+    it('should reject non-Vimeo URLs', () => {
+      expect(isVimeoUrl('https://youtube.com/watch?v=abc123xxxxx')).toBe(false)
+      expect(isVimeoUrl('https://example.com')).toBe(false)
+      expect(isVimeoUrl('')).toBe(false)
+    })
+
+    it('should reject Vimeo URLs without video ID', () => {
+      expect(isVimeoUrl('https://vimeo.com')).toBe(false)
+      expect(isVimeoUrl('https://vimeo.com/')).toBe(false)
+    })
+  })
+
+  // ----------------------------------------------------------
+  // extractVimeoVideoId
+  // ----------------------------------------------------------
+  describe('extractVimeoVideoId', () => {
+    it('should extract ID from standard URL', () => {
+      expect(extractVimeoVideoId('https://vimeo.com/123456789')).toBe('123456789')
+    })
+
+    it('should extract ID from player URL', () => {
+      expect(extractVimeoVideoId('https://player.vimeo.com/video/123456789')).toBe('123456789')
+    })
+
+    it('should extract ID from channel URL', () => {
+      expect(extractVimeoVideoId('https://vimeo.com/channels/mychannel/123456789')).toBe(
+        '123456789',
+      )
+    })
+
+    it('should extract ID from group URL', () => {
+      expect(extractVimeoVideoId('https://vimeo.com/groups/mygroup/videos/123456789')).toBe(
+        '123456789',
+      )
+    })
+
+    it('should extract ID from private video URL with hash', () => {
+      expect(extractVimeoVideoId('https://vimeo.com/123456789?h=abc123')).toBe('123456789')
+    })
+
+    it('should return null for non-Vimeo URL', () => {
+      expect(extractVimeoVideoId('https://example.com')).toBe(null)
+      expect(extractVimeoVideoId('')).toBe(null)
+    })
+  })
+
+  // ----------------------------------------------------------
+  // buildVimeoEmbedUrl
+  // ----------------------------------------------------------
+  describe('buildVimeoEmbedUrl', () => {
+    it('should build standard embed URL', () => {
+      expect(buildVimeoEmbedUrl('123456789')).toBe('https://player.vimeo.com/video/123456789')
+    })
+
+    it('should append private hash when provided', () => {
+      expect(buildVimeoEmbedUrl('123456789', 'abc123')).toBe(
+        'https://player.vimeo.com/video/123456789?h=abc123',
+      )
+    })
+
+    it('should not append hash when null', () => {
+      expect(buildVimeoEmbedUrl('123456789', null)).toBe('https://player.vimeo.com/video/123456789')
+    })
+  })
+
+  // ----------------------------------------------------------
+  // fetchVimeoMetadata
+  // ----------------------------------------------------------
+  describe('fetchVimeoMetadata', () => {
+    beforeEach(() => {
+      vi.stubGlobal('fetch', vi.fn())
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should return metadata with title and thumbnail on success', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          title: 'My Vimeo Video',
+          thumbnail_url: 'https://i.vimeocdn.com/video/123_1280x720.jpg',
+          author_name: 'Test Author',
+          author_url: 'https://vimeo.com/testauthor',
+          html: '<iframe .../>',
+        }),
+      } as Response)
+
+      const result = await fetchVimeoMetadata('123456789')
+
+      expect(result).toEqual({
+        provider: 'vimeo',
+        videoId: '123456789',
+        embedUrl: 'https://player.vimeo.com/video/123456789',
+        title: 'My Vimeo Video',
+        thumbnailUrl: 'https://i.vimeocdn.com/video/123_1280x720.jpg',
+      })
+    })
+
+    it('should return metadata without title/thumbnail on oEmbed failure', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 403,
+      } as Response)
+
+      const result = await fetchVimeoMetadata('123456789')
+
+      expect(result).toEqual({
+        provider: 'vimeo',
+        videoId: '123456789',
+        embedUrl: 'https://player.vimeo.com/video/123456789',
+        title: null,
+        thumbnailUrl: null,
+      })
+    })
+
+    it('should return metadata without title/thumbnail on network error', async () => {
+      vi.mocked(fetch).mockRejectedValue(new Error('Network error'))
+
+      const result = await fetchVimeoMetadata('123456789')
+
+      expect(result).toEqual({
+        provider: 'vimeo',
+        videoId: '123456789',
+        embedUrl: 'https://player.vimeo.com/video/123456789',
+        title: null,
+        thumbnailUrl: null,
+      })
+    })
+
+    it('should include private hash in embed URL when provided', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 403,
+      } as Response)
+
+      const result = await fetchVimeoMetadata('123456789', 'secrethash')
+
+      expect(result.embedUrl).toBe('https://player.vimeo.com/video/123456789?h=secrethash')
+    })
+  })
+
+  // ----------------------------------------------------------
+  // resolveVimeo
+  // ----------------------------------------------------------
+  describe('resolveVimeo', () => {
+    beforeEach(() => {
+      vi.stubGlobal('fetch', vi.fn())
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should return null for non-Vimeo URL', async () => {
+      const result = await resolveVimeo('https://youtube.com/watch?v=abc123xxxxx')
+      expect(result).toBeNull()
+    })
+
+    it('should return null for empty string', async () => {
+      const result = await resolveVimeo('')
+      expect(result).toBeNull()
+    })
+
+    it('should return EmbedMetadata for valid Vimeo URL', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          title: 'My Vimeo Video',
+          thumbnail_url: 'https://i.vimeocdn.com/video/123_1280x720.jpg',
+          author_name: 'Test',
+          author_url: 'https://vimeo.com/test',
+          html: '<iframe/>',
+        }),
+      } as Response)
+
+      const result = await resolveVimeo('https://vimeo.com/123456789')
+
+      expect(result).toEqual({
+        provider: 'vimeo',
+        videoId: '123456789',
+        embedUrl: 'https://player.vimeo.com/video/123456789',
+        title: 'My Vimeo Video',
+        thumbnailUrl: 'https://i.vimeocdn.com/video/123_1280x720.jpg',
+      })
+    })
+
+    it('should extract private hash from URL and pass it to embed URL', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: false,
+        status: 403,
+      } as Response)
+
+      const result = await resolveVimeo('https://vimeo.com/123456789?h=secrethash')
+
+      expect(result?.embedUrl).toBe('https://player.vimeo.com/video/123456789?h=secrethash')
+      expect(result?.videoId).toBe('123456789')
+    })
+  })
+})

--- a/tests/unit/infra/media/embed/youtube.test.ts
+++ b/tests/unit/infra/media/embed/youtube.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  isYouTubeUrl,
+  extractYouTubeVideoId,
+  buildYouTubeEmbedUrl,
+  fetchYouTubeMetadata,
+  resolveYouTube,
+} from '@/infra/media/embed/youtube'
+
+describe('YouTube embed utilities', () => {
+  // ----------------------------------------------------------
+  // isYouTubeUrl
+  // ----------------------------------------------------------
+  describe('isYouTubeUrl', () => {
+    it('should detect standard youtube.com/watch URL', () => {
+      expect(isYouTubeUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe(true)
+    })
+
+    it('should detect youtu.be short URL', () => {
+      expect(isYouTubeUrl('https://youtu.be/dQw4w9WgXcQ')).toBe(true)
+    })
+
+    it('should detect youtube.com/embed URL', () => {
+      expect(isYouTubeUrl('https://www.youtube.com/embed/dQw4w9WgXcQ')).toBe(true)
+    })
+
+    it('should detect youtube.com/shorts URL', () => {
+      expect(isYouTubeUrl('https://www.youtube.com/shorts/dQw4w9WgXcQ')).toBe(true)
+    })
+
+    it('should detect youtube.com/live URL', () => {
+      expect(isYouTubeUrl('https://www.youtube.com/live/dQw4w9WgXcQ')).toBe(true)
+    })
+
+    it('should detect mobile m.youtube.com URL', () => {
+      expect(isYouTubeUrl('https://m.youtube.com/watch?v=dQw4w9WgXcQ')).toBe(true)
+    })
+
+    it('should detect URL without https://', () => {
+      expect(isYouTubeUrl('youtube.com/watch?v=dQw4w9WgXcQ')).toBe(true)
+    })
+
+    it('should detect URL without www', () => {
+      expect(isYouTubeUrl('https://youtube.com/watch?v=dQw4w9WgXcQ')).toBe(true)
+    })
+
+    it('should reject non-YouTube URLs', () => {
+      expect(isYouTubeUrl('https://vimeo.com/123456')).toBe(false)
+      expect(isYouTubeUrl('https://example.com')).toBe(false)
+      expect(isYouTubeUrl('')).toBe(false)
+    })
+
+    it('should reject YouTube URLs without video ID', () => {
+      expect(isYouTubeUrl('https://www.youtube.com')).toBe(false)
+      expect(isYouTubeUrl('https://www.youtube.com/watch')).toBe(false)
+    })
+
+    it('should handle URL with extra query parameters', () => {
+      expect(isYouTubeUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42s')).toBe(true)
+      expect(isYouTubeUrl('https://www.youtube.com/watch?list=PLxxx&v=dQw4w9WgXcQ')).toBe(true)
+    })
+  })
+
+  // ----------------------------------------------------------
+  // extractYouTubeVideoId
+  // ----------------------------------------------------------
+  describe('extractYouTubeVideoId', () => {
+    it('should extract ID from standard watch URL', () => {
+      expect(extractYouTubeVideoId('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe(
+        'dQw4w9WgXcQ',
+      )
+    })
+
+    it('should extract ID from short URL', () => {
+      expect(extractYouTubeVideoId('https://youtu.be/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
+    })
+
+    it('should extract ID from embed URL', () => {
+      expect(extractYouTubeVideoId('https://www.youtube.com/embed/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ')
+    })
+
+    it('should extract ID from shorts URL', () => {
+      expect(extractYouTubeVideoId('https://www.youtube.com/shorts/dQw4w9WgXcQ')).toBe(
+        'dQw4w9WgXcQ',
+      )
+    })
+
+    it('should extract ID with extra query params', () => {
+      expect(extractYouTubeVideoId('https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=120')).toBe(
+        'dQw4w9WgXcQ',
+      )
+    })
+
+    it('should return null for non-YouTube URL', () => {
+      expect(extractYouTubeVideoId('https://vimeo.com/123456')).toBeNull()
+    })
+
+    it('should return null for empty string', () => {
+      expect(extractYouTubeVideoId('')).toBeNull()
+    })
+
+    it('should handle IDs with hyphens and underscores', () => {
+      expect(extractYouTubeVideoId('https://youtu.be/abc-def_123')).toBe('abc-def_123')
+    })
+  })
+
+  // ----------------------------------------------------------
+  // buildYouTubeEmbedUrl
+  // ----------------------------------------------------------
+  describe('buildYouTubeEmbedUrl', () => {
+    it('should build privacy-enhanced embed URL', () => {
+      expect(buildYouTubeEmbedUrl('dQw4w9WgXcQ')).toBe(
+        'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ',
+      )
+    })
+  })
+
+  // ----------------------------------------------------------
+  // fetchYouTubeMetadata (mocked fetch)
+  // ----------------------------------------------------------
+  describe('fetchYouTubeMetadata', () => {
+    beforeEach(() => {
+      vi.stubGlobal('fetch', vi.fn())
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should return full metadata on successful oEmbed response', async () => {
+      const mockResponse = {
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            title: 'Test Video Title',
+            author_name: 'Test Author',
+            author_url: 'https://www.youtube.com/@testauthor',
+            thumbnail_url: 'https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg',
+            thumbnail_width: 480,
+            thumbnail_height: 360,
+            html: '<iframe ...></iframe>',
+          }),
+      }
+      vi.mocked(fetch).mockResolvedValue(mockResponse as Response)
+
+      const result = await fetchYouTubeMetadata('dQw4w9WgXcQ')
+
+      expect(result).toEqual({
+        provider: 'youtube',
+        videoId: 'dQw4w9WgXcQ',
+        embedUrl: 'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ',
+        title: 'Test Video Title',
+        thumbnailUrl: 'https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg',
+      })
+
+      // Verify fetch was called with correct oEmbed URL
+      expect(fetch).toHaveBeenCalledWith(
+        'https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=dQw4w9WgXcQ&format=json',
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      )
+    })
+
+    it('should return metadata without title/thumbnail on non-OK response', async () => {
+      vi.mocked(fetch).mockResolvedValue({ ok: false } as Response)
+
+      const result = await fetchYouTubeMetadata('dQw4w9WgXcQ')
+
+      expect(result.provider).toBe('youtube')
+      expect(result.videoId).toBe('dQw4w9WgXcQ')
+      expect(result.embedUrl).toBe('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ')
+      expect(result.title).toBeNull()
+      expect(result.thumbnailUrl).toBeNull()
+    })
+
+    it('should return metadata without title/thumbnail on network error', async () => {
+      vi.mocked(fetch).mockRejectedValue(new Error('Network error'))
+
+      const result = await fetchYouTubeMetadata('dQw4w9WgXcQ')
+
+      expect(result.provider).toBe('youtube')
+      expect(result.videoId).toBe('dQw4w9WgXcQ')
+      expect(result.embedUrl).toBe('https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ')
+      expect(result.title).toBeNull()
+      expect(result.thumbnailUrl).toBeNull()
+    })
+  })
+
+  // ----------------------------------------------------------
+  // resolveYouTube (integration of the above)
+  // ----------------------------------------------------------
+  describe('resolveYouTube', () => {
+    beforeEach(() => {
+      vi.stubGlobal('fetch', vi.fn())
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('should return null for non-YouTube URLs', async () => {
+      const result = await resolveYouTube('https://vimeo.com/123456')
+      expect(result).toBeNull()
+    })
+
+    it('should resolve a YouTube URL to full metadata', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ title: 'My Video', thumbnail_url: 'https://thumb.jpg' }),
+      } as Response)
+
+      const result = await resolveYouTube('https://www.youtube.com/watch?v=dQw4w9WgXcQ')
+
+      expect(result).not.toBeNull()
+      expect(result!.provider).toBe('youtube')
+      expect(result!.videoId).toBe('dQw4w9WgXcQ')
+      expect(result!.title).toBe('My Video')
+    })
+  })
+})


### PR DESCRIPTION
- Add vimeo.ts utility for URL detection and embed URL generation
- Allow restricted file types in Media collection for large video files
- Add explicit MIME types for video (mp4, quicktime) for Safari compatibility
- Update admin ExternalPreview to show Vimeo video embeds
- Update frontend MediaAttachments to render Vimeo videos
- Update ExternalMedia component to support Vimeo embeds