### PR TITLE
fix: Resolve lesson 404 caused by depth reduction in security commit

### DIFF
--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/complete/page.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/complete/page.tsx
@@ -25,10 +25,13 @@ export async function generateMetadata({ params }: CompletePageProps): Promise<M
   }
 
   const lessonChapter = typeof lesson.chapter === 'string' ? null : lesson.chapter
-  const lessonCourse =
-    lessonChapter && typeof lessonChapter.course !== 'string' ? lessonChapter.course : null
+  const lessonCourseId = lessonChapter
+    ? typeof lessonChapter.course === 'string'
+      ? lessonChapter.course
+      : lessonChapter.course?.id
+    : null
 
-  if (!lessonCourse || lessonCourse.id !== course.id) {
+  if (!lessonCourseId || lessonCourseId !== course.id) {
     return { title: 'Lesson Complete' }
   }
 
@@ -55,10 +58,13 @@ export default async function CompletePage({ params }: CompletePageProps) {
   }
 
   const lessonChapter = typeof lesson.chapter === 'string' ? null : lesson.chapter
-  const lessonCourse =
-    lessonChapter && typeof lessonChapter.course !== 'string' ? lessonChapter.course : null
+  const lessonCourseId = lessonChapter
+    ? typeof lessonChapter.course === 'string'
+      ? lessonChapter.course
+      : lessonChapter.course?.id
+    : null
 
-  if (!lessonCourse || lessonCourse.id !== course.id) {
+  if (!lessonCourseId || lessonCourseId !== course.id) {
     notFound()
   }
 

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/page.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/page.tsx
@@ -66,10 +66,13 @@ export default async function ExercisePage({ params }: ExercisePageProps) {
   }
 
   const lessonChapter = typeof lesson.chapter === 'string' ? null : lesson.chapter
-  const lessonCourse =
-    lessonChapter && typeof lessonChapter.course !== 'string' ? lessonChapter.course : null
+  const lessonCourseId = lessonChapter
+    ? typeof lessonChapter.course === 'string'
+      ? lessonChapter.course
+      : lessonChapter.course?.id
+    : null
 
-  if (!lessonCourse || lessonCourse.id !== course.id) {
+  if (!lessonCourseId || lessonCourseId !== course.id) {
     notFound()
   }
 
@@ -124,10 +127,13 @@ export async function generateMetadata({ params }: ExercisePageProps) {
   }
 
   const lessonChapter = typeof lesson.chapter === 'string' ? null : lesson.chapter
-  const lessonCourse =
-    lessonChapter && typeof lessonChapter.course !== 'string' ? lessonChapter.course : null
+  const lessonCourseId = lessonChapter
+    ? typeof lessonChapter.course === 'string'
+      ? lessonChapter.course
+      : lessonChapter.course?.id
+    : null
 
-  if (!lessonCourse || lessonCourse.id !== course.id) {
+  if (!lessonCourseId || lessonCourseId !== course.id) {
     return {
       title: 'Exercise Not Found',
     }

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/page.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/page.tsx
@@ -40,10 +40,13 @@ export default async function LessonPage({ params }: LessonPageProps) {
   }
 
   const lessonChapter = typeof lesson.chapter === 'string' ? null : lesson.chapter
-  const lessonCourse =
-    lessonChapter && typeof lessonChapter.course !== 'string' ? lessonChapter.course : null
+  const lessonCourseId = lessonChapter
+    ? typeof lessonChapter.course === 'string'
+      ? lessonChapter.course
+      : lessonChapter.course?.id
+    : null
 
-  if (!lessonCourse || lessonCourse.id !== course.id) {
+  if (!lessonCourseId || lessonCourseId !== course.id) {
     notFound()
   }
 
@@ -194,10 +197,13 @@ export async function generateMetadata({ params }: LessonPageProps) {
   }
 
   const lessonChapter = typeof lesson.chapter === 'string' ? null : lesson.chapter
-  const lessonCourse =
-    lessonChapter && typeof lessonChapter.course !== 'string' ? lessonChapter.course : null
+  const lessonCourseId = lessonChapter
+    ? typeof lessonChapter.course === 'string'
+      ? lessonChapter.course
+      : lessonChapter.course?.id
+    : null
 
-  if (!lessonCourse || lessonCourse.id !== course.id) {
+  if (!lessonCourseId || lessonCourseId !== course.id) {
     return {
       title: 'Lesson Not Found',
     }

--- a/tests/unit/scripts/cody/scripted-stages.test.ts
+++ b/tests/unit/scripts/cody/scripted-stages.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
 import * as childProcess from 'child_process'
 import * as fs from 'fs'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getDefaultBranch } from '../../../../scripts/cody/git-utils'
 
 // Mock for fetch - need to use hoisted mock
@@ -29,7 +29,7 @@ vi.mock('../../../../scripts/cody/git-utils', () => ({
   getDefaultBranch: vi.fn().mockReturnValue('dev'),
 }))
 
-import { runVerifyStage, runPrStage } from '../../../../scripts/cody/scripted-stages'
+import { runPrStage, runVerifyStage } from '../../../../scripts/cody/scripted-stages'
 
 // Silence console output during tests
 vi.spyOn(console, 'log').mockImplementation(() => {})
@@ -499,6 +499,8 @@ describe('runVerifyStage', () => {
 describe('runPrStage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Set GitHub token for runPrStage tests
+    process.env.GH_PAT = 'test-token-for-pr-stage'
     // Reset getDefaultBranch mock to default
     mockGetDefaultBranch.mockReturnValue('dev')
     // Default mocks for fs
@@ -514,6 +516,10 @@ describe('runPrStage', () => {
       ok: true,
       json: async () => ({ html_url: 'https://github.com/owner/repo/pull/42' }),
     } as unknown as Response)
+  })
+
+  afterEach(() => {
+    delete process.env.GH_PAT
   })
 
   /**

--- a/tests/unit/scripts/scripted-stages.spec.ts
+++ b/tests/unit/scripts/scripted-stages.spec.ts
@@ -5,8 +5,8 @@
  * @ai-summary Tests for scripted-stages.ts: buildPrTitle (heading strip), buildPrBody (Closes # link), runPrStage (issueNumber wiring), and audit-history path in STAGE_CONTEXT_FILES
  */
 
-import { describe, expect, it, vi, beforeEach } from 'vitest'
 import * as path from 'path'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // ============================================================================
 // Mocks
@@ -65,6 +65,8 @@ const _DEFAULT_BRANCH = 'dev' // reserved for future use
 // ============================================================================
 
 function resetMocks() {
+  // Set GitHub token for runPrStage tests
+  process.env.GH_PAT = 'test-token-for-pr-stage'
   mockExecFileSync.mockReset()
   mockExecSync.mockReset()
   mockFetch.mockReset()
@@ -111,7 +113,7 @@ describe('STAGE_CONTEXT_FILES audit-history path', () => {
 
     expect(auditEntry).toBeDefined()
     const resolved = path.normalize(`${taskDir}/${auditEntry}`)
-    expect(resolved).toBe('.tasks/audit-history.json')
+    expect(resolved).toMatch(/^\.tasks[/\\]audit-history\.json$/)
   })
 })
 
@@ -533,4 +535,9 @@ describe('runPrStage failure handling', () => {
     expect(result.created).toBe(false)
     expect(result.url).toBe('')
   })
+})
+
+// Clean up environment variable after all tests
+afterAll(() => {
+  delete process.env.GH_PAT
 })


### PR DESCRIPTION
The security commit (869c6557) changed queryLessonBySlug depth from 2 to 1, but 3 page files still assumed lesson.chapter.course was a populated object. With depth 1, it's a string ID, so the hierarchy check always failed → 404.

Extract course ID (works for both string and object) instead of requiring a populated Course object for the ownership validation.