### PR TITLE
fix: bug: preventlastadmindemotion uses overrideaccess: false for admin count

### DIFF
--- a/.tasks/260226-fix-admin-demotion-hook/apply-audit.md
+++ b/.tasks/260226-fix-admin-demotion-hook/apply-audit.md
@@ -1,0 +1,41 @@
+# Apply Audit Report: 260226-fix-admin-demotion-hook
+
+## Improvements Applied
+
+| #   | Type | Where    | Status              |
+| --- | ---- | -------- | ------------------- |
+| 1   | DOC  | AGENTS.md | status: IMPLEMENTED |
+
+## Changes Made
+
+- **AGENTS.md** (lines 183-185): Added critical security note explaining the counterintuitive behavior of `overrideAccess: false`:
+  > ⚠️ **CRITICAL SECURITY NOTE**: `overrideAccess: false` filters queries by the **current user's** access control, not the `user` parameter. This is counterintuitive for system-level operations. For example, counting admins with `overrideAccess: false` will return 0 if the current user is not an admin, potentially causing the last admin to be demoted. Use `overrideAccess: true` for system operations that must bypass all access control.
+
+This documentation improvement was added to the Local API Access Control section (the same section that describes the security bug fixed in this task), making it highly visible to developers working with hooks and access control.
+
+## Suggested Improvements (Not Applied)
+
+1. **Type:** GUARDRAIL
+   - **Title:** Add security lint rule for Local API access control
+   - **Where:** `eslint.config.mjs` or `src/lib/eslint/`
+   - **Reason:** Not in safe-path whitelist - paths under `src/` and root config files are not whitelisted for direct editing
+   - **Suggestion:** Implement as a custom ESLint rule in the project's linting infrastructure
+
+2. **Type:** CODE_PATTERN
+   - **Title:** Add helper function for system-level operations
+   - **Where:** `src/server/payload/collections/Users/hooks/` or `src/access/`
+   - **Reason:** Not in safe-path whitelist - `src/**` paths are outside the allowed edit scope
+   - **Suggestion:** Create a helper function like `countAdmins()` that always uses `overrideAccess: true` for security-sensitive counts
+
+3. **Type:** AUTOMATION
+   - **Title:** Add security-focused code review checklist
+   - **Where:** `.github/CODEOWNERS` or `docs/security-checklist.md`
+   - **Reason:** Not in safe-path whitelist - `.github/` (except workflows) and `docs/` are not whitelisted
+   - **Suggestion:** Add security review requirement for hooks that query users/roles/permissions collections
+
+## Notes
+
+- The primary security bug fix (`overrideAccess: false` → `overrideAccess: true`) was already implemented in the build stage of this task
+- Unit tests (6 test cases) were added to prevent regression - excellent security practice
+- Only documentation improvement was applied via this audit (AGENTS.md is in the safe-path whitelist)
+- All three suggested improvements are valid but require code changes outside the safe-path whitelist scope

--- a/.tasks/260226-fix-admin-demotion-hook/architect.md
+++ b/.tasks/260226-fix-admin-demotion-hook/architect.md
@@ -1,0 +1,8 @@
+# Architect (promoted)
+
+Skipped via input_quality — taskify determined this stage is unnecessary.
+See task.json input_quality.reasoning for details.
+
+## Changes
+
+See task.md for implementation details.

