### PR TITLE
feat: Add configurable teacher profiles for AI chat identity

### DIFF
--- a/docs/specs/TEACHER-PROFILE-PLAN.md
+++ b/docs/specs/TEACHER-PROFILE-PLAN.md
@@ -1,0 +1,331 @@
+# Teacher Profile – Chat Identity Implementation Plan (v1.1)
+
+## Context
+
+The chat **is the teacher**. Currently, the AI chat uses a single behavioral identity for all users. This feature makes it configurable per-user via Teacher Profiles — each linked to a Prompt entry — that get injected into the system context on every request. The account settings already have a placeholder tab (`teachers-profile`) ready for the UI.
+
+**Scope:** TeacherProfiles collection, UserSettings (1:1), seed data, resolver with prompt injection, Account UI selection, chat header label, PR.
+
+---
+
+## Phase 1: Data Layer
+
+### 1.1 Create `TeacherProfiles` collection
+
+**New file:** `src/server/payload/collections/TeacherProfiles.ts`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `slug` | text | `unique: true`, `index: true`, required |
+| `label` | text | required, `useAsTitle` |
+| `description` | textarea | short UI explanation (1-2 sentences) |
+| `systemPrompt` | relationship → `prompts` | **required** (no text-field alternative) |
+| `isEnabled` | checkbox | `defaultValue: true`, `index: true` |
+
+- Access: `adminOnly` for all CRUD. Pipeline reads use `overrideAccess: true`.
+- Admin group: `'AI'` (alongside Prompts)
+- `timestamps: true`
+- No `tenantField` in v1.1 — avoids "no profiles found" bugs from tenant mismatch. Can be added later if multi-tenant filtering is needed.
+
+### 1.2 Create `UserSettings` collection
+
+**New file:** `src/server/payload/collections/UserSettings/index.ts`
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `user` | relationship → `users` | required, `unique: true` (1:1), `index: true`, `readOnly` in admin |
+| `teacherProfile` | relationship → `teacher_profiles` | optional (null = use default) |
+
+- Access: read/update → `authenticatedOrOwner` (reuse `src/server/payload/access/authenticatedOrOwner.ts`), create/delete → `adminOnly`
+- `timestamps: true`
+- If a selected profile becomes disabled (`isEnabled: false`), the DB value stays unchanged. Fallback is handled at runtime by the resolver.
+
+### 1.3 Register in Payload config
+
+**Modify:** `src/payload.config.ts`
+- Import and add `TeacherProfiles` and `UserSettings` to the collections array
+
+### 1.4 Auto-create UserSettings on user signup
+
+**New file:** `src/server/payload/collections/Users/hooks/createUserSettings-hook.ts`
+
+`afterChange` hook on Users collection:
+- Runs only when `operation === 'create'`
+- Creates `user_settings` record: `{ user: doc.id }` (teacherProfile left null)
+- Passes `req` for transaction safety
+- Logs error but does NOT fail user creation
+
+**Modify:** `src/server/payload/collections/Users/index.ts`
+- Add `createUserSettings` to `hooks.afterChange` (after `auditRoleChange`)
+
+### 1.5 Lazy creation for existing users
+
+No `onInit` backfill. Existing users without a `user_settings` record are handled by:
+- Resolver: Tier 1 returns null → falls through to default
+- API PATCH route: creates the record if missing (lazy creation on first profile selection)
+
+### 1.6 Generate types
+
+Run `pnpm generate:types` → produces `TeacherProfile` and `UserSetting` types in `src/payload-types.ts`
+
+---
+
+## Phase 2: Teacher Profile Resolution Service
+
+**New file:** `src/server/services/teacher-profile-resolver.ts`
+
+### Default profile slug — hardcoded constant for v1.1
+
+```typescript
+export const DEFAULT_TEACHER_PROFILE_SLUG = 'teacher_focused'
+```
+
+This is a hardcoded constant. Changing the default requires a code change + PR.
+
+### Resolution strategy (authenticated users)
+
+1. **Tier 1:** Load `UserSettings.teacherProfile` for this user (depth 2 to populate profile → systemPrompt). If exists AND `isEnabled === true` AND prompt `status === 'published'` AND `template` is non-empty → use it.
+2. **Tier 2:** Query `teacher_profiles` where `slug === DEFAULT_TEACHER_PROFILE_SLUG` AND `isEnabled === true`. Populate systemPrompt. If found AND prompt published + non-empty → use it.
+3. **Tier 3:** Query first `teacher_profiles` where `isEnabled === true`, `sort: 'createdAt'`, limit 1. If found → use it.
+4. **Tier 4:** Hardcoded `FAILSAFE_TEACHER_PROMPT` string. Never throws.
+
+### Resolution strategy (guests)
+
+Guests have no userId → skip Tier 1 and Tier 3:
+- **Tier 2:** Default profile by slug only.
+- **Tier 4:** If default is missing/disabled → hardcoded failsafe + log warning. **No Tier 3** for guests — a random profile would be confusing.
+
+### Per-request resolution
+
+Called on **every chat request** inside `composeFullSystemInstructions()`. No caching, no snapshot. Switching profile affects the very next message.
+
+### Resolver query strategy
+
+Use `depth: 1` (populate profile's systemPrompt one level) with `select` to fetch only needed fields:
+- From TeacherProfile: `slug`, `label`, `description`, `isEnabled`, `systemPrompt`
+- From Prompt (populated): `template`, `status`
+
+This avoids over-fetching and keeps the resolver fast.
+
+### Prompt validation in resolver
+
+When evaluating a profile's prompt (confirmed from `src/server/payload/collections/Prompts.ts`):
+- `prompt.status === 'published'` (exact enum: `'draft' | 'published' | 'archived'`)
+- `prompt.template` is non-empty after trim (field is `required: true` in schema, but guard defensively)
+- If either check fails, skip this tier
+
+### Return type
+
+```typescript
+interface ResolvedTeacherProfile {
+  profileSlug: string
+  profileLabel: string
+  profileDescription: string
+  promptTemplate: string
+  resolvedFrom: 'user-settings' | 'default-config' | 'first-active' | 'failsafe'
+}
+```
+
+---
+
+## Phase 3: System Prompt Injection
+
+### 3.1 Teacher profile block builder
+
+**New file:** `src/infra/llm/teacher-profile-block.ts`
+
+Builds the `<teacher_profile>` block per spec:
+
+```
+<teacher_profile>
+Name: {label}
+Description: {description}
+
+Behavior:
+{systemPrompt.template text}
+</teacher_profile>
+```
+
+Exports `buildTeacherProfileBlock(input)` function.
+
+### 3.2 Modify prompt composer
+
+**Modify:** `src/infra/llm/prompt-composer.server.ts`
+
+Add optional `teacherProfileBlock?: string` parameter to `composeSystemInstructions()`.
+
+**Strict injection order:**
+1. Base system prompts (joined with separator)
+2. **`<teacher_profile>` block** ← NEW
+3. Lesson/course prompt template
+4. Lesson/course context text
+
+Comment: teacher profile block is part of system role, NOT stored in `conversation.messages`, never enters memory extraction or embedding.
+
+### 3.3 Modify `composeFullSystemInstructions`
+
+**Modify:** `src/server/payload/endpoints/agent/chat/prompt-composition.ts`
+
+- Add `userId?: string` parameter
+- Import `resolveTeacherProfile` and `buildTeacherProfileBlock`
+- Call resolver (per-request), build block, pass to `composeSystemInstructions()`
+- Log: `{ teacherProfileSlug, resolvedFrom }`
+
+### 3.4 Thread `userId` through call sites
+
+Two call sites:
+
+1. **`src/server/payload/endpoints/agent/chat/pipeline.ts`** (line ~225)
+   - Pass `req.user?.id`
+
+2. **`src/server/payload/endpoints/agent/chat.ts`** (line ~677, `handleContextScopedChat`)
+   - Pass `userId`
+
+Streaming endpoint uses `runChatPipeline()` → gets the change automatically.
+Admin chat (`handleAdminModeChat`) is unaffected — not in scope.
+
+---
+
+## Phase 4: Seed Data
+
+**New file:** `src/server/payload/seed/teacher-profiles-seed.ts`
+
+Creates 5 Prompt entries + 5 TeacherProfile entries. Idempotent (checks by `key`/`slug`).
+
+| Slug | Label | Prompt Key |
+|------|-------|------------|
+| `teacher_strict` | Strict Teacher | `teacher-strict-v1` |
+| `teacher_thorough` | Thorough Teacher | `teacher-thorough-v1` |
+| `teacher_patient` | Patient Teacher | `teacher-patient-v1` |
+| `teacher_focused` | Focused Teacher (default) | `teacher-focused-v1` |
+| `teacher_challenging` | Challenging Teacher | `teacher-challenging-v1` |
+
+Prompt entries seeded with exact enum values from `src/server/payload/collections/Prompts.ts`:
+- `type: 'context'` (NOT `'system'` — `'system'` prompts are auto-included by `fetchPublishedSystemPrompts`)
+  - Exact options: `'system' | 'context'`
+- `status: 'published'` (only `'published'` used at runtime)
+  - Exact options: `'draft' | 'published' | 'archived'`
+- `usage: 'chat'`
+  - Exact options: `'chat' | 'extractor' | 'verifier'`
+- `template: '...'` (non-empty prompt text, field is `required: true`)
+- `isDefaultForAgentChat: false`
+
+All profiles: `isEnabled: true`.
+
+**Modify:** `src/payload.config.ts` — call `seedTeacherProfiles(payload)` in `onInit` after `runBackfillOnInit`. Idempotent — safe to re-run.
+
+---
+
+## Phase 5: API Routes
+
+### 5.1 List active teacher profiles
+
+**New file:** `src/app/(frontend)/api/teacher-profiles/route.ts`
+
+`GET` — auth-first pattern:
+1. Call `payload.auth({ headers })` → if no user, return `401` immediately
+2. Only after auth succeeds: query `teacher_profiles` where `isEnabled === true`, sorted by `label`
+3. Use `overrideAccess: true` (collection is `adminOnly`, server-side read is safe after auth check)
+4. Use `select: { slug: true, label: true, description: true, isEnabled: true }` — **never return `systemPrompt` or prompt `template`**
+5. Map response to `{ profiles: [{ slug, label, description }] }`
+
+### 5.2 User settings
+
+**New file:** `src/app/(frontend)/api/user-settings/route.ts`
+
+`GET` — auth-first pattern:
+1. Call `payload.auth({ headers })` → if no user, return `401` immediately
+2. Query `user_settings` where `user === userId`, depth 1 to populate `teacherProfile`
+3. Use `overrideAccess: true` after auth check (safe: we already verified the user)
+4. Shape response: `{ settings: { id, teacherProfile: { slug, label, description } | null } }` — **no systemPrompt/template**
+
+`PATCH` — auth-first pattern:
+1. Call `payload.auth({ headers })` → if no user, return `401` immediately
+2. Zod-validate body: `{ teacherProfileSlug: z.string() }`
+3. Verify profile exists and `isEnabled === true` via query with `overrideAccess: true`
+4. Find or create (lazy) `user_settings` record for this user
+5. Update with new `teacherProfile` ID
+6. Return `{ success: true }`
+
+---
+
+## Phase 6: Frontend UI
+
+### 6.1 Account → Teacher Profile tab
+
+**Modify:** `src/app/(frontend)/account/_components/TeachersProfileSection.tsx`
+
+Replace placeholder with:
+- Fetch active profiles + current selection on mount (parallel requests)
+- Grid of `Card` components showing label + short description
+- Selected card: `ring-2 ring-primary` + `Badge` "Selected"
+- Click → `PATCH /api/user-settings` → `toast.success()` / `toast.error()`
+- Immediate save on click (no explicit save button)
+
+### 6.2 Chat header label
+
+**Modify:** `src/ui/web/chat/ChatInterface/index.tsx`
+
+- Authenticated users only: fetch teacher profile label from `/api/user-settings` on mount
+- Small `Badge` at top of chat area with profile label
+- Guests: no badge
+
+### 6.3 Translations
+
+**Modify:** `src/i18n/en.json` — add keys under `auth.account.teacherProfile`:
+- `description`, `loading`, `selected`, `changeSuccess`, `changeFailed`, `noProfiles`
+
+**Modify:** `src/i18n/he.json` — Hebrew equivalents
+
+---
+
+## Files Summary
+
+### New files (8)
+| File | Purpose |
+|------|---------|
+| `src/server/payload/collections/TeacherProfiles.ts` | Collection definition |
+| `src/server/payload/collections/UserSettings/index.ts` | Collection definition |
+| `src/server/payload/collections/Users/hooks/createUserSettings-hook.ts` | Auto-create on signup |
+| `src/server/services/teacher-profile-resolver.ts` | Resolution (4-tier auth, 2-tier guest) |
+| `src/infra/llm/teacher-profile-block.ts` | `<teacher_profile>` block builder |
+| `src/server/payload/seed/teacher-profiles-seed.ts` | Seed 5 prompts + 5 profiles |
+| `src/app/(frontend)/api/teacher-profiles/route.ts` | GET active profiles (auth required) |
+| `src/app/(frontend)/api/user-settings/route.ts` | GET/PATCH user settings |
+
+### Modified files (9)
+| File | Change |
+|------|--------|
+| `src/payload.config.ts` | Register 2 collections + seed in onInit |
+| `src/server/payload/collections/Users/index.ts` | Add createUserSettings hook |
+| `src/infra/llm/prompt-composer.server.ts` | Add teacherProfileBlock param |
+| `src/server/payload/endpoints/agent/chat/prompt-composition.ts` | Add userId, resolve profile |
+| `src/server/payload/endpoints/agent/chat/pipeline.ts` | Pass userId |
+| `src/server/payload/endpoints/agent/chat.ts` | Pass userId in handleContextScopedChat |
+| `src/app/(frontend)/account/_components/TeachersProfileSection.tsx` | Replace placeholder |
+| `src/ui/web/chat/ChatInterface/index.tsx` | Add teacher profile badge |
+| `src/i18n/en.json` + `src/i18n/he.json` | Translation keys |
+
+### Reused utilities
+| Utility | Path |
+|---------|------|
+| `adminOnly` | `src/server/payload/access/adminOnly.ts` |
+| `authenticatedOrOwner` | `src/server/payload/access/authenticatedOrOwner.ts` |
+| `toast` (Sonner) | `import { toast } from 'sonner'` |
+| `Card`, `Badge` | `src/ui/web/components/` |
+| `useTranslations` | `src/ui/web/providers/I18n` |
+
+---
+
+## Verification
+
+1. `pnpm dev` → admin panel shows TeacherProfiles (AI group) and UserSettings with 5 seeded profiles
+2. `/account?section=teachers-profile` → cards render, click saves, toast confirms
+3. Send chat message → server logs show `Resolved teacher profile` with slug + resolvedFrom
+4. Change profile → next message uses new profile (verify in logs)
+5. Guest (incognito) → uses default `teacher_focused` profile
+6. Deactivate default in admin → guest falls to failsafe (warning logged)
+7. Deactivate user's selected profile → falls to default on next message
+8. Verify `/api/teacher-profiles` returns 401 for unauthenticated requests
+9. Verify no `systemPrompt`/`template` fields in API responses
+10. `pnpm ci:local` passes

--- a/src/app/(frontend)/account/_components/TeachersProfileSection.tsx
+++ b/src/app/(frontend)/account/_components/TeachersProfileSection.tsx
@@ -1,13 +1,131 @@
 'use client'
 
+import { useEffect, useState } from 'react'
+
+import { Badge } from '@/ui/web/components/badge'
+import { Card } from '@/ui/web/components/card'
 import { useTranslations } from '@/ui/web/providers/I18n'
+import { toast } from 'sonner'
+
+interface TeacherProfile {
+  slug: string
+  label: string
+  description: string
+  isEnabled: boolean
+}
 
 export function TeachersProfileSection() {
-  const t = useTranslations('auth.account')
+  const t = useTranslations('auth.account.teacherProfile')
+  const [profiles, setProfiles] = useState<TeacherProfile[]>([])
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+
+  // Fetch profiles and current selection on mount
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        // Fetch profiles and settings in parallel
+        const [profilesRes, settingsRes] = await Promise.all([
+          fetch('/api/teacher-profiles'),
+          fetch('/api/user-settings'),
+        ])
+
+        // Check for auth errors
+        if (profilesRes.status === 401 || settingsRes.status === 401) {
+          setLoading(false)
+          return
+        }
+
+        const profilesData = await profilesRes.json()
+        const settingsData = await settingsRes.json()
+
+        if (profilesData.profiles) {
+          setProfiles(profilesData.profiles)
+        }
+
+        if (settingsData.settings?.teacherProfile) {
+          setSelectedSlug(settingsData.settings.teacherProfile.slug)
+        }
+      } catch (error) {
+        console.error('Failed to fetch teacher profiles:', error)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchData()
+  }, [])
+
+  const handleSelect = async (slug: string) => {
+    if (saving) return
+    setSaving(true)
+
+    try {
+      const res = await fetch('/api/user-settings', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ teacherProfileSlug: slug }),
+      })
+
+      if (!res.ok) {
+        toast.error(t('changeFailed'))
+        return
+      }
+
+      setSelectedSlug(slug)
+      toast.success(t('changeSuccess'))
+    } catch (error) {
+      console.error('Failed to update teacher profile:', error)
+      toast.error(t('changeFailed'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="py-4">
+        <p className="text-muted-foreground">{t('loading')}</p>
+      </div>
+    )
+  }
+
+  if (profiles.length === 0) {
+    return (
+      <div className="py-4">
+        <p className="text-muted-foreground">{t('noProfiles')}</p>
+      </div>
+    )
+  }
 
   return (
-    <div className="py-4">
-      <p className="text-muted-foreground">{t('teachersProfilePlaceholder')}</p>
+    <div className="py-4 space-y-4">
+      <p className="text-sm text-muted-foreground">{t('description')}</p>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {profiles.map((profile) => (
+          <Card
+            key={profile.slug}
+            className={`cursor-pointer transition-all hover:border-primary/50 ${
+              selectedSlug === profile.slug ? 'ring-2 ring-primary border-primary' : 'border-border'
+            }`}
+            onClick={() => handleSelect(profile.slug)}
+          >
+            <div className="p-4">
+              <div className="flex items-center justify-between mb-2">
+                <h3 className="font-medium">{profile.label}</h3>
+                {selectedSlug === profile.slug && (
+                  <Badge variant="secondary">{t('selected')}</Badge>
+                )}
+              </div>
+              <p className="text-sm text-muted-foreground">{profile.description}</p>
+            </div>
+          </Card>
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/app/api/teacher-profiles/route.ts
+++ b/src/app/api/teacher-profiles/route.ts
@@ -1,0 +1,42 @@
+/**
+ * Teacher Profiles API
+ *
+ * GET /api/teacher-profiles
+ * Returns list of active teacher profiles for profile selection UI
+ */
+
+import { getPayload } from 'payload'
+
+import config from '@payload-config'
+
+export async function GET(req: Request) {
+  const payload = await getPayload({ config })
+
+  // Auth check - return 401 if not authenticated
+  const authResult = await payload.auth({ headers: req.headers })
+  if (!authResult.user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // Fetch active teacher profiles
+  const profiles = await payload.find({
+    collection: 'teacher_profiles',
+    where: {
+      isEnabled: { equals: true },
+    },
+    sort: 'label',
+    overrideAccess: true, // Collection is adminOnly, but we're authenticated
+  })
+
+  // Map to safe response (no systemPrompt/template)
+  const responseProfiles = profiles.docs.map((profile) => ({
+    slug: profile.slug,
+    label: profile.label,
+    description: profile.description,
+    isEnabled: profile.isEnabled,
+  }))
+
+  return Response.json({
+    profiles: responseProfiles,
+  })
+}

--- a/src/app/api/user-settings/route.ts
+++ b/src/app/api/user-settings/route.ts
@@ -1,0 +1,161 @@
+/**
+ * User Settings API
+ *
+ * GET /api/user-settings
+ * Returns the current user's settings including teacher profile selection
+ *
+ * PATCH /api/user-settings
+ * Updates the current user's teacher profile selection
+ */
+
+import { getPayload } from 'payload'
+import { z } from 'zod'
+
+import config from '@payload-config'
+
+const patchSchema = z.object({
+  teacherProfileSlug: z.string(),
+})
+
+export async function GET(req: Request) {
+  const payload = await getPayload({ config })
+
+  // Auth check - return 401 if not authenticated
+  const authResult = await payload.auth({ headers: req.headers })
+  if (!authResult.user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const userId = authResult.user.id
+
+  // Fetch user settings with populated teacher profile
+  const settings = await payload.find({
+    collection: 'user_settings',
+    where: {
+      user: { equals: userId },
+    },
+    depth: 1, // Populate teacherProfile
+    limit: 1,
+    overrideAccess: true, // Collection uses authenticatedOrOwner, but we verified user
+  })
+
+  if (settings.docs.length === 0) {
+    // No settings yet - return null for teacher profile
+    return Response.json({
+      settings: {
+        id: null,
+        teacherProfile: null,
+      },
+    })
+  }
+
+  const userSettings = settings.docs[0]
+
+  // Map to safe response (no systemPrompt/template)
+  const teacherProfile = userSettings.teacherProfile
+    ? {
+        slug: (userSettings.teacherProfile as { slug?: string }).slug,
+        label: (userSettings.teacherProfile as { label?: string }).label,
+        description: (userSettings.teacherProfile as { description?: string }).description,
+      }
+    : null
+
+  return Response.json({
+    settings: {
+      id: userSettings.id,
+      teacherProfile,
+    },
+  })
+}
+
+export async function PATCH(req: Request) {
+  const payload = await getPayload({ config })
+
+  // Auth check - return 401 if not authenticated
+  const authResult = await payload.auth({ headers: req.headers })
+  if (!authResult.user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const userId = authResult.user.id
+
+  // Validate request body
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const validation = patchSchema.safeParse(body)
+
+  if (!validation.success) {
+    return Response.json(
+      { error: 'Invalid request', details: validation.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const { teacherProfileSlug } = validation.data
+
+  // Verify profile exists and is enabled
+  const profileResult = await payload.find({
+    collection: 'teacher_profiles',
+    where: {
+      slug: { equals: teacherProfileSlug },
+      isEnabled: { equals: true },
+    },
+    limit: 1,
+    overrideAccess: true,
+  })
+
+  if (profileResult.docs.length === 0) {
+    return Response.json({ error: 'Teacher profile not found or disabled' }, { status: 404 })
+  }
+
+  const profileId = profileResult.docs[0].id
+
+  // Find or create user settings (lazy creation)
+  const existingSettings = await payload.find({
+    collection: 'user_settings',
+    where: {
+      user: { equals: userId },
+    },
+    limit: 1,
+    overrideAccess: true,
+  })
+
+  let settingsId: string
+
+  if (existingSettings.docs.length > 0) {
+    // Update existing
+    const updated = await payload.update({
+      collection: 'user_settings',
+      id: existingSettings.docs[0].id,
+      data: {
+        teacherProfile: profileId,
+      },
+      overrideAccess: true,
+    })
+    settingsId = updated.id as string
+  } else {
+    // Create new
+    const created = await payload.create({
+      collection: 'user_settings',
+      data: {
+        user: userId,
+        teacherProfile: profileId,
+      },
+      overrideAccess: true,
+    })
+    settingsId = created.id as string
+  }
+
+  return Response.json({
+    success: true,
+    settings: {
+      id: settingsId,
+      teacherProfileSlug,
+    },
+  })
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -79,6 +79,14 @@
       "collapse": "Collapse",
       "preferencesPlaceholder": "Preferences settings will be available soon.",
       "teachersProfilePlaceholder": "Teachers profile features coming soon.",
+      "teacherProfile": {
+        "description": "Choose how your AI teacher interacts with you. This affects your chat experience.",
+        "loading": "Loading teacher profiles...",
+        "selected": "Selected",
+        "changeSuccess": "Teacher profile updated successfully",
+        "changeFailed": "Failed to update teacher profile",
+        "noProfiles": "No teacher profiles available"
+      },
       "failedToLoadCourse": "Failed to load course",
       "tryAgain": "Try Again"
     },

--- a/src/i18n/he.json
+++ b/src/i18n/he.json
@@ -102,6 +102,14 @@
       "collapse": "כווץ",
       "preferencesPlaceholder": "הגדרות ההעדפות יהיו זמינות בקרוב.",
       "teachersProfilePlaceholder": "תכונות פרופיל המורה בקרוב.",
+      "teacherProfile": {
+        "description": "בחר כיצד המורה הבינה מלאכותית שלך יתקשר איתך. זה משפיע על חוויית הצ'אט שלך.",
+        "loading": "טוען פרופילי מורה...",
+        "selected": "נבחר",
+        "changeSuccess": "פרופיל המורה עודכן בהצלחה",
+        "changeFailed": "עדכון פרופיל המורה נכשל",
+        "noProfiles": "אין פרופילי מורה זמינים"
+      },
       "failedToLoadCourse": "טעינת הקורס נכשלה",
       "tryAgain": "נסה שוב"
     }

--- a/src/infra/llm/context-policy.ts
+++ b/src/infra/llm/context-policy.ts
@@ -50,6 +50,8 @@ export interface ComposedPrompt {
     summaryLength: number
     memoryCount: number
     messageCount: number
+    teacherProfileSlug?: string
+    teacherProfileResolvedFrom?: string
   }
 }
 

--- a/src/infra/llm/prompt-composer.server.ts
+++ b/src/infra/llm/prompt-composer.server.ts
@@ -14,18 +14,21 @@ export const SYSTEM_PROMPT_SEPARATOR = '\n\n---\n\n'
  *
  * Order (deterministic):
  * 1. All published system prompts (joined with separator)
- * 2. Lesson-specific resolved prompt
- * 3. Lesson context text injection (via buildLessonContextPrompt)
+ * 2. Teacher profile block (injected into system role, NOT stored in conversation)
+ * 3. Lesson-specific resolved prompt
+ * 4. Lesson context text injection (via buildLessonContextPrompt)
  *
  * @param systemPrompts - Array of system prompt templates (can be empty)
  * @param lessonPromptTemplate - Resolved lesson prompt template
  * @param lessonContextText - Optional lesson context to inject
+ * @param teacherProfileBlock - Optional teacher profile block to inject
  * @returns Final composed system instructions string
  */
 export function composeSystemInstructions(
   systemPrompts: string[],
   lessonPromptTemplate: string,
   lessonContextText?: string,
+  teacherProfileBlock?: string,
 ): string {
   // Step 1: Join system prompts (if any)
   const systemPart =
@@ -33,9 +36,14 @@ export function composeSystemInstructions(
       ? systemPrompts.join(SYSTEM_PROMPT_SEPARATOR) + SYSTEM_PROMPT_SEPARATOR
       : ''
 
-  // Step 2: Append lesson prompt
-  const withLessonPrompt = systemPart + lessonPromptTemplate
+  // Step 2: Append teacher profile block (if provided)
+  const withTeacherProfile = teacherProfileBlock
+    ? systemPart + teacherProfileBlock + '\n\n'
+    : systemPart
 
-  // Step 3: Inject lesson context (reuse existing function)
+  // Step 3: Append lesson prompt
+  const withLessonPrompt = withTeacherProfile + lessonPromptTemplate
+
+  // Step 4: Inject lesson context (reuse existing function)
   return buildLessonContextPrompt(withLessonPrompt, lessonContextText)
 }

--- a/src/infra/llm/services/exercise-chat-service.ts
+++ b/src/infra/llm/services/exercise-chat-service.ts
@@ -44,6 +44,31 @@ export interface ExerciseChatResult {
 const LEGACY_FALLBACK = 'You are a helpful assistant.'
 
 /**
+ * Log teacher profile debug info right before the LLM provider call.
+ * Gated behind DEBUG_TEACHER_PROFILE=true env flag.
+ */
+function logTeacherProfileDebug(
+  systemPrompt: string,
+  metadata?: { teacherProfileSlug?: string; teacherProfileResolvedFrom?: string },
+  mode: 'sync' | 'stream' = 'sync',
+): void {
+  if (process.env.DEBUG_TEACHER_PROFILE !== 'true') return
+
+  const tpIndex = systemPrompt.indexOf('<teacher_profile>')
+  logger.info(
+    {
+      mode,
+      teacherProfileSlug: metadata?.teacherProfileSlug ?? '(unknown)',
+      resolvedFrom: metadata?.teacherProfileResolvedFrom ?? '(unknown)',
+      teacherProfileIndex: tpIndex,
+      hasTeacherProfileBlock: tpIndex !== -1,
+      systemPromptLength: systemPrompt.length,
+    },
+    '[TeacherProfile] Provider call debug — final system message inspection',
+  )
+}
+
+/**
  * @deprecated Use resolveAgentSystemPrompt from prompt-resolver.server instead.
  */
 export function getSystemPrompt(): string {
@@ -106,6 +131,9 @@ export async function chatWithExerciseHelper(
         input.req,
       )
     }
+
+    // Debug: log teacher profile presence in final system message
+    logTeacherProfileDebug(systemPrompt, input.composedPrompt?.metadata, 'sync')
 
     // Text-only path using unified Genkit adapter
     const result = await adapter.generateChatCompletion(
@@ -193,6 +221,9 @@ export async function streamChatWithExerciseHelper(
     // Add current message
     messages.push({ role: 'user', content: input.message })
   }
+
+  // Debug: log teacher profile presence in final system message
+  logTeacherProfileDebug(systemPrompt, input.composedPrompt?.metadata, 'stream')
 
   // Call streaming API
   return adapter.generateStreamingChatCompletion(

--- a/src/infra/llm/teacher-profile-block.ts
+++ b/src/infra/llm/teacher-profile-block.ts
@@ -1,0 +1,41 @@
+/**
+ * Teacher Profile Block Builder
+ *
+ * Builds the <teacher_profile> block that gets injected into the system prompt.
+ * This defines the AI teacher's behavior and personality.
+ *
+ * @fileType ai-utility
+ * @domain chat
+ * @pattern server-only
+ */
+
+import type { ResolvedTeacherProfile } from '@/server/services/teacher-profile-resolver'
+
+/**
+ * Builds the teacher profile block for system prompt injection
+ *
+ * Format:
+ * ```
+ * <teacher_profile>
+ * Name: {label}
+ * Description: {description}
+ *
+ * Behavior:
+ * {systemPrompt.template text}
+ * </teacher_profile>
+ * ```
+ *
+ * @param profile - Resolved teacher profile
+ * @returns Formatted teacher profile block string
+ */
+export function buildTeacherProfileBlock(profile: ResolvedTeacherProfile): string {
+  const block = `<teacher_profile>
+Name: ${profile.profileLabel}
+Description: ${profile.profileDescription}
+
+Behavior:
+${profile.promptTemplate}
+</teacher_profile>`
+
+  return block
+}

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -82,6 +82,8 @@ export interface Config {
     lessons: Lesson;
     exercises: Exercise;
     prompts: Prompt;
+    teacher_profiles: TeacherProfile;
+    user_settings: UserSetting;
     'exercise-assets': ExerciseAsset;
     users: User;
     'user-progress': UserProgress;
@@ -118,6 +120,8 @@ export interface Config {
     lessons: LessonsSelect<false> | LessonsSelect<true>;
     exercises: ExercisesSelect<false> | ExercisesSelect<true>;
     prompts: PromptsSelect<false> | PromptsSelect<true>;
+    teacher_profiles: TeacherProfilesSelect<false> | TeacherProfilesSelect<true>;
+    user_settings: UserSettingsSelect<false> | UserSettingsSelect<true>;
     'exercise-assets': ExerciseAssetsSelect<false> | ExerciseAssetsSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     'user-progress': UserProgressSelect<false> | UserProgressSelect<true>;
@@ -1515,6 +1519,52 @@ export interface MemoryItem {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "teacher_profiles".
+ */
+export interface TeacherProfile {
+  id: string;
+  /**
+   * Machine-readable identifier (e.g., "teacher_strict")
+   */
+  slug: string;
+  /**
+   * Human-readable name displayed in UI
+   */
+  label: string;
+  /**
+   * Short explanation shown in profile selection UI (1-2 sentences)
+   */
+  description?: string | null;
+  /**
+   * The prompt template that defines this teacher's behavior
+   */
+  systemPrompt: string | Prompt;
+  /**
+   * Disabled profiles are not available for selection
+   */
+  isEnabled?: boolean | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "user_settings".
+ */
+export interface UserSetting {
+  id: string;
+  /**
+   * The user this settings record belongs to
+   */
+  user: string | User;
+  /**
+   * Selected teacher profile - leave empty to use default
+   */
+  teacherProfile?: (string | null) | TeacherProfile;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "exercise-assets".
  */
 export interface ExerciseAsset {
@@ -2120,6 +2170,14 @@ export interface PayloadLockedDocument {
         value: string | Prompt;
       } | null)
     | ({
+        relationTo: 'teacher_profiles';
+        value: string | TeacherProfile;
+      } | null)
+    | ({
+        relationTo: 'user_settings';
+        value: string | UserSetting;
+      } | null)
+    | ({
         relationTo: 'exercise-assets';
         value: string | ExerciseAsset;
       } | null)
@@ -2632,6 +2690,29 @@ export interface PromptsSelect<T extends boolean = true> {
   isDefaultForAgentChat?: T;
   tenant?: T;
   usage?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "teacher_profiles_select".
+ */
+export interface TeacherProfilesSelect<T extends boolean = true> {
+  slug?: T;
+  label?: T;
+  description?: T;
+  systemPrompt?: T;
+  isEnabled?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "user_settings_select".
+ */
+export interface UserSettingsSelect<T extends boolean = true> {
+  user?: T;
+  teacherProfile?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -642,9 +642,9 @@ export interface Prompt {
    */
   key?: string | null;
   /**
-   * System prompts are always included. Context prompts are lesson-specific.
+   * System prompts are always included. Context prompts are lesson-specific. Persona prompts define teacher identity.
    */
-  type: 'system' | 'context';
+  type: 'system' | 'context' | 'persona';
   /**
    * System prompt template for AI tutor
    */

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -6,8 +6,8 @@ import { fileURLToPath } from 'url'
 
 import { getServerSideURL } from '@/infra/utils/getURL'
 import { Categories } from '@/server/payload/collections/Categories'
-import { ChatAssets } from '@/server/payload/collections/ChatAssets'
 import { Chapters } from '@/server/payload/collections/Chapters'
+import { ChatAssets } from '@/server/payload/collections/ChatAssets'
 import { ConfigAuditLogs } from '@/server/payload/collections/ConfigAuditLogs'
 import { ConfigSecrets } from '@/server/payload/collections/ConfigSecrets'
 import { ConfigValues } from '@/server/payload/collections/ConfigValues'
@@ -15,6 +15,7 @@ import { Conversations } from '@/server/payload/collections/Conversations'
 import { Courses } from '@/server/payload/collections/Courses'
 import { ExerciseAssets } from '@/server/payload/collections/ExerciseAssets'
 import { Exercises } from '@/server/payload/collections/Exercises'
+import { GuestSessions } from '@/server/payload/collections/GuestSessions'
 import { Lessons } from '@/server/payload/collections/Lessons'
 import { MCPAuditLogs } from '@/server/payload/collections/MCPAuditLogs'
 import { Media } from '@/server/payload/collections/Media'
@@ -23,21 +24,23 @@ import { Pages } from '@/server/payload/collections/Pages'
 import { Posts } from '@/server/payload/collections/Posts'
 import { PricingPlans } from '@/server/payload/collections/PricingPlans'
 import { Prompts } from '@/server/payload/collections/Prompts'
+import { TeacherProfiles } from '@/server/payload/collections/TeacherProfiles'
 import { Tenants } from '@/server/payload/collections/Tenants'
-import { UserProgress } from '@/server/payload/collections/UserProgress'
 import { UploadSessions } from '@/server/payload/collections/UploadSessions'
+import { UserProgress } from '@/server/payload/collections/UserProgress'
 import { Users } from '@/server/payload/collections/Users'
+import { UserSettings } from '@/server/payload/collections/UserSettings'
 import { importExerciseFromImage } from '@/server/payload/endpoints/exercises/import-from-image'
 import { importExerciseFromLesson } from '@/server/payload/endpoints/exercises/import-from-lesson'
 import { defaultLexical } from '@/server/payload/fields/defaultLexical'
 import { pdfToExercisesTask } from '@/server/payload/jobs/pdf-to-exercises-task'
 import { pdfToExercisesV2Task } from '@/server/payload/jobs/pdf-to-exercises-v2-task'
-import { runBackfillOnInit } from '@/server/payload/migrations/backfillAdminTitle'
 import type { JobDocument } from '@/server/payload/jobs/types'
+import { runBackfillOnInit } from '@/server/payload/migrations/backfillAdminTitle'
 import { plugins } from '@/server/payload/plugins'
+import { seedTeacherProfiles } from '@/server/payload/seed/teacher-profiles-seed'
 import { Footer } from '@/ui/web/footer/config'
 import { Header } from '@/ui/web/header/config'
-import { GuestSessions } from '@/server/payload/collections/GuestSessions'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -151,6 +154,8 @@ export default buildConfig({
     Lessons,
     Exercises,
     Prompts,
+    TeacherProfiles,
+    UserSettings,
     ExerciseAssets,
     Users,
     UserProgress,
@@ -267,5 +272,6 @@ export default buildConfig({
   },
   onInit: async (payload) => {
     await runBackfillOnInit(payload)
+    await seedTeacherProfiles(payload)
   },
 })

--- a/src/server/payload/collections/Prompts.ts
+++ b/src/server/payload/collections/Prompts.ts
@@ -42,10 +42,12 @@ export const Prompts: CollectionConfig = {
       options: [
         { label: 'System', value: 'system' },
         { label: 'Context', value: 'context' },
+        { label: 'Persona', value: 'persona' },
       ],
       index: true,
       admin: {
-        description: 'System prompts are always included. Context prompts are lesson-specific.',
+        description:
+          'System prompts are always included. Context prompts are lesson-specific. Persona prompts define teacher identity.',
         position: 'sidebar',
       },
     },

--- a/src/server/payload/collections/TeacherProfiles.ts
+++ b/src/server/payload/collections/TeacherProfiles.ts
@@ -1,0 +1,75 @@
+/**
+ * TeacherProfiles Collection
+ *
+ * @fileType collection-config
+ * @domain ai
+ * @pattern teacher-profile
+ * @ai-summary Collection for managing teacher profiles that define AI chat behavior
+ */
+
+import type { CollectionConfig } from 'payload'
+
+import { adminOnly } from '../access/adminOnly'
+
+export const TeacherProfiles: CollectionConfig = {
+  slug: 'teacher_profiles',
+  access: {
+    create: adminOnly,
+    read: adminOnly, // OverrideAccess: true used server-side for authorized reads
+    update: adminOnly,
+    delete: adminOnly,
+  },
+  admin: {
+    useAsTitle: 'label',
+    defaultColumns: ['label', 'slug', 'systemPrompt', 'isEnabled', 'createdAt'],
+    group: 'AI',
+  },
+  fields: [
+    {
+      name: 'slug',
+      type: 'text',
+      required: true,
+      unique: true,
+      index: true,
+      admin: {
+        description: 'Machine-readable identifier (e.g., "teacher_strict")',
+        position: 'sidebar',
+      },
+    },
+    {
+      name: 'label',
+      type: 'text',
+      required: true,
+      admin: {
+        description: 'Human-readable name displayed in UI',
+      },
+    },
+    {
+      name: 'description',
+      type: 'textarea',
+      admin: {
+        description: 'Short explanation shown in profile selection UI (1-2 sentences)',
+        rows: 2,
+      },
+    },
+    {
+      name: 'systemPrompt',
+      type: 'relationship',
+      relationTo: 'prompts',
+      required: true,
+      admin: {
+        description: "The prompt template that defines this teacher's behavior",
+      },
+    },
+    {
+      name: 'isEnabled',
+      type: 'checkbox',
+      defaultValue: true,
+      index: true,
+      admin: {
+        description: 'Disabled profiles are not available for selection',
+      },
+    },
+  ],
+  timestamps: true,
+}

--- a/src/server/payload/collections/UserSettings/index.ts
+++ b/src/server/payload/collections/UserSettings/index.ts
@@ -1,0 +1,52 @@
+/**
+ * UserSettings Collection
+ *
+ * @fileType collection-config
+ * @domain user
+ * @pattern user-settings
+ * @ai-summary Collection for storing per-user settings including teacher profile selection
+ */
+
+import type { CollectionConfig } from 'payload'
+
+import { adminOnly } from '../../access/adminOnly'
+import { authenticatedOrOwner } from '../../access/authenticatedOrOwner'
+
+export const UserSettings: CollectionConfig = {
+  slug: 'user_settings',
+  access: {
+    create: adminOnly,
+    read: authenticatedOrOwner,
+    update: authenticatedOrOwner,
+    delete: adminOnly,
+  },
+  admin: {
+    useAsTitle: 'id',
+    defaultColumns: ['user', 'teacherProfile', 'createdAt'],
+    group: 'Users',
+  },
+  fields: [
+    {
+      name: 'user',
+      type: 'relationship',
+      relationTo: 'users',
+      required: true,
+      unique: true,
+      index: true,
+      admin: {
+        description: 'The user this settings record belongs to',
+        readOnly: true,
+      },
+    },
+    {
+      name: 'teacherProfile',
+      type: 'relationship',
+      relationTo: 'teacher_profiles',
+      required: false,
+      admin: {
+        description: 'Selected teacher profile - leave empty to use default',
+      },
+    },
+  ],
+  timestamps: true,
+}

--- a/src/server/payload/collections/Users/hooks/createUserSettings-hook.ts
+++ b/src/server/payload/collections/Users/hooks/createUserSettings-hook.ts
@@ -1,0 +1,41 @@
+/**
+ * Create UserSettings Hook
+ *
+ * Automatically creates a user_settings record when a new user is created.
+ * This runs in the same transaction as user creation for data integrity.
+ */
+
+import type { CollectionAfterChangeHook } from 'payload'
+
+/**
+ * Hook that creates a user_settings record after user creation
+ */
+export const createUserSettings: CollectionAfterChangeHook = async ({ doc, req, operation }) => {
+  // Only run on create operations
+  if (operation !== 'create') {
+    return doc
+  }
+
+  try {
+    await req.payload.create({
+      collection: 'user_settings',
+      data: {
+        user: doc.id,
+      },
+      req, // Pass req for transaction safety
+    })
+  } catch (error) {
+    // Log error but don't fail user creation
+    // This could fail if user_settings has unique constraint on user field
+    // and there's already a record (e.g., from a previous failed attempt)
+    req.payload.logger.error(
+      {
+        err: error,
+        userId: doc.id,
+      },
+      'Failed to create user_settings record',
+    )
+  }
+
+  return doc
+}

--- a/src/server/payload/collections/Users/index.ts
+++ b/src/server/payload/collections/Users/index.ts
@@ -12,12 +12,13 @@ import type { CollectionConfig } from 'payload'
 import { adminOnly } from '../../access/adminOnly'
 import { adminOrSelf } from '../../access/adminOrSelf'
 // anyone import kept for future re-enablement of public signup
+import { isUsersCollectionUser } from '@/server/payload/access/isUsersCollectionUser'
 import { anyone } from '../../access/anyone'
+import { auditRoleChange } from './hooks/auditRoleChange-hook'
+import { createUserSettings } from './hooks/createUserSettings-hook'
 import { ensureRoleOnSignup } from './hooks/ensureRoleOnSignup-hook'
 import { preventLastAdminDemotion } from './hooks/preventLastAdminDemotion-hook'
-import { auditRoleChange } from './hooks/auditRoleChange-hook'
-import { AccountRole, ACCOUNT_ROLE_LABEL } from './roles'
-import { isUsersCollectionUser } from '@/server/payload/access/isUsersCollectionUser'
+import { ACCOUNT_ROLE_LABEL, AccountRole } from './roles'
 
 export const Users: CollectionConfig = {
   slug: 'users',
@@ -130,7 +131,7 @@ export const Users: CollectionConfig = {
     // Prevent demoting the last admin
     beforeChange: [preventLastAdminDemotion],
     // Audit trail for role changes
-    afterChange: [auditRoleChange],
+    afterChange: [auditRoleChange, createUserSettings],
   },
   timestamps: true,
 }

--- a/src/server/payload/endpoints/agent/chat.ts
+++ b/src/server/payload/endpoints/agent/chat.ts
@@ -710,12 +710,22 @@ async function handleContextScopedChat(
   }
 
   // Compose prompt using Context Policy V1
-  const composedPrompt = composePrompt(composedInstructions.instructions, {
+  const basePrompt = composePrompt(composedInstructions.instructions, {
     systemMessage: composedInstructions.instructions,
     summary: conversation?.summary || undefined,
     memoryItems: memoryResult.items,
     recentMessages: recentMessages,
   })
+
+  // Thread teacher profile metadata for downstream debug logging (immutable)
+  const composedPrompt = {
+    ...basePrompt,
+    metadata: {
+      ...basePrompt.metadata,
+      teacherProfileSlug: composedInstructions.teacherProfileSlug,
+      teacherProfileResolvedFrom: composedInstructions.teacherProfileResolvedFrom,
+    },
+  }
 
   logPromptSnapshot(conversationId, composedPrompt)
 

--- a/src/server/payload/endpoints/agent/chat.ts
+++ b/src/server/payload/endpoints/agent/chat.ts
@@ -26,7 +26,6 @@ import {
 } from '@/infra/llm/providers/factory'
 import { chatWithExerciseHelper } from '@/infra/llm/services/exercise-chat-service'
 import { logger } from '@/infra/utils/logger'
-import type { Logger } from 'pino'
 import { isUsersCollectionUser } from '@/server/payload/access/isUsersCollectionUser'
 import { AccountRole } from '@/server/payload/collections/Users/roles'
 import { getMCPClient } from '@/server/repos/mcp/client/mcp-client'
@@ -34,7 +33,6 @@ import {
   ConversationService,
   GuestConversationLimitError,
 } from '@/server/services/conversation-service'
-import { checkRateLimit } from '@/server/services/rate-limit'
 import {
   buildGuestSessionCookieHeader,
   checkAndIncrementGuestMessageCount,
@@ -44,7 +42,9 @@ import {
   hashIP,
   hashUserAgent,
 } from '@/server/services/guest-session'
+import { checkRateLimit } from '@/server/services/rate-limit'
 import type { PayloadRequest } from 'payload'
+import type { Logger } from 'pino'
 import { z } from 'zod'
 
 import {
@@ -681,6 +681,7 @@ async function handleContextScopedChat(
       logger as Logger,
       lessonContext.coursePrompt,
       lessonContext.courseContextText,
+      userId,
     )
   } catch (error) {
     if (error instanceof Error && error.message.includes('exceeds maximum')) {

--- a/src/server/payload/endpoints/agent/chat/pipeline.ts
+++ b/src/server/payload/endpoints/agent/chat/pipeline.ts
@@ -262,12 +262,22 @@ export async function runChatPipeline(
   }
 
   // Compose prompt using Context Policy V1
-  const composedPrompt = composePrompt(composedInstructions.instructions, {
+  const basePrompt = composePrompt(composedInstructions.instructions, {
     systemMessage: composedInstructions.instructions,
     summary: conversation?.summary || undefined,
     memoryItems: memoryResult.items,
     recentMessages: recentMessages,
   })
+
+  // Thread teacher profile metadata for downstream debug logging (immutable)
+  const composedPrompt = {
+    ...basePrompt,
+    metadata: {
+      ...basePrompt.metadata,
+      teacherProfileSlug: composedInstructions.teacherProfileSlug,
+      teacherProfileResolvedFrom: composedInstructions.teacherProfileResolvedFrom,
+    },
+  }
 
   return {
     result: {

--- a/src/server/payload/endpoints/agent/chat/pipeline.ts
+++ b/src/server/payload/endpoints/agent/chat/pipeline.ts
@@ -8,7 +8,6 @@
  */
 import { composePrompt, getRecentWindow, type Message } from '@/infra/llm/context-policy'
 import { logger } from '@/infra/utils/logger'
-import type { Logger } from 'pino'
 import { isUsersCollectionUser } from '@/server/payload/access/isUsersCollectionUser'
 import { AccountRole } from '@/server/payload/collections/Users/roles'
 import {
@@ -16,6 +15,7 @@ import {
   GuestConversationLimitError,
 } from '@/server/services/conversation-service'
 import type { PayloadRequest } from 'payload'
+import type { Logger } from 'pino'
 import { z } from 'zod'
 import {
   composeFullSystemInstructions,
@@ -229,6 +229,7 @@ export async function runChatPipeline(
       reqLogger as Logger,
       lessonContext.coursePrompt,
       lessonContext.courseContextText,
+      req.user?.id,
     )
   } catch (error) {
     if (error instanceof Error && error.message.includes('exceeds maximum')) {

--- a/src/server/payload/endpoints/agent/chat/prompt-composition.ts
+++ b/src/server/payload/endpoints/agent/chat/prompt-composition.ts
@@ -8,7 +8,9 @@ import type { Logger } from 'pino'
 import { composeSystemInstructions } from '@/infra/llm/prompt-composer.server'
 import { resolveAgentSystemPrompt } from '@/infra/llm/prompt-resolver.server'
 import { fetchPublishedSystemPrompts } from '@/infra/llm/system-prompts.server'
+import { buildTeacherProfileBlock } from '@/infra/llm/teacher-profile-block'
 import type { Prompt } from '@/payload-types'
+import { resolveTeacherProfile } from '@/server/services/teacher-profile-resolver'
 
 import type { ResolvedContext } from './context-resolution'
 
@@ -258,6 +260,7 @@ export async function composeFullSystemInstructions(
   reqLogger: Logger,
   coursePrompt?: Prompt | null,
   courseContextText?: string,
+  userId?: string,
 ): Promise<ComposedSystemInstructions> {
   // Fetch published system prompts (always included)
   const systemPromptsResult = await fetchPublishedSystemPrompts(payload)
@@ -291,12 +294,27 @@ export async function composeFullSystemInstructions(
     'Resolved system prompt',
   )
 
-  // Compose final system instructions: system prompts + lesson/course prompt + lesson/course context
+  // Resolve teacher profile (per-request, no caching)
+  const teacherProfile = await resolveTeacherProfile(payload, userId)
+
+  // Build teacher profile block
+  const teacherProfileBlock = buildTeacherProfileBlock(teacherProfile)
+
+  reqLogger.info(
+    {
+      teacherProfileSlug: teacherProfile.profileSlug,
+      resolvedFrom: teacherProfile.resolvedFrom,
+    },
+    'Resolved teacher profile',
+  )
+
+  // Compose final system instructions: system prompts + teacher profile + lesson/course prompt + lesson/course context
   // Priority: lesson context > course context
   const instructions = composeSystemInstructions(
     systemPromptsResult.templates,
     promptResolution.template,
     lessonContextText || courseContextText,
+    teacherProfileBlock,
   )
 
   return {

--- a/src/server/payload/endpoints/agent/chat/prompt-composition.ts
+++ b/src/server/payload/endpoints/agent/chat/prompt-composition.ts
@@ -247,6 +247,8 @@ export interface ComposedSystemInstructions {
     fallbackReason?: string
   }
   systemPromptCount: number
+  teacherProfileSlug: string
+  teacherProfileResolvedFrom: string
 }
 
 /**
@@ -321,5 +323,7 @@ export async function composeFullSystemInstructions(
     instructions,
     promptResolution,
     systemPromptCount: systemPromptsResult.count,
+    teacherProfileSlug: teacherProfile.profileSlug,
+    teacherProfileResolvedFrom: teacherProfile.resolvedFrom,
   }
 }

--- a/src/server/payload/seed/teacher-profiles-seed.ts
+++ b/src/server/payload/seed/teacher-profiles-seed.ts
@@ -1,0 +1,178 @@
+/**
+ * Teacher Profiles Seed
+ *
+ * Seeds 5 Prompt entries and 5 TeacherProfile entries for teacher profile functionality.
+ * Idempotent - checks by key/slug before creating.
+ *
+ * @fileType seed
+ * @domain ai
+ */
+
+import type { Payload } from 'payload'
+
+/**
+ * Teacher profile configurations to seed
+ */
+const TEACHER_PROFILES = [
+  {
+    slug: 'teacher_strict',
+    label: 'Strict Teacher',
+    description: 'Maintains high standards and expects precise, accurate responses.',
+    promptKey: 'teacher-strict-v1',
+    promptTitle: 'Strict Teacher v1',
+    promptTemplate: `You are a strict but fair teacher who maintains high academic standards.
+- Require precise, accurate answers from students
+- Point out errors and misconceptions clearly
+- Encourage rigorous thinking and attention to detail
+- Celebrate correct answers but remain professional
+- Do not accept incomplete or sloppy work`,
+  },
+  {
+    slug: 'teacher_thorough',
+    label: 'Thorough Teacher',
+    description: 'Provides comprehensive explanations with extensive detail.',
+    promptKey: 'teacher-thorough-v1',
+    promptTitle: 'Thorough Teacher v1',
+    promptTemplate: `You are a thorough teacher who provides comprehensive, detailed explanations.
+- Break down concepts into small, digestible parts
+- Provide multiple examples and analogies
+- Connect new information to previously learned concepts
+- Anticipate follow-up questions and address them proactively
+- Ensure complete understanding before moving on`,
+  },
+  {
+    slug: 'teacher_patient',
+    label: 'Patient Teacher',
+    description: 'Approaches learning with patience and encouragement.',
+    promptKey: 'teacher-patient-v1',
+    promptTitle: 'Patient Teacher v1',
+    promptTemplate: `You are a patient, supportive teacher who prioritizes student confidence.
+- Allow students time to think and process information
+- Offer gentle hints and guidance rather than direct answers
+- Celebrate small victories and progress
+- Never make students feel rushed or inadequate
+- Reassure students that making mistakes is part of learning`,
+  },
+  {
+    slug: 'teacher_focused',
+    label: 'Focused Teacher',
+    description: 'Keeps lessons on track with clear objectives and efficient delivery.',
+    promptKey: 'teacher-focused-v1',
+    promptTitle: 'Focused Teacher v1',
+    promptTemplate: `You are a focused teacher who keeps lessons efficient and goal-oriented.
+- Start each interaction by clarifying the learning objective
+- Stay on topic and minimize tangents
+- Provide concise, relevant information
+- Redirect off-topic discussions politely
+- Summarize key points at the end of each interaction`,
+  },
+  {
+    slug: 'teacher_challenging',
+    label: 'Challenging Teacher',
+    description: 'Pushes students with thought-provoking questions and advanced material.',
+    promptKey: 'teacher-challenging-v1',
+    promptTitle: 'Challenging Teacher v1',
+    promptTemplate: `You are a challenging teacher who pushes students to reach their full potential.
+- Ask probing questions that require deep thinking
+- Introduce advanced concepts and extensions
+- Encourage students to explain their reasoning
+- Challenge assumptions and invite debate
+- Set high expectations and help students meet them`,
+  },
+]
+
+/**
+ * Seed teacher profiles and their associated prompts
+ * Idempotent - safe to re-run
+ */
+export async function seedTeacherProfiles(payload: Payload): Promise<void> {
+  payload.logger.info('[TeacherProfilesSeed] Starting teacher profiles seed...')
+
+  // Get default tenant (required for Prompts collection which has tenantField)
+  const tenantSlug = process.env.DEFAULT_TENANT_SLUG || 'default'
+  const tenants = await payload.find({
+    collection: 'tenants',
+    where: { slug: { equals: tenantSlug } },
+    limit: 1,
+    overrideAccess: true,
+  })
+
+  if (tenants.docs.length === 0) {
+    payload.logger.error(
+      `[TeacherProfilesSeed] Default tenant "${tenantSlug}" not found. ` +
+        'Prompts cannot be created without a tenant, so TeacherProfiles will have no linked prompts. ' +
+        'The resolver will fall back to the failsafe prompt for all users.',
+    )
+    return
+  }
+
+  const tenantId = tenants.docs[0].id as string
+
+  for (const profile of TEACHER_PROFILES) {
+    // Check if prompt already exists
+    const existingPrompt = await payload.find({
+      collection: 'prompts',
+      where: { key: { equals: profile.promptKey } },
+      limit: 1,
+      overrideAccess: true,
+    })
+
+    let promptId: string
+
+    if (existingPrompt.docs.length > 0) {
+      promptId = existingPrompt.docs[0].id as string
+      payload.logger.info(
+        `[TeacherProfilesSeed] Prompt ${profile.promptKey} already exists, skipping`,
+      )
+    } else {
+      // Create prompt
+      const createdPrompt = await payload.create({
+        collection: 'prompts',
+        data: {
+          title: profile.promptTitle,
+          key: profile.promptKey,
+          type: 'context',
+          template: profile.promptTemplate,
+          status: 'published',
+          usage: 'chat',
+          isDefaultForAgentChat: false,
+          tenant: tenantId,
+        },
+        draft: false,
+        overrideAccess: true,
+      })
+      promptId = createdPrompt.id as string
+      payload.logger.info(`[TeacherProfilesSeed] Created prompt ${profile.promptKey}`)
+    }
+
+    // Check if teacher profile already exists
+    const existingProfile = await payload.find({
+      collection: 'teacher_profiles',
+      where: { slug: { equals: profile.slug } },
+      limit: 1,
+      overrideAccess: true,
+    })
+
+    if (existingProfile.docs.length > 0) {
+      payload.logger.info(
+        `[TeacherProfilesSeed] Teacher profile ${profile.slug} already exists, skipping`,
+      )
+    } else {
+      // Create teacher profile
+      await payload.create({
+        collection: 'teacher_profiles',
+        data: {
+          slug: profile.slug,
+          label: profile.label,
+          description: profile.description,
+          systemPrompt: promptId,
+          isEnabled: true,
+        },
+        overrideAccess: true,
+      })
+      payload.logger.info(`[TeacherProfilesSeed] Created teacher profile ${profile.slug}`)
+    }
+  }
+
+  payload.logger.info('[TeacherProfilesSeed] Teacher profiles seed completed')
+}

--- a/src/server/services/teacher-profile-resolver.ts
+++ b/src/server/services/teacher-profile-resolver.ts
@@ -1,0 +1,256 @@
+/**
+ * Teacher Profile Resolver Service
+ *
+ * Resolves the appropriate teacher profile for a given user or guest.
+ * Implements a tiered resolution strategy:
+ * - Authenticated users: Tier 1 (user settings) → Tier 2 (default) → Tier 3 (first active) → Tier 4 (failsafe)
+ * - Guests: Tier 2 (default) → Tier 4 (failsafe)
+ */
+
+import type { Payload } from 'payload'
+
+import { logger as rootLogger } from '@/infra/utils/logger'
+import type { UserSetting } from '@/payload-types'
+
+/**
+ * Default teacher profile slug - hardcoded for v1.1
+ * Changing this requires a code change + PR
+ */
+export const DEFAULT_TEACHER_PROFILE_SLUG = 'teacher_focused'
+
+/**
+ * Failsafe prompt template - used when no other profile is available
+ * This should never be reached in normal operation
+ */
+const FAILSAFE_TEACHER_PROMPT = `You are a helpful and knowledgeable AI teacher.
+Provide clear, accurate explanations tailored to the student's level of understanding.
+Always encourage critical thinking and questions.
+Be patient, supportive, and maintain a positive learning environment.`
+
+const log = rootLogger.child({ module: 'TeacherProfileResolver' })
+
+/**
+ * Resolution source tracking for logging
+ */
+export type ResolvedFrom = 'user-settings' | 'default-config' | 'first-active' | 'failsafe'
+
+/**
+ * Resolved teacher profile result
+ */
+export interface ResolvedTeacherProfile {
+  profileSlug: string
+  profileLabel: string
+  profileDescription: string
+  promptTemplate: string
+  resolvedFrom: ResolvedFrom
+}
+
+/**
+ * Payload types for the populated profile
+ */
+interface PopulatedTeacherProfile {
+  slug: string
+  label: string
+  description: string | null
+  isEnabled: boolean
+  systemPrompt: {
+    template: string
+    status: string
+  }
+}
+
+/**
+ * Validates that a profile's prompt is usable
+ */
+function isPromptValid(
+  prompt: PopulatedTeacherProfile['systemPrompt'] | null | undefined,
+): boolean {
+  if (!prompt) return false
+  if (prompt.status !== 'published') return false
+  if (!prompt.template || prompt.template.trim() === '') return false
+  return true
+}
+
+/**
+ * Resolves the teacher profile for a given user ID or guest
+ *
+ * @param payload - Payload instance
+ * @param userId - Optional user ID (omit for guest)
+ * @returns Resolved teacher profile with all necessary details
+ */
+export async function resolveTeacherProfile(
+  payload: Payload,
+  userId?: string,
+): Promise<ResolvedTeacherProfile> {
+  // Authenticated user resolution path
+  if (userId) {
+    // Tier 1: Load from user settings
+    const tier1Result = await resolveTier1UserSettings(payload, userId)
+    if (tier1Result) return tier1Result
+  }
+
+  // Tier 2: Default profile by slug
+  const tier2Result = await resolveTier2DefaultProfile(payload)
+  if (tier2Result) return tier2Result
+
+  // Tier 3: First active profile (authenticated users only)
+  if (userId) {
+    const tier3Result = await resolveTier3FirstActive(payload)
+    if (tier3Result) return tier3Result
+  }
+
+  // Tier 4: Failsafe
+  return resolveTier4Failsafe()
+}
+
+/**
+ * Tier 1: Load user settings and check selected profile
+ */
+async function resolveTier1UserSettings(
+  payload: Payload,
+  userId: string,
+): Promise<ResolvedTeacherProfile | null> {
+  try {
+    const userSettings = await payload.find({
+      collection: 'user_settings',
+      where: {
+        user: { equals: userId },
+      },
+      depth: 2, // Populate teacherProfile → systemPrompt
+      limit: 1,
+      overrideAccess: true, // Server-side read, auth verified by caller
+    })
+
+    if (userSettings.docs.length === 0) {
+      return null
+    }
+
+    const settings = userSettings.docs[0] as unknown as UserSetting & {
+      teacherProfile: PopulatedTeacherProfile | null
+    }
+
+    const profile = settings.teacherProfile
+
+    if (!profile) {
+      return null
+    }
+
+    // Check if profile is enabled and prompt is valid
+    if (profile.isEnabled === true && isPromptValid(profile.systemPrompt)) {
+      log.debug({ profileSlug: profile.slug, userId }, 'Resolved from user-settings')
+
+      return {
+        profileSlug: profile.slug,
+        profileLabel: profile.label,
+        profileDescription: profile.description || '',
+        promptTemplate: profile.systemPrompt.template,
+        resolvedFrom: 'user-settings',
+      }
+    }
+
+    // Profile disabled or prompt invalid - fall through to next tier
+    return null
+  } catch (error) {
+    log.error({ err: error, userId }, 'Error resolving user settings')
+    return null
+  }
+}
+
+/**
+ * Tier 2: Default profile by slug
+ */
+async function resolveTier2DefaultProfile(
+  payload: Payload,
+): Promise<ResolvedTeacherProfile | null> {
+  try {
+    const result = await payload.find({
+      collection: 'teacher_profiles',
+      where: {
+        slug: { equals: DEFAULT_TEACHER_PROFILE_SLUG },
+        isEnabled: { equals: true },
+      },
+      depth: 1, // Populate systemPrompt one level
+      limit: 1,
+      overrideAccess: true, // Server-side read, collection is adminOnly
+    })
+
+    if (result.docs.length === 0) {
+      return null
+    }
+
+    const profile = result.docs[0] as unknown as PopulatedTeacherProfile
+
+    if (isPromptValid(profile.systemPrompt)) {
+      log.debug({ profileSlug: profile.slug }, 'Resolved from default-config')
+
+      return {
+        profileSlug: profile.slug,
+        profileLabel: profile.label,
+        profileDescription: profile.description || '',
+        promptTemplate: profile.systemPrompt.template,
+        resolvedFrom: 'default-config',
+      }
+    }
+
+    return null
+  } catch (error) {
+    log.error({ err: error }, 'Error resolving default profile')
+    return null
+  }
+}
+
+/**
+ * Tier 3: First active profile (authenticated users only)
+ */
+async function resolveTier3FirstActive(payload: Payload): Promise<ResolvedTeacherProfile | null> {
+  try {
+    const result = await payload.find({
+      collection: 'teacher_profiles',
+      where: {
+        isEnabled: { equals: true },
+      },
+      depth: 1,
+      limit: 1,
+      sort: 'createdAt',
+      overrideAccess: true, // Server-side read, collection is adminOnly
+    })
+
+    if (result.docs.length === 0) {
+      return null
+    }
+
+    const profile = result.docs[0] as unknown as PopulatedTeacherProfile
+
+    if (isPromptValid(profile.systemPrompt)) {
+      log.debug({ profileSlug: profile.slug }, 'Resolved from first-active')
+
+      return {
+        profileSlug: profile.slug,
+        profileLabel: profile.label,
+        profileDescription: profile.description || '',
+        promptTemplate: profile.systemPrompt.template,
+        resolvedFrom: 'first-active',
+      }
+    }
+
+    return null
+  } catch (error) {
+    log.error({ err: error }, 'Error resolving first active profile')
+    return null
+  }
+}
+
+/**
+ * Tier 4: Failsafe - hardcoded prompt
+ */
+function resolveTier4Failsafe(): ResolvedTeacherProfile {
+  log.warn('Using failsafe prompt - no valid profiles found')
+
+  return {
+    profileSlug: 'failsafe',
+    profileLabel: 'Default Teacher',
+    profileDescription: 'Fallback teacher profile',
+    promptTemplate: FAILSAFE_TEACHER_PROMPT,
+    resolvedFrom: 'failsafe',
+  }
+}

--- a/src/ui/web/chat/ChatInterface/index.tsx
+++ b/src/ui/web/chat/ChatInterface/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { ChatMessageRole } from '@/infra/llm/chat-message-role'
+import { useCurrentUser } from '@/client/hooks/useCurrentUser'
 import { cn } from '@/infra/utils/ui'
 import { useTranslations } from '@/ui/web/providers/I18n'
 import {
@@ -22,6 +23,7 @@ import { ChatErrorSurface } from '../ChatErrorSurface'
 import { ChatMessageContent } from '../ChatMessageContent'
 import { TTSButton } from '../TTSButton'
 import { useNotebookChat } from '../hooks/useNotebookChat'
+import { useTeacherProfileLabel } from '../hooks/useTeacherProfileLabel'
 import { useTTS } from '../hooks/useTTS'
 
 // Optional components - will be lazy-loaded if needed
@@ -187,6 +189,10 @@ export function ChatInterface({
   })
 
   const { speak, playingMessageId } = useTTS()
+
+  // Teacher profile badge (authenticated users only)
+  const { user: currentUser } = useCurrentUser()
+  const { label: teacherProfileLabel } = useTeacherProfileLabel(!!currentUser)
 
   // Auto-send contextual help on incorrect answer (ref pattern for stable listener)
   const incorrectAnswerRef = useRef<(e: Event) => void>(() => {})
@@ -383,10 +389,17 @@ export function ChatInterface({
 
   return (
     <div className="flex flex-col h-full min-h-0">
-      {/* Header with optional reset button */}
+      {/* Header with optional reset button and teacher profile badge */}
       {showResetButton && (
         <div className="flex items-center justify-between p-3 border-b border-border">
-          <h3 className="font-medium text-sm text-foreground">{tCourses('chatTitle')}</h3>
+          <div className="flex items-center gap-2">
+            <h3 className="font-medium text-sm text-foreground">{tCourses('chatTitle')}</h3>
+            {teacherProfileLabel && (
+              <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary">
+                {teacherProfileLabel}
+              </span>
+            )}
+          </div>
           {contextKey && (
             <button
               onClick={handleReset}

--- a/src/ui/web/chat/hooks/useTeacherProfileLabel.ts
+++ b/src/ui/web/chat/hooks/useTeacherProfileLabel.ts
@@ -1,0 +1,53 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface TeacherProfileLabel {
+  label: string | null
+  isLoading: boolean
+}
+
+/**
+ * Fetches the authenticated user's selected teacher profile label.
+ * Returns null for guests or when no profile is selected.
+ */
+export function useTeacherProfileLabel(isAuthenticated: boolean): TeacherProfileLabel {
+  const [label, setLabel] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setLabel(null)
+      return
+    }
+
+    const controller = new AbortController()
+    setIsLoading(true)
+
+    const doFetch = async () => {
+      try {
+        const res = await fetch('/api/user-settings', {
+          credentials: 'include',
+          signal: controller.signal,
+        })
+        if (controller.signal.aborted) return
+        if (!res.ok) {
+          setLabel(null)
+          return
+        }
+        const data = await res.json()
+        if (controller.signal.aborted) return
+        setLabel(data.settings?.teacherProfile?.label ?? null)
+      } catch {
+        if (!controller.signal.aborted) setLabel(null)
+      } finally {
+        if (!controller.signal.aborted) setIsLoading(false)
+      }
+    }
+
+    doFetch()
+    return () => controller.abort()
+  }, [isAuthenticated])
+
+  return { label, isLoading }
+}


### PR DESCRIPTION
Implement per-user teacher profile selection that controls the AI chat's behavioral identity. Each profile links to a Prompt entry injected into the system context on every request.

- Add TeacherProfiles collection (slug, label, description, systemPrompt, isEnabled)
- Add UserSettings collection (1:1 user relationship, optional teacherProfile)
- Add 4-tier resolver: user-settings → default-config → first-active → failsafe
- Add <teacher_profile> block injection in prompt composition pipeline
- Add seed data for 5 teacher profiles (strict, thorough, patient, focused, challenging)
- Add GET /api/teacher-profiles and GET/PATCH /api/user-settings API routes
- Add Account UI profile selection with card grid and toast feedback
- Add auto-create UserSettings hook on user signup
- Add en/he translations for teacher profile UI