### PR TITLE
feat: Add test teardown helpers and improve test data cleanup

### DIFF
--- a/tests/factories/chat-asset.factory.ts
+++ b/tests/factories/chat-asset.factory.ts
@@ -1,5 +1,6 @@
 import type { Payload } from 'payload'
 import type { ChatAsset } from '@/payload-types'
+import type { TestDataTracker } from '../helpers/test-data-tracker'
 
 export interface ChatAssetFactoryInput {
   url?: string
@@ -27,13 +28,16 @@ export function buildChatAssetData(input: ChatAssetFactoryInput = {}) {
 export async function createTestChatAsset(
   payload: Payload,
   input: ChatAssetFactoryInput = {},
+  tracker?: TestDataTracker,
 ): Promise<ChatAsset> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Test factory: Payload's create() union types are strict
-  return payload.create({
+  const asset = await payload.create({
     collection: 'chat-assets',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Test factory: Payload's create() union types are strict
     data: buildChatAssetData(input) as any,
     overrideAccess: true,
   })
+  tracker?.track('chat-assets', asset.id)
+  return asset
 }
 
 /** Create an expired chat asset for cleanup testing */

--- a/tests/factories/context.factory.ts
+++ b/tests/factories/context.factory.ts
@@ -1,5 +1,7 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Payload } from 'payload'
 import { DEFAULT_CONTENT } from '@/server/payload/collections/Exercises/defaults'
+import type { TestDataTracker } from '../helpers/test-data-tracker'
 
 export interface ContextHierarchy {
   categoryId: string
@@ -10,7 +12,10 @@ export interface ContextHierarchy {
   cleanup: () => Promise<void>
 }
 
-export async function createContextHierarchy(payload: Payload): Promise<ContextHierarchy> {
+export async function createContextHierarchy(
+  payload: Payload,
+  tracker?: TestDataTracker,
+): Promise<ContextHierarchy> {
   const timestamp = Date.now()
 
   const category = await payload.create({
@@ -74,6 +79,13 @@ export async function createContextHierarchy(payload: Payload): Promise<ContextH
     } as any,
     overrideAccess: true,
   })
+
+  // Register with tracker if provided
+  tracker?.track('exercises', exercise.id)
+  tracker?.track('lessons', lesson.id)
+  tracker?.track('chapters', chapter.id)
+  tracker?.track('courses', course.id)
+  tracker?.track('categories', category.id)
 
   const cleanup = async () => {
     await payload.delete({ collection: 'exercises', id: exercise.id, overrideAccess: true })

--- a/tests/factories/conversation.factory.ts
+++ b/tests/factories/conversation.factory.ts
@@ -1,5 +1,6 @@
 import type { Payload } from 'payload'
 import { ChatRole } from '@/infra/llm/chat-message-role'
+import type { TestDataTracker } from '../helpers/test-data-tracker'
 
 export interface ConversationMessageInput {
   role?: ChatRole
@@ -42,11 +43,17 @@ export function buildConversationData(input: ConversationFactoryInput) {
   }
 }
 
-export async function createConversation(payload: Payload, input: ConversationFactoryInput) {
-  return payload.create({
+export async function createConversation(
+  payload: Payload,
+  input: ConversationFactoryInput,
+  tracker?: TestDataTracker,
+) {
+  const conversation = await payload.create({
     collection: 'conversations',
     data: buildConversationData(input),
     draft: false,
     overrideAccess: true,
   })
+  tracker?.track('conversations', conversation.id)
+  return conversation
 }

--- a/tests/factories/guest-session.factory.ts
+++ b/tests/factories/guest-session.factory.ts
@@ -6,8 +6,10 @@
  * @domain auth
  * @pattern test-factory, guest-session
  */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Payload } from 'payload'
 import crypto from 'crypto'
+import type { TestDataTracker } from '../helpers/test-data-tracker'
 
 export interface GuestSessionFactoryInput {
   status?: 'active' | 'expired' | 'revoked'
@@ -67,8 +69,9 @@ export function buildGuestSessionData(input: GuestSessionFactoryInput = {}) {
 export async function createGuestSession(
   payload: Payload,
   input: GuestSessionFactoryInput = {},
+  tracker?: TestDataTracker,
 ): Promise<GuestSessionResult> {
-  const { token, tokenHash, data } = buildGuestSessionData(input)
+  const { token, data } = buildGuestSessionData(input)
 
   const session = await payload.create({
     collection: 'guest-sessions',
@@ -76,6 +79,8 @@ export async function createGuestSession(
     overrideAccess: true,
     draft: false,
   })
+
+  tracker?.track('guest-sessions', session.id)
 
   return {
     session: session as GuestSessionResult['session'],
@@ -105,7 +110,7 @@ export async function createGuestSessionRaw(
   payload: Payload,
   input: GuestSessionFactoryInput = {},
 ): Promise<GuestSessionResult> {
-  const { token, tokenHash, data } = buildGuestSessionData(input)
+  const { token, tokenHash: _tokenHash, data } = buildGuestSessionData(input)
 
   // Use direct MongoDB insert to bypass any hooks
   const db = payload.db as any

--- a/tests/factories/media.factory.ts
+++ b/tests/factories/media.factory.ts
@@ -1,5 +1,6 @@
 import type { Payload } from 'payload'
 import type { Media } from '@/payload-types'
+import type { TestDataTracker } from '../helpers/test-data-tracker'
 
 export interface MediaFactoryInput {
   filename?: string
@@ -25,10 +26,17 @@ export function buildMediaData(input: MediaFactoryInput = {}) {
 export async function createTestMedia(
   payload: Payload,
   input: MediaFactoryInput = {},
+  tracker?: TestDataTracker,
 ): Promise<Media> {
   const data = buildMediaData(input)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Test factory: Payload's create() union types are strict
-  return payload.create({ collection: 'media', data: data as any, overrideAccess: true })
+  const media = await payload.create({
+    collection: 'media',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Test factory: Payload's create() union types are strict
+    data: data as any,
+    overrideAccess: true,
+  })
+  tracker?.track('media', media.id)
+  return media
 }
 
 /** Generate a minimal 1x1 JPEG buffer for upload tests */

--- a/tests/factories/memory-item.factory.ts
+++ b/tests/factories/memory-item.factory.ts
@@ -1,5 +1,6 @@
 import type { Payload } from 'payload'
 import { ChatRole } from '@/infra/llm/chat-message-role'
+import type { TestDataTracker } from '../helpers/test-data-tracker'
 
 export interface MemoryItemFactoryInput {
   userId: string
@@ -33,10 +34,16 @@ export function buildMemoryItemData(input: MemoryItemFactoryInput) {
   }
 }
 
-export async function createMemoryItem(payload: Payload, input: MemoryItemFactoryInput) {
-  return payload.create({
+export async function createMemoryItem(
+  payload: Payload,
+  input: MemoryItemFactoryInput,
+  tracker?: TestDataTracker,
+) {
+  const item = await payload.create({
     collection: 'memory_items',
     data: buildMemoryItemData(input),
     overrideAccess: true,
   })
+  tracker?.track('memory_items', item.id)
+  return item
 }

--- a/tests/factories/prompt.factory.ts
+++ b/tests/factories/prompt.factory.ts
@@ -1,5 +1,6 @@
 import type { Payload } from 'payload'
 import type { Prompt } from '@/payload-types'
+import type { TestDataTracker } from '../helpers/test-data-tracker'
 
 export interface PromptFactoryInput {
   title?: string
@@ -25,11 +26,14 @@ export function buildPromptData(input: PromptFactoryInput = {}) {
 export async function createTestPrompt(
   payload: Payload,
   input: PromptFactoryInput = {},
+  tracker?: TestDataTracker,
 ): Promise<Prompt> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Test factory: Payload's create() union types are strict
-  return payload.create({
+  const prompt = await payload.create({
     collection: 'prompts',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Test factory: Payload's create() union types are strict
     data: buildPromptData(input) as any,
     overrideAccess: true,
   })
+  tracker?.track('prompts', prompt.id)
+  return prompt
 }

--- a/tests/factories/tenant.factory.ts
+++ b/tests/factories/tenant.factory.ts
@@ -1,5 +1,6 @@
 import type { Payload } from 'payload'
 import type { Tenant } from '@/payload-types'
+import type { TestDataTracker } from '../helpers/test-data-tracker'
 
 export interface TenantFactoryInput {
   name?: string
@@ -17,10 +18,13 @@ export function buildTenantData(input: TenantFactoryInput = {}) {
 export async function createTestTenant(
   payload: Payload,
   input: TenantFactoryInput = {},
+  tracker?: TestDataTracker,
 ): Promise<Tenant> {
-  return payload.create({
+  const tenant = await payload.create({
     collection: 'tenants',
     data: buildTenantData(input),
     overrideAccess: true,
   })
+  tracker?.track('tenants', tenant.id)
+  return tenant
 }

--- a/tests/factories/upload-session.factory.ts
+++ b/tests/factories/upload-session.factory.ts
@@ -1,5 +1,6 @@
 import type { Payload } from 'payload'
 import type { UploadSession } from '@/payload-types'
+import type { TestDataTracker } from '../helpers/test-data-tracker'
 
 export interface UploadSessionFactoryInput {
   purpose?: string
@@ -26,13 +27,16 @@ export function buildUploadSessionData(input: UploadSessionFactoryInput = {}) {
 export async function createTestUploadSession(
   payload: Payload,
   input: UploadSessionFactoryInput = {},
+  tracker?: TestDataTracker,
 ): Promise<UploadSession> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Test factory: Payload's create() union types are strict
-  return payload.create({
+  const session = await payload.create({
     collection: 'upload-sessions',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Test factory: Payload's create() union types are strict
     data: buildUploadSessionData(input) as any,
     overrideAccess: true,
   })
+  tracker?.track('upload-sessions', session.id)
+  return session
 }
 
 /** Create an expired upload session for cleanup testing */

--- a/tests/factories/user.factory.ts
+++ b/tests/factories/user.factory.ts
@@ -1,6 +1,7 @@
 import type { Payload } from 'payload'
 import type { User } from '@/payload-types'
 import { AccountRole } from '@/server/payload/collections/Users/roles'
+import type { TestDataTracker } from '../helpers/test-data-tracker'
 
 export interface UserFactoryInput {
   email?: string
@@ -19,9 +20,15 @@ export function buildUserData(input: UserFactoryInput = {}) {
   }
 }
 
-export async function createTestUser(payload: Payload, input: UserFactoryInput = {}) {
-  return payload.create({
+export async function createTestUser(
+  payload: Payload,
+  input: UserFactoryInput = {},
+  tracker?: TestDataTracker,
+) {
+  const user = await payload.create({
     collection: 'users',
     data: buildUserData(input),
   })
+  tracker?.track('users', user.id)
+  return user
 }

--- a/tests/helpers/cleanup-helpers.ts
+++ b/tests/helpers/cleanup-helpers.ts
@@ -1,0 +1,196 @@
+/**
+ * Reusable cleanup helpers for integration tests
+ *
+ * These helpers delete test-generated data by known identifiers
+ * (user IDs, collection filters, etc.) without affecting
+ * production or seeded data.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { Payload } from 'payload'
+
+/**
+ * Delete all conversations belonging to a user
+ */
+export async function cleanupUserConversations(payload: Payload, userId: string): Promise<number> {
+  const conversations = await payload.find({
+    collection: 'conversations',
+    where: { user: { equals: userId } },
+    limit: 1000,
+    overrideAccess: true,
+  })
+
+  for (const conv of conversations.docs) {
+    await payload.delete({
+      collection: 'conversations',
+      id: conv.id,
+      overrideAccess: true,
+    })
+  }
+
+  return conversations.docs.length
+}
+
+/**
+ * Delete all memory items belonging to a user
+ */
+export async function cleanupUserMemories(payload: Payload, userId: string): Promise<number> {
+  const memories = await payload.find({
+    collection: 'memory_items',
+    where: { userId: { equals: userId } },
+    limit: 1000,
+    overrideAccess: true,
+  })
+
+  for (const mem of memories.docs) {
+    await payload.delete({
+      collection: 'memory_items',
+      id: mem.id,
+      overrideAccess: true,
+    })
+  }
+
+  return memories.docs.length
+}
+
+/**
+ * Delete all progress records belonging to a user
+ */
+export async function cleanupUserProgress(payload: Payload, userId: string): Promise<number> {
+  const records = await payload.find({
+    collection: 'user-progress',
+    where: { user: { equals: userId } },
+    limit: 1000,
+    overrideAccess: true,
+  })
+
+  for (const record of records.docs) {
+    await payload.delete({
+      collection: 'user-progress',
+      id: record.id,
+      overrideAccess: true,
+    })
+  }
+
+  return records.docs.length
+}
+
+/**
+ * Delete a user and all their associated data
+ * Cleans up in dependency order: memories, conversations,
+ * progress, settings, then the user itself.
+ */
+export async function cleanupUserAndRelatedData(payload: Payload, userId: string): Promise<void> {
+  if (!userId) return
+
+  try {
+    await cleanupUserMemories(payload, userId)
+  } catch {
+    // Best effort
+  }
+
+  try {
+    await cleanupUserConversations(payload, userId)
+  } catch {
+    // Best effort
+  }
+
+  try {
+    await cleanupUserProgress(payload, userId)
+  } catch {
+    // Best effort
+  }
+
+  try {
+    const settings = await payload.find({
+      collection: 'user_settings',
+      where: { user: { equals: userId } },
+      limit: 10,
+      overrideAccess: true,
+    })
+    for (const setting of settings.docs) {
+      await payload.delete({
+        collection: 'user_settings',
+        id: setting.id,
+        overrideAccess: true,
+      })
+    }
+  } catch {
+    // Best effort
+  }
+
+  try {
+    await payload.delete({
+      collection: 'users',
+      id: userId,
+      overrideAccess: true,
+    })
+  } catch {
+    // Best effort - user may already be deleted
+  }
+}
+
+/**
+ * Delete guest sessions matching a filter
+ */
+export async function cleanupGuestSessions(
+  payload: Payload,
+  where: Record<string, unknown>,
+): Promise<number> {
+  const sessions = await payload.find({
+    collection: 'guest-sessions',
+    where: where as any,
+    limit: 1000,
+    overrideAccess: true,
+  })
+
+  for (const session of sessions.docs) {
+    await payload.delete({
+      collection: 'guest-sessions',
+      id: session.id,
+      overrideAccess: true,
+    })
+  }
+
+  return sessions.docs.length
+}
+
+/**
+ * Clean up a full content hierarchy: exercises -> lessons -> chapters -> courses -> categories
+ * Pass IDs of records YOUR test created. Does not delete pre-existing/seeded data.
+ */
+export async function cleanupContentHierarchy(
+  payload: Payload,
+  ids: {
+    exerciseIds?: string[]
+    lessonIds?: string[]
+    chapterIds?: string[]
+    courseIds?: string[]
+    categoryIds?: string[]
+    mediaIds?: string[]
+    promptIds?: string[]
+  },
+): Promise<void> {
+  const deleteMany = async (collection: string, idList?: string[]) => {
+    if (!idList?.length) return
+    for (const id of idList) {
+      try {
+        await (payload as any).delete({
+          collection,
+          id,
+          overrideAccess: true,
+        })
+      } catch {
+        // Best effort - record may not exist
+      }
+    }
+  }
+
+  // Delete in dependency order (children first)
+  await deleteMany('exercises', ids.exerciseIds)
+  await deleteMany('lessons', ids.lessonIds)
+  await deleteMany('chapters', ids.chapterIds)
+  await deleteMany('courses', ids.courseIds)
+  await deleteMany('categories', ids.categoryIds)
+  await deleteMany('media', ids.mediaIds)
+  await deleteMany('prompts', ids.promptIds)
+}

--- a/tests/helpers/index.ts
+++ b/tests/helpers/index.ts
@@ -1,0 +1,10 @@
+export { TestDataTracker } from './test-data-tracker'
+export {
+  cleanupContentHierarchy,
+  cleanupGuestSessions,
+  cleanupUserAndRelatedData,
+  cleanupUserConversations,
+  cleanupUserMemories,
+  cleanupUserProgress,
+} from './cleanup-helpers'
+export { verifyNoTestData, verifyUserDataCleaned } from './verify-cleanup'

--- a/tests/helpers/test-data-tracker.ts
+++ b/tests/helpers/test-data-tracker.ts
@@ -1,0 +1,175 @@
+/**
+ * TestDataTracker - Tracks test-created records for automatic cleanup
+ *
+ * Usage:
+ * ```typescript
+ * const tracker = new TestDataTracker(payload)
+ *
+ * // Track records as you create them
+ * const user = await payload.create({ collection: 'users', data: {...} })
+ * tracker.track('users', user.id)
+ *
+ * // Or use the create helper (tracks automatically)
+ * const tenant = await tracker.create('tenants', { name: 'Test' })
+ *
+ * // In afterAll/afterEach - cleans up in reverse dependency order
+ * await tracker.cleanup()
+ * ```
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { Payload } from 'payload'
+
+type CollectionSlug = string
+
+/**
+ * Dependency order for cleanup (children first, parents last).
+ * Collections listed earlier are deleted first.
+ */
+const CLEANUP_ORDER: CollectionSlug[] = [
+  'extraction-logs',
+  'memory_items',
+  'chat-assets',
+  'upload-sessions',
+  'user-progress',
+  'conversations',
+  'guest-sessions',
+  'user_settings',
+  'exercises',
+  'lessons',
+  'chapters',
+  'courses',
+  'categories',
+  'media',
+  'prompts',
+  'pages',
+  'posts',
+  'users',
+  'tenants',
+]
+
+export class TestDataTracker {
+  private records: Map<CollectionSlug, Set<string>> = new Map()
+  private payload: Payload
+
+  constructor(payload: Payload) {
+    this.payload = payload
+  }
+
+  /**
+   * Register a record for cleanup
+   */
+  track(collection: CollectionSlug, id: string): void {
+    if (!this.records.has(collection)) {
+      this.records.set(collection, new Set())
+    }
+    this.records.get(collection)!.add(id)
+  }
+
+  /**
+   * Create a record and automatically track it
+   */
+  async create(
+    collection: CollectionSlug,
+    data: Record<string, unknown>,
+    options: { overrideAccess?: boolean; draft?: boolean } = {},
+  ): Promise<{ id: string; [key: string]: unknown }> {
+    const result = await (this.payload as any).create({
+      collection,
+      data,
+      overrideAccess: options.overrideAccess ?? true,
+      draft: options.draft,
+    })
+
+    this.track(collection, (result as any).id)
+    return result as { id: string; [key: string]: unknown }
+  }
+
+  /**
+   * Remove a record from tracking (e.g., if test already deleted it)
+   */
+  untrack(collection: CollectionSlug, id: string): void {
+    this.records.get(collection)?.delete(id)
+  }
+
+  /**
+   * Get all tracked IDs for a collection
+   */
+  getTracked(collection: CollectionSlug): string[] {
+    return Array.from(this.records.get(collection) ?? [])
+  }
+
+  /**
+   * Clean up all tracked records in dependency-safe order.
+   * Runs even if individual deletes fail (failure-safe).
+   */
+  async cleanup(): Promise<{ deleted: number; errors: string[] }> {
+    let deleted = 0
+    const errors: string[] = []
+
+    const sortedCollections = this.getSortedCollections()
+
+    for (const collection of sortedCollections) {
+      const ids = this.records.get(collection)
+      if (!ids || ids.size === 0) continue
+
+      for (const id of ids) {
+        try {
+          await (this.payload as any).delete({
+            collection,
+            id,
+            overrideAccess: true,
+          })
+          deleted++
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error)
+          if (!msg.includes('not found') && !msg.includes('Not Found')) {
+            errors.push(`Failed to delete ${collection}/${id}: ${msg}`)
+          }
+        }
+      }
+    }
+
+    this.records.clear()
+    return { deleted, errors }
+  }
+
+  /**
+   * Sort tracked collections by dependency order.
+   * Collections in CLEANUP_ORDER are sorted by their position.
+   * Unknown collections are cleaned up first (safest default).
+   */
+  private getSortedCollections(): CollectionSlug[] {
+    const tracked = Array.from(this.records.keys())
+
+    return tracked.sort((a, b) => {
+      const indexA = CLEANUP_ORDER.indexOf(a)
+      const indexB = CLEANUP_ORDER.indexOf(b)
+
+      if (indexA === -1 && indexB === -1) return 0
+      if (indexA === -1) return -1
+      if (indexB === -1) return 1
+      return indexA - indexB
+    })
+  }
+
+  /**
+   * Check if any records are still tracked (for verification)
+   */
+  get isEmpty(): boolean {
+    for (const ids of this.records.values()) {
+      if (ids.size > 0) return false
+    }
+    return true
+  }
+
+  /**
+   * Get total count of tracked records
+   */
+  get count(): number {
+    let total = 0
+    for (const ids of this.records.values()) {
+      total += ids.size
+    }
+    return total
+  }
+}

--- a/tests/helpers/verify-cleanup.ts
+++ b/tests/helpers/verify-cleanup.ts
@@ -1,0 +1,89 @@
+/**
+ * Verification helper to assert no test data was left behind.
+ *
+ * Usage in afterAll:
+ * ```typescript
+ * afterAll(async () => {
+ *   await tracker.cleanup()
+ *   await verifyNoTestData(payload, testUserEmail)
+ * })
+ * ```
+ */
+import type { Payload } from 'payload'
+
+interface VerifyResult {
+  clean: boolean
+  leftover: { collection: string; count: number }[]
+}
+
+/**
+ * Verify that no test data remains for a given user email pattern.
+ * Pass the email (or prefix) used during the test to check for leftovers.
+ */
+export async function verifyNoTestData(
+  payload: Payload,
+  testEmailPattern: string,
+): Promise<VerifyResult> {
+  const leftover: { collection: string; count: number }[] = []
+
+  // Check for leftover users matching the test email pattern
+  try {
+    const users = await payload.find({
+      collection: 'users',
+      where: { email: { like: testEmailPattern } },
+      limit: 1,
+      overrideAccess: true,
+    })
+    if (users.totalDocs > 0) {
+      leftover.push({ collection: 'users', count: users.totalDocs })
+    }
+  } catch {
+    // Collection may not exist in this test env
+  }
+
+  return {
+    clean: leftover.length === 0,
+    leftover,
+  }
+}
+
+/**
+ * Verify that no records exist for a specific user ID across
+ * common test-generated collections.
+ */
+export async function verifyUserDataCleaned(
+  payload: Payload,
+  userId: string,
+): Promise<VerifyResult> {
+  const leftover: { collection: string; count: number }[] = []
+
+  const collectionsToCheck = [
+    { slug: 'conversations', field: 'user' },
+    { slug: 'memory_items', field: 'userId' },
+    { slug: 'user-progress', field: 'user' },
+    { slug: 'user_settings', field: 'user' },
+  ]
+
+  for (const { slug, field } of collectionsToCheck) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (payload as any).find({
+        collection: slug,
+        where: { [field]: { equals: userId } },
+        limit: 1,
+        overrideAccess: true,
+      })
+
+      if (result.totalDocs > 0) {
+        leftover.push({ collection: slug, count: result.totalDocs })
+      }
+    } catch {
+      // Collection may not exist
+    }
+  }
+
+  return {
+    clean: leftover.length === 0,
+    leftover,
+  }
+}

--- a/tests/int/auth-oauth-google.int.spec.ts
+++ b/tests/int/auth-oauth-google.int.spec.ts
@@ -5,6 +5,7 @@ import { encrypt, decrypt, generateSecret } from '@/infra/auth/oauth_crypto'
 
 describe('Google OAuth Integration', () => {
   let payload: Payload
+  const createdUserIds: string[] = []
 
   beforeAll(async () => {
     // Ensure PAYLOAD_SECRET is set for crypto operations
@@ -81,6 +82,7 @@ describe('Google OAuth Integration', () => {
         },
       })
 
+      createdUserIds.push(user.id)
       expect(user.id).toBeDefined()
       expect(user.email).toBe(testEmail)
       expect(user.googleSub).toBeDefined()
@@ -110,6 +112,7 @@ describe('Google OAuth Integration', () => {
           oauthLoginSecretEnc: encryptedSecret,
         },
       })
+      createdUserIds.push(user1.id)
 
       // Try to create second user with same googleSub
 
@@ -153,6 +156,7 @@ describe('Google OAuth Integration', () => {
           oauthLoginSecretEnc: encryptedSecret,
         },
       })
+      createdUserIds.push(createdUser.id)
 
       const foundUsers = await payload.find({
         collection: 'users',
@@ -184,6 +188,7 @@ describe('Google OAuth Integration', () => {
         },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any)) as any
+      createdUserIds.push(emailUser.id)
 
       // Check for collision (simulating OAuth callback logic)
       const existingByEmail = await payload.find({
@@ -207,7 +212,7 @@ describe('Google OAuth Integration', () => {
       const emailPassword = 'original-password-123'
       const googleSub = `google-link-${Date.now()}`
 
-      // Create email/password user first
+      // Create email/password user first (tracked for cleanup)
       const emailUser = (await payload.create({
         collection: 'users',
         data: {
@@ -218,6 +223,7 @@ describe('Google OAuth Integration', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any)) as any
 
+      createdUserIds.push(emailUser.id)
       expect(emailUser.googleSub).toBeUndefined()
 
       // Simulate OAuth callback linking (without replacing password)
@@ -295,6 +301,7 @@ describe('Google OAuth Integration', () => {
         },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any)) as any
+      createdUserIds.push(user.id)
 
       // Decrypt and login (simulating OAuth callback)
       const decryptedSecret = decrypt(encryptedSecret)
@@ -312,6 +319,17 @@ describe('Google OAuth Integration', () => {
   })
 
   afterAll(async () => {
+    // Safety net: clean up any users that weren't deleted inline
+    if (payload) {
+      for (const userId of createdUserIds) {
+        try {
+          await payload.delete({ collection: 'users', id: userId, overrideAccess: true })
+        } catch {
+          // May already be deleted by inline cleanup
+        }
+      }
+    }
+
     // Close DB connection to prevent connection leaks
     if (payload?.db?.destroy) {
       await payload.db.destroy()

--- a/tests/int/exercise-conversion-api.int.spec.ts
+++ b/tests/int/exercise-conversion-api.int.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * Integration tests for Exercise Conversion API endpoints
  *
@@ -15,6 +16,7 @@ import { getPayload } from 'payload'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 let payload: Payload
+let testAdminUserId: string
 
 // Skip tests if DATABASE_URL is not set
 const hasDatabaseUrl = !!process.env.DATABASE_URL
@@ -36,8 +38,8 @@ describe.skipIf(!hasDatabaseUrl)('Exercise Conversion API', () => {
     const timestamp = Date.now()
     const testEmail = `exercise-conversion-test-${timestamp}@example.com`
 
-    // Create admin user (unused but creates test data for potential future use)
-    await payload.create({
+    // Create admin user for testing
+    const adminUser = await payload.create({
       collection: 'users',
       data: {
         email: testEmail,
@@ -45,6 +47,7 @@ describe.skipIf(!hasDatabaseUrl)('Exercise Conversion API', () => {
         role: 'admin',
       },
     })
+    testAdminUserId = adminUser.id
 
     // Generate auth token for the admin user
     // The API checks for admin role via user.role.includes('admin')
@@ -54,8 +57,18 @@ describe.skipIf(!hasDatabaseUrl)('Exercise Conversion API', () => {
   afterAll(async () => {
     if (!hasDatabaseUrl || !payload) return
 
-    // Clean up any test data
-    // Note: In a real test, we'd delete the test user and any created jobs
+    // Clean up test admin user
+    if (testAdminUserId) {
+      try {
+        await payload.delete({
+          collection: 'users',
+          id: testAdminUserId,
+          overrideAccess: true,
+        })
+      } catch {
+        // Best effort cleanup
+      }
+    }
 
     if (payload.db?.destroy) {
       await payload.db.destroy()

--- a/tests/int/lesson-context-injection.int.spec.ts
+++ b/tests/int/lesson-context-injection.int.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * Integration tests for lesson context injection
  *
@@ -122,6 +123,7 @@ let testUserId: string
 let testLessonId: string
 let testLessonIdB: string
 let testChapterId: string
+let createdChapter = false
 
 beforeAll(async () => {
   payload = await getPayload({ config })
@@ -154,6 +156,7 @@ beforeAll(async () => {
       draft: true,
     })
     testChapterId = chapter.id
+    createdChapter = true
   }
 
   // Create lesson A with context text
@@ -192,25 +195,58 @@ beforeAll(async () => {
 afterAll(async () => {
   if (!payload) return
 
+  // Clean up conversations created during tests
   if (testUserId) {
-    await payload.delete({
-      collection: 'users',
-      id: testUserId,
-    })
+    try {
+      const conversations = await payload.find({
+        collection: 'conversations',
+        where: { user: { equals: testUserId } },
+        limit: 1000,
+        overrideAccess: true,
+      })
+      for (const conv of conversations.docs) {
+        await payload.delete({
+          collection: 'conversations',
+          id: conv.id,
+          overrideAccess: true,
+        })
+      }
+    } catch {
+      // Best effort cleanup
+    }
   }
 
   if (testLessonId) {
-    await payload.delete({
-      collection: 'lessons',
-      id: testLessonId,
-    })
+    try {
+      await payload.delete({ collection: 'lessons', id: testLessonId, overrideAccess: true })
+    } catch {
+      // Best effort cleanup
+    }
   }
 
   if (testLessonIdB) {
-    await payload.delete({
-      collection: 'lessons',
-      id: testLessonIdB,
-    })
+    try {
+      await payload.delete({ collection: 'lessons', id: testLessonIdB, overrideAccess: true })
+    } catch {
+      // Best effort cleanup
+    }
+  }
+
+  // Only delete chapter if we created it (not a pre-existing one)
+  if (createdChapter && testChapterId) {
+    try {
+      await payload.delete({ collection: 'chapters', id: testChapterId, overrideAccess: true })
+    } catch {
+      // Best effort cleanup
+    }
+  }
+
+  if (testUserId) {
+    try {
+      await payload.delete({ collection: 'users', id: testUserId, overrideAccess: true })
+    } catch {
+      // Best effort cleanup
+    }
   }
 
   // Close DB connection to prevent connection leaks


### PR DESCRIPTION
Add TestDataTracker utility class for tracking and cleaning up test-generated data in dependency order. Add reusable cleanup helpers for users, conversations, memories, progress, guest sessions, and content hierarchies. Add verification helpers to assert no test data was left behind.

Update all test factories to accept optional tracker parameter for automatic cleanup tracking. Fix cleanup gaps in exercise-conversion-api, lesson-context-injection, and auth-oauth-google integration tests.