### PR TITLE
refactor: performance: missing indexes on status and relationship fields

### DIFF
--- a/.tasks/260226-add-missing-indexes/apply-audit.md
+++ b/.tasks/260226-add-missing-indexes/apply-audit.md
@@ -1,0 +1,57 @@
+# Apply Audit Report: 260226-add-missing-indexes
+
+## Improvements Applied
+
+| #   | Type         | Where                              | Status              |
+| --- | ------------ | ---------------------------------- | ------------------- |
+| 1   | SKILL        | .agents/skills/new-collection/SKILL.md | status: IMPLEMENTED |
+| 2   | PROMPT       | AGENTS.md                          | status: IMPLEMENTED |
+
+## Changes Made
+
+### 1. .agents/skills/new-collection/SKILL.md (status: IMPLEMENTED)
+
+Added a comprehensive **Index Checklist** section that prompts developers to consider indexes when creating new collections:
+
+- **Required Indexes**: Status fields, owner/relationship fields, slug fields
+- **Common Indexes**: Foreign keys, sortable fields, date fields
+- **Code examples** showing proper index usage
+
+This addresses **Additional Finding #2** from the auditor: "Add index checklist to collection template"
+
+### 2. AGENTS.md (status: IMPLEMENTED)
+
+Enhanced the **Database Indexes** section in Best Practices:
+
+- Added detailed code examples for index usage on common field types
+- Documented which field types typically need indexes:
+  - Status/state select fields
+  - Owner/user relationship fields
+  - Slug fields
+  - Frequently sorted fields
+  - Date fields used in range queries
+
+This addresses **Additional Finding #4** from the auditor: "Remind agents about indexes in feature tasks"
+
+## Suggested Improvements (Not Applied)
+
+### 1. AUTOMATION: Add index validation to CI quality gates
+- **Where:** `.github/workflows/quality.yml`
+- **Reason:** This path is in the safe-path whitelist as "suggest-only" - CI/CD workflows should be reviewed by humans before implementation
+- **Suggestion:** Add a CI check that scans collection files for relationship/status fields lacking `index: true`, running as part of the standard lint/typecheck pipeline
+
+### 2. DOC: Document database index best practices
+- **Where:** `docs/PERFORMANCE.md` (new file)
+- **Reason:** The `docs/**` path is not in the safe-path whitelist (only `.ai-docs/**` is allowed for documentation)
+- **Suggestion:** Create a new PERFORMANCE.md guide specifically listing which field types should always have indexes for junior developers
+
+### 3. CODE_PATTERN: Standardize index naming convention
+- **Where:** Collection configuration files (`src/collections/*.ts`)
+- **Reason:** The `src/**` path is not in the safe-path whitelist - production code changes require proper implementation workflow
+- **Suggestion:** Consider adding custom index names for clarity (e.g., `index: { name: 'statusPublished' }`) rather than relying on auto-generated names
+
+## Notes
+
+- Both implemented improvements directly address process documentation gaps identified by the auditor
+- The new-collection skill now proactively prompts developers about indexes, preventing future performance issues
+- AGENTS.md now has clear guidance on when and how to add database indexes, accessible to all AI agents working on the project

--- a/.tasks/260226-add-missing-indexes/auditor.md
+++ b/.tasks/260226-add-missing-indexes/auditor.md
@@ -1,0 +1,70 @@
+# Auditor Report: 260226-add-missing-indexes
+
+## Task Info
+
+- **Task ID:** 260226-add-missing-indexes
+- **Task Type:** chore
+- **Run State:** SUCCESS
+- **Date:** 2026-02-26T17:22:27Z
+- **Previous Improvements Reviewed:** 0 from audit-history.json
+
+## Stage Analysis
+
+| Stage | Quality |
+| ------ | ------- |
+| spec   | Excellent - Detailed table with exact file paths, line numbers, and field names for all 10 fields. Clear acceptance criteria. |
+| plan   | Not applicable - This was a straightforward chore with no plan.md (single-step task) |
+| build  | Excellent - Added all 10 indexes as specified, plus proactively wrote unit tests to verify changes. All quality gates passed on first try. |
+| verify | Complete - TypeScript, Lint, Format, and Unit Tests all passed |
+
+## Process Delta
+
+- Task executed smoothly with no retries required
+- Spec provided exact line numbers, enabling precise execution
+- Build agent added value by writing unit tests (collection-indexes.spec.ts) - this is a best practice
+- All quality gates passed on first attempt (TypeScript, Lint, Format, Unit Tests)
+
+## Primary Improvement
+
+- **Type:** AUTOMATION
+- **Title:** Add index validation to CI quality gates
+- **Rationale:** While this specific task was executed perfectly, missing indexes are a common performance issue that can slip through code reviews. Automating detection ensures consistency.
+- **Where:** `.github/workflows/quality.yml` or similar CI configuration
+- **Acceptance Criteria:**
+  - Add a CI check that scans collection files for relationship/status fields lacking `index: true`
+  - Run as part of the standard lint/typecheck pipeline
+  - Document the expected index patterns in AGENTS.md or a new PERFORMANCE.md guide
+- **Effectiveness:** neutral
+
+## Additional Findings
+
+1. **Type:** DOC
+   - **Title:** Document database index best practices
+   - **Where:** `docs/PERFORMANCE.md` (new file)
+   - **Rationale:** Create a reference guide listing which field types (status selects, frequently-filtered relationships) should always have indexes for junior developers
+
+2. **Type:** INDEX
+   - **Title:** Add index checklist to collection template
+   - **Where:** `.agents/skills/new-collection/SKILL.md`
+   - **Rationale:** When creating new collections, prompt developers to consider adding indexes on status, owner, and commonly filtered relationship fields
+
+3. **Type:** CODE_PATTERN
+   - **Title:** Standardize index naming convention
+   - **Where:** Collection configuration files
+   - **Rationale:** Consider adding custom index names for clarity (e.g., `index: { name: 'statusPublished' }`) rather than relying on auto-generated names
+
+4. **Type:** PROMPT
+   - **Title:** Remind agents about indexes in feature tasks
+   - **Where:** `AGENTS.md` or task generation prompts
+   - **Rationale:** When agents add new status or relationship fields, remind them to consider `index: true` as part of the standard field definition
+
+## Failure Analysis (if FAILED)
+
+Not applicable - task completed successfully.
+
+## Chosen Improvement (DEPRECATED - use Primary Improvement)
+
+- **Type:** AUTOMATION
+- **Title:** Add index validation to CI quality gates
+- **Where:** `.github/workflows/quality.yml`
+- **Rationale:** Automate detection of missing indexes to prevent performance issues from being merged

