### PR TITLE
fix: perf: streammessage not wrapped in usecallback — causes unnecessary r...

### DIFF
--- a/.tasks/260226-fix-admin-demotion-hook/pr.md
+++ b/.tasks/260226-fix-admin-demotion-hook/pr.md
@@ -1,0 +1,5 @@
+# PR Stage
+
+PR created: https://github.com/A-Guy-educ/A-Guy/pull/603
+
+Title: fix: bug: preventlastadmindemotion uses overrideaccess: false for admin count

--- a/.tasks/260226-fix-stream-message-callback/apply-audit.md
+++ b/.tasks/260226-fix-stream-message-callback/apply-audit.md
@@ -1,0 +1,52 @@
+# Apply Audit Report: 260226-fix-stream-message-callback
+
+## Improvements Applied
+
+| #   | Type   | Where                          | Status              |
+| --- | ------ | ------------------------------ | ------------------- |
+| 1   | PROMPT | AGENTS.md                     | IMPLEMENTED         |
+| 2   | PROMPT | AGENTS.md                     | IMPLEMENTED         |
+| 3   | INDEX  | .ai-docs/indexes/pattern-index.json | IMPLEMENTED |
+
+## Changes Made
+
+### AGENTS.md
+
+Added two new sections to improve performance bug identification and spec writing:
+
+1. **Performance Optimization** section (lines 1236-1272):
+   - Added systematic approach for diagnosing React performance issues
+   - Documented the common pitfall of misattributing performance issues
+   - Included code examples showing the correct refs pattern for callback stabilization
+
+2. **Spec Writing Best Practices** section (lines 1274-1285):
+   - Guidelines for verifying pre-existing conditions before writing specs
+   - Requirements to include actual code context (dependency arrays, useCallback usage)
+   - Requirement to include ESLint warnings verbatim
+   - Warning against misattribution with concrete example from this task
+
+### .ai-docs/indexes/pattern-index.json
+
+Added new pattern entry:
+- **Pattern**: `refs-pattern`
+- **Description**: Using refs to stabilize callback dependencies and prevent unnecessary recreations
+- **Files**: [] (empty - pattern discovered but no canonical examples yet)
+
+## Suggested Improvements (Not Applied)
+
+1. **Type:** DOC
+   - **Where:** docs/performance-patterns.md (new file)
+   - **Reason:** Not in safe-path whitelist - creating new documentation files outside of the whitelisted paths requires manual review
+   - **Suggestion:** Create `docs/performance-patterns.md` with the refs pattern documentation
+
+2. **Type:** CODE_PATTERN
+   - **Where:** tests/README.md
+   - **Reason:** tests/README.md is not in safe-path whitelist - testing documentation is not part of the whitelisted paths
+   - **Suggestion:** Add hooks stability test pattern documentation to tests/README.md
+
+## Notes
+
+- The auditor identified that the spec incorrectly attributed the issue to `streamMessage` needing useCallback, when the actual problem was `isLoading`/`isLoadingHistory` state dependencies in `injectExerciseContext`
+- All three implementable improvements have been applied to whitelisted files
+- The Primary Improvement (PROMPT) has been addressed by adding spec writing best practices to AGENTS.md
+- Additional Finding #4 (INDEX) has been addressed by adding refs-pattern to the pattern index

--- a/.tasks/260226-fix-stream-message-callback/architect.md
+++ b/.tasks/260226-fix-stream-message-callback/architect.md
@@ -1,0 +1,8 @@
+# Architect (promoted)
+
+Skipped via input_quality — taskify determined this stage is unnecessary.
+See task.json input_quality.reasoning for details.
+
+## Changes
+
+See task.md for implementation details.