--- a/.tasks/260226-fix-admin-demotion-hook/auditor.md
+++ b/.tasks/260226-fix-admin-demotion-hook/auditor.md
@@ -1,0 +1,63 @@
+# Auditor Report: 260226-fix-admin-demotion-hook
+
+## Task Info
+
+- **Task ID:** 260226-fix-admin-demotion-hook
+- **Task Type:** fix
+- **Run State:** SUCCESS
+- **Date:** 2026-02-26T15:32:39.300Z
+- **Previous Improvements Reviewed:** 0 from audit-history.json
+
+## Stage Analysis
+
+| Stage  | Quality |
+| ------ | ------- |
+| spec   | skipped (appropriate - simple fix with clear requirements) |
+| plan   | implicit (straightforward security fix) |
+| build  | excellent (fix applied + unit tests created) |
+| verify | pass (TypeScript, Lint, Format, Unit Tests) |
+
+## Process Delta
+
+- Security bug fixed: `overrideAccess: false` → `overrideAccess: true` prevents last admin demotion
+- Unit tests added (6 test cases) - excellent practice for security-critical code
+- All quality gates passed without retry
+
+## Primary Improvement
+
+- **Type:** GUARDRAIL
+- **Title:** Add security lint rule for Local API access control
+- **Rationale:** This security bug occurred because `overrideAccess: false` filters by current user's access control, which is counterintuitive for system-level operations like counting admins. A lint rule can catch this pattern.
+- **Where:** `eslint.config.mjs` or create a custom rule in `src/lib/eslint/`
+- **Acceptance Criteria:**
+  - Rule detects `payload.count`, `payload.find`, `payload.findByID` with `overrideAccess: false` on sensitive collections (users, roles, permissions)
+  - Rule suggests `overrideAccess: true` with comment explaining why
+- **Effectiveness:** effective
+
+## Additional Findings
+
+1. **Type:** DOC
+   - **Title:** Document overrideAccess patterns in AGENTS.md
+   - **Where:** `AGENTS.md` (Security Patterns section)
+   - **Rationale:** The AGENTS.md already covers Local API access control, but a specific warning about `overrideAccess: false` filtering by user permissions would help prevent future issues.
+
+2. **Type:** CODE_PATTERN
+   - **Title:** Add helper function for system-level operations
+   - **Where:** `src/server/payload/collections/Users/hooks/` or `src/access/`
+   - **Rationale:** Create a `countAdmins()` or similar helper that always uses `overrideAccess: true` for security-sensitive counts, making the pattern explicit and harder to misuse.
+
+3. **Type:** AUTOMATION
+   - **Title:** Add security-focused code review checklist
+   - **Where:** `.github/CODEOWNERS` or `docs/security-checklist.md`
+   - **Rationale:** Any change to hooks that query users/roles/permissions collections should require security review to catch access control misconfigurations.
+
+## Failure Analysis (if FAILED)
+
+Not applicable - task completed successfully.
+
+## Chosen Improvement (DEPRECATED - use Primary Improvement)
+
+- **Type:** GUARDRAIL
+- **Title:** Add security lint rule for Local API access control
+- **Where:** `eslint.config.mjs` or custom rule
+- **Rationale:** This security bug occurred because `overrideAccess: false` filters by current user's access control. A lint rule can catch this pattern before it reaches production.

--- a/.tasks/260226-fix-admin-demotion-hook/build.md
+++ b/.tasks/260226-fix-admin-demotion-hook/build.md
@@ -1,0 +1,27 @@
+# Build Agent Report: 260226-fix-admin-demotion-hook
+
+## Changes
+
+- **Modified**: `src/server/payload/collections/Users/hooks/preventLastAdminDemotion-hook.ts` - Changed `overrideAccess: false` to `overrideAccess: true` on line 27 to fix the security bug that could allow the last admin to be demoted
+- **Created**: `tests/unit/collections/preventLastAdminDemotion-hook.test.ts` - Unit tests for the preventLastAdminDemotion hook
+
+## Tests Written
+
+- `tests/unit/collections/preventLastAdminDemotion-hook.test.ts` - 6 test cases:
+  1. should call count with overrideAccess: true (system-level check) - Reproduction test that verifies overrideAccess: true is passed
+  2. should throw ValidationError when demoting the last admin
+  3. should allow demotion when multiple admins exist
+  4. should skip check on create operations
+  5. should skip check when role is not changing to student
+  6. should skip check when original role is not admin
+
+## Quality
+
+- TypeScript: PASS
+- Lint: PASS (only pre-existing warnings, no errors)
+
+## Summary
+
+Fixed the HIGH-priority security bug in the `preventLastAdminDemotion` hook. The bug was that the admin count query used `overrideAccess: false`, which filtered results based on the current user's access control. If a non-admin triggered this code path, they couldn't see other admins, causing `adminCount` to return 0 — incorrectly allowing the last admin to be demoted.
+
+The fix changes `overrideAccess: false` to `overrideAccess: true`, ensuring a system-level admin count that bypasses user-specific access control.

--- a/.tasks/260226-fix-admin-demotion-hook/commit.md
+++ b/.tasks/260226-fix-admin-demotion-hook/commit.md
@@ -1,0 +1,6 @@
+# Commit Stage
+
+✅ **Committed and pushed**
+
+- **Branch:** fix/260226-fix-high-bug-preventlastadmindemotion-uses-
+- **Hash:** 07be89d