--- a/.tasks/260226-add-missing-indexes/build.md
+++ b/.tasks/260226-add-missing-indexes/build.md
@@ -1,0 +1,24 @@
+# Build Agent Report: 260226-add-missing-indexes
+
+## Changes
+
+- **Courses.ts**: Added `index: true` to `status` field (line 108) and `categories` field (line 172)
+- **Chapters.ts**: Added `index: true` to `status` field (line 106)
+- **Lessons.ts**: Added `index: true` to `status` field (line 120)
+- **Tenants.ts**: Added `index: true` to `status` field (line 37)
+- **Posts/index.ts**: Added `index: true` to `categories` field (line 125, nested in tabs) and `authors` field (line 186)
+- **Exercises/index.ts**: Added `index: true` to `sourceDoc` field (line 177)
+- **ConfigAuditLogs.ts**: Added `index: true` to `tenant` field (line 49)
+- **GuestSessions.ts**: Added `index: true` to `claimedByUser` field (line 148)
+
+## Tests Written
+
+- `tests/unit/collections/collection-indexes.spec.ts` - 10 tests verifying all 10 fields have `index: true`
+  - 4 status field tests: Courses.status, Chapters.status, Lessons.status, Tenants.status
+  - 6 relationship field tests: Courses.categories, Posts.categories, Posts.authors, Exercises.sourceDoc, ConfigAuditLogs.tenant, GuestSessions.claimedByUser
+
+## Quality
+
+- TypeScript: PASS
+- Lint: PASS (only pre-existing warnings)
+- Unit tests: 2400 passed (including 10 new collection-indexes tests)

--- a/.tasks/260226-add-missing-indexes/commit.md
+++ b/.tasks/260226-add-missing-indexes/commit.md
@@ -1,0 +1,6 @@
+# Commit Stage
+
+✅ **Committed and pushed**
+
+- **Branch:** refactor/260226-add-medium-performance-missing-indexes-on-s
+- **Hash:** 18aafad

--- a/.tasks/260226-add-missing-indexes/gap.md
+++ b/.tasks/260226-add-missing-indexes/gap.md
@@ -1,0 +1,102 @@
+# Gap Analysis: 260226-add-missing-indexes
+
+## Summary
+
+- Gaps Found: 10
+- Spec Revised: Yes
+
+## Gaps Found
+
+### Gap 1: Missing index on Courses.status
+
+**Severity:** High
+**Location:** src/server/payload/collections/Courses.ts, line 108
+**Issue:** The status field (lines 108-129) has no index. Status is frequently queried to filter published content.
+**Fix Applied:** Updated spec line number from 104 to 108.
+
+### Gap 2: Missing index on Chapters.status
+
+**Severity:** High
+**Location:** src/server/payload/collections/Chapters.ts, line 106
+**Issue:** The status field (lines 106-127) has no index. Status is frequently queried to filter published chapters.
+**Fix Applied:** Updated spec line number from 104 to 106.
+
+### Gap 3: Missing index on Lessons.status
+
+**Severity:** High
+**Location:** src/server/payload/collections/Lessons.ts, line 120
+**Issue:** The status field (lines 120-141) has no index. Status is frequently queried to filter published lessons.
+**Fix Applied:** Updated spec line number from 116 to 120.
+
+### Gap 4: Missing index on Tenants.status
+
+**Severity:** Medium
+**Location:** src/server/payload/collections/Tenants.ts, line 37
+**Issue:** The status field (lines 37-47) has no index. Status is queried to filter active tenants.
+**Fix Applied:** Spec line number was correct (37).
+
+### Gap 5: Missing index on Courses.categories
+
+**Severity:** High
+**Location:** src/server/payload/collections/Courses.ts, line 172
+**Issue:** The categories relationship field (lines 172-180) has no index. Categories are frequently used to filter courses.
+**Fix Applied:** Updated spec with line number 172.
+
+### Gap 6: Missing index on Posts.authors
+
+**Severity:** High
+**Location:** src/server/payload/collections/Posts/index.ts, line 186
+**Issue:** The authors relationship field (lines 186-193) has no index. Authors are frequently used to filter posts.
+**Fix Applied:** Updated spec with line number 186.
+
+### Gap 7: Missing index on Posts.categories
+
+**Severity:** High
+**Location:** src/server/payload/collections/Posts/index.ts, line 125
+**Issue:** The categories relationship field (lines 125-132) has no index. Categories are frequently used to filter posts.
+**Fix Applied:** Updated spec with line number 125.
+
+### Gap 8: Missing index on Exercises.sourceDoc
+
+**Severity:** Medium
+**Location:** src/server/payload/collections/Exercises/index.ts, line 177
+**Issue:** The sourceDoc relationship field (lines 177-181) has no index. This field is used to track conversion source.
+**Fix Applied:** Updated spec with line number 177.
+
+### Gap 9: Missing index on ConfigAuditLogs.tenant
+
+**Severity:** Medium
+**Location:** src/server/payload/collections/ConfigAuditLogs.ts, line 49
+**Issue:** The tenant relationship field (lines 49-56) has no index. Tenant is frequently used to filter audit logs.
+**Fix Applied:** Updated spec with line number 49.
+
+### Gap 10: Missing index on GuestSessions.claimedByUser
+
+**Severity:** Medium
+**Location:** src/server/payload/collections/GuestSessions.ts, line 148
+**Issue:** The claimedByUser relationship field (lines 148-155) has no index. This field is used when users claim guest sessions.
+**Fix Applied:** Updated spec with line number 148.
+
+## Changes Made
+
+- Updated line number for Courses.status: 104 → 108
+- Updated line number for Chapters.status: 104 → 106
+- Updated line number for Lessons.status: 116 → 120
+- Added line number 172 for Courses.categories
+- Added line number 186 for Posts.authors
+- Added line number 125 for Posts.categories
+- Added line number 177 for Exercises.sourceDoc
+- Added line number 49 for ConfigAuditLogs.tenant
+- Added line number 148 for GuestSessions.claimedByUser
+
+## No Other Gaps Identified
+
+The codebase already has indexes on many other commonly queried fields:
+- Courses: courseLabel, title, prompt, slug (already indexed)
+- Chapters: course, chapterLabel, title, slug (already indexed)
+- Lessons: chapter, type, title, prompt, slug (already indexed)
+- Tenants: slug (already indexed)
+- ConfigAuditLogs: key, actor (already indexed)
+- GuestSessions: tokenHash, createdAt, lastActiveAt, expiresAt, hardExpiresAt, ipHash, status (already indexed)
+
+The spec correctly identifies all 10 fields that need new indexes added.

