### PR TITLE
feat(conversion): Add diagram-to-TikZ conversion pass (Step 1)

### DIFF
--- a/src/app/api/prompts/for-conversion/route.ts
+++ b/src/app/api/prompts/for-conversion/route.ts
@@ -116,6 +116,21 @@ export async function POST(request: NextRequest) {
       overrideAccess: true,
     })
 
+    // Fetch published diagram-generator prompts for this tenant
+    const diagramGenerators = await payload.find({
+      collection: 'prompts',
+      where: {
+        and: [
+          { tenant: { equals: tenantId } },
+          { status: { equals: 'published' } },
+          { usage: { equals: 'diagram-generator' } },
+        ],
+      },
+      limit: 100,
+      depth: 0,
+      overrideAccess: true,
+    })
+
     // Return in PromptOption format used by UI
     // v2.1 Fix 1: Include status field in response
     const mapPromptToOption = (p: Prompt): PromptOption => ({
@@ -131,6 +146,7 @@ export async function POST(request: NextRequest) {
       extractors: extractors.docs.map(mapPromptToOption),
       verifiers: verifiers.docs.map(mapPromptToOption),
       contextExtractors: contextExtractors.docs.map(mapPromptToOption),
+      diagramGenerators: diagramGenerators.docs.map(mapPromptToOption),
     })
   } catch (error) {
     const Sentry = await import('@sentry/nextjs')

--- a/src/infra/llm/prompts/diagram-generator.ts
+++ b/src/infra/llm/prompts/diagram-generator.ts
@@ -1,0 +1,57 @@
+/**
+ * Default system prompt for diagram-to-TikZ generation (Step 1).
+ *
+ * This prompt is used as the base template when no tenant-specific
+ * prompt is configured in the Prompts collection.
+ *
+ * The per-diagram context (description, exercise title, output format)
+ * is appended by buildDiagramPrompt() in diagram-pass.ts.
+ */
+export const DEFAULT_DIAGRAM_GENERATOR_PROMPT = `You are an expert at converting textual diagram descriptions into TikZ/LaTeX code for educational math materials.
+
+Your job is to read a textual description of a diagram (geometry figure, coordinate graph, or other diagram) and produce clean, compilable TikZ code that accurately represents the described elements.
+
+## Critical Constraints
+
+1. **Schematic Only**: Create simple geometric representations, not artistic drawings
+2. **No Inference**: Only include elements explicitly described — never add assumed details
+3. **No Solutions**: Do not solve, compute, or interpret the exercise — only draw what is described
+4. **Omit When Uncertain**: If a described element is ambiguous, omit it rather than guess
+5. **Hebrew Support**: Use \\texthebrew{} for Hebrew text labels
+
+## TikZ Best Practices
+
+- Wrap all output in \\begin{tikzpicture}...\\end{tikzpicture}
+- Use basic primitives: \\draw, \\node, \\filldraw, \\coordinate
+- Keep coordinates simple (integers when possible)
+- Label vertices and points clearly using \\node
+- Use \\draw[dashed] for dashed lines, \\draw[thick] for emphasis
+- Mark right angles with the square corner mark pattern
+- Mark equal segments with tick marks
+
+## Common Patterns
+
+**Labeled triangle**:
+\\begin{tikzpicture}
+  \\coordinate (A) at (0,0);
+  \\coordinate (B) at (4,0);
+  \\coordinate (C) at (1,3);
+  \\draw (A) -- (B) -- (C) -- cycle;
+  \\node[below left] at (A) {$A$};
+  \\node[below right] at (B) {$B$};
+  \\node[above] at (C) {$C$};
+\\end{tikzpicture}
+
+**Coordinate axes with function**:
+\\begin{tikzpicture}
+  \\draw[->] (-3,0) -- (3,0) node[right] {$x$};
+  \\draw[->] (0,-1) -- (0,5) node[above] {$y$};
+  \\draw[domain=-2:2, smooth, thick] plot (\\x, {\\x*\\x});
+\\end{tikzpicture}
+
+**Circle with center and radius**:
+\\begin{tikzpicture}
+  \\draw (2,2) circle (1.5);
+  \\filldraw (2,2) circle (1.5pt) node[below] {$O$};
+  \\draw (2,2) -- (3.5,2) node[midway, above] {$r$};
+\\end{tikzpicture}`

--- a/src/infra/llm/services/data-extractor-service.ts
+++ b/src/infra/llm/services/data-extractor-service.ts
@@ -275,10 +275,12 @@ export interface ImageToExerciseV3Response {
  * Returns extended response including diagram description and position
  *
  * Uses V3_EXERCISE_WITH_DIAGRAMS_PROMPT to also extract diagram information.
+ * Optionally accepts a prompt override for tenant-specific prompts.
  */
 export async function extractFromImageV3(
   input: ImageToExerciseInput,
   payload: Payload,
+  promptOverride?: string,
 ): Promise<ImageToExerciseV3Response> {
   const startTime = Date.now()
   let modelConfig: AIModel | null = null
@@ -290,7 +292,9 @@ export async function extractFromImageV3(
     modelConfig = resolveModelConfig('IMAGE_TO_EXERCISE')
 
     // Prepare multimodal input with V3 prompt that includes diagram extraction
-    const prompt = `${V3_EXERCISE_WITH_DIAGRAMS_PROMPT}\n\nExtract the exercise from this image. Return JSON with: title (topic description, 3-8 words), stem (shared context), subQuestions[] (each with prompt, type, options if MCQ, correctAnswer if MCQ, acceptedAnswers if free response), diagramDescription (optional), diagramPosition (optional).`
+    // Use override if provided (for tenant-specific prompts), otherwise use default
+    const basePrompt = promptOverride ?? V3_EXERCISE_WITH_DIAGRAMS_PROMPT
+    const prompt = `${basePrompt}\n\nExtract the exercise from this image. Return JSON with: title (topic description, 3-8 words), stem (shared context), subQuestions[] (each with prompt, type, options if MCQ, correctAnswer if MCQ, acceptedAnswers if free response), diagramDescription (optional), diagramPosition (optional).`
 
     // For PDFs, pass directly to Gemini (it handles PDF natively)
     // For images, optimize before sending to reduce API latency/costs

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -680,9 +680,9 @@ export interface Prompt {
    */
   tenant: string | Tenant;
   /**
-   * Purpose of this prompt: chat conversation, PDF extraction, PDF verification, or context extraction for AI tutor
+   * Purpose of this prompt: chat conversation, PDF extraction, PDF verification, context extraction, or diagram generation
    */
-  usage?: ('chat' | 'extractor' | 'verifier' | 'context_extractor') | null;
+  usage?: ('chat' | 'extractor' | 'verifier' | 'context_extractor' | 'diagram-generator') | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -1574,9 +1574,9 @@ export interface ExtractionLog {
    */
   status: 'success' | 'failed';
   /**
-   * Lifecycle stage - extract or create
+   * Lifecycle stage - extract, create, or diagram-tikz
    */
-  stage: 'extract' | 'create';
+  stage: 'extract' | 'create' | 'diagram-tikz';
   /**
    * Raw LLM response string
    */

--- a/src/server/payload/collections/ExtractionLogs.ts
+++ b/src/server/payload/collections/ExtractionLogs.ts
@@ -104,10 +104,11 @@ export const ExtractionLogs: CollectionConfig = {
       options: [
         { label: 'Extract', value: 'extract' },
         { label: 'Create', value: 'create' },
+        { label: 'Diagram TikZ', value: 'diagram-tikz' },
       ],
       index: true,
       admin: {
-        description: 'Lifecycle stage - extract or create',
+        description: 'Lifecycle stage - extract, create, or diagram-tikz',
       },
     },
 

--- a/src/server/payload/collections/Prompts.ts
+++ b/src/server/payload/collections/Prompts.ts
@@ -109,11 +109,12 @@ export const Prompts: CollectionConfig = {
         { label: 'PDF Extractor', value: 'extractor' },
         { label: 'PDF Verifier', value: 'verifier' },
         { label: 'Context Extractor', value: 'context_extractor' },
+        { label: 'Diagram Generator', value: 'diagram-generator' },
       ],
       defaultValue: 'chat',
       admin: {
         description:
-          'Purpose of this prompt: chat conversation, PDF extraction, PDF verification, or context extraction for AI tutor',
+          'Purpose of this prompt: chat conversation, PDF extraction, PDF verification, context extraction, or diagram generation',
         position: 'sidebar',
       },
     },

--- a/src/server/payload/jobs/pdf-to-exercises-task.ts
+++ b/src/server/payload/jobs/pdf-to-exercises-task.ts
@@ -518,14 +518,14 @@ Return JSON: { "valid": boolean, "reason": "..." }`
 
   // ========== DIAGRAM PASS ==========
   // Generate TikZ for detected diagram description blocks
-  let diagramMetrics = createEmptyMetrics()
-
   // Use configured prompt or built-in default
   const effectiveDiagramPrompt = diagramGeneratorPrompt ?? DEFAULT_DIAGRAM_GENERATOR_PROMPT
 
+  let diagramResult = { metrics: createEmptyMetrics(), conversions: [] as Array<unknown> }
+
   if (validExercises.length > 0) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    diagramMetrics = await runDiagramPass(payload as any, {
+    diagramResult = await runDiagramPass(payload as any, {
       attachments,
       diagramPrompt: effectiveDiagramPrompt,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -535,7 +535,7 @@ Return JSON: { "valid": boolean, "reason": "..." }`
 
   // Store diagram metrics in output for segment debug
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ;(output as any).diagramMetrics = diagramMetrics
+  ;(output as any).diagramMetrics = diagramResult.metrics
 
   return validExercises
 }

--- a/src/server/payload/jobs/pdf-to-exercises-task.ts
+++ b/src/server/payload/jobs/pdf-to-exercises-task.ts
@@ -11,11 +11,16 @@ import { ObjectId } from 'mongodb'
 import { getPayload } from 'payload'
 
 import type { MediaPartWithPath } from '@/infra/llm/multimodal/types'
+import { DEFAULT_DIAGRAM_GENERATOR_PROMPT } from '@/infra/llm/prompts/diagram-generator'
 import {
   getLLMProvider,
   getProviderModelConfig,
   getProviderTypeFromEnv,
 } from '@/infra/llm/providers/factory'
+import {
+  createEmptyMetrics,
+  runDiagramPass,
+} from '@/server/services/exercise-conversion/diagram-pass'
 import {
   enrichBlockIds,
   normalizeExerciseInput,
@@ -115,6 +120,7 @@ export const pdfToExercisesTask = {
             segment,
             extractorPrompt: input.promptSnapshot.extractor,
             verifierPrompt: input.promptSnapshot.verifier,
+            diagramGeneratorPrompt: input.promptSnapshot.diagramGenerator,
             output, // v2.1: Pass output for exercisesSkipped tracking
             tenantId, // For SystemParams access
           })
@@ -407,11 +413,20 @@ async function processSegmentWithMultimodal(
     segment: { pageStart: number; pageEnd: number }
     extractorPrompt: string
     verifierPrompt: string
+    diagramGeneratorPrompt?: string
     output: { exercisesSkipped?: number; errors: unknown[] }
     tenantId: string // For SystemParams access
   },
 ) {
-  const { attachments, segment, extractorPrompt, verifierPrompt, output, tenantId } = context
+  const {
+    attachments,
+    segment,
+    extractorPrompt,
+    verifierPrompt,
+    diagramGeneratorPrompt,
+    output,
+    tenantId,
+  } = context
 
   // ========== Call Extractor with MULTIMODAL PDF Attachment ==========
   const extractorPromptWithContext = `${extractorPrompt}
@@ -500,6 +515,27 @@ Return JSON: { "valid": boolean, "reason": "..." }`
 
     validExercises.push(exercise)
   }
+
+  // ========== DIAGRAM PASS ==========
+  // Generate TikZ for detected diagram description blocks
+  let diagramMetrics = createEmptyMetrics()
+
+  // Use configured prompt or built-in default
+  const effectiveDiagramPrompt = diagramGeneratorPrompt ?? DEFAULT_DIAGRAM_GENERATOR_PROMPT
+
+  if (validExercises.length > 0) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    diagramMetrics = await runDiagramPass(payload as any, {
+      attachments,
+      diagramPrompt: effectiveDiagramPrompt,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      exercises: validExercises as any,
+    })
+  }
+
+  // Store diagram metrics in output for segment debug
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(output as any).diagramMetrics = diagramMetrics
 
   return validExercises
 }

--- a/src/server/payload/jobs/types.ts
+++ b/src/server/payload/jobs/types.ts
@@ -42,6 +42,7 @@ export interface PdfToExercisesInput {
   promptSnapshot: {
     extractor: string
     verifier: string
+    diagramGenerator?: string // null/undefined if not configured
   }
   promptSnapshotHash: {
     extractor: string
@@ -60,6 +61,14 @@ export interface PdfToExercisesOutput {
     exerciseCount: number
     debug?: {
       proposedIdempotencyKeys: string[]
+      diagramPass?: {
+        detected: number
+        attempted: number
+        succeeded: number
+        failed: number
+        latencyMs: number
+        byType: { geometry: number; axis: number; other: number }
+      }
     }
   }>
 }

--- a/src/server/services/exercise-conversion/diagram-pass.ts
+++ b/src/server/services/exercise-conversion/diagram-pass.ts
@@ -1,0 +1,415 @@
+/**
+ * Diagram Pass Module
+ *
+ * Converts diagram description blocks to TikZ/LaTeX code.
+ * Used by both the PDF batch pipeline and V3 single-exercise pipeline.
+ *
+ * @fileType service-module
+ * @domain conversion
+ * @pattern diagram-conversion
+ */
+import { nanoid } from 'nanoid'
+
+import type { Payload } from 'payload'
+
+import type {
+  DiagramBlockInfo,
+  DiagramPassMetrics,
+  DiagramToTikzOutput,
+} from './diagram-pass.types'
+import { DiagramToTikzOutputSchema } from './diagram-pass.types'
+
+import type { AIModelKey } from '@/infra/llm/models'
+import {
+  getLLMProvider,
+  getProviderModelConfig,
+  getProviderTypeFromEnv,
+  type UnifiedLLMProvider,
+} from '@/infra/llm/providers/factory'
+
+// ── Constants ──
+
+const TIKZ_MAX_LENGTH = 10_000
+
+/**
+ * Commands that could be used for file system access or code execution.
+ * Checked case-insensitively against the TikZ output.
+ */
+const TIKZ_DENYLIST = [
+  '\\input',
+  '\\include',
+  '\\write',
+  '\\openout',
+  '\\openin',
+  '\\closein',
+  '\\closeout',
+  '\\newwrite',
+  '\\newread',
+  '\\immediate',
+  '\\catcode',
+  '\\csname',
+  '\\endcsname',
+  '\\makeatletter',
+  '\\makeatother',
+  '\\directlua',
+  '\\luaexec',
+]
+
+// ── Detection ──
+
+/**
+ * Detection patterns for V3 diagram blocks.
+ *
+ * V3 prompt (v3-exercise-with-diagrams.ts) instructs LLM to produce:
+ * - Global:          "**Diagram:** Right triangle $ABC$..."
+ * - Per-sub-question: "**Diagram for א:** A coordinate plane..."
+ *
+ * These become rich_text blocks in exercise content via transform.ts.
+ */
+const GLOBAL_DIAGRAM_PREFIX = '**Diagram:**'
+const PER_SQ_DIAGRAM_REGEX = /^\*\*Diagram for (.+?):\*\*/
+
+/**
+ * Detect diagram blocks in exercises.
+ * Looks for rich_text blocks starting with "**Diagram:**" or "**Diagram for X:**"
+ */
+export function detectDiagramBlocks(
+  exercises: Array<{
+    blocks: Array<{ type: string; id?: string; value?: string }>
+  }>,
+): DiagramBlockInfo[] {
+  const diagrams: DiagramBlockInfo[] = []
+
+  for (let exIdx = 0; exIdx < exercises.length; exIdx++) {
+    const exercise = exercises[exIdx]
+    for (let blkIdx = 0; blkIdx < exercise.blocks.length; blkIdx++) {
+      const block = exercise.blocks[blkIdx]
+      if (block.type !== 'rich_text' || !block.value) continue
+
+      const value = block.value
+
+      // Check global pattern: "**Diagram:** ..."
+      if (value.startsWith(GLOBAL_DIAGRAM_PREFIX)) {
+        diagrams.push({
+          exerciseIndex: exIdx,
+          blockIndex: blkIdx,
+          blockId: block.id ?? nanoid(),
+          description: value.slice(GLOBAL_DIAGRAM_PREFIX.length).trim(),
+          isPerSubQuestion: false,
+        })
+        continue
+      }
+
+      // Check per-sub-question pattern: "**Diagram for X:** ..."
+      const match = PER_SQ_DIAGRAM_REGEX.exec(value)
+      if (match) {
+        // Find end of bold prefix: "**Diagram for X:**" → skip past closing "**"
+        const closingBold = value.indexOf('**', 2)
+        const prefixEnd = closingBold >= 0 ? closingBold + 2 : match[0].length
+        diagrams.push({
+          exerciseIndex: exIdx,
+          blockIndex: blkIdx,
+          blockId: block.id ?? nanoid(),
+          description: value.slice(prefixEnd).trim(),
+          isPerSubQuestion: true,
+          subQuestionLabel: match[1],
+        })
+      }
+    }
+  }
+
+  return diagrams
+}
+
+// ── Validation ──
+
+interface TikzValidationResult {
+  valid: boolean
+  reason?: string
+}
+
+/**
+ * Validate TikZ for safety before insertion.
+ * Checks: size limit, balanced braces, command denylist
+ */
+export function validateTikzSafety(tikz: string): TikzValidationResult {
+  if (tikz.length > TIKZ_MAX_LENGTH) {
+    return {
+      valid: false,
+      reason: `TikZ exceeds max length (${tikz.length} > ${TIKZ_MAX_LENGTH})`,
+    }
+  }
+
+  let depth = 0
+  for (const char of tikz) {
+    if (char === '{') depth++
+    else if (char === '}') depth--
+    if (depth < 0) return { valid: false, reason: 'Unbalanced braces (extra closing brace)' }
+  }
+  if (depth !== 0) {
+    return { valid: false, reason: `Unbalanced braces (${depth} unclosed)` }
+  }
+
+  const tikzLower = tikz.toLowerCase()
+  for (const cmd of TIKZ_DENYLIST) {
+    if (tikzLower.includes(cmd.toLowerCase())) {
+      return { valid: false, reason: `Blocked command: ${cmd}` }
+    }
+  }
+
+  return { valid: true }
+}
+
+// ── Response Parsing ──
+
+/**
+ * Parse and validate LLM response for diagram conversion.
+ * Extracts JSON from markdown code blocks or raw text, then validates against schema.
+ */
+export function parseDiagramResponse(responseText: string): DiagramToTikzOutput | null {
+  try {
+    // Extract JSON — handle markdown code blocks wrapping
+    const jsonMatch =
+      responseText.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/) ||
+      responseText.match(/(\{[\s\S]*\})/)
+    const jsonStr = jsonMatch?.[1] || responseText
+
+    const parsed = JSON.parse(jsonStr)
+    const result = DiagramToTikzOutputSchema.safeParse(parsed)
+
+    if (!result.success) {
+      return null
+    }
+
+    return result.data
+  } catch {
+    return null
+  }
+}
+
+// ── Block Insertion ──
+
+/**
+ * Insert a latex block immediately after the diagram description block.
+ * Mutates the blocks array in place.
+ *
+ * Returns the new block for logging/metrics.
+ */
+export function insertTikzBlock(
+  blocks: Array<Record<string, unknown>>,
+  afterIndex: number,
+  tikzContent: string,
+): { id: string } {
+  const id = nanoid()
+  const latexBlock = {
+    id,
+    type: 'latex' as const,
+    latex: tikzContent,
+    renderMode: 'block' as const,
+  }
+
+  blocks.splice(afterIndex + 1, 0, latexBlock)
+  return { id }
+}
+
+// ── LLM Caller ──
+
+/**
+ * Call the LLM to generate TikZ from a diagram description.
+ */
+async function callDiagramGenerator(
+  payload: Payload,
+  provider: UnifiedLLMProvider,
+  attachments: Array<{ data: string; mimeType: string }>,
+  prompt: string,
+): Promise<{ output: DiagramToTikzOutput | null; latencyMs: number }> {
+  const startTime = Date.now()
+
+  try {
+    const providerType = await getProviderTypeFromEnv(payload)
+    const modelConfig = getProviderModelConfig(providerType, 'PDF_TO_EXERCISE' as AIModelKey)
+
+    const result = await provider.generateMultimodalCompletion(
+      {
+        prompt,
+        model: modelConfig,
+        attachments,
+      },
+      payload,
+    )
+
+    const output = parseDiagramResponse(result.text)
+    return { output, latencyMs: Date.now() - startTime }
+  } catch {
+    return { output: null, latencyMs: Date.now() - startTime }
+  }
+}
+
+// ── Prompt Building ──
+
+/**
+ * Build the full prompt for a single diagram conversion.
+ * Injects the diagram description into the base prompt template.
+ */
+function buildDiagramPrompt(
+  basePrompt: string,
+  diagramDescription: string,
+  exerciseTitle: string,
+): string {
+  return `${basePrompt}
+
+## Diagram to Convert
+
+**Exercise**: ${exerciseTitle}
+
+**Diagram Description**:
+${diagramDescription}
+
+## Required Output Format
+
+Return ONLY valid JSON (no markdown code blocks, no surrounding text):
+{
+  "tikz": "\\\\begin{tikzpicture}...\\\\end{tikzpicture}",
+  "diagramType": "geometry",
+  "confidence": 0.85,
+  "warnings": [],
+  "notes": "optional"
+}
+
+## Classification Rules
+- "geometry": Euclidean geometry — triangles, circles, angles, line segments, polygons, parallel lines
+- "axis": Coordinate systems — graphs, functions, plotted points, number lines, asymptotes
+- "other": Everything else — flowcharts, Venn diagrams, circuit diagrams, tables, trees
+
+## TikZ Rules
+1. Create a SCHEMATIC representation — simple geometric shapes, not photorealistic
+2. Use basic TikZ primitives: \\draw, \\node, \\filldraw, \\coordinate
+3. Do NOT infer or add elements not described
+4. Do NOT solve or interpret the exercise
+5. If uncertain about an element, OMIT it rather than guess
+6. Use \\texthebrew{} for Hebrew labels if needed
+7. Keep coordinates as simple integers when possible`
+}
+
+// ── Metrics ──
+
+/**
+ * Create empty metrics object for initial state.
+ */
+export function createEmptyMetrics(): DiagramPassMetrics {
+  return {
+    detected: 0,
+    attempted: 0,
+    succeeded: 0,
+    failed: 0,
+    skipped: 0,
+    latencyMs: 0,
+    byType: { geometry: 0, axis: 0, other: 0 },
+    failureReasons: [],
+  }
+}
+
+// ── Orchestrator ──
+
+export interface DiagramPassContext {
+  attachments: Array<{ data: string; mimeType: string }>
+  diagramPrompt: string
+  exercises: Array<{
+    title?: string
+    blocks: Array<{ type: string; id?: string; value?: string; [key: string]: unknown }>
+  }>
+}
+
+/**
+ * Run the diagram pass for a set of exercises.
+ *
+ * Detects diagram blocks → generates TikZ via LLM → validates safety → inserts latex blocks.
+ * Mutates exercise blocks arrays in place. Returns metrics.
+ *
+ * Used by:
+ * - PDF batch pipeline (per segment, on ValidatedExercise[])
+ * - V3 single pipeline (per extraction, on ContentBlock[])
+ */
+export async function runDiagramPass(
+  payload: Payload,
+  context: DiagramPassContext,
+): Promise<DiagramPassMetrics> {
+  const { attachments, diagramPrompt, exercises } = context
+  const metrics = createEmptyMetrics()
+
+  // Step 1: Detect diagram blocks across all exercises
+  const diagramBlocks = detectDiagramBlocks(exercises)
+  metrics.detected = diagramBlocks.length
+
+  if (diagramBlocks.length === 0) {
+    return metrics
+  }
+
+  // Get LLM provider
+  const provider = await getLLMProvider(payload)
+
+  // Step 2: Process each diagram sequentially
+  // Track insertion offsets per exercise (inserting latex blocks shifts later indices)
+  const insertionOffsets = new Map<number, number>()
+
+  for (const diagram of diagramBlocks) {
+    metrics.attempted++
+
+    const exercise = exercises[diagram.exerciseIndex]
+    const offset = insertionOffsets.get(diagram.exerciseIndex) ?? 0
+    const adjustedBlockIndex = diagram.blockIndex + offset
+
+    // Build the full prompt
+    const fullPrompt = buildDiagramPrompt(
+      diagramPrompt,
+      diagram.description,
+      exercise.title ?? 'Untitled',
+    )
+
+    // Call LLM
+    const { output: result, latencyMs } = await callDiagramGenerator(
+      payload,
+      provider,
+      attachments,
+      fullPrompt,
+    )
+    metrics.latencyMs += latencyMs
+
+    // Handle failure: invalid response
+    if (!result) {
+      metrics.failed++
+      metrics.failureReasons.push(`LLM call failed or invalid JSON (exercise: "${exercise.title}")`)
+      continue
+    }
+
+    // Handle refusal or null tikz
+    if (!result.tikz || result.refusal) {
+      metrics.failed++
+      metrics.failureReasons.push(
+        `Refused: ${result.refusal?.reason ?? 'tikz is null'} (exercise: "${exercise.title}")`,
+      )
+      continue
+    }
+
+    // Validate TikZ safety
+    const safety = validateTikzSafety(result.tikz)
+    if (!safety.valid) {
+      metrics.failed++
+      metrics.failureReasons.push(`TikZ safety: ${safety.reason} (exercise: "${exercise.title}")`)
+      continue
+    }
+
+    // Success: insert latex block after the diagram description block
+    insertTikzBlock(
+      exercise.blocks as Array<Record<string, unknown>>,
+      adjustedBlockIndex,
+      result.tikz,
+    )
+    insertionOffsets.set(diagram.exerciseIndex, offset + 1)
+
+    metrics.byType[result.diagramType]++
+    metrics.succeeded++
+  }
+
+  return metrics
+}

--- a/src/server/services/exercise-conversion/diagram-pass.ts
+++ b/src/server/services/exercise-conversion/diagram-pass.ts
@@ -14,7 +14,9 @@ import type { Payload } from 'payload'
 
 import type {
   DiagramBlockInfo,
+  DiagramConversionInfo,
   DiagramPassMetrics,
+  DiagramPassResult,
   DiagramToTikzOutput,
 } from './diagram-pass.types'
 import { DiagramToTikzOutputSchema } from './diagram-pass.types'
@@ -324,7 +326,7 @@ export interface DiagramPassContext {
  * Run the diagram pass for a set of exercises.
  *
  * Detects diagram blocks → generates TikZ via LLM → validates safety → inserts latex blocks.
- * Mutates exercise blocks arrays in place. Returns metrics.
+ * Mutates exercise blocks arrays in place. Returns metrics and per-diagram conversion info.
  *
  * Used by:
  * - PDF batch pipeline (per segment, on ValidatedExercise[])
@@ -333,16 +335,17 @@ export interface DiagramPassContext {
 export async function runDiagramPass(
   payload: Payload,
   context: DiagramPassContext,
-): Promise<DiagramPassMetrics> {
+): Promise<DiagramPassResult> {
   const { attachments, diagramPrompt, exercises } = context
   const metrics = createEmptyMetrics()
+  const conversions: DiagramConversionInfo[] = []
 
   // Step 1: Detect diagram blocks across all exercises
   const diagramBlocks = detectDiagramBlocks(exercises)
   metrics.detected = diagramBlocks.length
 
   if (diagramBlocks.length === 0) {
-    return metrics
+    return { metrics, conversions }
   }
 
   // Get LLM provider
@@ -400,7 +403,7 @@ export async function runDiagramPass(
     }
 
     // Success: insert latex block after the diagram description block
-    insertTikzBlock(
+    const latexBlock = insertTikzBlock(
       exercise.blocks as Array<Record<string, unknown>>,
       adjustedBlockIndex,
       result.tikz,
@@ -409,7 +412,20 @@ export async function runDiagramPass(
 
     metrics.byType[result.diagramType]++
     metrics.succeeded++
+
+    // Track conversion info for Step 2
+    conversions.push({
+      exerciseIndex: diagram.exerciseIndex,
+      latexBlockId: latexBlock.id,
+      richTextBlockId: diagram.blockId,
+      diagramType: result.diagramType,
+      tikz: result.tikz,
+      description: diagram.description,
+      confidence: result.confidence,
+      isPerSubQuestion: diagram.isPerSubQuestion,
+      subQuestionLabel: diagram.subQuestionLabel,
+    })
   }
 
-  return metrics
+  return { metrics, conversions }
 }

--- a/src/server/services/exercise-conversion/diagram-pass.types.ts
+++ b/src/server/services/exercise-conversion/diagram-pass.types.ts
@@ -52,3 +52,43 @@ export interface DiagramPassMetrics {
   }
   failureReasons: string[]
 }
+
+// ── Per-Diagram Conversion Info (Step 1 Output) ──
+
+/**
+ * Information about each successful diagram-to-TikZ conversion from Step 1.
+ * Used by Step 2 (geometry-pass) to convert TikZ to GeometrySpecV1/AxisSpecV1.
+ */
+export interface DiagramConversionInfo {
+  /** Index of exercise in the exercises array */
+  exerciseIndex: number
+  /** ID of the inserted latex block */
+  latexBlockId: string
+  /** ID of the original rich_text diagram block */
+  richTextBlockId: string
+  /** Classification: geometry, axis, or other */
+  diagramType: 'geometry' | 'axis' | 'other'
+  /** Generated TikZ code */
+  tikz: string
+  /** Original diagram description text */
+  description: string
+  /** LLM confidence score from Step 1 */
+  confidence: number
+  /** true if "**Diagram for X:**", false if "**Diagram:**" */
+  isPerSubQuestion: boolean
+  /** Sub-question label (e.g., "א", "ב", "a") — only when isPerSubQuestion */
+  subQuestionLabel?: string
+}
+
+// ── Combined Result ──
+
+/**
+ * Full result from the diagram pass (Step 1).
+ * Includes both aggregate metrics and per-diagram conversion info.
+ */
+export interface DiagramPassResult {
+  /** Aggregate metrics for the pass */
+  metrics: DiagramPassMetrics
+  /** Per-diagram conversion information for Step 2 */
+  conversions: DiagramConversionInfo[]
+}

--- a/src/server/services/exercise-conversion/diagram-pass.types.ts
+++ b/src/server/services/exercise-conversion/diagram-pass.types.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod'
+
+// ── LLM Output Contract (spec FR-003) ──
+
+export const DiagramToTikzOutputSchema = z.object({
+  tikz: z.string().nullable(),
+  diagramType: z.enum(['geometry', 'axis', 'other']),
+  confidence: z.number().min(0).max(1),
+  warnings: z.array(z.string()),
+  notes: z.string().optional(),
+  requiredPackages: z.array(z.string()).optional(),
+  refusal: z
+    .object({
+      reason: z.string(),
+      detail: z.string().optional(),
+    })
+    .optional(),
+})
+
+export type DiagramToTikzOutput = z.infer<typeof DiagramToTikzOutputSchema>
+
+// ── Detection Result ──
+
+export interface DiagramBlockInfo {
+  /** Index of exercise in the exercises array */
+  exerciseIndex: number
+  /** Index of the diagram block within exercise.blocks */
+  blockIndex: number
+  /** Block ID for correlation */
+  blockId: string
+  /** Diagram description text (without the "**Diagram:**" prefix) */
+  description: string
+  /** true if "**Diagram for X:**", false if "**Diagram:**" */
+  isPerSubQuestion: boolean
+  /** Sub-question label (e.g., "א", "ב", "a") — only when isPerSubQuestion */
+  subQuestionLabel?: string
+}
+
+// ── Metrics ──
+
+export interface DiagramPassMetrics {
+  detected: number
+  attempted: number
+  succeeded: number
+  failed: number
+  skipped: number
+  latencyMs: number
+  byType: {
+    geometry: number
+    axis: number
+    other: number
+  }
+  failureReasons: string[]
+}

--- a/src/server/services/exercise-conversion/v3/extract-single.ts
+++ b/src/server/services/exercise-conversion/v3/extract-single.ts
@@ -17,6 +17,7 @@
 
 import type { Payload } from 'payload'
 
+import { DEFAULT_DIAGRAM_GENERATOR_PROMPT } from '@/infra/llm/prompts/diagram-generator'
 import {
   extractFromImageV3,
   type ImageToExerciseV3Response,
@@ -24,7 +25,8 @@ import {
 import { fetchBuffer } from '@/infra/utils/http'
 import type { Lesson, Media } from '@/payload-types'
 import { getPdfBufferFromBlob, normalizeToAbsoluteUrl } from '@/server/services/pdf-fetcher'
-import { resolveExtractorPrompt } from './prompt-resolver'
+import { runDiagramPass } from '../diagram-pass'
+import { resolveDiagramPrompt, resolveExtractorPrompt } from './prompt-resolver'
 import {
   autoAssignDiagrams,
   multiPartToExerciseContent,
@@ -209,6 +211,7 @@ export async function extractSingle(
         mimeType,
       },
       payload,
+      resolvedPrompt?.template,
     )
   } catch (llmError) {
     // Log failed extraction
@@ -243,12 +246,74 @@ export async function extractSingle(
     // Apply auto-detect heuristic to move misclassified diagrams to correct sub-question
     const extractionData = autoAssignDiagrams(rawExtractionData)
 
+    // Transform to content first, then run diagram pass on the blocks
+    const preTransformResult = multiPartToExerciseContent(extractionData)
+    let finalContent = preTransformResult.content
+
+    // ========== DIAGRAM PASS (V3 single) ==========
+    // Resolve diagram prompt (non-fatal if not configured)
+    let diagramPromptId: string | undefined
+    let diagramPromptVersion: string | undefined
+    try {
+      const resolved = await resolveDiagramPrompt(payload, lessonTenantId)
+      const diagramPromptTemplate = resolved?.template ?? DEFAULT_DIAGRAM_GENERATOR_PROMPT
+      diagramPromptId = resolved?.prompt.id
+      diagramPromptVersion = resolved?.version
+
+      // Build attachments from the media buffer
+      const diagramAttachments = [
+        {
+          data: imageBuffer.toString('base64'),
+          mimeType,
+        },
+      ]
+
+      // Run diagram pass on the content blocks
+      const diagramExercise = {
+        title: preTransformResult.title,
+        blocks: [...finalContent.blocks] as Array<{
+          type: string
+          id?: string
+          value?: string
+          [key: string]: unknown
+        }>,
+      }
+
+      const diagramMetrics = await runDiagramPass(payload, {
+        attachments: diagramAttachments,
+        diagramPrompt: diagramPromptTemplate,
+        exercises: [diagramExercise],
+      })
+
+      // Use mutated blocks if diagram pass found and processed anything
+      if (diagramMetrics.detected > 0) {
+        finalContent = { blocks: diagramExercise.blocks as typeof finalContent.blocks }
+      }
+
+      // Log diagram pass as a separate extraction log entry
+      if (diagramMetrics.attempted > 0) {
+        await createExtractionLog(payload, {
+          tenant: lessonTenantId,
+          lesson: lessonId,
+          media: mediaId,
+          prompt: diagramPromptId,
+          promptVersion: diagramPromptVersion,
+          status: diagramMetrics.succeeded > 0 ? 'success' : 'failed',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          stage: 'diagram-tikz' as any,
+          processingTimeMs: diagramMetrics.latencyMs,
+          model: '',
+        })
+      }
+    } catch {
+      // Diagram pass is non-fatal — continue without it
+    }
+
     // Transform to preview draft (preserves null correctAnswer)
     previewDraft = multiPartToPreviewDraft(extractionData)
 
-    // Transform to exercise content (uses deterministic fallback for null)
-    const transformResult = multiPartToExerciseContent(extractionData)
-    exerciseContent = transformResult.content
+    // Use the content with diagram pass results applied
+    exerciseContent = finalContent
 
     // Log successful extraction (use raw data)
     const logId = await createExtractionLog(payload, {
@@ -440,6 +505,7 @@ export async function extractAndCreate(
         mimeType,
       },
       payload,
+      resolvedPrompt?.template,
     )
   } catch (llmError) {
     // Log failed extraction
@@ -471,9 +537,47 @@ export async function extractAndCreate(
     // Apply auto-detect heuristic to move misclassified diagrams to correct sub-question
     const extractionData = autoAssignDiagrams(rawExtractionData)
 
+    // Transform to content first, then run diagram pass on the blocks
+    const preTransformResult = multiPartToExerciseContent(extractionData)
+    let finalContent = preTransformResult.content
+
+    // ========== DIAGRAM PASS (V3 single — create path) ==========
+    try {
+      const resolved = await resolveDiagramPrompt(payload, lessonTenantId)
+      const diagramPromptTemplate = resolved?.template ?? DEFAULT_DIAGRAM_GENERATOR_PROMPT
+
+      const diagramAttachments = [
+        {
+          data: imageBuffer.toString('base64'),
+          mimeType,
+        },
+      ]
+
+      const diagramExercise = {
+        title: preTransformResult.title,
+        blocks: [...finalContent.blocks] as Array<{
+          type: string
+          id?: string
+          value?: string
+          [key: string]: unknown
+        }>,
+      }
+
+      const diagramMetrics = await runDiagramPass(payload, {
+        attachments: diagramAttachments,
+        diagramPrompt: diagramPromptTemplate,
+        exercises: [diagramExercise],
+      })
+
+      if (diagramMetrics.detected > 0) {
+        finalContent = { blocks: diagramExercise.blocks as typeof finalContent.blocks }
+      }
+    } catch {
+      // Non-fatal
+    }
+
     // Transform to exercise content (uses deterministic fallback for null)
-    const transformResult = multiPartToExerciseContent(extractionData)
-    const { title, content } = transformResult
+    const { title, content } = { title: preTransformResult.title, content: finalContent }
 
     // Step 7: Create exercise immediately
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/server/services/exercise-conversion/v3/extract-single.ts
+++ b/src/server/services/exercise-conversion/v3/extract-single.ts
@@ -279,29 +279,29 @@ export async function extractSingle(
         }>,
       }
 
-      const diagramMetrics = await runDiagramPass(payload, {
+      const diagramResult = await runDiagramPass(payload, {
         attachments: diagramAttachments,
         diagramPrompt: diagramPromptTemplate,
         exercises: [diagramExercise],
       })
 
       // Use mutated blocks if diagram pass found and processed anything
-      if (diagramMetrics.detected > 0) {
+      if (diagramResult.metrics.detected > 0) {
         finalContent = { blocks: diagramExercise.blocks as typeof finalContent.blocks }
       }
 
       // Log diagram pass as a separate extraction log entry
-      if (diagramMetrics.attempted > 0) {
+      if (diagramResult.metrics.attempted > 0) {
         await createExtractionLog(payload, {
           tenant: lessonTenantId,
           lesson: lessonId,
           media: mediaId,
           prompt: diagramPromptId,
           promptVersion: diagramPromptVersion,
-          status: diagramMetrics.succeeded > 0 ? 'success' : 'failed',
+          status: diagramResult.metrics.succeeded > 0 ? 'success' : 'failed',
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           stage: 'diagram-tikz' as any,
-          processingTimeMs: diagramMetrics.latencyMs,
+          processingTimeMs: diagramResult.metrics.latencyMs,
           model: '',
         })
       }
@@ -563,13 +563,13 @@ export async function extractAndCreate(
         }>,
       }
 
-      const diagramMetrics = await runDiagramPass(payload, {
+      const diagramResult = await runDiagramPass(payload, {
         attachments: diagramAttachments,
         diagramPrompt: diagramPromptTemplate,
         exercises: [diagramExercise],
       })
 
-      if (diagramMetrics.detected > 0) {
+      if (diagramResult.metrics.detected > 0) {
         finalContent = { blocks: diagramExercise.blocks as typeof finalContent.blocks }
       }
     } catch {

--- a/src/server/services/exercise-conversion/v3/prompt-resolver.ts
+++ b/src/server/services/exercise-conversion/v3/prompt-resolver.ts
@@ -9,12 +9,13 @@
  * @pattern prompt-resolution
  */
 
-import type { Payload } from 'payload'
 import type { Prompt } from '@/payload-types'
+import type { Payload } from 'payload'
 
 export interface ResolvedPrompt {
   prompt: Prompt
   version: string // `${prompt.promptKey}:${prompt.updatedAt}`
+  template?: string // For diagram prompt which returns template
 }
 
 /**
@@ -68,7 +69,7 @@ export async function resolveExtractorPrompt(
       : 'unknown'
     const version = `${typedPrompt.promptKey}:${updatedAt}`
 
-    return { prompt: typedPrompt, version }
+    return { prompt: typedPrompt, version, template: typedPrompt.template }
   }
 
   // No prompt ID - find latest published extractor prompt for tenant
@@ -96,7 +97,7 @@ export async function resolveExtractorPrompt(
   const updatedAt = prompt.updatedAt ? new Date(prompt.updatedAt).toISOString() : 'unknown'
   const version = `${prompt.promptKey}:${updatedAt}`
 
-  return { prompt, version }
+  return { prompt, version, template: prompt.template }
 }
 
 /**
@@ -105,4 +106,41 @@ export async function resolveExtractorPrompt(
  */
 export function getPromptTemplate(prompt: Prompt): string {
   return prompt.template
+}
+
+/**
+ * Resolve diagram generator prompt for a given tenant.
+ * Returns null if no published prompt exists (diagram pass will use default).
+ *
+ * Unlike resolveExtractorPrompt, this does NOT throw on missing prompt.
+ * The diagram pass is optional — if no prompt exists, use the built-in default.
+ */
+export async function resolveDiagramPrompt(
+  payload: Payload,
+  tenantId: string,
+): Promise<ResolvedPrompt | null> {
+  const result = await payload.find({
+    collection: 'prompts',
+    where: {
+      and: [
+        { tenant: { equals: tenantId } },
+        { usage: { equals: 'diagram-generator' } },
+        { status: { equals: 'published' } },
+      ],
+    },
+    sort: '-updatedAt',
+    limit: 1,
+    depth: 0,
+    overrideAccess: true,
+  })
+
+  if (result.docs.length === 0) {
+    return null
+  }
+
+  const prompt = result.docs[0] as unknown as Prompt
+  const updatedAt = prompt.updatedAt ? new Date(prompt.updatedAt).toISOString() : 'unknown'
+  const version = `${prompt.promptKey}:${updatedAt}`
+
+  return { prompt, version, template: prompt.template }
 }


### PR DESCRIPTION
Add a two-phase diagram conversion pipeline to the exercise conversion system. Step 1 detects diagram description blocks, generates TikZ via LLM, validates safety, and inserts latex blocks into exercise content.

New files:
- diagram-pass.ts: Core module (detection, validation, LLM caller, orchestrator)
- diagram-pass.types.ts: Zod schema for DiagramToTikzOutput, metrics types
- diagram-generator.ts: Default system prompt for TikZ generation
- spec-step1.md, spec-step2.md: Split specs for the two-step pipeline

Modified:
- Prompts collection: Added 'diagram-generator' usage option
- ExtractionLogs: Added 'diagram-tikz' stage
- Job types: Extended with diagram metrics in snapshot and debug output
- prompt-resolver: Added resolveDiagramPrompt(), fixed template return (FR-008)
- extract-single: Integrated diagram pass into both extractSingle/extractAndCreate
- data-extractor-service: Accept prompt override for audit trail accuracy
- for-conversion API: Returns diagramGenerators in prompt listing
- pdf-to-exercises-task: Integrated diagram pass into batch pipeline