### PR TITLE
fix: Harden health endpoint and optimize hooks

### DIFF
--- a/.claude/hooks/hooks.json
+++ b/.claude/hooks/hooks.json
@@ -115,20 +115,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"const{execSync}=require('child_process');const fs=require('fs');const path=require('path');let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const i=JSON.parse(d);const p=i.tool_input?.file_path;if(p&&fs.existsSync(p)){let dir=path.dirname(p);while(dir!==path.dirname(dir)&&!fs.existsSync(path.join(dir,'tsconfig.json'))){dir=path.dirname(dir)}if(fs.existsSync(path.join(dir,'tsconfig.json'))){try{const r=execSync('npx tsc --noEmit --pretty false 2>&1',{cwd:dir,encoding:'utf8',stdio:['pipe','pipe','pipe']});const lines=r.split('\\n').filter(l=>l.includes(p)).slice(0,10);if(lines.length)console.error(lines.join('\\n'))}catch(e){const lines=(e.stdout||'').split('\\n').filter(l=>l.includes(p)).slice(0,10);if(lines.length)console.error(lines.join('\\n'))}}}console.log(d)})\""
+            "command": "node -e \"const{execSync}=require('child_process');const fs=require('fs');const path=require('path');let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const i=JSON.parse(d);const p=i.tool_input?.file_path;if(p&&fs.existsSync(p)){let dir=path.dirname(p);while(dir!==path.dirname(dir)&&!fs.existsSync(path.join(dir,'tsconfig.json'))){dir=path.dirname(dir)}if(fs.existsSync(path.join(dir,'tsconfig.json'))){try{const r=execSync('npx tsc --noEmit --pretty false 2>&1',{cwd:dir,encoding:'utf8',stdio:['pipe','pipe','pipe']});const lines=r.split('\\n').filter(l=>l.includes(p)).slice(0,10);if(lines.length)console.error(lines.join('\\n'))}catch(e){const lines=(e.stdout||'').split('\\n').filter(l=>l.includes(p)).slice(0,10);if(lines.length)console.error(lines.join('\\n'))}}}console.log(d)})\"",
+            "async": true,
+            "timeout": 30
           }
         ],
-        "description": "TypeScript check after editing .ts/.tsx files"
-      },
-      {
-        "matcher": "tool == \"Edit\" && tool_input.file_path matches \"\\\\.(ts|tsx|js|jsx)$\"",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node -e \"const fs=require('fs');let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const i=JSON.parse(d);const p=i.tool_input?.file_path;if(p&&fs.existsSync(p)){const c=fs.readFileSync(p,'utf8');const lines=c.split('\\n');const matches=[];lines.forEach((l,idx)=>{if(/console\\.log/.test(l))matches.push((idx+1)+': '+l.trim())});if(matches.length){console.error('[Hook] WARNING: console.log found in '+p);matches.slice(0,5).forEach(m=>console.error(m));console.error('[Hook] Remove console.log before committing')}}console.log(d)})\""
-          }
-        ],
-        "description": "Warn about console.log statements after edits"
+        "description": "TypeScript check after editing .ts/.tsx files (async, non-blocking)"
       }
     ],
     "Stop": [

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,73 +1,43 @@
 import { NextResponse } from 'next/server'
-import { execSync } from 'child_process'
-import { readFileSync } from 'fs'
-import { join } from 'path'
+import { getPayload } from 'payload'
+import configPromise from '@payload-config'
 
 export const dynamic = 'force-dynamic'
 
 interface HealthResponse {
   ok: boolean
+  checks: {
+    database: boolean
+  }
+  version: string
   gitSha: string
-  payloadVersion: string
-  projectVersion: string
   timestamp: string
-}
-
-function getGitSha(): string {
-  if (process.env.GIT_SHA) {
-    return process.env.GIT_SHA
-  }
-  try {
-    return execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim()
-  } catch {
-    return 'unknown'
-  }
-}
-
-function getPayloadVersion(): string {
-  try {
-    const packageJsonPath = join(process.cwd(), 'package.json')
-    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'))
-    return packageJson.dependencies?.payload || packageJson.devDependencies?.payload || 'unknown'
-  } catch {
-    return 'unknown'
-  }
-}
-
-function getProjectVersion(): string {
-  try {
-    const packageJsonPath = join(process.cwd(), 'package.json')
-    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'))
-    return packageJson.version || 'unknown'
-  } catch {
-    return 'unknown'
-  }
 }
 
 export async function GET(): Promise<
   NextResponse<HealthResponse> | NextResponse<{ error: string }>
 > {
-  try {
-    const gitSha = getGitSha()
-    const payloadVersion = getPayloadVersion()
-    const projectVersion = getProjectVersion()
-    const timestamp = new Date().toISOString()
-
-    const response: HealthResponse = {
-      ok: true,
-      gitSha,
-      payloadVersion,
-      projectVersion,
-      timestamp,
-    }
-
-    return NextResponse.json(response, { status: 200 })
-  } catch {
-    return NextResponse.json({ error: 'Health check failed' }, { status: 500 })
+  const checks = {
+    database: false,
   }
+
+  try {
+    const payload = await getPayload({ config: configPromise })
+    await payload.find({ collection: 'users', limit: 1, depth: 0 })
+    checks.database = true
+  } catch {
+    checks.database = false
+  }
+
+  const ok = checks.database
+  const version = process.env.npm_package_version || 'unknown'
+  const gitSha = process.env.GIT_SHA || 'unknown'
+  const timestamp = new Date().toISOString()
+
+  return NextResponse.json({ ok, checks, version, gitSha, timestamp }, { status: ok ? 200 : 503 })
 }
 
-// Simple ping endpoint for load balancers and health checks - no expensive operations
+// Simple ping endpoint for load balancers - no expensive operations
 export async function HEAD(): Promise<NextResponse> {
   return new NextResponse(null, { status: 200 })
 }

--- a/tests/int/health.api.int.spec.ts
+++ b/tests/int/health.api.int.spec.ts
@@ -11,16 +11,16 @@ describe('GET /api/health', () => {
     const response = await GET()
     const data = (await response.json()) as {
       ok: boolean
+      checks: { database: boolean }
+      version: string
       gitSha: string
-      payloadVersion: string
-      projectVersion: string
       timestamp: string
     }
 
     expect(data).toHaveProperty('ok')
+    expect(data).toHaveProperty('checks')
+    expect(data).toHaveProperty('version')
     expect(data).toHaveProperty('gitSha')
-    expect(data).toHaveProperty('payloadVersion')
-    expect(data).toHaveProperty('projectVersion')
     expect(data).toHaveProperty('timestamp')
   })
 
@@ -35,15 +35,13 @@ describe('GET /api/health', () => {
   it('returns string values for all fields', async () => {
     const response = await GET()
     const data = (await response.json()) as {
+      version: string
       gitSha: string
-      payloadVersion: string
-      projectVersion: string
       timestamp: string
     }
 
     expect(typeof data.gitSha).toBe('string')
-    expect(typeof data.payloadVersion).toBe('string')
-    expect(typeof data.projectVersion).toBe('string')
+    expect(typeof data.version).toBe('string')
     expect(typeof data.timestamp).toBe('string')
   })
 


### PR DESCRIPTION
Task 6: Rewrite health endpoint with DB connectivity check, remove

execSync/readFileSync, return 503 on failure with structured response.

Task 8: Make TSC hook async, remove duplicate console.log check hook.