### PR TITLE
fix: Revert logical properties to fix RTL menu positioning

### DIFF
--- a/src/ui/web/header/MobileMenu/index.tsx
+++ b/src/ui/web/header/MobileMenu/index.tsx
@@ -62,7 +62,7 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({
 
       <div
         ref={portalContainerRef}
-        className={`fixed top-0 end-0 h-full w-[280px] sm:w-[320px] bg-background border-s border-border z-[70] transform transition-transform duration-300 ease-in-out ${
+        className={`fixed top-0 right-0 h-full w-[280px] sm:w-[320px] bg-background border-l border-border z-[70] transform transition-transform duration-300 ease-in-out ${
           isOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
       >


### PR DESCRIPTION
## Summary

- Reverts logical properties in MobileMenu to fix RTL menu positioning issue

## Changes

- Changed `inset-inline-end` back to `right` in MobileMenu styling

## Testing

- Verified menu positions correctly in RTL mode