--- a/.tasks/260226-add-missing-indexes/plan-gap.md
+++ b/.tasks/260226-add-missing-indexes/plan-gap.md
@@ -1,0 +1,10 @@
+# Plan Gap Analysis: 260226-add-missing-indexes
+
+## Summary
+
+- Gaps Found: 0
+- Plan Revised: No
+
+## No Gaps Found
+
+No gaps identified. The plan covers all spec requirements, follows codebase patterns, and is logically structured. All file paths and proposed changes are consistent with the project's architecture and Payload CMS best practices.

--- a/.tasks/260226-add-missing-indexes/plan.md
+++ b/.tasks/260226-add-missing-indexes/plan.md
@@ -1,0 +1,197 @@
+# Plan: Add Missing Database Indexes
+
+**Task ID**: 260226-add-missing-indexes
+**Task Type**: refactor
+**Estimated Total Time**: 20-30 minutes (2 steps)
+
+## Assumptions
+
+- All 10 fields identified in the spec currently lack `index: true`
+- Adding `index: true` to Payload field definitions is a non-breaking, additive change
+- MongoDB will create indexes on next startup/migration — no manual migration needed
+- Posts `categories` field is nested inside a `tabs` > `Meta` tab (line 125 in `Posts/index.ts`)
+- Posts `authors` field is a top-level field (line 186 in `Posts/index.ts`)
+- No `clarified.md` exists; proceeding with spec as written
+
+---
+
+## Step 1: Add `index: true` to all 10 fields across 6 collection files
+
+**Time**: 10-15 minutes
+
+### Files to Touch
+
+| # | File | Field | Line | Change |
+|---|------|-------|------|--------|
+| 1 | `src/server/payload/collections/Courses.ts` (MODIFIED) | `status` | ~108 | Add `index: true` |
+| 2 | `src/server/payload/collections/Courses.ts` (MODIFIED) | `categories` | ~172 | Add `index: true` |
+| 3 | `src/server/payload/collections/Chapters.ts` (MODIFIED) | `status` | ~106 | Add `index: true` |
+| 4 | `src/server/payload/collections/Lessons.ts` (MODIFIED) | `status` | ~120 | Add `index: true` |
+| 5 | `src/server/payload/collections/Tenants.ts` (MODIFIED) | `status` | ~37 | Add `index: true` |
+| 6 | `src/server/payload/collections/Posts/index.ts` (MODIFIED) | `categories` | ~125 | Add `index: true` |
+| 7 | `src/server/payload/collections/Posts/index.ts` (MODIFIED) | `authors` | ~186 | Add `index: true` |
+| 8 | `src/server/payload/collections/Exercises/index.ts` (MODIFIED) | `sourceDoc` | ~177 | Add `index: true` |
+| 9 | `src/server/payload/collections/ConfigAuditLogs.ts` (MODIFIED) | `tenant` | ~49 | Add `index: true` |
+| 10 | `src/server/payload/collections/GuestSessions.ts` (MODIFIED) | `claimedByUser` | ~148 | Add `index: true` |
+
+### Exact Behavior
+
+For each field listed above, add the property `index: true` to the field definition object. The property should be placed alongside other top-level field properties (e.g., next to `required`, `type`, `name`), following the existing pattern seen in sibling fields that already have `index: true`.
+
+**Example transformation** (Courses.ts `status` field, currently around line 108):
+
+```typescript
+// BEFORE
+{
+  name: 'status',
+  type: 'select',
+  required: true,
+  defaultValue: 'draft',
+  options: [ ... ],
+  admin: { ... },
+}
+
+// AFTER
+{
+  name: 'status',
+  type: 'select',
+  required: true,
+  defaultValue: 'draft',
+  index: true,           // ← ADD THIS LINE
+  options: [ ... ],
+  admin: { ... },
+}
+```
+
+**Note on Posts `categories`**: This field is nested inside a `tabs` field → second tab (`Meta`) → `fields` array → second field. The path is: `Posts.fields[1].tabs[1].fields[1]` (where `fields[1]` is the tabs field at the root). The `index: true` should be added to the field object at line ~125.
+
+### Tests (FAIL before, PASS after)
+
+**Test file**: `tests/unit/collections/collection-indexes.spec.ts` (NEW)
+
+1. **Test: "status fields should be indexed in Courses, Chapters, Lessons, Tenants"**
+   - Import collection configs from each file
+   - For each collection, find the field with `name === 'status'`
+   - Assert `field.index === true`
+   - FAILS before: `status` fields don't have `index: true`
+   - PASSES after: all 4 status fields have `index: true`
+
+2. **Test: "relationship fields should be indexed in Courses, Posts, Exercises, ConfigAuditLogs, GuestSessions"**
+   - Import collection configs
+   - For Courses: find field `name === 'categories'`, assert `index === true`
+   - For Posts: find the `categories` field inside tabs → Meta tab → fields, assert `index === true`
+   - For Posts: find field `name === 'authors'`, assert `index === true`
+   - For Exercises: find field `name === 'sourceDoc'` (inside tabs/groups), assert `index === true`
+   - For ConfigAuditLogs: find field `name === 'tenant'`, assert `index === true`
+   - For GuestSessions: find field `name === 'claimedByUser'`, assert `index === true`
+   - FAILS before: none of these fields have `index: true`
+   - PASSES after: all 6 relationship fields have `index: true`
+
+### Acceptance Criteria
+
+- [ ] `Courses.ts` `status` field has `index: true`
+- [ ] `Courses.ts` `categories` field has `index: true`
+- [ ] `Chapters.ts` `status` field has `index: true`
+- [ ] `Lessons.ts` `status` field has `index: true`
+- [ ] `Tenants.ts` `status` field has `index: true`
+- [ ] `Posts/index.ts` `categories` field has `index: true`
+- [ ] `Posts/index.ts` `authors` field has `index: true`
+- [ ] `Exercises/index.ts` `sourceDoc` field has `index: true`
+- [ ] `ConfigAuditLogs.ts` `tenant` field has `index: true`
+- [ ] `GuestSessions.ts` `claimedByUser` field has `index: true`
+- [ ] All unit tests in `tests/unit/collections/collection-indexes.spec.ts` pass
+
+---
+
+## Step 2: Verify TypeScript compilation and lint
+
+**Time**: 5-10 minutes
+
+### Files to Touch
+
+None (verification only)
+
+### Exact Behavior
+
+Run the following commands to confirm no regressions:
+
+```bash
+pnpm tsc --noEmit          # TypeScript compilation
+pnpm lint                   # Lint check
+```
+
+Both must pass with zero errors.
+
+### Tests (FAIL before, PASS after)
+
+No additional test file. The validation is:
+1. `pnpm tsc --noEmit` exits with code 0
+2. `pnpm lint` exits with code 0
+3. Existing test suite passes: `pnpm vitest run tests/unit/collections/`
+
+### Acceptance Criteria
+
+- [ ] `pnpm tsc --noEmit` passes
+- [ ] `pnpm lint` passes
+- [ ] No existing tests are broken
+
+---
+
+## Test Implementation Guide
+
+The test file `tests/unit/collections/collection-indexes.spec.ts` needs a helper to find fields inside nested structures (tabs, groups). Here's the approach:
+
+```typescript
+import { describe, expect, it } from 'vitest'
+import type { Field } from 'payload'
+
+// Helper: recursively find a field by name in a collection config
+// Handles tabs, groups, rows, collapsibles, and arrays
+function findFieldByName(fields: Field[], name: string): Field | undefined {
+  for (const field of fields) {
+    if ('name' in field && field.name === name) return field
+    // Check tabs
+    if (field.type === 'tabs' && 'tabs' in field) {
+      for (const tab of field.tabs) {
+        const found = findFieldByName(tab.fields, name)
+        if (found) return found
+      }
+    }
+    // Check group/collapsible/row sub-fields
+    if ('fields' in field && Array.isArray(field.fields)) {
+      const found = findFieldByName(field.fields as Field[], name)
+      if (found) return found
+    }
+  }
+  return undefined
+}
+```
+
+This recursive helper is needed because:
+- Posts `categories` is nested inside `tabs > Meta > fields`
+- Exercises `sourceDoc` is nested inside `tabs` or similar structures
+- Other fields are at the root level
+
+Import each collection config directly:
+```typescript
+import { Courses } from '@/server/payload/collections/Courses'
+import { Chapters } from '@/server/payload/collections/Chapters'
+import { Lessons } from '@/server/payload/collections/Lessons'
+import { Tenants } from '@/server/payload/collections/Tenants'
+import { Posts } from '@/server/payload/collections/Posts/index'
+import { Exercises } from '@/server/payload/collections/Exercises/index'
+import { ConfigAuditLogs } from '@/server/payload/collections/ConfigAuditLogs'
+import { GuestSessions } from '@/server/payload/collections/GuestSessions'
+```
+
+---
+
+## Spec Requirement Traceability
+
+| Spec Requirement | Plan Step | Test |
+|---|---|---|
+| Status fields indexed (4 collections) | Step 1, items 1-4 | Test 1: "status fields should be indexed" |
+| Relationship fields indexed (6 collections) | Step 1, items 5-10 | Test 2: "relationship fields should be indexed" |
+| TypeScript compilation passes | Step 2 | `pnpm tsc --noEmit` |
+| No breaking changes | Step 2 | Existing test suite + lint |
+| Follows existing patterns | Step 1 | Manual review; `index: true` placed consistently with existing indexed fields |