--- a/.tasks/260226-fix-stream-message-callback/auditor.md
+++ b/.tasks/260226-fix-stream-message-callback/auditor.md
@@ -1,0 +1,68 @@
+# Auditor Report: 260226-fix-stream-message-callback
+
+## Task Info
+
+- **Task ID:** 260226-fix-stream-message-callback
+- **Task Type:** fix
+- **Run State:** SUCCESS
+- **Date:** 2026-02-26
+- **Previous Improvements Reviewed:** 0 from audit-history.json
+
+## Stage Analysis
+
+| Stage | Quality |
+| ----- |---------|
+| spec  | The spec correctly identified the performance issue but incorrectly attributed it to `streamMessage` needing useCallback. In reality, `streamMessage` was already wrapped at line 393. The actual root cause was `isLoading`/`isLoadingHistory` state dependencies in `injectExerciseContext`. |
+| plan  | Not explicitly recorded in build.md - build agent identified the correct root cause during implementation. |
+| build | Implemented refs pattern to stabilize callback references. Added `isLoadingRef` and `isLoadingHistoryRef` to avoid recreating `injectExerciseContext` on every render. |
+| verify| All checks passed: TypeScript, Lint, Format, Unit Tests. |
+
+## Process Delta
+
+- Spec misidentified the root cause (streamMessage already had useCallback)
+- Build agent correctly identified actual issue (loading state dependencies) and implemented refs pattern
+- All verification gates passed successfully
+
+## Primary Improvement
+
+- **Type:** PROMPT
+- **Title:** Improve performance bug root cause identification in task specs
+- **Rationale:** The spec incorrectly attributed the issue to `streamMessage` needing useCallback, but the actual problem was `isLoading`/`isLoadingHistory` dependencies in `injectExerciseContext`. More precise root cause analysis in specs will reduce implementation iterations.
+- **Where:** AGENTS.md or task template
+- **Acceptance Criteria:**
+  - Task specs should include actual code context (dependency arrays, current useCallback usage)
+  - Spec authors should verify the issue exists before writing requirements
+  - Include ESLint warning verbatim in spec for accuracy
+- **Effectiveness:** neutral
+
+## Additional Findings
+
+1. **Type:** DOC
+   - **Title:** Document refs pattern for callback stabilization
+   - **Where:** docs/performance-patterns.md (new file)
+   - **Rationale:** The refs pattern used here (mirroring volatile state in refs for stable callback access) is a valuable React performance pattern that should be documented for future reuse.
+
+2. **Type:** CODE_PATTERN
+   - **Title:** Add hooks stability test pattern
+   - **Where:** tests/README.md
+   - **Rationale:** The build agent added a test verifying referential equality. This pattern should be documented for similar performance fixes.
+
+3. **Type:** PROMPT
+   - **Title:** Verify pre-existing conditions before writing specs
+   - **Rationale:** Future spec authors should run linting or read actual code to confirm issues exist as described, avoiding spec-implementation mismatch.
+
+4. **Type:** INDEX
+   - **Title:** Add refs-pattern to pattern index
+   - **Where:** .ai-docs/indexes/pattern-index.json
+   - **Rationale:** The refs pattern for callback stabilization is a useful pattern that should be discoverable via the pattern index.
+
+## Failure Analysis (if FAILED)
+
+Not applicable - task completed successfully.
+
+## Chosen Improvement (DEPRECATED - use Primary Improvement)
+
+- **Type:** PROMPT
+- **Title:** Improve performance bug root cause identification in task specs
+- **Where:** AGENTS.md or task template
+- **Rationale:** Spec misidentified root cause; prompt improvement will help future accuracy.

--- a/.tasks/260226-fix-stream-message-callback/build.md
+++ b/.tasks/260226-fix-stream-message-callback/build.md
@@ -1,0 +1,31 @@
+# Build Agent Report: 260226-fix-stream-message-callback
+
+## Changes
+
+- **src/ui/web/chat/hooks/useNotebookChat.ts**: Added refs (`isLoadingRef`, `isLoadingHistoryRef`) to mirror volatile state for stable callback access, updated `injectExerciseContext` to use refs instead of state variables in its dependency array to prevent unnecessary re-renders
+
+## Tests Written
+
+- **tests/unit/hooks/useNotebookChat.test.ts**: Added test "injectExerciseContext should maintain stable reference across loading state changes" to verify that `injectExerciseContext` maintains referential equality across loading state transitions
+
+## Quality
+
+- TypeScript: PASS
+- Lint: PASS (no new warnings in modified file)
+- Unit Tests: PASS (all 12 tests in useNotebookChat.test.ts pass, including the new stability test)
+
+## Acceptance Criteria
+
+- [x] `streamMessage` at line 393 was already wrapped with `useCallback` (pre-existing)
+- [x] ESLint `react-hooks/exhaustive-deps` warning on line 689 was already resolved (pre-existing)
+- [x] `injectExerciseContext` no longer re-creates on every render due to `isLoading`/`isLoadingHistory` dependency (fixed via refs pattern)
+
+## Technical Details
+
+The fix implements the refs pattern for stable callback access:
+1. Added `isLoadingRef` and `isLoadingHistoryRef` refs initialized with state values
+2. Sync refs with state during render (synchronous assignment: `isLoadingRef.current = isLoading`)
+3. Updated `injectExerciseContext` to check `isLoadingRef.current` and `isLoadingHistoryRef.current` instead of direct state values
+4. Removed `isLoading` and `isLoadingHistory` from the useCallback dependency array
+
+This ensures `injectExerciseContext` maintains a stable reference across loading state changes, preventing unnecessary re-renders in dependent components like `ChatInterface/index.tsx`.