--- a/.tasks/260226-fix-admin-demotion-hook/gap.md
+++ b/.tasks/260226-fix-admin-demotion-hook/gap.md
@@ -1,0 +1,51 @@
+# Gap Analysis: 260226-fix-admin-demotion-hook
+
+## Summary
+
+- Gaps Found: 3
+- Spec Revised: Yes
+
+## Gaps Found
+
+### Gap 1: Spec describes incorrect query structure
+
+**Severity:** Medium
+**Location:** spec.md - "Current Code" and "Expected Fix" sections
+**Issue:** The spec shows `where: { roles: { contains: 'admin' } }` but the actual code uses `where: { role: { equals: AccountRole.Admin } }`. This is because:
+- The `role` field is a single-value enum (AccountRole.Admin = 'admin'), not an array
+- Uses `equals` for exact match, not `contains` for array search
+
+**Fix Applied:** Updated spec.md to reflect the actual code structure with correct field name and operator.
+
+### Gap 2: Spec incorrectly states `req` needs to be added
+
+**Severity:** Low
+**Location:** spec.md - "Expected Fix" section  
+**Issue:** The spec shows adding `req` parameter, but line 28 of the actual code already includes `req`. Only `overrideAccess: false` needs to change to `overrideAccess: true`.
+
+**Fix Applied:** Updated spec.md to show only the `overrideAccess` change is needed.
+
+### Gap 3: No test requirement clarification
+
+**Severity:** Low
+**Location:** spec.md - Acceptance Criteria
+**Issue:** Acceptance criteria mentions "Unit tests pass" but there are no existing tests for this hook. This criterion cannot be verified.
+
+**Fix Applied:** Added note acknowledging no tests exist and that this criterion is not applicable.
+
+## Changes Made to Spec
+
+- Updated "Current Code" to reflect actual implementation: `role: { equals: AccountRole.Admin }`
+- Updated "Expected Fix" to show only `overrideAccess: true` change (req already present)
+- Added clarification that no tests exist for this hook
+- Updated Acceptance Criteria to remove "Unit tests pass" as it's not applicable
+
+## Verification Notes
+
+The actual code at `src/server/payload/collections/Users/hooks/preventLastAdminDemotion-hook.ts`:
+- Line 27: `overrideAccess: false` - THIS IS THE BUG
+- Line 28: `req` - already present
+
+The fix is simply changing `overrideAccess: false` to `overrideAccess: true` on line 27.
+
+This aligns with codebase patterns - 77 instances of `overrideAccess: true` exist in the codebase for system-level operations like counting records, bypassing access control for server-side operations, etc.

--- a/.tasks/260226-fix-admin-demotion-hook/plan-gap.md
+++ b/.tasks/260226-fix-admin-demotion-hook/plan-gap.md
@@ -1,0 +1,19 @@
+# Plan Gap Analysis: 260226-fix-admin-demotion-hook
+
+## Summary
+
+- Gaps Found: 1
+- Plan Revised: Yes
+
+## Gaps Identified
+
+### Gap 1: Missing Test Directory Creation
+
+**Severity:** High
+**Issue:** The original plan assumed the `tests/unit/collections/` directory existed for the new test file, but it does not.
+**Fix Applied:** Added a new Step 1 to create the `tests/unit/collections/` directory before proceeding with test file creation.
+
+## Changes Made to Plan
+
+- Added Step 1: Create test directory
+- Renumbered original Step 1 to Step 2: Write reproduction test + apply fix

