### PR TITLE
fix(cody): Clean up noisy CI run logs

### DIFF
--- a/scripts/cody/agent-runner.ts
+++ b/scripts/cody/agent-runner.ts
@@ -352,6 +352,18 @@ export function runAgentWithFileWatch(
         // Non-fatal: skip artifact file if can't create
       }
 
+      // Stderr capture for failure debugging
+      let stderrLineCount = 0
+      const stderrTailLines: string[] = [] // Rolling buffer of last N lines
+      const STDERR_TAIL_SIZE = 50
+      let stderrLogFd: number | null = null
+      try {
+        const stderrLogPath = path.join(path.dirname(outputFile), `${stage}-stderr.log`)
+        stderrLogFd = fs.openSync(stderrLogPath, 'w')
+      } catch {
+        // Non-fatal: skip stderr file if can't create
+      }
+
       // Register cleanup handler to prevent FD leak on unexpected exit
       const cleanupFd = () => {
         if (jsonLogFd !== null) {
@@ -361,6 +373,14 @@ export function runAgentWithFileWatch(
             /* ignore */
           }
           jsonLogFd = null
+        }
+        if (stderrLogFd !== null) {
+          try {
+            fs.closeSync(stderrLogFd)
+          } catch {
+            /* ignore */
+          }
+          stderrLogFd = null
         }
       }
       process.on('exit', cleanupFd)
@@ -409,6 +429,38 @@ export function runAgentWithFileWatch(
         })
       }
 
+      // Handle stderr - write to file, surface on failure
+      if (currentChild.stderr) {
+        let stderrBuffer = ''
+        currentChild.stderr.on('data', (data: Buffer) => {
+          const chunk = data.toString()
+          stderrBuffer += chunk
+
+          const lines = stderrBuffer.split('\n')
+          stderrBuffer = lines.pop() || ''
+
+          for (const line of lines) {
+            if (!line.trim()) continue
+            stderrLineCount++
+
+            // Write to file
+            if (stderrLogFd !== null) {
+              try {
+                fs.writeSync(stderrLogFd, line + '\n')
+              } catch {
+                /* ignore */
+              }
+            }
+
+            // Keep rolling tail buffer
+            stderrTailLines.push(line)
+            if (stderrTailLines.length > STDERR_TAIL_SIZE) {
+              stderrTailLines.shift()
+            }
+          }
+        })
+      }
+
       const finish = (result: { succeeded: boolean; timedOut: boolean }) => {
         if (resolved) return
         resolved = true
@@ -448,6 +500,15 @@ export function runAgentWithFileWatch(
           }
           jsonLogFd = null
         }
+        // Close stderr log file descriptor
+        if (stderrLogFd !== null) {
+          try {
+            fs.closeSync(stderrLogFd)
+          } catch {
+            /* ignore */
+          }
+          stderrLogFd = null
+        }
         // Remove exit cleanup handler (FD already closed)
         process.removeListener('exit', cleanupFd)
         resolve({ ...result, retries, validationErrors, sessionId: extractedSessionId })