--- a/.tasks/260226-fix-stream-message-callback/commit.md
+++ b/.tasks/260226-fix-stream-message-callback/commit.md
@@ -1,0 +1,6 @@
+# Commit Stage
+
+✅ **Committed and pushed**
+
+- **Branch:** fix/260226-fix-medium-perf-streammessage-not-wrapped-i
+- **Hash:** 73c8b80

--- a/.tasks/260226-fix-stream-message-callback/plan.md
+++ b/.tasks/260226-fix-stream-message-callback/plan.md
@@ -1,20 +1,140 @@
-# Implementation Plan
+# Implementation Plan: Fix streamMessage useCallback Performance Bug
 
-## Step 1: Add useCallback wrapper to streamMessage
-**File**: `src/ui/web/chat/hooks/useNotebookChat.ts`
-**Line**: ~446
+**Task ID**: 260226-fix-stream-message-callback
+**Task Type**: fix_bug
+**Spec Requirements**: FR-1, FR-2
 
-Change:
+---
+
+## Rerun Context
+
+The previous plan was a skeleton that didn't match the current code state. The code has already been partially fixed — `streamMessage` IS wrapped in `useCallback` (line 393). However, the downstream stability issue remains: `injectExerciseContext` depends on `isLoading` and `isLoadingHistory` state variables, causing it to recreate on every loading state change. This triggers the `useEffect` in `ChatInterface/index.tsx` (line 310-314) repeatedly. The plan now addresses the remaining acceptance criteria (AC #3).
+
+---
+
+## Analysis
+
+### Current State
+- `streamMessage` is already wrapped in `useCallback` at line 393 with deps: `[errorMessage, authRequiredMessage, guestLimitMessage, scrollToBottom, onConversationCreated]` ✅
+- No ESLint `react-hooks/exhaustive-deps` warnings exist on useNotebookChat.ts ✅
+- `injectExerciseContext` (line 623) depends on `isLoading` and `isLoadingHistory` — these are state variables that change frequently, causing the callback to recreate unnecessarily ❌
+
+### Root Cause
+`injectExerciseContext` uses `isLoading` and `isLoadingHistory` only as early-return guards (line 647). These state values are in the `useCallback` dependency array (lines 663-664), so the callback reference changes on every loading state transition. Since `ChatInterface/index.tsx` line 314 has `injectExerciseContext` in a `useEffect` dep array, this causes the exercise context injection to re-fire whenever loading state changes.
+
+### Fix Strategy
+Use refs to track `isLoading` and `isLoadingHistory` so they can be read inside the callback without being in the dependency array. This keeps the callback reference stable.
+
+---
+
+## Step 1: Stabilize `injectExerciseContext` by using refs for volatile state
+
+**Root Cause**: `injectExerciseContext` depends on `isLoading` and `isLoadingHistory` state variables which change frequently, causing the callback to get a new reference on every loading state change. This triggers the `useEffect` in `ChatInterface/index.tsx:310-314` repeatedly.
+
+**Files to Touch**:
+- `src/ui/web/chat/hooks/useNotebookChat.ts` (MODIFIED — lines ~80-90, ~623-673)
+
+**Changes**:
+
+1. Add refs to mirror `isLoading` and `isLoadingHistory` state (after the useState declarations, around line 90):
+   ```tsx
+   const isLoadingRef = useRef(false)
+   const isLoadingHistoryRef = useRef(true)
+   ```
+
+2. Keep refs in sync with state by adding `useEffect` hooks (or inline sync after the useState calls):
+   ```tsx
+   // Sync refs with state for stable callback access
+   isLoadingRef.current = isLoading
+   isLoadingHistoryRef.current = isLoadingHistory
+   ```
+   (This is a synchronous assignment during render — no useEffect needed. Place right after the useState declarations.)
+
+3. Update `injectExerciseContext` (line 623-673) to use refs instead of state:
+   - Change line 647 from `if (isLoading || isLoadingHistory) return` to `if (isLoadingRef.current || isLoadingHistoryRef.current) return`
+   - Remove `isLoading` and `isLoadingHistory` from the dependency array (lines 663-664)
+
+**After the fix**, the dependency array of `injectExerciseContext` should be:
 ```tsx
-const streamMessage = async (...) => { ... }
+[streamMessage, acknowledgment, exerciseId, lessonId, chapterId, courseId, categoryId]
 ```
 