--- a/.tasks/260226-fix-admin-demotion-hook/plan.md
+++ b/.tasks/260226-fix-admin-demotion-hook/plan.md
@@ -1,0 +1,169 @@
+# Plan: Fix preventLastAdminDemotion hook — overrideAccess bug
+
+**Task ID**: 260226-fix-admin-demotion-hook
+**Task Type**: fix_bug
+**Priority**: HIGH — Security bug allowing last admin demotion
+
+---
+
+## Summary
+
+The `preventLastAdminDemotion` beforeChange hook counts admins using `overrideAccess: false`, which means the count query is filtered by the current user's access control. If a non-admin (or a user whose access control hides other admin records) triggers this code path, `adminCount` may return 0 — incorrectly allowing the last admin to be demoted. The fix is a one-line change: `overrideAccess: false` → `overrideAccess: true`.
+
+## Assumptions
+
+- No `clarified.md` or `rerun-feedback.md` exist — this is the first run.
+- The spec says "no unit tests exist for this hook." We will CREATE a unit test as the reproduction test — this is the TDD bug-fix approach.
+- The Users collection access control may restrict which users a non-admin can see, so `count` with `overrideAccess: false` could return 0 for a non-admin caller.
+
+---
+
+## Spec Requirements Reference
+
+- **AC-1**: Change `overrideAccess: false` to `overrideAccess: true` on line 27
+- **AC-2**: TypeScript compilation passes
+
+---
+
+### Step 1: Create test directory
+
+**Description**: Create the necessary directory for the new unit test file.
+
+**Files to Touch**:
+- `tests/unit/collections/` (NEW DIRECTORY)
+
+**Verification**:
+1. Run `ls tests/unit/collections/` → directory exists.
+
+**Time Estimate**: 1 minute
+
+### Step 2: Write reproduction test + apply fix
+
+**Root Cause**: `preventLastAdminDemotion` hook calls `req.payload.count()` with `overrideAccess: false`. This means the count is filtered by the calling user's access control. If access control restricts visibility (e.g., a non-admin can't see other admins), the count returns 0, and the hook incorrectly allows demotion of the last admin.
+
+**Files to Touch**:
+
+- `tests/unit/collections/preventLastAdminDemotion-hook.test.ts` (NEW)
+- `src/server/payload/collections/Users/hooks/preventLastAdminDemotion-hook.ts` (MODIFIED — line 27)
+
+**Reproduction Test** (`tests/unit/collections/preventLastAdminDemotion-hook.test.ts`):
+
+This test file will import the hook and exercise it with mock `req` objects. The key reproduction test:
+
+1. **Test: "should call count with overrideAccess: true (system-level check)"**
+   - Create a mock `req.payload.count` that records the arguments it's called with.
+   - Invoke `preventLastAdminDemotion` with:
+     - `operation: 'update'`
+     - `data: { role: 'student' }` (demoting)
+     - `originalDoc: { role: 'admin' }` (was admin)
+   - Mock `count` returns `{ totalDocs: 2 }` (multiple admins — demotion allowed).
+   - **Assert**: `req.payload.count` was called with `overrideAccess: true`.
+   - **Why it fails now**: The current code passes `overrideAccess: false`, so the assertion on `overrideAccess: true` will fail.
+
+2. **Test: "should throw ValidationError when demoting the last admin"**
+   - Mock `count` returns `{ totalDocs: 1 }`.
+   - Invoke hook with same demotion scenario.
+   - **Assert**: throws `ValidationError` with message containing 'Cannot demote the last admin'.
+
+3. **Test: "should allow demotion when multiple admins exist"**
+   - Mock `count` returns `{ totalDocs: 3 }`.
+   - Invoke hook.
+   - **Assert**: returns data without throwing.
+
+4. **Test: "should skip check on create operations"**
+   - Invoke with `operation: 'create'`.
+   - **Assert**: `count` is never called, data returned as-is.
+
+5. **Test: "should skip check when role is not changing to student"**
+   - Invoke with `data: { role: 'admin' }`.
+   - **Assert**: `count` is never called.
+
+6. **Test: "should skip check when original role is not admin"**
+   - Invoke with `originalDoc: { role: 'student' }`, `data: { role: 'student' }`.
+   - **Assert**: `count` is never called.
+
+**Fix**: In `src/server/payload/collections/Users/hooks/preventLastAdminDemotion-hook.ts`, line 27:
+
+```diff
+-    overrideAccess: false,
++    overrideAccess: true,
+```
+
+**Verification**:
+
+1. Run reproduction test BEFORE fix → Test 1 ("overrideAccess: true") FAILS (current code uses `false`)
+2. Apply the one-line fix
+3. Run reproduction test AFTER fix → ALL tests PASS
+4. Run `pnpm -s tsc --noEmit` → passes
+5. Run full unit test suite `pnpm test:unit` → passes
+
+**Acceptance Criteria**:
+
+- [ ] New test file `tests/unit/collections/preventLastAdminDemotion-hook.test.ts` exists with ≥ 6 test cases
+- [ ] Test 1 asserts `overrideAccess: true` is passed to `payload.count`
+- [ ] `overrideAccess` changed from `false` to `true` on line 27 of the hook
+- [ ] `pnpm -s tsc --noEmit` passes (AC-2)
+- [ ] `pnpm test:unit` passes — all new tests green
+- [ ] No other files modified
+
+**Time Estimate**: 10-15 minutes
+
+---
+
+## Test Implementation Notes for Build Agent
+
+### Mock Structure
+
+The hook is a `CollectionBeforeChangeHook`. Create mock args matching this pattern (follow the convention in `tests/unit/collections/exercises-hooks.test.ts`):
+
+```typescript
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { preventLastAdminDemotion } from '@/server/payload/collections/Users/hooks/preventLastAdminDemotion-hook'
+import { AccountRole } from '@/server/payload/collections/Users/roles'
+
+const mockCount = vi.fn()
+
+const createHookArgs = (overrides: Record<string, unknown> = {}): any => ({
+  data: { role: AccountRole.Student },
+  operation: 'update',
+  originalDoc: { role: AccountRole.Admin },
+  req: {
+    payload: { count: mockCount },
+  },
+  ...overrides,
+})
+```
+
+### Key assertion for the reproduction test
+
+```typescript
+it('should call count with overrideAccess: true (system-level visibility)', async () => {
+  mockCount.mockResolvedValue({ totalDocs: 2 })
+  const args = createHookArgs()
+  await preventLastAdminDemotion(args)
+  expect(mockCount).toHaveBeenCalledWith(
+    expect.objectContaining({ overrideAccess: true })
+  )
+})
+```
+
+### Run Commands
+
+```bash
+# Run just the new test
+pnpm test:unit -- --reporter=verbose tests/unit/collections/preventLastAdminDemotion-hook.test.ts
+
+# Type check
+pnpm -s tsc --noEmit
+
+# Full unit suite
+pnpm test:unit
+```
+
+---
+
+## Quality Gates
+
+1. **Type check**: `pnpm -s tsc --noEmit` — must pass
+2. **Unit tests**: `pnpm test:unit` — must pass (includes new test file)
+3. **Lint**: `pnpm -s lint` — must pass