@@ -477,6 +538,20 @@ export function runAgentWithFileWatch(
       // Process exit handler - wait for file stability after exit
       currentChild.on('exit', async (code) => {
         logger.info(`  📡 Process exited with code: ${code}`)
+
+        // Surface stderr on failure
+        if (code !== 0 && stderrTailLines.length > 0) {
+          const isCI = !!process.env.GITHUB_ACTIONS
+          if (isCI) process.stderr.write('::group::Agent stderr (last lines)\n')
+          for (const line of stderrTailLines) {
+            process.stderr.write('  ' + line + '\n')
+          }
+          if (isCI) process.stderr.write('::endgroup::\n')
+        } else if (stderrLineCount > 0) {
+          logger.info(
+            `  📝 Agent stderr: ${stderrLineCount} lines captured (see ${stage}-stderr.log)`,
+          )
+        }
 
         if (resolved) return
 

--- a/scripts/cody/chat-history.ts
+++ b/scripts/cody/chat-history.ts
@@ -173,6 +173,7 @@ export async function appendSession(
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: process.cwd(),
+      maxBuffer: 50 * 1024 * 1024, // 50MB — session exports can be very large
     }).replace(/^Exporting session:.*\n/, '') // Remove the "Exporting session:" line
 
     const rawExport = JSON.parse(output)

--- a/scripts/cody/engine/state-machine.ts
+++ b/scripts/cody/engine/state-machine.ts
@@ -14,7 +14,7 @@ import type {
   StageResult,
   PipelineStep,
 } from './types'
-import { logger } from '../logger'
+import { logger, ciGroup, ciGroupEnd } from '../logger'
 import { PipelinePausedError } from './types'
 import {
   loadState,
@@ -276,12 +276,14 @@ async function executeSingleStep(
   }
 
   // Get handler and execute
-  const handler = getHandler(def.name, def.type)
-
+  ciGroup(`Stage: ${stageName}`)
   try {
+    const handler = getHandler(def.name, def.type)
     const result = await handler.execute(ctx, def)
+    ciGroupEnd()
     return await handleStageResult(ctx, state, stageName, result, def)
   } catch (error) {
+    ciGroupEnd()
     if (error instanceof PipelinePausedError) {
       // Handle paused - mark stage as paused and pipeline as paused
       state = updateStage(state, stageName, { state: 'paused' })
@@ -404,7 +406,9 @@ async function executeParallelStep(
 
       const reason = (result as PromiseRejectedResult).reason
       const name =
-        reason instanceof StageError ? reason.stageName : (reason as any)?.stageName || 'unknown'
+        reason instanceof StageError
+          ? reason.stageName
+          : (((reason as Record<string, unknown>)?.stageName as string) ?? 'unknown')
       const message = reason instanceof Error ? reason.message : String(reason)
       // R7: Use dynamic advisory lookup from pipeline definition
       const isAdvisory = pipeline.stages.get(name)?.advisory === true

--- a/scripts/cody/logger.ts
+++ b/scripts/cody/logger.ts
@@ -15,23 +15,18 @@ let _logger: ReturnType<typeof pino> | null = null
 function getPinoLogger() {
   if (!_logger) {
     const env = getEnv()
-    // JSON in CI (for log aggregation), pretty-print locally
     const isCI = !!env.GITHUB_ACTIONS
 
     _logger = pino({
       level: env.LOG_LEVEL || 'info',
-      ...(isCI
-        ? {} // Default JSON output for CI
-        : {
-            transport: {
-              target: 'pino-pretty',
-              options: {
-                colorize: true,
-                translateTime: 'SYS:HH:MM:ss',
-                ignore: 'pid,hostname',
-              },
-            },
-          }),
+      transport: {
+        target: 'pino-pretty',
+        options: {
+          colorize: !isCI,
+          translateTime: 'SYS:HH:MM:ss',
+          ignore: 'pid,hostname',
+        },
+      },
     })
   }
   return _logger
@@ -54,6 +49,30 @@ export function createStageLogger(stage: string, taskId?: string) {
 // Re-export pino logger for backward compatibility
 export const logger = getPinoLogger()
 export default logger
+
+// ============================================================================
+// CI Log Grouping (GitHub Actions)
+// ============================================================================
+
+/**
+ * Emit a GitHub Actions collapsible group header.
+ * No-op when not running in CI.
+ */
+export function ciGroup(title: string): void {
+  if (process.env.GITHUB_ACTIONS) {
+    process.stdout.write(`::group::${title}\n`)
+  }
+}
+
+/**
+ * Emit a GitHub Actions collapsible group footer.
+ * No-op when not running in CI.
+ */
+export function ciGroupEnd(): void {
+  if (process.env.GITHUB_ACTIONS) {
+    process.stdout.write('::endgroup::\n')
+  }
+}
 
 // ============================================================================
 // Legacy structured logging functions (using console)

--- a/scripts/cody/pipeline/post-actions.ts
+++ b/scripts/cody/pipeline/post-actions.ts
@@ -289,10 +289,15 @@ export async function executePostAction(
 
       logger.info('   Running tsc...')
       try {
-        execFileSync('pnpm', ['-s', 'tsc', '--noEmit'], { stdio: 'inherit' })
+        execFileSync('pnpm', ['-s', 'tsc', '--noEmit'], {
+          encoding: 'utf-8',
+          maxBuffer: 10 * 1024 * 1024,
+        })
         logger.info('   ✓ tsc passed')
-      } catch {
-        throw new Error('TypeScript compilation failed')
+      } catch (error) {
+        const err = error as { stdout?: string; stderr?: string; message?: string }
+        const output = (err.stdout || '') + (err.stderr || '') || err.message || ''
+        throw new Error(`TypeScript compilation failed:\n${output.slice(0, 3000)}`)
       }
       break
     }
@@ -302,7 +307,10 @@ export async function executePostAction(
 
       logger.info('   Running unit tests...')
       try {
-        execFileSync('pnpm', ['-s', 'test:unit'], { stdio: 'inherit' })
+        execFileSync('pnpm', ['-s', 'test:unit'], {
+          encoding: 'utf-8',
+          maxBuffer: 10 * 1024 * 1024,
+        })
         logger.info('   ✓ Unit tests passed')
       } catch (error) {
         // G25: Include output text (3000 chars) for supervisor retry

--- a/scripts/cody/runner-backend.ts
+++ b/scripts/cody/runner-backend.ts
@@ -26,12 +26,6 @@ export class GitHubRunner implements RunnerBackend {
   name = 'opencode-github'
 
   spawn(stage: string, prompt: string, env: NodeJS.ProcessEnv, cwd: string): ChildProcess {
-    console.error(
-      '[DEBUG] GitHubRunner spawn called, stage:',
-      stage,
-      'prompt length:',
-      prompt.length,
-    )
     // Use opencode run --agent instead of opencode github run
     // opencode github run does NOT support --agent flag and ignores AGENT env var
     // opencode run supports --agent which loads correct agent from opencode.json
@@ -42,8 +36,8 @@ export class GitHubRunner implements RunnerBackend {
       ['exec', 'opencode', 'run', '--agent', stage, '--format', 'json', prompt],
       {
         cwd,
-        // Pipe stdout for JSON parsing (sessionID extraction), inherit stderr
-        stdio: ['ignore', 'pipe', 'inherit'], // stdin=ignore prevents opencode blocking on stdin read
+        // Pipe stdout for JSON parsing (sessionID extraction), pipe stderr for capture
+        stdio: ['ignore', 'pipe', 'pipe'], // stdin=ignore prevents opencode blocking on stdin read
         env,
       },
     )
@@ -63,8 +57,8 @@ export class LocalRunner implements RunnerBackend {
     // Use --format json to get sessionID in output for chat history capture
     return spawn('pnpm', ['ocode', 'run', '--agent', stage, '--format', 'json', prompt], {
       cwd,
-      // Pipe stdout for JSON parsing (sessionID extraction), inherit stderr
-      stdio: ['ignore', 'pipe', 'inherit'], // stdin=ignore prevents opencode blocking on stdin read
+      // Pipe stdout for JSON parsing (sessionID extraction), pipe stderr for capture
+      stdio: ['ignore', 'pipe', 'pipe'], // stdin=ignore prevents opencode blocking on stdin read
       env: {
         ...env,
         AGENT: stage,

--- a/tests/unit/scripts/cody/runner-backend.test.ts
+++ b/tests/unit/scripts/cody/runner-backend.test.ts
@@ -31,7 +31,7 @@ describe('GitHubRunner', () => {
       ['exec', 'opencode', 'run', '--agent', 'spec', '--format', 'json', 'Write tests'],
       {
         cwd: '/my/project',
-        stdio: ['ignore', 'pipe', 'inherit'],
+        stdio: ['ignore', 'pipe', 'pipe'],
         env: { PATH: '/usr/bin' },
       },
     )
@@ -48,7 +48,7 @@ describe('GitHubRunner', () => {
       ['exec', 'opencode', 'run', '--agent', 'execute', '--format', 'json', 'Do the thing'],
       expect.objectContaining({
         cwd: '/workspace/repo',
-        stdio: ['ignore', 'pipe', 'inherit'],
+        stdio: ['ignore', 'pipe', 'pipe'],
         env: {},
       }),
     )
@@ -89,7 +89,7 @@ describe('LocalRunner', () => {
     expect(spawn).toHaveBeenCalledWith(
       'pnpm',
       ['ocode', 'run', '--agent', 'spec', '--format', 'json', 'Write a spec'],
-      expect.objectContaining({ cwd: '/my/project', stdio: ['ignore', 'pipe', 'inherit'] }),
+      expect.objectContaining({ cwd: '/my/project', stdio: ['ignore', 'pipe', 'pipe'] }),
     )
   })
 


### PR DESCRIPTION
## What / Why

The Cody pipeline run logs were extremely noisy and hard to read. Six compounding issues made debugging in GitHub Actions painful:

1. **Raw JSON pino output in CI** — Every log line was a full JSON blob like `{"level":30,"time":...,"msg":"..."}` instead of human-readable format. The JSON was added "for log aggregation" but **no log aggregation service exists** — nothing parses it.

2. **Agent stderr inherited directly to run log** — `stdio: ['ignore', 'pipe', 'inherit']` meant opencode's internal logs flowed unfiltered into the run log. This was the single noisiest source.

3. **tsc/test output dumped via `stdio: 'inherit'`** — Full TypeScript compilation and test runner output went straight to the log even on success.

4. **No collapsible sections** — Verbose stage execution details had no visual grouping.

5. **Leftover debug console.error** — `[DEBUG] GitHubRunner spawn called...` emitted on every agent spawn.

6. **ENOBUFS crash on large session exports** — `execFileSync` with no `maxBuffer` crashed when session export JSON exceeded the OS pipe buffer (~64KB). Seen in production with task `ses_340a053aeffep5FHrnvuOJ0i86`.

## Scope of Changes

| File | Change |
|------|--------|
| `scripts/cody/logger.ts` | Always use pino-pretty (no more JSON in CI). Added `ciGroup()`/`ciGroupEnd()` helpers. |
| `scripts/cody/runner-backend.ts` | Pipe stderr instead of inheriting. Removed debug console.error. |
| `scripts/cody/agent-runner.ts` | Stderr capture → `<stage>-stderr.log` file, rolling 50-line tail buffer, surface only on failure. |
| `scripts/cody/pipeline/post-actions.ts` | Pipe tsc/test output, log only on failure (with 10MB maxBuffer). |
| `scripts/cody/engine/state-machine.ts` | Wrap stage execution with `::group::`/`::endgroup::`. Fixed pre-existing eslint `any` warning. |
| `scripts/cody/chat-history.ts` | Added 50MB maxBuffer to session export. |
| `tests/unit/scripts/cody/runner-backend.test.ts` | Updated stdio expectations from `'inherit'` to `'pipe'`. |

## How It Was Tested

✓ pnpm -s tsc --noEmit - PASSED (0 errors)
✓ pnpm -s lint - PASSED (0 warnings)
✓ pnpm -s format - PASSED
✓ pnpm vitest run - PASSED (179 files, 3039 tests, 0 failures)
✓ Pre-commit hooks passed (lint-staged + typecheck)
✓ Pre-push hooks passed (full verification gate)

## Before/After

**Before** (raw JSON, unfiltered agent output):
```
{"level":30,"time":1772738222332,"pid":32495,"hostname":"macs-MacBook-Pro.local","msg":"  💓 Still working on stage 'build'..."}
[DEBUG] GitHubRunner spawn called, stage: build prompt length: 4523
<hundreds of lines of opencode internal stderr>
```

**After** (human-readable, quiet on success):
```
21:53:29 INFO: 💓 Still working on stage 'build'...
📝 Agent stderr: 142 lines captured (see build-stderr.log)
```

## Risks / Rollback Notes

- **Low risk**: All changes are about output routing, not business logic
- **Rollback**: Revert the single commit
- **Monitor**: Check next pipeline run to confirm logs are cleaner and no output is lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)