-To:
+All of these are either stable callbacks (streamMessage via useCallback) or props that change only when the user navigates to a different exercise/lesson — not on every loading state transition.
+
+**Reproduction Test**:
+- Test location: `tests/unit/hooks/useNotebookChat.test.ts`
+- Test name: `injectExerciseContext should maintain stable reference across loading state changes`
+- What it tests: Renders the hook, captures `injectExerciseContext` reference, triggers a loading state change (e.g., by sending a message), then verifies that the `injectExerciseContext` reference is the SAME object (referential equality).
+- Why it fails before fix: `isLoading` changes from `false → true → false` during message send, causing `injectExerciseContext` to get a new reference each time.
+- Why it passes after fix: `isLoading` is accessed via ref, not in the dep array, so the callback reference stays stable.
+
+**Test implementation sketch** (the build agent writes the actual code):
 ```tsx
-const streamMessage = useCallback(async (...) => {
-  // ... existing logic
-}, [apiService, setMessages, scrollToBottom, /* other stable deps */])
+it('injectExerciseContext should maintain stable reference across loading state changes', async () => {
+  const { result } = renderHook(() => useNotebookChat(defaultProps))
+  await waitFor(() => expect(result.current.isLoadingHistory).toBe(false))
+
+  // Capture initial reference
+  const initialRef = result.current.injectExerciseContext
+
+  // Trigger a loading state change by sending a message
+  act(() => {
+    result.current.setInputValue('Hello')
+  })
+  await act(async () => {
+    result.current.handleSubmit({ preventDefault: () => undefined } as React.FormEvent)
+  })
+  await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+  // Reference should be the same (stable callback)
+  expect(result.current.injectExerciseContext).toBe(initialRef)
+})
 ```
 