--- a/.tasks/260226-fix-admin-demotion-hook/spec.md
+++ b/.tasks/260226-fix-admin-demotion-hook/spec.md
@@ -1,0 +1,45 @@
+# Specification (promoted)
+
+Skipped via input_quality — taskify determined spec is unnecessary.
+
+## Requirements
+
+# Task
+
+## Issue Title
+
+[HIGH] Bug: preventLastAdminDemotion uses overrideAccess: false for admin count
+## Description
+The `preventLastAdminDemotion` hook counts existing admins with `overrideAccess: false`. This means the count is filtered by the **current user's access control**. If a non-admin triggers this path, they can't see other admins, so `adminCount` returns 0 — incorrectly allowing the last admin to be demoted.
+
+## Files Affected
+- `src/server/payload/collections/Users/hooks/preventLastAdminDemotion-hook.ts` — line 27
+
+## Current Code
+```typescript
+const adminCount = await req.payload.count({
+  collection: 'users',
+  where: { roles: { contains: 'admin' } },
+  overrideAccess: false, // ❌ Filtered by current user's access
+})
+```
+
+## Expected Fix
+```typescript
+const adminCount = await req.payload.count({
+  collection: 'users',
+  where: { roles: { contains: 'admin' } },
+  overrideAccess: true, // ✅ System-level check needs full visibility
+  req,
+})
+```
+
+## Priority
+HIGH — Security bug, could allow last admin demotion
+
+
+## Acceptance Criteria
+
+- [ ] Fix applied as described in task.md
+- [ ] TypeScript compilation passes
+- [ ] Unit tests pass

--- a/.tasks/260226-fix-admin-demotion-hook/spec.md
+++ b/.tasks/260226-fix-admin-demotion-hook/spec.md
@@ -17,18 +17,23 @@ The `preventLastAdminDemotion` hook counts existing admins with `overrideAccess:
 
 ## Current Code
 ```typescript