--- a/.tasks/260226-add-missing-indexes/spec.md
+++ b/.tasks/260226-add-missing-indexes/spec.md
@@ -8,19 +8,19 @@ Add MongoDB indexes to frequently queried fields to improve query performance an
 
 ### Status Fields (4 collections)
 Add `index: true` to status select fields in:
-1. `Courses.ts` - line 104, field: status
-2. `Chapters.ts` - line 104, field: status
-3. `Lessons.ts` - line 116, field: status
+1. `Courses.ts` - line 108, field: status
+2. `Chapters.ts` - line 106, field: status
+3. `Lessons.ts` - line 120, field: status
 4. `Tenants.ts` - line 37, field: status
 
 ### Relationship Fields (6 collections)
 Add `index: true` to relationship fields in:
-1. `Courses.ts` - field: categories (HIGH priority)
-2. `Posts/index.ts` - field: authors (HIGH priority)
-3. `Posts/index.ts` - field: categories (HIGH priority)
-4. `Exercises/index.ts` - field: sourceDoc (MEDIUM priority)
-5. `ConfigAuditLogs.ts` - field: tenant (MEDIUM priority)
-6. `GuestSessions.ts` - field: claimedByUser (MEDIUM priority)
+1. `Courses.ts` - line 172, field: categories (HIGH priority)
+2. `Posts/index.ts` - line 186, field: authors (HIGH priority)
+3. `Posts/index.ts` - line 125, field: categories (HIGH priority)
+4. `Exercises/index.ts` - line 177, field: sourceDoc (MEDIUM priority)
+5. `ConfigAuditLogs.ts` - line 49, field: tenant (MEDIUM priority)
+6. `GuestSessions.ts` - line 148, field: claimedByUser (MEDIUM priority)
 
 ## Acceptance Criteria
 