-## Step 2: Verify ESLint warning resolved
-Run ESLint to confirm the `react-hooks/exhaustive-deps` warning on line 689 is resolved.
+**Acceptance Criteria**:
+- [ ] `injectExerciseContext` dependency array does NOT contain `isLoading` or `isLoadingHistory`
+- [ ] `injectExerciseContext` still correctly returns early when loading (tested via ref)
+- [ ] `injectExerciseContext` reference stays stable across loading state changes (referential equality test)
+- [ ] ESLint passes with no new warnings (`pnpm -s lint`)
+- [ ] TypeScript compiles cleanly (`pnpm -s tsc --noEmit`)
+- [ ] All existing tests in `tests/unit/hooks/useNotebookChat.test.ts` continue to pass
+
+---
+
+## Step 2: Verify all spec acceptance criteria are met
+
+**Files to Touch**: None (verification only)
+
+**Verification Commands**:
+```bash
+# TypeScript compilation
+pnpm -s tsc --noEmit
+
+# ESLint (no exhaustive-deps warnings)
+pnpm -s lint
+
+# Run unit tests
+pnpm vitest run tests/unit/hooks/useNotebookChat.test.ts
+```
+
+**Spec Acceptance Criteria Mapping**:
+- [FR-1] `streamMessage` at line 393 is wrapped with `useCallback` → Already done ✅
+- [FR-2] ESLint `react-hooks/exhaustive-deps` warning resolved → Already resolved, verify no regressions ✅
+- [AC #3] `injectExerciseContext` no longer re-creates on every render due to `streamMessage` dependency → Fixed in Step 1 by removing volatile state from deps ✅
+
+---
+
+## Assumptions
+
+1. The spec line numbers (446, 689) refer to an older version of the code. The current `streamMessage` is at line 393 and `injectExerciseContext` deps are at line 662-672.
+2. No `clarified.md` or `rerun-feedback.md` exist — this is treated as a first proper plan run.
+3. The synchronous ref-sync pattern (`isLoadingRef.current = isLoading` during render) is the standard React pattern for keeping refs in sync without useEffect overhead. This is safe because refs don't trigger re-renders.
+4. `sendContextualHelp` and `sendVisibleHelp` being plain functions (not useCallback) is acceptable because ChatInterface uses the ref pattern for their event handlers (lines 192-202, 227-265, 274-301), avoiding stale closure issues.
+
+---
+
+## Risk Assessment
+
+- **Risk**: LOW — Single file change, refs are a well-established React pattern
+- **Breaking change risk**: NONE — The callback signature and behavior are identical; only reference stability improves
+- **Regression risk**: LOW — Existing tests cover all hook functionality; new test explicitly verifies the fix

--- a/.tasks/260226-fix-stream-message-callback/plan.md
+++ b/.tasks/260226-fix-stream-message-callback/plan.md
@@ -1,0 +1,20 @@
+# Implementation Plan
+
+## Step 1: Add useCallback wrapper to streamMessage
+**File**: `src/ui/web/chat/hooks/useNotebookChat.ts`
+**Line**: ~446
+
+Change:
+```tsx
+const streamMessage = async (...) => { ... }
+```
+
+To:
+```tsx
+const streamMessage = useCallback(async (...) => {
+  // ... existing logic
+}, [apiService, setMessages, scrollToBottom, /* other stable deps */])
+```
+
+## Step 2: Verify ESLint warning resolved
+Run ESLint to confirm the `react-hooks/exhaustive-deps` warning on line 689 is resolved.

--- a/.tasks/260226-fix-stream-message-callback/spec.md
+++ b/.tasks/260226-fix-stream-message-callback/spec.md
@@ -1,0 +1,15 @@
+# Fix streamMessage useCallback Performance Bug
+
+## Overview
+Fix a React performance bug in `useNotebookChat` where the `streamMessage` function is not wrapped in `useCallback`, causing unnecessary re-renders.
+
+## Requirements
+
+- FR-1: Wrap the `streamMessage` function (line 446) in `useCallback` to prevent recreation on every render
+- FR-2: Ensure the callback dependencies are stable to avoid triggering re-renders in dependent hooks
+
+## Acceptance Criteria
+
+- [ ] `streamMessage` at line 446 is wrapped with `useCallback`
+- [ ] ESLint `react-hooks/exhaustive-deps` warning on line 689 is resolved
+- [ ] `injectExerciseContext` no longer re-creates on every render due to `streamMessage` dependency

--- a/.tasks/260226-fix-stream-message-callback/status.json
+++ b/.tasks/260226-fix-stream-message-callback/status.json
@@ -4,7 +4,7 @@
   "mode": "full",
   "pipeline": "spec_execute_verify",
   "startedAt": "2026-02-26T15:36:00.721Z",
-  "updatedAt": "2026-02-26T15:46:53.235Z",
+  "updatedAt": "2026-02-26T15:46:54.768Z",
   "state": "running",
   "cursor": null,
   "stages": {
@@ -30,9 +30,10 @@
       "outputFile": "build.md"
     },
     "commit": {
-      "state": "running",
+      "state": "completed",
       "retries": 0,
-      "startedAt": "2026-02-26T15:46:53.235Z"
+      "startedAt": "2026-02-26T15:46:53.235Z",
+      "completedAt": "2026-02-26T15:46:54.768Z"
     }
   }
 }

--- a/.tasks/260226-fix-stream-message-callback/status.json
+++ b/.tasks/260226-fix-stream-message-callback/status.json
@@ -4,14 +4,35 @@
   "mode": "full",
   "pipeline": "spec_execute_verify",
   "startedAt": "2026-02-26T15:36:00.721Z",
-  "updatedAt": "2026-02-26T15:36:00.722Z",
+  "updatedAt": "2026-02-26T15:46:53.235Z",
   "state": "running",
   "cursor": null,
   "stages": {
     "taskify": {
+      "state": "completed",
+      "retries": 0,
+      "startedAt": "2026-02-26T15:36:00.722Z",
+      "completedAt": "2026-02-26T15:37:12.018Z",
+      "outputFile": "taskify.md"
+    },
+    "architect": {
+      "state": "completed",
+      "retries": 0,
+      "startedAt": "2026-02-26T15:37:15.503Z",
+      "completedAt": "2026-02-26T15:40:02.506Z",
+      "outputFile": "architect.md"
+    },
+    "build": {
+      "state": "completed",
+      "retries": 0,
+      "startedAt": "2026-02-26T15:40:02.507Z",
+      "completedAt": "2026-02-26T15:46:33.197Z",
+      "outputFile": "build.md"
+    },
+    "commit": {
       "state": "running",
       "retries": 0,
-      "startedAt": "2026-02-26T15:36:00.722Z"
+      "startedAt": "2026-02-26T15:46:53.235Z"
     }
   }
 }