-const adminCount = await req.payload.count({
+const { totalDocs: adminCount } = await req.payload.count({
   collection: 'users',
-  where: { roles: { contains: 'admin' } },
+  where: {
+    role: { equals: AccountRole.Admin },
+  },
   overrideAccess: false, // ❌ Filtered by current user's access
+  req,
 })
 ```
 
 ## Expected Fix
 ```typescript
-const adminCount = await req.payload.count({
+const { totalDocs: adminCount } = await req.payload.count({
   collection: 'users',
-  where: { roles: { contains: 'admin' } },
+  where: {
+    role: { equals: AccountRole.Admin },
+  },
   overrideAccess: true, // ✅ System-level check needs full visibility
   req,
 })
@@ -40,6 +45,6 @@ HIGH — Security bug, could allow last admin demotion
 
 ## Acceptance Criteria
 
-- [ ] Fix applied as described in task.md
+- [ ] Fix applied: change `overrideAccess: false` to `overrideAccess: true` on line 27
 - [ ] TypeScript compilation passes
-- [ ] Unit tests pass
+- [ ] Note: No unit tests exist for this hook - test criterion not applicable

--- a/.tasks/260226-fix-admin-demotion-hook/status.json
+++ b/.tasks/260226-fix-admin-demotion-hook/status.json
@@ -4,14 +4,54 @@
   "mode": "full",
   "pipeline": "spec_execute_verify",
   "startedAt": "2026-02-26T15:18:06.431Z",
-  "updatedAt": "2026-02-26T15:18:06.433Z",
+  "updatedAt": "2026-02-26T15:31:21.783Z",
   "state": "running",
   "cursor": null,
   "stages": {
     "taskify": {
+      "state": "completed",
+      "retries": 0,
+      "startedAt": "2026-02-26T15:18:06.433Z",
+      "completedAt": "2026-02-26T15:19:08.530Z",
+      "outputFile": "taskify.md"
+    },
+    "spec": {
+      "state": "skipped",
+      "retries": 0,
+      "skipped": "Promoted via input_quality (file exists)"
+    },
+    "gap": {
+      "state": "completed",
+      "retries": 0,
+      "startedAt": "2026-02-26T15:19:11.671Z",
+      "completedAt": "2026-02-26T15:21:31.326Z",
+      "outputFile": "gap.md"
+    },
+    "architect": {
+      "state": "completed",
+      "retries": 0,
+      "startedAt": "2026-02-26T15:21:31.327Z",
+      "completedAt": "2026-02-26T15:23:05.734Z",
+      "outputFile": "architect.md"
+    },
+    "plan-gap": {
+      "state": "completed",
+      "retries": 0,
+      "startedAt": "2026-02-26T15:23:05.735Z",
+      "completedAt": "2026-02-26T15:23:48.669Z",
+      "outputFile": "plan-gap.md"
+    },
+    "build": {
+      "state": "completed",
+      "retries": 0,
+      "startedAt": "2026-02-26T15:23:48.670Z",
+      "completedAt": "2026-02-26T15:31:01.747Z",
+      "outputFile": "build.md"
+    },
+    "commit": {
       "state": "running",
       "retries": 0,
-      "startedAt": "2026-02-26T15:18:06.433Z"
+      "startedAt": "2026-02-26T15:31:21.783Z"
     }
   }
 }

--- a/.tasks/260226-fix-admin-demotion-hook/status.json
+++ b/.tasks/260226-fix-admin-demotion-hook/status.json
@@ -4,7 +4,7 @@
   "mode": "full",
   "pipeline": "spec_execute_verify",
   "startedAt": "2026-02-26T15:18:06.431Z",
-  "updatedAt": "2026-02-26T15:31:21.783Z",
+  "updatedAt": "2026-02-26T15:31:24.376Z",
   "state": "running",
   "cursor": null,
   "stages": {
@@ -49,9 +49,10 @@
       "outputFile": "build.md"
     },
     "commit": {
-      "state": "running",
+      "state": "completed",
       "retries": 0,
-      "startedAt": "2026-02-26T15:31:21.783Z"
+      "startedAt": "2026-02-26T15:31:21.783Z",
+      "completedAt": "2026-02-26T15:31:24.376Z"
     }
   }
 }

--- a/.tasks/260226-fix-admin-demotion-hook/status.json
+++ b/.tasks/260226-fix-admin-demotion-hook/status.json
@@ -4,7 +4,7 @@
   "mode": "full",
   "pipeline": "spec_execute_verify",
   "startedAt": "2026-02-26T15:18:06.431Z",
-  "updatedAt": "2026-02-26T15:31:24.376Z",
+  "updatedAt": "2026-02-26T15:33:13.593Z",
   "state": "running",
   "cursor": null,
   "stages": {
@@ -53,6 +53,23 @@
       "retries": 0,
       "startedAt": "2026-02-26T15:31:21.783Z",
       "completedAt": "2026-02-26T15:31:24.376Z"
+    },
+    "verify": {
+      "state": "completed",
+      "retries": 0,
+      "completedAt": "2026-02-26T15:33:13.404Z",
+      "outputFile": "verify.md"
+    },
+    "auditor": {
+      "state": "completed",
+      "retries": 0,
+      "completedAt": "2026-02-26T15:33:13.593Z",
+      "outputFile": "auditor.md"
+    },
+    "apply-audit": {
+      "state": "running",
+      "retries": 0,
+      "startedAt": "2026-02-26T15:33:13.593Z"
     }
   }
 }

