### PR TITLE
feat: Filter courses and chapters by content locale

### DIFF
--- a/src/app/(frontend)/ask/_components/AskContent/index.tsx
+++ b/src/app/(frontend)/ask/_components/AskContent/index.tsx
@@ -5,7 +5,7 @@ import { getUserProfile } from '@/client/state/localStorage/userProfile'
 import { ChatInterface } from '@/ui/web/chat'
 import { logger } from '@/infra/utils/logger'
 import { Loader2 } from 'lucide-react'
-import { useTranslations } from '@/ui/web/providers/I18n'
+import { useLocale, useTranslations } from '@/ui/web/providers/I18n'
 import { ExerciseWorkspace } from '@/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/ExerciseWorkspace'
 import { AskPrimaryContent } from '../AskPrimaryContent'
 
@@ -16,6 +16,7 @@ interface AskContentProps {
 
 export function AskContent({ conversationContextKey }: AskContentProps) {
   const t = useTranslations('homepage.ask')
+  const locale = useLocale()
   const [courseId, setCourseId] = useState<string>('')
   const [isLoading, setIsLoading] = useState(true)
 
@@ -28,7 +29,9 @@ export function AskContent({ conversationContextKey }: AskContentProps) {
       }
 
       try {
-        const response = await fetch(`/api/chapters/by-grade?grade=${profile.gradeLevel}`)
+        const response = await fetch(
+          `/api/chapters/by-grade?grade=${profile.gradeLevel}&locale=${locale}`,
+        )
         if (response.ok) {
           const data = await response.json()
           const courseIdFromData = data.courseId || ''
@@ -52,7 +55,7 @@ export function AskContent({ conversationContextKey }: AskContentProps) {
     }
 
     loadCourse()
-  }, [])
+  }, [locale])
 
   if (isLoading) {
     return (

--- a/src/app/(frontend)/ask/_components/AskConversationGrid/index.tsx
+++ b/src/app/(frontend)/ask/_components/AskConversationGrid/index.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation'
 import { MessageSquare, Sparkles } from 'lucide-react'
 import { getUserProfile } from '@/client/state/localStorage/userProfile'
 import { useExamCountdown } from '@/client/hooks/useExamCountdown'
-import { useTranslations } from '@/ui/web/providers/I18n'
+import { useLocale, useTranslations } from '@/ui/web/providers/I18n'
 import { SystemLink } from '@/infra/loading/components/SystemLink'
 import { cn } from '@/infra/utils/ui'
 import { logger } from '@/infra/utils/logger'
@@ -28,6 +28,7 @@ interface CourseInfo {
 export function AskConversationGrid() {
   const t = useTranslations('coursePage')
   const ts = useTranslations('study')
+  const locale = useLocale()
   const router = useRouter()
   const [conversations, setConversations] = useState<ConversationItem[]>([])
   const [courseInfo, setCourseInfo] = useState<CourseInfo | null>(null)
@@ -65,7 +66,9 @@ export function AskConversationGrid() {
       }
 
       try {
-        const res = await fetch(`/api/chapters/by-grade?grade=${profile.gradeLevel}`)
+        const res = await fetch(
+          `/api/chapters/by-grade?grade=${profile.gradeLevel}&locale=${locale}`,
+        )
         if (res.ok) {
           const data = await res.json()
           const courseId = data.courseId || ''
@@ -96,7 +99,7 @@ export function AskConversationGrid() {
     }
 
     loadData()
-  }, [])
+  }, [locale])
 
   if (isLoading) {
     return (

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/complete/page.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/complete/page.tsx
@@ -1,4 +1,6 @@
 import { notFound } from 'next/navigation'
+import { getSystemLocale } from '@/i18n/server-locale'
+import { isValidContentLocale } from '@/server/payload/fields/contentLocale'
 import { queryCourseBySlug } from '@/server/repos/queries/courses'
 import { queryLessonBySlug } from '@/server/repos/queries/lessons'
 import type { Metadata } from 'next'
@@ -14,9 +16,11 @@ interface CompletePageProps {
 
 export async function generateMetadata({ params }: CompletePageProps): Promise<Metadata> {
   const { courseSlug, chapterSlug, lessonSlug } = await params
+  const locale = await getSystemLocale()
+  const contentLocale = isValidContentLocale(locale) ? locale : undefined
 
   const [course, lesson] = await Promise.all([
-    queryCourseBySlug({ slug: courseSlug }),
+    queryCourseBySlug({ slug: courseSlug, locale: contentLocale }),
     queryLessonBySlug({ slug: lessonSlug }),
   ])
 
@@ -47,9 +51,11 @@ export async function generateMetadata({ params }: CompletePageProps): Promise<M
 
 export default async function CompletePage({ params }: CompletePageProps) {
   const { courseSlug, chapterSlug, lessonSlug } = await params
+  const locale = await getSystemLocale()
+  const contentLocale = isValidContentLocale(locale) ? locale : undefined
 
   const [course, lesson] = await Promise.all([
-    queryCourseBySlug({ slug: courseSlug }),
+    queryCourseBySlug({ slug: courseSlug, locale: contentLocale }),
     queryLessonBySlug({ slug: lessonSlug }),
   ])
 

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/page.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/page.tsx
@@ -1,4 +1,6 @@
 import { notFound, redirect } from 'next/navigation'
+import { getSystemLocale } from '@/i18n/server-locale'
+import { isValidContentLocale } from '@/server/payload/fields/contentLocale'
 import { queryCourseBySlug } from '@/server/repos/queries/courses'
 import { queryLessonBySlug } from '@/server/repos/queries/lessons'
 import {
@@ -55,9 +57,11 @@ async function resolveExercise(lessonId: string, param: string) {
 
 export default async function ExercisePage({ params }: ExercisePageProps) {
   const { courseSlug, chapterSlug, lessonSlug, exerciseSlug } = await params
+  const locale = await getSystemLocale()
+  const contentLocale = isValidContentLocale(locale) ? locale : undefined
 
   const [course, lesson] = await Promise.all([
-    queryCourseBySlug({ slug: courseSlug }),
+    queryCourseBySlug({ slug: courseSlug, locale: contentLocale }),
     queryLessonBySlug({ slug: lessonSlug }),
   ])
 
@@ -114,9 +118,11 @@ export default async function ExercisePage({ params }: ExercisePageProps) {
 
 export async function generateMetadata({ params }: ExercisePageProps) {
   const { courseSlug, chapterSlug, lessonSlug, exerciseSlug } = await params
+  const locale = await getSystemLocale()
+  const contentLocale = isValidContentLocale(locale) ? locale : undefined
 
   const [course, lesson] = await Promise.all([
-    queryCourseBySlug({ slug: courseSlug }),
+    queryCourseBySlug({ slug: courseSlug, locale: contentLocale }),
     queryLessonBySlug({ slug: lessonSlug }),
   ])
 

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/page.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/page.tsx
@@ -4,6 +4,8 @@ import { EmptyLessonPlaceholder } from './_components/EmptyLessonPlaceholder'
 import type { Media } from '@/payload-types'
 import { SystemParams } from '@/infra/config/system-params'
 import { resolveAccessType } from '@/server/constants/access-types'
+import { getSystemLocale } from '@/i18n/server-locale'
+import { isValidContentLocale } from '@/server/payload/fields/contentLocale'
 import { queryCourseBySlug } from '@/server/repos/queries/courses'
 import { queryExercisesByLesson } from '@/server/repos/queries/exercises'
 import { queryLessonBySlug } from '@/server/repos/queries/lessons'
@@ -29,9 +31,11 @@ interface LessonPageProps {
 
 export default async function LessonPage({ params }: LessonPageProps) {
   const { courseSlug, chapterSlug, lessonSlug } = await params
+  const locale = await getSystemLocale()
+  const contentLocale = isValidContentLocale(locale) ? locale : undefined
 
   const [course, lesson] = await Promise.all([
-    queryCourseBySlug({ slug: courseSlug }),
+    queryCourseBySlug({ slug: courseSlug, locale: contentLocale }),
     queryLessonBySlug({ slug: lessonSlug }),
   ])
 
@@ -184,9 +188,11 @@ export default async function LessonPage({ params }: LessonPageProps) {
 
 export async function generateMetadata({ params }: LessonPageProps) {
   const { courseSlug, chapterSlug, lessonSlug } = await params
+  const locale = await getSystemLocale()
+  const contentLocale = isValidContentLocale(locale) ? locale : undefined
 
   const [course, lesson] = await Promise.all([
-    queryCourseBySlug({ slug: courseSlug }),
+    queryCourseBySlug({ slug: courseSlug, locale: contentLocale }),
     queryLessonBySlug({ slug: lessonSlug }),
   ])
 

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/page.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/page.tsx
@@ -1,6 +1,8 @@
 import '@/infra/config/server-init'
 
 import { notFound } from 'next/navigation'
+import { getSystemLocale } from '@/i18n/server-locale'
+import { isValidContentLocale } from '@/server/payload/fields/contentLocale'
 import { queryCourseBySlug } from '@/server/repos/queries/courses'
 import { queryChapterBySlug } from '@/server/repos/queries/chapters'
 import { queryLessonsByChapter } from '@/server/repos/queries/lessons'
@@ -23,9 +25,11 @@ interface ChapterPageProps {
 
 export default async function ChapterPage({ params }: ChapterPageProps) {
   const { courseSlug, chapterSlug } = await params
+  const locale = await getSystemLocale()
+  const contentLocale = isValidContentLocale(locale) ? locale : undefined
 
   const [course, chapter] = await Promise.all([
-    queryCourseBySlug({ slug: courseSlug }),
+    queryCourseBySlug({ slug: courseSlug, locale: contentLocale }),
     queryChapterBySlug({ slug: chapterSlug }),
   ])
 
@@ -107,9 +111,11 @@ export default async function ChapterPage({ params }: ChapterPageProps) {
 
 export async function generateMetadata({ params }: ChapterPageProps) {
   const { courseSlug, chapterSlug } = await params
+  const locale = await getSystemLocale()
+  const contentLocale = isValidContentLocale(locale) ? locale : undefined
 
   const [course, chapter] = await Promise.all([
-    queryCourseBySlug({ slug: courseSlug }),
+    queryCourseBySlug({ slug: courseSlug, locale: contentLocale }),
     queryChapterBySlug({ slug: chapterSlug }),
   ])
 

--- a/src/app/(frontend)/courses/[courseSlug]/page.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/page.tsx
@@ -1,6 +1,8 @@
 import '@/infra/config/server-init'
 
 import { notFound } from 'next/navigation'
+import { getSystemLocale } from '@/i18n/server-locale'
+import { isValidContentLocale } from '@/server/payload/fields/contentLocale'
 import { queryCourseBySlug } from '@/server/repos/queries/courses'
 import { queryChaptersByCourse } from '@/server/repos/queries/chapters'
 import { queryLessonsByCourse } from '@/server/repos/queries/lessons'
@@ -18,7 +20,9 @@ interface CoursePageProps {
 
 export default async function CoursePage({ params }: CoursePageProps) {
   const { courseSlug } = await params
-  const course = await queryCourseBySlug({ slug: courseSlug })
+  const locale = await getSystemLocale()
+  const contentLocale = isValidContentLocale(locale) ? locale : undefined
+  const course = await queryCourseBySlug({ slug: courseSlug, locale: contentLocale })
 
   if (!course) {
     notFound()
@@ -67,7 +71,9 @@ export default async function CoursePage({ params }: CoursePageProps) {
 
 export async function generateMetadata({ params }: CoursePageProps) {
   const { courseSlug } = await params
-  const course = await queryCourseBySlug({ slug: courseSlug })
+  const locale = await getSystemLocale()
+  const contentLocale = isValidContentLocale(locale) ? locale : undefined
+  const course = await queryCourseBySlug({ slug: courseSlug, locale: contentLocale })
 
   if (!course) {
     return { title: 'Course Not Found' }

--- a/src/app/(frontend)/courses/page.tsx
+++ b/src/app/(frontend)/courses/page.tsx
@@ -1,3 +1,6 @@
+import { getDirection } from '@/i18n/config'
+import { getSystemLocale } from '@/i18n/server-locale'
+import { isValidContentLocale } from '@/server/payload/fields/contentLocale'
 import { queryPublishedCourses } from '@/server/repos/queries/courses'
 import { CourseCard } from './_components/CourseCard'
 import { EmptyState } from './_components/EmptyState'
@@ -5,10 +8,12 @@ import { CourseShopHeader } from './_components/CourseShopHeader'
 import { CourseCatalogHeader } from './_components/CourseCatalogHeader'
 
 export default async function CoursesPage() {
-  const courses = await queryPublishedCourses()
+  const locale = await getSystemLocale()
+  const contentLocale = isValidContentLocale(locale) ? locale : undefined
+  const courses = await queryPublishedCourses(contentLocale)
 
   return (
-    <div className="min-h-screen text-card-foreground antialiased" dir="rtl">
+    <div className="min-h-screen text-card-foreground antialiased" dir={getDirection(locale)}>
       {/* Store Header */}
       <CourseShopHeader />
 
@@ -34,8 +39,13 @@ export default async function CoursesPage() {
 }
 
 export async function generateMetadata() {
+  const locale = await getSystemLocale()
+  const isHebrew = locale === 'he'
+
   return {
-    title: 'חנות הקורסים - A-Guy',
-    description: 'בחר את התוכנית המתאימה לך והתקדם להצלחה במתמטיקה.',
+    title: isHebrew ? 'חנות הקורסים - A-Guy' : 'Course Store - A-Guy',
+    description: isHebrew
+      ? 'בחר את התוכנית המתאימה לך והתקדם להצלחה במתמטיקה.'
+      : 'Choose the right plan for you and advance in mathematics.',
   }
 }

--- a/src/app/(frontend)/study/_components/StudyContent/index.tsx
+++ b/src/app/(frontend)/study/_components/StudyContent/index.tsx
@@ -9,7 +9,7 @@ import {
   getEffectiveLessonType,
   type LessonType,
 } from '@/server/constants/lesson-types'
-import { useTranslations } from '@/ui/web/providers/I18n'
+import { useLocale, useTranslations } from '@/ui/web/providers/I18n'
 import type { Chapter, Lesson } from '@/payload-types'
 import { AccessGateProvider } from '@/ui/web/auth/AccessGateProvider'
 import { SystemLink } from '@/infra/loading/components/SystemLink'
@@ -38,6 +38,7 @@ interface StudyContentProps {
 export function StudyContent({ lessonType = DEFAULT_LESSON_TYPE }: StudyContentProps) {
   const t = useTranslations('coursePage')
   const ts = useTranslations('study')
+  const locale = useLocale()
   const [chapters, setChapters] = useState<ChapterWithLessons[]>([])
   const [courseInfo, setCourseInfo] = useState<CourseInfo | null>(null)
   const [isLoading, setIsLoading] = useState(true)
@@ -51,7 +52,9 @@ export function StudyContent({ lessonType = DEFAULT_LESSON_TYPE }: StudyContentP
       }
 
       try {
-        const res = await fetch(`/api/chapters/by-grade?grade=${profile.gradeLevel}`)
+        const res = await fetch(
+          `/api/chapters/by-grade?grade=${profile.gradeLevel}&locale=${locale}`,
+        )
         if (res.ok) {
           const data = await res.json()
           setChapters(data.chapters || [])
@@ -74,7 +77,7 @@ export function StudyContent({ lessonType = DEFAULT_LESSON_TYPE }: StudyContentP
     }
 
     loadData()
-  }, [])
+  }, [locale])
 
   if (isLoading) {
     return (

--- a/src/app/api/chapters/by-grade/route.ts
+++ b/src/app/api/chapters/by-grade/route.ts
@@ -7,17 +7,21 @@ import configPromise from '@payload-config'
 import type { Lesson } from '@/payload-types'
 import { DEFAULT_PAGE_ACCESS_TYPE } from '@/server/constants/access-types'
 import { SystemParams } from '@/infra/config/system-params'
+import { isValidContentLocale } from '@/server/payload/fields/contentLocale'
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams
   const grade = searchParams.get('grade')
+  const localeParam = searchParams.get('locale')
 
   if (!grade) {
     return NextResponse.json({ error: 'Grade parameter is required' }, { status: 400 })
   }
 
+  const locale = localeParam && isValidContentLocale(localeParam) ? localeParam : undefined
+
   try {
-    const chapters = await queryChaptersByGrade({ gradeLevel: grade })
+    const chapters = await queryChaptersByGrade({ gradeLevel: grade, locale })
     const course = chapters[0]?.course
     const courseObj = typeof course === 'object' && course !== null ? course : null
     const courseSlug = courseObj && 'slug' in courseObj ? (courseObj.slug as string) : ''

--- a/src/server/repos/queries/chapters.ts
+++ b/src/server/repos/queries/chapters.ts
@@ -1,6 +1,9 @@
 import { cache } from 'react'
 import { getPayload } from 'payload'
+import type { Where } from 'payload'
 import configPromise from '@payload-config'
+
+import type { ContentLocale } from '@/server/payload/fields/contentLocale'
 
 export const queryChaptersByCourse = cache(async ({ courseId }: { courseId: string }) => {
   const payload = await getPayload({ config: configPromise })
@@ -106,27 +109,33 @@ export const queryChapterBySlug = cache(async ({ slug }: { slug: string }) => {
 /**
  * Fetch chapters by grade level (filters by courseLabel)
  */
-export const queryChaptersByGrade = cache(async ({ gradeLevel }: { gradeLevel: string }) => {
-  const payload = await getPayload({ config: configPromise })
+export const queryChaptersByGrade = cache(
+  async ({ gradeLevel, locale }: { gradeLevel: string; locale?: ContentLocale }) => {
+    const payload = await getPayload({ config: configPromise })
 
-  // Find course for this grade
-  const courseResult = await payload.find({
-    collection: 'courses',
-    where: {
-      and: [
-        { courseLabel: { equals: gradeLevel } },
-        { status: { equals: 'published' } },
-        { isActive: { equals: true } },
-      ],
-    },
-    limit: 1,
-    pagination: false,
-    overrideAccess: false,
-  })
+    const conditions: Where[] = [
+      { courseLabel: { equals: gradeLevel } },
+      { status: { equals: 'published' } },
+      { isActive: { equals: true } },
+    ]
 
-  const course = courseResult.docs?.[0]
-  if (!course) return []
+    if (locale) {
+      conditions.push({ locale: { equals: locale } })
+    }
 
-  // Reuse existing function
-  return queryChaptersByCourse({ courseId: course.id })
-})
+    // Find course for this grade
+    const courseResult = await payload.find({
+      collection: 'courses',
+      where: { and: conditions },
+      limit: 1,
+      pagination: false,
+      overrideAccess: false,
+    })
+
+    const course = courseResult.docs?.[0]
+    if (!course) return []
+
+    // Reuse existing function
+    return queryChaptersByCourse({ courseId: course.id })
+  },
+)

--- a/src/server/repos/queries/courses.ts
+++ b/src/server/repos/queries/courses.ts
@@ -1,59 +1,49 @@
 import configPromise from '@payload-config'
 import { getPayload } from 'payload'
+import type { Where } from 'payload'
 import { cache } from 'react'
 
-export const queryCourseBySlug = cache(async ({ slug }: { slug: string }) => {
+import type { ContentLocale } from '@/server/payload/fields/contentLocale'
+
+export const queryCourseBySlug = cache(
+  async ({ slug, locale }: { slug: string; locale?: ContentLocale }) => {
+    const payload = await getPayload({ config: configPromise })
+
+    const conditions: Where[] = [
+      { slug: { equals: slug } },
+      { status: { equals: 'published' } },
+      { isActive: { equals: true } },
+    ]
+
+    if (locale) {
+      conditions.push({ locale: { equals: locale } })
+    }
+
+    const result = await payload.find({
+      collection: 'courses',
+      where: { and: conditions },
+      limit: 1,
+      pagination: false,
+      depth: 1,
+      overrideAccess: false,
+    })
+
+    return result.docs?.[0] || null
+  },
+)
+
+export const queryPublishedCourses = cache(async (locale?: ContentLocale) => {
   const payload = await getPayload({ config: configPromise })
+
+  const conditions: Where[] = [{ status: { equals: 'published' } }, { isActive: { equals: true } }]
+
+  if (locale) {
+    conditions.push({ locale: { equals: locale } })
+  }
 
   const result = await payload.find({
     collection: 'courses',
-    where: {
-      and: [
-        {
-          slug: {
-            equals: slug,
-          },
-        },
-        {
-          status: {
-            equals: 'published',
-          },
-        },
-        {
-          isActive: {
-            equals: true,
-          },
-        },
-      ],
-    },
-    limit: 1,
-    pagination: false,
-    depth: 1,
-    overrideAccess: false,
-  })
-
-  return result.docs?.[0] || null
-})
-
-export const queryPublishedCourses = cache(async () => {
-  const payload = await getPayload({ config: configPromise })
-
-  const result = await payload.find({
-    collection: 'courses',
-    where: {
-      and: [
-        {
-          status: {
-            equals: 'published',
-          },
-        },
-        {
-          isActive: {
-            equals: true,
-          },
-        },
-      ],
-    },
+    where: { and: conditions },
     sort: 'order',
     limit: 1000,
     pagination: false,


### PR DESCRIPTION
Courses, chapters, and related API calls now respect the UI language selected in the header. When a user switches language, only courses matching that locale are displayed.

Updated query functions (queryPublishedCourses,
queryCourseBySlug, queryChaptersByGrade) to accept an optional locale parameter. All server pages and client components pass the current locale through.