--- a/.tasks/260226-add-missing-indexes/spec.md
+++ b/.tasks/260226-add-missing-indexes/spec.md
@@ -1,0 +1,30 @@
+# Spec: Add Missing Database Indexes
+
+## Overview
+
+Add MongoDB indexes to frequently queried fields to improve query performance and prevent full collection scans.
+
+## Requirements
+
+### Status Fields (4 collections)
+Add `index: true` to status select fields in:
+1. `Courses.ts` - line 104, field: status
+2. `Chapters.ts` - line 104, field: status
+3. `Lessons.ts` - line 116, field: status
+4. `Tenants.ts` - line 37, field: status
+
+### Relationship Fields (6 collections)
+Add `index: true` to relationship fields in:
+1. `Courses.ts` - field: categories (HIGH priority)
+2. `Posts/index.ts` - field: authors (HIGH priority)
+3. `Posts/index.ts` - field: categories (HIGH priority)
+4. `Exercises/index.ts` - field: sourceDoc (MEDIUM priority)
+5. `ConfigAuditLogs.ts` - field: tenant (MEDIUM priority)
+6. `GuestSessions.ts` - field: claimedByUser (MEDIUM priority)
+
+## Acceptance Criteria
+
+- [ ] All 10 fields have `index: true` added
+- [ ] TypeScript compilation passes (`pnpm tsc --noEmit`)
+- [ ] No breaking changes to existing functionality
+- [ ] Code follows existing field definition patterns in codebase

--- a/.tasks/260226-add-missing-indexes/status.json
+++ b/.tasks/260226-add-missing-indexes/status.json
@@ -4,7 +4,7 @@
   "mode": "full",
   "pipeline": "spec_execute_verify",
   "startedAt": "2026-02-26T17:03:29.690Z",
-  "updatedAt": "2026-02-26T17:21:18.497Z",
+  "updatedAt": "2026-02-26T17:23:16.536Z",
   "state": "running",
   "cursor": null,
   "stages": {
@@ -53,6 +53,23 @@
       "retries": 0,
       "startedAt": "2026-02-26T17:21:16.939Z",
       "completedAt": "2026-02-26T17:21:18.497Z"
+    },
+    "verify": {
+      "state": "completed",
+      "retries": 0,
+      "completedAt": "2026-02-26T17:23:16.344Z",
+      "outputFile": "verify.md"
+    },
+    "auditor": {
+      "state": "completed",
+      "retries": 0,
+      "completedAt": "2026-02-26T17:23:16.535Z",
+      "outputFile": "auditor.md"
+    },
+    "apply-audit": {
+      "state": "running",
+      "retries": 0,
+      "startedAt": "2026-02-26T17:23:16.536Z"
     }
   }
 }

--- a/.tasks/260226-add-missing-indexes/status.json
+++ b/.tasks/260226-add-missing-indexes/status.json
@@ -1,0 +1,17 @@
+{
+  "version": 2,
+  "taskId": "260226-add-missing-indexes",
+  "mode": "full",
+  "pipeline": "spec_execute_verify",
+  "startedAt": "2026-02-26T16:16:12.671Z",
+  "updatedAt": "2026-02-26T16:16:12.672Z",
+  "state": "running",
+  "cursor": null,
+  "stages": {
+    "taskify": {
+      "state": "running",
+      "retries": 0,
+      "startedAt": "2026-02-26T16:16:12.672Z"
+    }
+  }
+}