--- a/.tasks/260226-fix-stream-message-callback/status.json
+++ b/.tasks/260226-fix-stream-message-callback/status.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "taskId": "260226-fix-stream-message-callback",
+  "mode": "full",
+  "pipeline": "spec_execute_verify",
+  "startedAt": "2026-02-26T15:36:00.721Z",
+  "updatedAt": "2026-02-26T15:36:00.722Z",
+  "state": "running",
+  "cursor": null,
+  "stages": {
+    "taskify": {
+      "state": "running",
+      "retries": 0,
+      "startedAt": "2026-02-26T15:36:00.722Z"
+    }
+  }
+}

--- a/.tasks/260226-fix-stream-message-callback/status.json
+++ b/.tasks/260226-fix-stream-message-callback/status.json
@@ -4,7 +4,7 @@
   "mode": "full",
   "pipeline": "spec_execute_verify",
   "startedAt": "2026-02-26T15:36:00.721Z",
-  "updatedAt": "2026-02-26T15:46:54.768Z",
+  "updatedAt": "2026-02-26T15:49:04.309Z",
   "state": "running",
   "cursor": null,
   "stages": {
@@ -34,6 +34,23 @@
       "retries": 0,
       "startedAt": "2026-02-26T15:46:53.235Z",
       "completedAt": "2026-02-26T15:46:54.768Z"
+    },
+    "verify": {
+      "state": "completed",
+      "retries": 0,
+      "completedAt": "2026-02-26T15:49:04.113Z",
+      "outputFile": "verify.md"
+    },
+    "auditor": {
+      "state": "completed",
+      "retries": 0,
+      "completedAt": "2026-02-26T15:49:04.308Z",
+      "outputFile": "auditor.md"
+    },
+    "apply-audit": {
+      "state": "running",
+      "retries": 0,
+      "startedAt": "2026-02-26T15:49:04.309Z"
     }
   }
 }

--- a/.tasks/260226-fix-stream-message-callback/task.json
+++ b/.tasks/260226-fix-stream-message-callback/task.json
@@ -1,0 +1,23 @@
+{
+  "task_type": "fix_bug",
+  "risk_level": "low",
+  "confidence": 1,
+  "primary_domain": "frontend",
+  "scope": [
+    "src/ui/web/chat/hooks/useNotebookChat.ts"
+  ],
+  "missing_inputs": [],
+  "assumptions": [
+    "The dependencies listed in the expected fix (apiService, setMessages, scrollToBottom) are the correct stable dependencies for memoization"
+  ],
+  "input_quality": {
+    "level": "detailed_plan",
+    "skip_stages": [
+      "spec",
+      "architect"
+    ],
+    "reasoning": "Task provides exact file path (line 446, line 689), current code snippet, expected fix pattern, and ESLint warning context. This is a step-by-step implementation guide."
+  },
+  "pipeline_profile": "lightweight",
+  "pipeline": "spec_execute_verify"
+}

--- a/.tasks/260226-fix-stream-message-callback/task.md
+++ b/.tasks/260226-fix-stream-message-callback/task.md
@@ -1,0 +1,34 @@
+# Task
+
+## Issue Title
+
+[MEDIUM] Perf: streamMessage not wrapped in useCallback — causes unnecessary re-renders
+## Description
+In `useNotebookChat`, the `streamMessage` function (line 446) is a bare `async` arrow function not wrapped in `useCallback`. It is listed as a dependency of `injectExerciseContext` (line 689), causing that callback to re-create on every render, defeating memoization.
+
+## Files Affected
+- `src/ui/web/chat/hooks/useNotebookChat.ts` — line 446 (definition), line 689 (dependency array)
+
+## Current Code
+```tsx
+// Line 446 — NOT memoized, recreated every render
+const streamMessage = async (...) => { ... }
+
+// Line 689 — depends on streamMessage, so also recreated every render
+const injectExerciseContext = useCallback((...) => {
+  // uses streamMessage
+}, [streamMessage, ...otherDeps])
+```
+
+## Expected Fix
+```tsx
+const streamMessage = useCallback(async (...) => {
+  // ... existing logic
+}, [apiService, setMessages, scrollToBottom, /* other stable deps */])
+```
+
+## ESLint Warning
+This is the `react-hooks/exhaustive-deps` warning on line 689.
+
+## Priority
+MEDIUM — Performance bug causing unnecessary re-renders in chat components

