### PR TITLE
fix: Trim whitespace from slug fields to prevent 404s

### DIFF
--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/page.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/page.tsx
@@ -35,24 +35,11 @@ export default async function LessonPage({ params }: LessonPageProps) {
     queryLessonBySlug({ slug: lessonSlug }),
   ])
 
-  // DEBUG: Log to identify 404 cause
-  console.log('[LessonPage DEBUG] courseSlug:', courseSlug, 'course:', course?.id)
-  console.log(
-    '[LessonPage DEBUG] lessonSlug:',
-    lessonSlug,
-    'lesson:',
-    lesson?.id,
-    'lesson.chapter:',
-    lesson?.chapter,
-  )
-
   if (!course || !lesson) {
-    console.log('[LessonPage DEBUG] 404: course or lesson not found')
     notFound()
   }
 
   const lessonChapter = typeof lesson.chapter === 'string' ? null : lesson.chapter
-  console.log('[LessonPage DEBUG] lessonChapter:', lessonChapter)
   const lessonCourseId = lessonChapter
     ? typeof lessonChapter.course === 'string'
       ? lessonChapter.course
@@ -60,22 +47,13 @@ export default async function LessonPage({ params }: LessonPageProps) {
     : null
 
   if (!lessonCourseId || lessonCourseId !== course.id) {
-    console.log('[LessonPage DEBUG] 404: lessonCourseId mismatch', lessonCourseId, '!=', course.id)
     notFound()
   }
 
   // Verify lesson belongs to the specified chapter
   if (!lessonChapter || lessonChapter.slug !== chapterSlug) {
-    console.log(
-      '[LessonPage DEBUG] 404: chapter slug mismatch',
-      lessonChapter?.slug,
-      '!=',
-      chapterSlug,
-    )
     notFound()
   }
-
-  console.log('[LessonPage DEBUG] All checks passed, rendering page')
 
   const effectiveAccessType = resolveAccessType(lesson.accessType, course.accessType)
   const [gatedDelayMs, gatedWarningMs] = await Promise.all([

--- a/src/server/payload/collections/Chapters.ts
+++ b/src/server/payload/collections/Chapters.ts
@@ -18,6 +18,9 @@ export const Chapters: CollectionConfig = {
   hooks: {
     beforeChange: [
       ({ data }) => {
+        if (data?.slug) {
+          data.slug = data.slug.trim()
+        }
         if (data?.title && !data?.slug) {
           data.slug = formatSlug(data.title)
         }

--- a/src/server/payload/collections/Courses.ts
+++ b/src/server/payload/collections/Courses.ts
@@ -31,6 +31,9 @@ export const Courses: CollectionConfig = {
   hooks: {
     beforeChange: [
       ({ data }) => {
+        if (data?.slug) {
+          data.slug = data.slug.trim()
+        }
         if (data?.title && !data?.slug) {
           data.slug = formatSlug(data.title)
         }

--- a/src/server/payload/collections/Lessons.ts
+++ b/src/server/payload/collections/Lessons.ts
@@ -18,6 +18,9 @@ export const Lessons: CollectionConfig = {
   hooks: {
     beforeChange: [
       ({ data }) => {
+        if (data?.slug) {
+          data.slug = data.slug.trim()
+        }
         if (data?.title && !data?.slug) {
           // Generate unique slug from title
           // Include timestamp for uniqueness, falling back to random if timestamp not available

--- a/src/server/payload/fields/formatSlug.ts
+++ b/src/server/payload/fields/formatSlug.ts
@@ -11,7 +11,7 @@ import slugify from 'slugify'
  * @returns A URL-safe, lowercase slug string
  */
 export function formatSlug(input: string, fallback?: string): string {
-  const slug = slugify(input, {
+  const slug = slugify(input.trim(), {
     lower: true,
     strict: true,
     locale: 'he',

--- a/src/server/repos/queries/lessons.ts
+++ b/src/server/repos/queries/lessons.ts
@@ -100,12 +100,10 @@ export const queryLessonBySlug = cache(async ({ slug }: { slug: string }) => {
   })
 
   const lesson = result.docs?.[0]
-  console.log('[queryLessonBySlug DEBUG] slug:', slug, 'found:', !!lesson)
   if (!lesson) return null
 
   // Verify parent chapter is published+active
   const chapterId = typeof lesson.chapter === 'string' ? lesson.chapter : lesson.chapter?.id
-  console.log('[queryLessonBySlug DEBUG] chapterId:', chapterId)
 
   if (!chapterId) return null
 
@@ -117,14 +115,6 @@ export const queryLessonBySlug = cache(async ({ slug }: { slug: string }) => {
     disableErrors: true,
   })
 
-  console.log(
-    '[queryLessonBySlug DEBUG] chapterResult:',
-    chapterResult?.id,
-    'status:',
-    chapterResult?.status,
-    'isActive:',
-    chapterResult?.isActive,
-  )
   if (!chapterResult || chapterResult.status !== 'published' || !chapterResult.isActive) {
     return null
   }
@@ -132,8 +122,6 @@ export const queryLessonBySlug = cache(async ({ slug }: { slug: string }) => {
   // Verify grandparent course is published+active (hierarchy invariant)
   const courseId =
     typeof chapterResult.course === 'string' ? chapterResult.course : chapterResult.course?.id
-
-  console.log('[queryLessonBySlug DEBUG] courseId:', courseId)
 
   if (!courseId) return null
 
@@ -145,20 +133,10 @@ export const queryLessonBySlug = cache(async ({ slug }: { slug: string }) => {
     disableErrors: true,
   })
 
-  console.log(
-    '[queryLessonBySlug DEBUG] courseResult:',
-    courseResult?.id,
-    'status:',
-    courseResult?.status,
-    'isActive:',
-    courseResult?.isActive,
-  )
-
   if (!courseResult || courseResult.status !== 'published' || !courseResult.isActive) {
     return null
   }
 
-  console.log('[queryLessonBySlug DEBUG] returning lesson:', lesson.id)
   return lesson
 })
 

--- a/tests/unit/fields/formatSlug.test.ts
+++ b/tests/unit/fields/formatSlug.test.ts
@@ -88,4 +88,21 @@ describe('formatSlug', () => {
       expect(result).toBe('uppercase-lowercase-mixed')
     })
   })
+
+  describe('whitespace trimming (slug 404 prevention)', () => {
+    it('should trim leading whitespace from input', () => {
+      const result = formatSlug(' hello-world')
+      expect(result).toBe('hello-world')
+    })
+
+    it('should trim trailing whitespace from input', () => {
+      const result = formatSlug('hello-world ')
+      expect(result).toBe('hello-world')
+    })
+
+    it('should trim input with only trailing space after numbers', () => {
+      const result = formatSlug('test-slug-682076 ')
+      expect(result).toBe('test-slug-682076')
+    })
+  })
 })


### PR DESCRIPTION
Trailing spaces in manually-entered slugs caused URL mismatch and 404 errors. Added trim() in beforeChange hooks for Courses, Chapters, and Lessons collections, and in the formatSlug utility. Also removed leftover debug console.log statements.