--- a/.tasks/260226-add-missing-indexes/status.json
+++ b/.tasks/260226-add-missing-indexes/status.json
@@ -4,7 +4,7 @@
   "mode": "full",
   "pipeline": "spec_execute_verify",
   "startedAt": "2026-02-26T17:03:29.690Z",
-  "updatedAt": "2026-02-26T17:21:16.939Z",
+  "updatedAt": "2026-02-26T17:21:18.497Z",
   "state": "running",
   "cursor": null,
   "stages": {
@@ -49,9 +49,10 @@
       "outputFile": "build.md"
     },
     "commit": {
-      "state": "running",
+      "state": "completed",
       "retries": 0,
-      "startedAt": "2026-02-26T17:21:16.939Z"
+      "startedAt": "2026-02-26T17:21:16.939Z",
+      "completedAt": "2026-02-26T17:21:18.497Z"
     }
   }
 }

--- a/.tasks/260226-add-missing-indexes/status.json
+++ b/.tasks/260226-add-missing-indexes/status.json
@@ -3,15 +3,55 @@
   "taskId": "260226-add-missing-indexes",
   "mode": "full",
   "pipeline": "spec_execute_verify",
-  "startedAt": "2026-02-26T16:16:12.671Z",
-  "updatedAt": "2026-02-26T16:16:12.672Z",
+  "startedAt": "2026-02-26T17:03:29.690Z",
+  "updatedAt": "2026-02-26T17:21:16.939Z",
   "state": "running",
   "cursor": null,
   "stages": {
     "taskify": {
+      "state": "completed",
+      "retries": 0,
+      "startedAt": "2026-02-26T17:03:29.692Z",
+      "completedAt": "2026-02-26T17:04:40.202Z",
+      "outputFile": "taskify.md"
+    },
+    "spec": {
+      "state": "skipped",
+      "retries": 0,
+      "skipped": "Promoted via input_quality (file exists)"
+    },
+    "gap": {
+      "state": "completed",
+      "retries": 1,
+      "startedAt": "2026-02-26T17:04:43.518Z",
+      "completedAt": "2026-02-26T17:12:07.560Z",
+      "outputFile": "gap.md"
+    },
+    "architect": {
+      "state": "completed",
+      "retries": 0,
+      "startedAt": "2026-02-26T17:12:07.560Z",
+      "completedAt": "2026-02-26T17:13:50.036Z",
+      "outputFile": "architect.md"
+    },
+    "plan-gap": {
+      "state": "completed",
+      "retries": 0,
+      "startedAt": "2026-02-26T17:13:50.037Z",
+      "completedAt": "2026-02-26T17:14:18.843Z",
+      "outputFile": "plan-gap.md"
+    },
+    "build": {
+      "state": "completed",
+      "retries": 0,
+      "startedAt": "2026-02-26T17:14:18.844Z",
+      "completedAt": "2026-02-26T17:20:56.656Z",
+      "outputFile": "build.md"
+    },
+    "commit": {
       "state": "running",
       "retries": 0,
-      "startedAt": "2026-02-26T16:16:12.672Z"
+      "startedAt": "2026-02-26T17:21:16.939Z"
     }
   }
 }

--- a/.tasks/260226-add-missing-indexes/task.json
+++ b/.tasks/260226-add-missing-indexes/task.json
@@ -1,0 +1,31 @@
+{
+  "task_type": "refactor",
+  "risk_level": "medium",
+  "confidence": 0.95,
+  "primary_domain": "infra",
+  "scope": [
+    "src/server/payload/collections/Courses.ts",
+    "src/server/payload/collections/Chapters.ts",
+    "src/server/payload/collections/Lessons.ts",
+    "src/server/payload/collections/Tenants.ts",
+    "src/server/payload/collections/Posts/index.ts",
+    "src/server/payload/collections/Exercises/index.ts",
+    "src/server/payload/collections/ConfigAuditLogs.ts",
+    "src/server/payload/collections/GuestSessions.ts"
+  ],
+  "missing_inputs": [],
+  "assumptions": [
+    "All specified collection files exist at the provided paths",
+    "Fields already exist at the specified line numbers and only need index: true added",
+    "No breaking changes - adding index is a non-destructive operation"
+  ],
+  "input_quality": {
+    "level": "good_spec",
+    "skip_stages": [
+      "spec"
+    ],
+    "reasoning": "Task contains detailed table with exact file paths, line numbers, and field names for 10 fields across 8 collections. Has clear requirements with code example. Promoted spec.md."
+  },
+  "pipeline_profile": "standard",
+  "pipeline": "spec_execute_verify"
+}