--- a/.tasks/260226-fix-stream-message-callback/verify.md
+++ b/.tasks/260226-fix-stream-message-callback/verify.md
@@ -1,0 +1,12 @@
+# Verification Report
+
+## TypeScript: PASS ✅
+
+## Lint: PASS ✅
+
+## Format: PASS ✅
+
+## Unit Tests: PASS ✅
+
+
+## Result: PASS

--- a/src/ui/web/chat/hooks/useNotebookChat.ts
+++ b/src/ui/web/chat/hooks/useNotebookChat.ts
@@ -89,6 +89,14 @@ export function useNotebookChat({
   const [isLoading, setIsLoading] = useState(false)
   const [isLoadingHistory, setIsLoadingHistory] = useState(true)
 
+  // Refs to mirror state for stable callback access
+  const isLoadingRef = useRef(false)
+  const isLoadingHistoryRef = useRef(true)
+
+  // Sync refs with state during render for stable callback access
+  isLoadingRef.current = isLoading
+  isLoadingHistoryRef.current = isLoadingHistory
+
   // Direct-to-Blob chat asset uploads
   const {
     uploadingFiles: directUploads,
@@ -644,7 +652,7 @@ export function useNotebookChat({
         }
       >,
     ) => {
-      if (isLoading || isLoadingHistory) return
+      if (isLoadingRef.current || isLoadingHistoryRef.current) return
       if (lastInjectedExerciseId.current === exercise.id) return
 
       lastInjectedExerciseId.current = exercise.id
@@ -659,17 +667,7 @@ export function useNotebookChat({
       const context = { exerciseId, lessonId, chapterId, courseId, categoryId }
       await streamMessage(prompt, acknowledgment, context, { hidden: true })
     },
-    [
-      isLoading,
-      isLoadingHistory,
-      streamMessage,
-      acknowledgment,
-      exerciseId,
-      lessonId,
-      chapterId,
-      courseId,
-      categoryId,
-    ],
+    [streamMessage, acknowledgment, exerciseId, lessonId, chapterId, courseId, categoryId],
   )
 
   /**

--- a/tests/unit/hooks/useNotebookChat.test.ts
+++ b/tests/unit/hooks/useNotebookChat.test.ts
@@ -210,6 +210,32 @@ describe('useNotebookChat', () => {
     ])
   })
 
+  it('injectExerciseContext should maintain stable reference across loading state changes', async () => {
+    const { result } = renderHook(() => useNotebookChat(defaultProps))
+
+    // Wait for initial load to complete
+    await waitFor(() => expect(result.current.isLoadingHistory).toBe(false))
+
+    // Capture the initial injectExerciseContext reference
+    const initialInjectExerciseContext = result.current.injectExerciseContext
+
+    // Set input and trigger a loading state change by submitting
+    act(() => {
+      result.current.setInputValue('Test message')
+    })
+
+    // Submit the message - this will change isLoading from false to true, then back to false
+    await act(async () => {
+      result.current.handleSubmit({ preventDefault: () => undefined } as React.FormEvent)
+    })
+
+    // Wait for loading to complete
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    // Verify that injectExerciseContext has the SAME reference (not recreated)
+    expect(result.current.injectExerciseContext).toBe(initialInjectExerciseContext)
+  })
+
   describe('error logging', () => {
     let consoleErrorSpy: ReturnType<typeof vi.spyOn>
 


### PR DESCRIPTION
## Summary

Fix a React performance bug in `useNotebookChat` where the `streamMessage` function is not wrapped in `useCallback`, causing unnecessary re-renders.

## Commits

```
2d529e4b ci(cody): commit task files for 260226-fix-stream-message-callback
c0598702 ci(cody): commit task files for 260226-fix-stream-message-callback
73c8b803 fix(260226-fix-stream-message-callback): Issue Title
57ebc66f ci(cody): commit task files for 260226-fix-stream-message-callback
```

Closes #511

---
🤖 Generated by Cody pipeline