--- a/.tasks/260226-fix-admin-demotion-hook/status.json
+++ b/.tasks/260226-fix-admin-demotion-hook/status.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "taskId": "260226-fix-admin-demotion-hook",
+  "mode": "full",
+  "pipeline": "spec_execute_verify",
+  "startedAt": "2026-02-26T15:18:06.431Z",
+  "updatedAt": "2026-02-26T15:18:06.433Z",
+  "state": "running",
+  "cursor": null,
+  "stages": {
+    "taskify": {
+      "state": "running",
+      "retries": 0,
+      "startedAt": "2026-02-26T15:18:06.433Z"
+    }
+  }
+}

--- a/.tasks/260226-fix-admin-demotion-hook/task.json
+++ b/.tasks/260226-fix-admin-demotion-hook/task.json
@@ -1,0 +1,21 @@
+{
+  "task_type": "fix_bug",
+  "risk_level": "high",
+  "confidence": 1,
+  "primary_domain": "backend",
+  "scope": [
+    "src/server/payload/collections/Users/hooks/preventLastAdminDemotion-hook.ts"
+  ],
+  "missing_inputs": [],
+  "assumptions": [],
+  "input_quality": {
+    "level": "detailed_plan",
+    "skip_stages": [
+      "spec",
+      "architect"
+    ],
+    "reasoning": "Task provides exact file path (line 27), current buggy code, and expected fix with overrideAccess: true and req parameter. This is a one-line security fix."
+  },
+  "pipeline_profile": "standard",
+  "pipeline": "spec_execute_verify"
+}

--- a/.tasks/260226-fix-admin-demotion-hook/task.md
+++ b/.tasks/260226-fix-admin-demotion-hook/task.md
@@ -1,0 +1,32 @@
+# Task
+
+## Issue Title
+
+[HIGH] Bug: preventLastAdminDemotion uses overrideAccess: false for admin count
+## Description
+The `preventLastAdminDemotion` hook counts existing admins with `overrideAccess: false`. This means the count is filtered by the **current user's access control**. If a non-admin triggers this path, they can't see other admins, so `adminCount` returns 0 — incorrectly allowing the last admin to be demoted.
+
+## Files Affected
+- `src/server/payload/collections/Users/hooks/preventLastAdminDemotion-hook.ts` — line 27
+
+## Current Code
+```typescript
+const adminCount = await req.payload.count({
+  collection: 'users',
+  where: { roles: { contains: 'admin' } },
+  overrideAccess: false, // ❌ Filtered by current user's access
+})
+```
+
+## Expected Fix
+```typescript
+const adminCount = await req.payload.count({
+  collection: 'users',
+  where: { roles: { contains: 'admin' } },
+  overrideAccess: true, // ✅ System-level check needs full visibility
+  req,
+})
+```
+
+## Priority
+HIGH — Security bug, could allow last admin demotion

--- a/.tasks/260226-fix-admin-demotion-hook/verify.md
+++ b/.tasks/260226-fix-admin-demotion-hook/verify.md
@@ -1,0 +1,12 @@
+# Verification Report
+
+## TypeScript: PASS ✅
+
+## Lint: PASS ✅
+
+## Format: PASS ✅
+
+## Unit Tests: PASS ✅
+
+
+## Result: PASS

--- a/.tasks/260226-fix-guest-session-as-any/pr.md
+++ b/.tasks/260226-fix-guest-session-as-any/pr.md
@@ -1,0 +1,5 @@
+# PR Stage
+
+PR created: https://github.com/A-Guy-educ/A-Guy/pull/601
+
+Title: fix: bug: guest-sessions collection uses 'as any' x7 — not in type registry

--- a/src/server/payload/collections/Users/hooks/preventLastAdminDemotion-hook.ts
+++ b/src/server/payload/collections/Users/hooks/preventLastAdminDemotion-hook.ts
@@ -24,7 +24,7 @@ export const preventLastAdminDemotion: CollectionBeforeChangeHook = async ({
     where: {
       role: { equals: AccountRole.Admin },
     },
-    overrideAccess: false,
+    overrideAccess: true,
     req,
   })
 