--- a/.tasks/260226-add-missing-indexes/task.md
+++ b/.tasks/260226-add-missing-indexes/task.md
@@ -1,0 +1,35 @@
+# Task
+
+## Issue Title
+
+[MEDIUM] Performance: Missing indexes on status and relationship fields
+## Description
+Several frequently queried fields are missing `index: true`, causing full collection scans in MongoDB.
+
+## Status Fields Missing Index
+| Collection | File | Line | Field |
+|-----------|------|------|-------|
+| courses | `src/server/payload/collections/Courses.ts` | 104 | `status` |
+| chapters | `src/server/payload/collections/Chapters.ts` | 104 | `status` |
+| lessons | `src/server/payload/collections/Lessons.ts` | 116 | `status` |
+| tenants | `src/server/payload/collections/Tenants.ts` | 37 | `status` |
+
+## Relationship Fields Missing Index
+| Collection | File | Field | Priority |
+|-----------|------|-------|----------|
+| courses | `Courses.ts` | `categories` | HIGH — admin defaultColumn, frontend filter |
+| posts | `Posts/index.ts` | `authors` | HIGH — used in populateAuthors hook |
+| posts | `Posts/index.ts` | `categories` | HIGH — common frontend filter |
+| exercises | `Exercises/index.ts` | `sourceDoc` | MEDIUM — conversion pipeline lookups |
+| config_audit_logs | `ConfigAuditLogs.ts` | `tenant` | MEDIUM — admin filtered by tenant |
+| guest-sessions | `GuestSessions.ts` | `claimedByUser` | MEDIUM — session upgrade query |
+
+## Expected Fix
+Add `index: true` to each field definition:
+```typescript
+{ name: 'status', type: 'select', options: [...], index: true }
+{ name: 'categories', type: 'relationship', relationTo: 'categories', index: true }
+```
+
+## Priority
+MEDIUM — Performance optimization, becomes critical at scale

--- a/.tasks/260226-add-missing-indexes/verify.md
+++ b/.tasks/260226-add-missing-indexes/verify.md
@@ -1,0 +1,12 @@
+# Verification Report
+
+## TypeScript: PASS ✅
+
+## Lint: PASS ✅
+
+## Format: PASS ✅
+
+## Unit Tests: PASS ✅
+
+
+## Result: PASS

--- a/.tasks/260226-add-zod-validation/pr.md
+++ b/.tasks/260226-add-zod-validation/pr.md
@@ -1,0 +1,5 @@
+# PR Stage
+
+PR created: https://github.com/A-Guy-educ/A-Guy/pull/606
+
+Title: fix: security: missing zod validation on conversion queue api endpoints