--- a/tests/unit/collections/preventLastAdminDemotion-hook.test.ts
+++ b/tests/unit/collections/preventLastAdminDemotion-hook.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+import { ValidationError } from 'payload'
+
+import { preventLastAdminDemotion } from '@/server/payload/collections/Users/hooks/preventLastAdminDemotion-hook'
+import { AccountRole } from '@/server/payload/collections/Users/roles'
+
+describe('preventLastAdminDemotion Hook', () => {
+  let mockCount: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCount = vi.fn()
+  })
+
+  // Helper to create minimal CollectionBeforeChangeHook args
+  const createHookArgs = (overrides: Record<string, unknown> = {}) => {
+    return {
+      data: {},
+      req: {
+        payload: {
+          count: mockCount,
+        },
+      },
+      operation: 'update' as const,
+      originalDoc: undefined,
+      collection: { config: { slug: 'users' } },
+      context: {},
+      ...overrides,
+    }
+  }
+
+  describe('Test 1: should call count with overrideAccess: true (system-level check)', () => {
+    it('should call count with overrideAccess: true', async () => {
+      // Setup: Admin being demoted to student, only 1 admin exists
+      mockCount.mockResolvedValue({ totalDocs: 1 })
+
+      const hookArgs = createHookArgs({
+        operation: 'update',
+        data: { role: AccountRole.Student },
+        originalDoc: { role: AccountRole.Admin },
+      })
+
+      // Execute - expect to throw due to last admin
+      await expect(preventLastAdminDemotion(hookArgs as any)).rejects.toThrow(ValidationError)
+
+      // Assert: This will FAIL because current code uses overrideAccess: false
+      expect(mockCount).toHaveBeenCalledWith(expect.objectContaining({ overrideAccess: true }))
+    })
+  })
+
+  describe('Test 2: should throw ValidationError when demoting the last admin', () => {
+    it('should throw ValidationError when there is only one admin', async () => {
+      // Setup: Only 1 admin exists
+      mockCount.mockResolvedValue({ totalDocs: 1 })
+
+      const hookArgs = createHookArgs({
+        operation: 'update',
+        data: { role: AccountRole.Student },
+        originalDoc: { role: AccountRole.Admin },
+      })
+
+      // Execute & Assert
+      await expect(preventLastAdminDemotion(hookArgs as any)).rejects.toThrow(ValidationError)
+    })
+  })
+
+  describe('Test 3: should allow demotion when multiple admins exist', () => {
+    it('should allow demotion when there are multiple admins', async () => {
+      // Setup: 3 admins exist
+      mockCount.mockResolvedValue({ totalDocs: 3 })
+
+      const hookArgs = createHookArgs({
+        operation: 'update',
+        data: { role: AccountRole.Student },
+        originalDoc: { role: AccountRole.Admin },
+      })
+
+      // Execute
+      const result = await preventLastAdminDemotion(hookArgs as any)
+
+      // Assert: Should return data without throwing
+      expect(result).toEqual({ role: AccountRole.Student })
+      expect(mockCount).toHaveBeenCalled()
+    })
+  })
+
+  describe('Test 4: should skip check on create operations', () => {
+    it('should not call count on create operations', async () => {
+      const hookArgs = createHookArgs({
+        operation: 'create',
+        data: { role: AccountRole.Student },
+        originalDoc: undefined,
+      })
+
+      await preventLastAdminDemotion(hookArgs as any)
+
+      expect(mockCount).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Test 5: should skip check when role is not changing to student', () => {
+    it('should not call count when role is admin', async () => {
+      const hookArgs = createHookArgs({
+        operation: 'update',
+        data: { role: AccountRole.Admin },
+        originalDoc: { role: AccountRole.Admin },
+      })
+
+      await preventLastAdminDemotion(hookArgs as any)
+
+      expect(mockCount).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Test 6: should skip check when original role is not admin', () => {
+    it('should not call count when original role is student', async () => {
+      const hookArgs = createHookArgs({
+        operation: 'update',
+        data: { role: AccountRole.Student },
+        originalDoc: { role: AccountRole.Student },
+      })
+
+      await preventLastAdminDemotion(hookArgs as any)
+
+      expect(mockCount).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

# Specification (promoted)

## Commits

```
da94ccf4 ci(cody): commit task files for 260226-fix-admin-demotion-hook
23ba39a1 ci(cody): commit task files for 260226-fix-admin-demotion-hook
07be89d7 fix(260226-fix-admin-demotion-hook): Issue Title
0cba47ba ci(cody): commit task files for 260226-fix-admin-demotion-hook
```

Closes #515

---
🤖 Generated by Cody pipeline