--- a/src/server/payload/collections/Chapters.ts
+++ b/src/server/payload/collections/Chapters.ts
@@ -106,6 +106,7 @@ export const Chapters: CollectionConfig = {
       name: 'status',
       type: 'select',
       required: true,
+      index: true,
       defaultValue: 'draft',
       options: [
         {

--- a/src/server/payload/collections/ConfigAuditLogs.ts
+++ b/src/server/payload/collections/ConfigAuditLogs.ts
@@ -50,6 +50,7 @@ export const ConfigAuditLogs: CollectionConfig = {
       type: 'relationship',
       relationTo: 'tenants',
       required: true,
+      index: true,
       admin: {
         description: 'Tenant of the mutated config entry',
       },

--- a/src/server/payload/collections/Courses.ts
+++ b/src/server/payload/collections/Courses.ts
@@ -108,6 +108,7 @@ export const Courses: CollectionConfig = {
       name: 'status',
       type: 'select',
       required: true,
+      index: true,
       defaultValue: 'draft',
       options: [
         {
@@ -174,6 +175,7 @@ export const Courses: CollectionConfig = {
       relationTo: 'categories',
       required: true,
       hasMany: true,
+      index: true,
       admin: {
         position: 'sidebar',
       },

--- a/src/server/payload/collections/Exercises/index.ts
+++ b/src/server/payload/collections/Exercises/index.ts
@@ -177,6 +177,7 @@ export const Exercises: CollectionConfig = {
           name: 'sourceDoc',
           type: 'relationship',
           relationTo: 'media',
+          index: true,
           admin: { description: 'Original PDF media for conversion exercises' },
         },
         {

--- a/src/server/payload/collections/GuestSessions.ts
+++ b/src/server/payload/collections/GuestSessions.ts
@@ -148,6 +148,7 @@ export const GuestSessions: CollectionConfig = {
       name: 'claimedByUser',
       type: 'relationship',
       relationTo: 'users',
+      index: true,
       admin: {
         hidden: true,
         description: 'User who claimed this session on upgrade',

--- a/src/server/payload/collections/Lessons.ts
+++ b/src/server/payload/collections/Lessons.ts
@@ -120,6 +120,7 @@ export const Lessons: CollectionConfig = {
       name: 'status',
       type: 'select',
       required: true,
+      index: true,
       defaultValue: 'draft',
       options: [
         {

--- a/src/server/payload/collections/Posts/index.ts
+++ b/src/server/payload/collections/Posts/index.ts
@@ -124,6 +124,7 @@ export const Posts: CollectionConfig<'posts'> = {
             {
               name: 'categories',
               type: 'relationship',
+              index: true,
               admin: {
                 position: 'sidebar',
               },
@@ -185,6 +186,7 @@ export const Posts: CollectionConfig<'posts'> = {
     {
       name: 'authors',
       type: 'relationship',
+      index: true,
       admin: {
         position: 'sidebar',
       },

--- a/src/server/payload/collections/Tenants.ts
+++ b/src/server/payload/collections/Tenants.ts
@@ -36,6 +36,7 @@ export const Tenants: CollectionConfig = {
     {
       name: 'status',
       type: 'select',
+      index: true,
       defaultValue: 'active',
       options: [
         { label: 'Active', value: 'active' },

--- a/tests/unit/collections/collection-indexes.spec.ts
+++ b/tests/unit/collections/collection-indexes.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * Unit Tests for Collection Indexes
+ *
+ * Tests that index: true is set on the following fields:
+ * - Status fields: Courses.status, Chapters.status, Lessons.status, Tenants.status
+ * - Relationship fields: Courses.categories, Posts.categories, Posts.authors,
+ *   Exercises.sourceDoc, ConfigAuditLogs.tenant, GuestSessions.claimedByUser
+ *
+ * These tests should FAIL initially (TDD Red Phase) because index: true
+ * is not yet added to these fields.
+ */
+import { describe, expect, it } from 'vitest'
+import type { Field } from 'payload'
+
+import { Courses } from '@/server/payload/collections/Courses'
+import { Chapters } from '@/server/payload/collections/Chapters'
+import { Lessons } from '@/server/payload/collections/Lessons'
+import { Tenants } from '@/server/payload/collections/Tenants'
+import { Posts } from '@/server/payload/collections/Posts/index'
+import { Exercises } from '@/server/payload/collections/Exercises/index'
+import { ConfigAuditLogs } from '@/server/payload/collections/ConfigAuditLogs'
+import { GuestSessions } from '@/server/payload/collections/GuestSessions'
+
+/**
+ * Helper to recursively find fields in nested structures (tabs, groups, rows, collapsibles, arrays)
+ */
+function findFieldByName(fields: Field[], name: string): Field | undefined {
+  for (const field of fields) {
+    if ('name' in field && field.name === name) return field
+    // Check tabs
+    if (field.type === 'tabs' && 'tabs' in field) {
+      for (const tab of field.tabs) {
+        const found = findFieldByName(tab.fields as Field[], name)
+        if (found) return found
+      }
+    }
+    // Check group/collapsible/row sub-fields
+    if ('fields' in field && Array.isArray(field.fields)) {
+      const found = findFieldByName(field.fields as Field[], name)
+      if (found) return found
+    }
+    // Check array items
+    if (field.type === 'array' && field.fields) {
+      const found = findFieldByName(field.fields as Field[], name)
+      if (found) return found
+    }
+  }
+  return undefined
+}
+
+describe('Collection Indexes', () => {
+  describe('Status Fields', () => {
+    describe('Courses.status', () => {
+      it('should have index: true', () => {
+        const field = Courses.fields?.find((f) => 'name' in f && f.name === 'status') as
+          | { name: string; index?: boolean }
+          | undefined
+        expect(field).toBeDefined()
+        expect(field?.index).toBe(true)
+      })
+    })
+
+    describe('Chapters.status', () => {
+      it('should have index: true', () => {
+        const field = Chapters.fields?.find((f) => 'name' in f && f.name === 'status') as
+          | { name: string; index?: boolean }
+          | undefined
+        expect(field).toBeDefined()
+        expect(field?.index).toBe(true)
+      })
+    })
+
+    describe('Lessons.status', () => {
+      it('should have index: true', () => {
+        const field = Lessons.fields?.find((f) => 'name' in f && f.name === 'status') as
+          | { name: string; index?: boolean }
+          | undefined
+        expect(field).toBeDefined()
+        expect(field?.index).toBe(true)
+      })
+    })
+
+    describe('Tenants.status', () => {
+      it('should have index: true', () => {
+        const field = Tenants.fields?.find((f) => 'name' in f && f.name === 'status') as
+          | { name: string; index?: boolean }
+          | undefined
+        expect(field).toBeDefined()
+        expect(field?.index).toBe(true)
+      })
+    })
+  })
+
+  describe('Relationship Fields', () => {
+    describe('Courses.categories', () => {
+      it('should have index: true', () => {
+        const field = Courses.fields?.find((f) => 'name' in f && f.name === 'categories') as
+          | { name: string; index?: boolean }
+          | undefined
+        expect(field).toBeDefined()
+        expect(field?.index).toBe(true)
+      })
+    })
+
+    describe('Posts.categories', () => {
+      it('should have index: true', () => {
+        const field = findFieldByName(Posts.fields as Field[], 'categories') as
+          | { name: string; index?: boolean }
+          | undefined
+        expect(field).toBeDefined()
+        expect(field?.index).toBe(true)
+      })
+    })
+
+    describe('Posts.authors', () => {
+      it('should have index: true', () => {
+        const field = findFieldByName(Posts.fields as Field[], 'authors') as
+          | { name: string; index?: boolean }
+          | undefined
+        expect(field).toBeDefined()
+        expect(field?.index).toBe(true)
+      })
+    })
+
+    describe('Exercises.sourceDoc', () => {
+      it('should have index: true', () => {
+        const field = findFieldByName(Exercises.fields as Field[], 'sourceDoc') as
+          | { name: string; index?: boolean }
+          | undefined
+        expect(field).toBeDefined()
+        expect(field?.index).toBe(true)
+      })
+    })
+
+    describe('ConfigAuditLogs.tenant', () => {
+      it('should have index: true', () => {
+        const field = ConfigAuditLogs.fields?.find((f) => 'name' in f && f.name === 'tenant') as
+          | { name: string; index?: boolean }
+          | undefined
+        expect(field).toBeDefined()
+        expect(field?.index).toBe(true)
+      })
+    })
+
+    describe('GuestSessions.claimedByUser', () => {
+      it('should have index: true', () => {
+        const field = GuestSessions.fields?.find(
+          (f) => 'name' in f && f.name === 'claimedByUser',
+        ) as { name: string; index?: boolean } | undefined
+        expect(field).toBeDefined()
+        expect(field?.index).toBe(true)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Add MongoDB indexes to frequently queried fields to improve query performance and prevent full collection scans.

## Commits

```
24589769 ci(cody): commit task files for 260226-add-missing-indexes
674f9e5f ci(cody): commit task files for 260226-add-missing-indexes
18aafadb refactor(260226-add-missing-indexes): Issue Title
8a26936b Merge remote-tracking branch 'origin/dev' into refactor/260226-add-medium-performance-missing-indexes-on-s
f2f55e95 ci(cody): commit task files for 260226-add-missing-indexes
```

Closes #508

---
🤖 Generated by Cody pipeline