### PR TITLE
fix: Guard inspector digest/nudge actions against missing WATCHDOG_ISSUE

### DIFF
--- a/.tasks/fix-inspector-watchdog/plan.md
+++ b/.tasks/fix-inspector-watchdog/plan.md
@@ -1,0 +1,338 @@
+# Plan: Fix Inspector WATCHDOG_ISSUE + Robustness Improvements
+
+**Task ID**: fix-inspector-watchdog
+**Task Type**: fix_bug
+**Steps**: 4
+**Estimated Time**: ~60 minutes
+
+## Summary
+
+Fix 5 bugs in the Inspector workflow: (B1/B2) digest posts to issue #0 when `WATCHDOG_ISSUE` is unset, (B3/B4) `gh issue` subcommands missing `--repo` flag, and (B5) document ephemeral state. Add tests — no existing tests for inspector.
+
+## Assumptions
+
+1. `WATCHDOG_ISSUE` is parsed once at startup, stored on `InspectorContext`, and consumed by plugins via `ctx` — no `process.env` reads inside execute closures.
+2. The `--repo` flag uses the `repo` variable already in closure scope of `createGitHubClient`.
+3. B5 (ephemeral state) is by design; we document but don't fix.
+4. All tests use vitest with mocked `execFileSync` / mocked context objects — no real GitHub API calls.
+5. Test directory: `tests/unit/scripts/inspector/` (new directory).
+
+---
+
+### Step 1: Fix digest action guard — skip when WATCHDOG_ISSUE is missing
+
+**Root Cause**: `createDigestAction` at `health-check/index.ts:264` calls `Number(process.env.WATCHDOG_ISSUE) || 0`. When env var is unset, this evaluates to `0`, and `postComment(0, ...)` fires `gh issue comment 0` which fails silently. The digest is produced but never actually posted.
+
+**Files to Touch**:
+- `scripts/inspector/core/types.ts` (MODIFIED — lines 55-64, 130-135): Add `watchdogIssue?: number` to `InspectorContext` and `InspectorConfig`
+- `scripts/inspector/index.ts` (MODIFIED — lines 22-55): Parse `WATCHDOG_ISSUE`, add startup warning, pass to config
+- `scripts/inspector/core/inspector.ts` (MODIFIED — lines 54-63): Pass `watchdogIssue` from config to context
+- `scripts/inspector/plugins/cody/health-check/index.ts` (MODIFIED — lines 212-269): Replace `process.env.WATCHDOG_ISSUE` read with `ctx.watchdogIssue`; return `null` if undefined
+
+**Reproduction Test** (MUST FAIL before fix):
+- **Test location**: `tests/unit/scripts/inspector/health-check.test.ts` (NEW)
+- **Test 1**: `createDigestAction should return null when ctx.watchdogIssue is undefined`
+  - Setup: Create mock `InspectorContext` without `watchdogIssue` field. Create array of `EvaluatedTask` with at least one failed task (so digest would normally be produced).
+  - Call the digest creation logic (import and test `createDigestAction` — if not exported, test via `healthCheckPlugin.run()` and assert no digest action is returned).
+  - **Why it fails now**: Currently returns an action that reads `process.env.WATCHDOG_ISSUE` and gets `0`, so the action IS returned and execute posts to issue #0.
+  - **After fix**: Returns `null` when `ctx.watchdogIssue` is undefined → no digest action.
+
+- **Test 2**: `createDigestAction should post to correct issue number when ctx.watchdogIssue is set`
+  - Setup: Create mock context with `watchdogIssue: 42`. Create evaluated tasks with failures.
+  - Execute the returned action, verify `ctx.github.postComment` is called with `42` as first arg.
+  - **Why it fails now**: postComment is called with `Number(process.env.WATCHDOG_ISSUE) || 0` = `0` instead of `42`.
+  - **After fix**: postComment called with `42`.
+
+**Fix Details**:
+1. In `core/types.ts`, add to `InspectorContext` interface (after line 63):
+   ```typescript
+   watchdogIssue?: number
+   ```
+   Add to `InspectorConfig` interface (after line 133):
+   ```typescript
+   watchdogIssue?: number
+   ```
+
+2. In `index.ts`, after line 26 (dryRun parsing):
+   ```typescript
+   const watchdogIssue = process.env.WATCHDOG_ISSUE ? Number(process.env.WATCHDOG_ISSUE) : undefined
+   if (!watchdogIssue) {
+     logger.warn('WATCHDOG_ISSUE not set — digest reports will be skipped')
+   }
+   ```
+   In config object (line 50-55), add `watchdogIssue`.
+
+3. In `core/inspector.ts`, add `watchdogIssue` to the context object (line 54-63):
+   ```typescript
+   watchdogIssue: config.watchdogIssue,
+   ```
+
+4. In `health-check/index.ts`, replace lines 263-264:
+   ```typescript
+   // Before (BUG):
+   ctx.github.postComment(Number(process.env.WATCHDOG_ISSUE) || 0, ...)
+   
+   // After (FIX):
+   // At top of createDigestAction, after healthCounts check:
+   if (!ctx.watchdogIssue) {
+     ctx.log.warn('WATCHDOG_ISSUE not configured — skipping digest')
+     return null
+   }
+   // In execute closure:
+   ctx.github.postComment(ctx.watchdogIssue, ...)
+   ```
+
+**Test Implementation Notes**:
+- Since `createDigestAction` and `createNudgeAction` are module-private functions, tests should either:
+  - (a) Export them for testing (preferred — add `export` keyword), OR
+  - (b) Test through `healthCheckPlugin.run()` by mocking `discoverTasks` and inspecting returned actions
+- Recommended: export `createDigestAction` and `createNudgeAction` as named exports for testability. Add a `/** @internal — exported for testing */` comment.
+
+**Verification**:
+- [ ] Test confirms `null` returned when `ctx.watchdogIssue` is undefined
+- [ ] Test confirms postComment called with correct issue number when set
+- [ ] No `process.env.WATCHDOG_ISSUE` reads remain inside health-check/index.ts
+
+**Acceptance Criteria**:
+- [ ] When `WATCHDOG_ISSUE` is not set, digest action is skipped with `ctx.log.warn` message
+- [ ] When `WATCHDOG_ISSUE` is set to e.g. `42`, digest posts to issue #42
+- [ ] No `process.env` reads inside plugin execute closures — all config comes through `ctx`
+
+---
+
+### Step 2: Fix nudge action guard — validate issueNumber before posting
+
+**Root Cause**: `createNudgeAction` at `health-check/index.ts:199-204` uses `task.issueNumber` directly. If a task was discovered from a local `.tasks/` directory without a matching GitHub issue (or issue number is `0`), `postComment(0, ...)` fails silently.
+
+**Files to Touch**:
+- `scripts/inspector/plugins/cody/health-check/index.ts` (MODIFIED — lines 175-207): Add guard for `task.issueNumber`
+
+**Reproduction Test** (MUST FAIL before fix):
+- **Test location**: `tests/unit/scripts/inspector/health-check.test.ts` (same file as Step 1)
+- **Test 3**: `createNudgeAction should return null when task.issueNumber is 0`
+  - Setup: Create `EvaluatedTask` with `health: 'gated'`, `gatedMinutes: 60`, `issueNumber: 0`.
+  - Call `createNudgeAction(task, ctx)`.
+  - **Why it fails now**: Returns an action that calls `postComment(0, ...)`.
+  - **After fix**: Returns `null`.
+
+- **Test 4**: `createNudgeAction should return action for valid issueNumber`
+  - Setup: Create `EvaluatedTask` with `health: 'gated'`, `gatedMinutes: 60`, `issueNumber: 123`.
+  - Call `createNudgeAction(task, ctx)`.
+  - Execute the action, verify `ctx.github.postComment` called with `123`.
+  - **Why it fails now**: This test PASSES already (correct behavior for valid issue numbers). Include for regression.
+
+**Fix Details**:
+1. In `createNudgeAction`, add guard after line 176:
+   ```typescript
+   if (!task.issueNumber || task.issueNumber <= 0) {
+     return null
+   }
+   ```
+
+**Verification**:
+- [ ] Test confirms `null` for `issueNumber: 0`
+- [ ] Test confirms `null` for `issueNumber: -1` (edge case)
+- [ ] Test confirms action created for `issueNumber: 123`
+- [ ] Nudge still works correctly for valid gated tasks after ≥30 minutes
+
+**Acceptance Criteria**:
+- [ ] No `postComment` calls with issue number ≤ 0
+- [ ] Nudge actions are created correctly for valid issue numbers
+- [ ] Gated tasks under 30 minutes still return `null` (existing behavior preserved)
+
+---
+
+### Step 3: Add `--repo` flag to all gh CLI issue subcommands
+
+**Root Cause**: `postComment` (line 33), `addLabel` (line 99), and `removeLabel` (line 103) in `clients/github.ts` don't pass `--repo`. They rely on CWD having a `.git` directory. In CI (GitHub Actions), CWD is a temp checkout dir which may not have proper git config. The `repo` variable is already available in the closure scope of `createGitHubClient`.
+
+**Files to Touch**:
+- `scripts/inspector/clients/github.ts` (MODIFIED — lines 32-34, 98-104): Add `--repo`, `repo` args
+
+**Reproduction Test** (MUST FAIL before fix):
+- **Test location**: `tests/unit/scripts/inspector/github-client.test.ts` (NEW)
+- **Test 5**: `postComment should include --repo flag in gh CLI args`
+  - Setup: Mock `execFileSync`. Create client via `createGitHubClient('owner/repo', 'fake-token')`.
+  - Call `client.postComment(42, 'hello')`.
+  - Assert: `execFileSync` called with args containing `'--repo'` and `'owner/repo'`.
+  - **Why it fails now**: args are `['issue', 'comment', '42', '--body-file', '-']` — no `--repo`.
+
+- **Test 6**: `addLabel should include --repo flag in gh CLI args`
+  - Setup: Same mock pattern.
+  - Call `client.addLabel(42, 'bug')`.
+  - Assert: args contain `'--repo'` and `'owner/repo'`.
+  - **Why it fails now**: args are `['issue', 'add-label', '42', 'bug']` — no `--repo`.
+
+- **Test 7**: `removeLabel should include --repo flag in gh CLI args`
+  - Setup: Same mock pattern.
+  - Call `client.removeLabel(42, 'bug')`.
+  - Assert: args contain `'--repo'` and `'owner/repo'`.
+  - **Why it fails now**: args are `['issue', 'remove-label', '42', 'bug']` — no `--repo`.
+
+- **Test 8**: `closeIssue already includes --repo flag` (regression test)
+  - Assert: args contain `--repo=owner/repo` (already present at line 122).
+
+**Fix Details**:
+1. `postComment` (line 33): Change from:
+   ```typescript
+   gh(['issue', 'comment', String(issueNumber), '--body-file', '-'], body)
+   ```
+   To:
+   ```typescript
+   gh(['issue', 'comment', String(issueNumber), '--repo', repo, '--body-file', '-'], body)
+   ```
+
+2. `addLabel` (line 99): Change from:
+   ```typescript
+   gh(['issue', 'add-label', String(issueNumber), label])
+   ```
+   To:
+   ```typescript
+   gh(['issue', 'add-label', String(issueNumber), '--repo', repo, label])
+   ```
+
+3. `removeLabel` (line 103): Change from:
+   ```typescript
+   gh(['issue', 'remove-label', String(issueNumber), label])
+   ```
+   To:
+   ```typescript
+   gh(['issue', 'remove-label', String(issueNumber), '--repo', repo, label])
+   ```
+
+**Note on `--repo` format**: Use `'--repo', repo` (two separate args) instead of `--repo=${repo}` for consistency with the label arg. The `closeIssue` method already uses `--repo=${repo}` (single arg) format — either format works with `gh`. For max consistency across the client, you may normalize to either format.
+
+**Verification**:
+- [ ] Mock `execFileSync` and verify all 3 methods include `--repo`
+- [ ] `closeIssue` regression test passes (already has `--repo`)
+- [ ] `triggerWorkflow` regression test passes (already has `--repo=`)
+- [ ] `getIssue` and `getOpenIssues` use `gh api repos/${repo}/...` pattern (no change needed — they already embed repo in the URL)
+
+**Acceptance Criteria**:
+- [ ] All `gh issue` subcommands (`postComment`, `addLabel`, `removeLabel`, `closeIssue`) pass `--repo` explicitly
+- [ ] No `gh issue` subcommand relies on implicit CWD repo detection
+- [ ] Existing functionality unchanged (same commands, just with explicit repo)
+
+---
+
+### Step 4: Add startup validation and structured logging for missing config
+
+**Root Cause**: Inspector starts and runs all plugins even when critical configuration is missing. Operators have no visibility into what's degraded. Missing `WATCHDOG_ISSUE` causes digest to silently fail (B1/B2). Missing `MINIMAX_API_KEY` causes failure analysis to use fallback mode with no indication.
+
+**Files to Touch**:
+- `scripts/inspector/index.ts` (MODIFIED — lines 22-55): Add validation warnings at startup
+- `scripts/inspector/core/inspector.ts` (MODIFIED — lines 54-63): Pass `watchdogIssue` through context (done in Step 1, verify)
+- `tests/unit/scripts/inspector/inspector.test.ts` (NEW): Test startup validation
+
+**Reproduction Test** (MUST FAIL before fix):
+- **Test location**: `tests/unit/scripts/inspector/inspector.test.ts` (NEW)
+- **Test 9**: `runInspector should include watchdogIssue on context when configured`
+  - Setup: Mock all dependencies (state, github, pino). Create `InspectorConfig` with `watchdogIssue: 42` and an empty plugins array.
+  - Call `runInspector(config)`.
+  - Verify: The context passed to plugins has `watchdogIssue: 42`.
+  - **Why it fails now**: `InspectorConfig` and `InspectorContext` don't have `watchdogIssue` field.
+
+- **Test 10**: `runInspector should have watchdogIssue undefined on context when not configured`
+  - Setup: Same as Test 9 but config has no `watchdogIssue`.
+  - Call `runInspector(config)`.
+  - Verify: The context passed to plugins has `watchdogIssue: undefined`.
+  - **Why it fails now**: Same reason — field doesn't exist on types.
+
+- **Test 11**: `main() should log warning when WATCHDOG_ISSUE is not set`
+  - This is harder to test since `main()` is not exported. Alternative: test the parsing logic in isolation by extracting it to a helper, OR test via the `index.ts` module behavior.
+  - **Recommended approach**: Extract config parsing into a `createInspectorConfigFromEnv()` function that can be unit-tested. If the build agent finds this too invasive, the warnings in Step 1 are sufficient — this test can verify via `runInspector` spy.
+
+**Fix Details**:
+1. In `index.ts`, add after line 26:
+   ```typescript
+   const watchdogIssue = process.env.WATCHDOG_ISSUE ? Number(process.env.WATCHDOG_ISSUE) : undefined
+   if (!watchdogIssue) {
+     logger.warn('WATCHDOG_ISSUE not set — digest reports will be skipped')
+   }
+   if (!process.env.MINIMAX_API_KEY) {
+     logger.warn('MINIMAX_API_KEY not set — failure analysis will use fallback mode')
+   }
+   ```
+2. Add `watchdogIssue` to config object at line 50.
+3. In `core/inspector.ts`, add `watchdogIssue: config.watchdogIssue` to context at line 54-63.
+
+**Verification**:
+- [ ] Test `watchdogIssue` flows from config to context
+- [ ] Test `watchdogIssue` is undefined when not configured
+- [ ] `pnpm tsc --noEmit` passes (type changes are compatible)
+
+**Acceptance Criteria**:
+- [ ] Inspector logs clear startup warnings for missing optional config
+- [ ] `watchdogIssue` flows: env → config → context → plugins
+- [ ] No breaking changes to existing plugin API (field is optional)
+- [ ] `pnpm tsc --noEmit` passes
+- [ ] `pnpm vitest run tests/unit/scripts/inspector/` passes all tests
+
+---
+
+## Test Strategy
+
+**All tests are unit tests** with mocked dependencies:
+- Mock `child_process.execFileSync` for GitHub client tests
+- Mock `InspectorContext` with fake `state`, `github`, and `log` for plugin tests
+- Use `vi.fn()` / `vi.spyOn()` for verification
+- Use `vi.mock()` for module-level mocks
+
+**Mock InspectorContext factory** (shared across test files):
+
+```typescript
+function createMockContext(overrides?: Partial<InspectorContext>): InspectorContext {
+  return {
+    repo: 'owner/repo',
+    dryRun: false,
+    state: { get: vi.fn(), set: vi.fn(), save: vi.fn() },
+    github: {
+      postComment: vi.fn(),
+      getIssue: vi.fn().mockReturnValue({ body: null, title: null }),
+      getOpenIssues: vi.fn().mockReturnValue([]),
+      triggerWorkflow: vi.fn(),
+      addLabel: vi.fn(),
+      removeLabel: vi.fn(),
+      setLifecycleLabel: vi.fn(),
+      closeIssue: vi.fn(),
+      getIssueComments: vi.fn().mockReturnValue([]),
+    },
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as any,
+    runTimestamp: new Date().toISOString(),
+    cycleNumber: 1,
+    ...overrides,
+  }
+}
+```
+
+**Test commands**:
+```bash
+pnpm vitest run tests/unit/scripts/inspector/
+pnpm tsc --noEmit
+```
+
+## File Summary
+
+| File | Action | Approximate Changes |
+|------|--------|---------------------|
+| `scripts/inspector/core/types.ts` | MODIFIED | +2 lines (add `watchdogIssue?: number` to InspectorConfig + InspectorContext) |
+| `scripts/inspector/index.ts` | MODIFIED | +10 lines (parse WATCHDOG_ISSUE, add warnings, pass to config) |
+| `scripts/inspector/core/inspector.ts` | MODIFIED | +1 line (pass watchdogIssue from config to context) |
+| `scripts/inspector/plugins/cody/health-check/index.ts` | MODIFIED | +8 lines (guard digest + nudge actions, export functions, use ctx.watchdogIssue) |
+| `scripts/inspector/clients/github.ts` | MODIFIED | +3 lines (add `--repo` to 3 methods) |
+| `tests/unit/scripts/inspector/health-check.test.ts` | NEW | ~130 lines (Tests 1-4: digest + nudge guards) |
+| `tests/unit/scripts/inspector/github-client.test.ts` | NEW | ~90 lines (Tests 5-8: --repo flag verification) |
+| `tests/unit/scripts/inspector/inspector.test.ts` | NEW | ~70 lines (Tests 9-11: config flow + startup validation) |
+
+## Operational Fix (Manual — Not Code)
+
+After the code changes are merged, the repo admin must:
+1. **Create a watchdog issue** in the repo (e.g., "Inspector Digest Reports")
+2. **Set the `WATCHDOG_ISSUE` repo variable**: Settings → Secrets and Variables → Actions → Variables → New variable → Name: `WATCHDOG_ISSUE`, Value: `<issue-number>`
+
+## Quality Gates
+
+```bash
+pnpm vitest run tests/unit/scripts/inspector/   # All 11 tests pass
+pnpm tsc --noEmit                                 # Type check passes
+```

--- a/scripts/inspector/clients/github.ts
+++ b/scripts/inspector/clients/github.ts
@@ -30,7 +30,7 @@ export function createGitHubClient(repo: string, token: string, patToken?: strin
 
   return {
     postComment(issueNumber: number, body: string): void {
-      gh(['issue', 'comment', String(issueNumber), '--body-file', '-'], body)
+      gh(['issue', 'comment', String(issueNumber), '--repo', repo, '--body-file', '-'], body)
     },
 
     getIssue(issueNumber: number): { body: string | null; title: string | null } {
@@ -96,11 +96,11 @@ export function createGitHubClient(repo: string, token: string, patToken?: strin
     },
 
     addLabel(issueNumber: number, label: string): void {
-      gh(['issue', 'add-label', String(issueNumber), label])
+      gh(['issue', 'add-label', String(issueNumber), '--repo', repo, label])
     },
 
     removeLabel(issueNumber: number, label: string): void {
-      gh(['issue', 'remove-label', String(issueNumber), label])
+      gh(['issue', 'remove-label', String(issueNumber), '--repo', repo, label])
     },
 
     setLifecycleLabel(issueNumber: number, label: string): void {

--- a/scripts/inspector/core/inspector.ts
+++ b/scripts/inspector/core/inspector.ts
@@ -60,6 +60,7 @@ export async function runInspector(config: InspectorConfig): Promise<InspectorRe
     runTimestamp: timestamp,
     cycleNumber,
     slack,
+    watchdogIssue: config.watchdogIssue,
   }
 
   // Clean up expired dedup entries (older than 24 hours)

--- a/scripts/inspector/core/types.ts
+++ b/scripts/inspector/core/types.ts
@@ -61,6 +61,8 @@ export interface InspectorContext {
   runTimestamp: string
   cycleNumber: number
   slack?: SlackClient
+  /** Issue number for posting digest reports. Parsed from WATCHDOG_ISSUE env var. */
+  watchdogIssue?: number
 }
 
 export interface StateStore {
@@ -132,6 +134,8 @@ export interface InspectorConfig {
   dryRun: boolean
   stateFile: string
   plugins: InspectorPlugin[]
+  /** Issue number for posting digest reports */
+  watchdogIssue?: number
 }
 
 export interface InspectorResult {

--- a/scripts/inspector/index.ts
+++ b/scripts/inspector/index.ts
@@ -25,6 +25,9 @@ async function main(): Promise<void> {
   const token = process.env.GH_TOKEN || ''
   const dryRun = process.env.DRY_RUN === 'true'
 
+  // Parse optional config
+  const watchdogIssue = process.env.WATCHDOG_ISSUE ? Number(process.env.WATCHDOG_ISSUE) : undefined
+
   // Validate required env vars
   if (!repo) {
     logger.error('Missing required environment variable: REPO')
@@ -37,6 +40,14 @@ async function main(): Promise<void> {
   }
 
   logger.info({ repo, dryRun }, 'Starting Inspector')
+
+  // Warn about missing optional config
+  if (!watchdogIssue) {
+    logger.warn('WATCHDOG_ISSUE not set — digest reports will be skipped')
+  }
+  if (!process.env.MINIMAX_API_KEY) {
+    logger.warn('MINIMAX_API_KEY not set — failure analysis will use fallback mode')
+  }
 
   // Create plugin registry
   const registry = createPluginRegistry()
@@ -52,6 +63,7 @@ async function main(): Promise<void> {
     dryRun,
     stateFile: `${process.cwd()}/.inspector/state.json`,
     plugins: registry.getAll(),
+    watchdogIssue,
   }
 
   // Run Inspector

--- a/scripts/inspector/plugins/cody/health-check/index.ts
+++ b/scripts/inspector/plugins/cody/health-check/index.ts
@@ -171,9 +171,18 @@ function evaluateHealth(task: TaskSnapshot, ctx: InspectorContext): EvaluatedTas
 
 /**
  * Create a nudge action for gated tasks.
+ * @internal — exported for testing
  */
-function createNudgeAction(task: EvaluatedTask, ctx: InspectorContext): ActionRequest | null {
+export function createNudgeAction(
+  task: EvaluatedTask,
+  ctx: InspectorContext,
+): ActionRequest | null {
   if (task.health !== 'gated') {
+    return null
+  }
+
+  // Guard: skip if issue number is invalid (e.g., task discovered without a GitHub issue)
+  if (!task.issueNumber || task.issueNumber <= 0) {
     return null
   }
 
@@ -208,8 +217,18 @@ function createNudgeAction(task: EvaluatedTask, ctx: InspectorContext): ActionRe
 
 /**
  * Create a digest action summarizing all task health.
+ * @internal — exported for testing
  */
-function createDigestAction(tasks: EvaluatedTask[], ctx: InspectorContext): ActionRequest | null {
+export function createDigestAction(
+  tasks: EvaluatedTask[],
+  ctx: InspectorContext,
+): ActionRequest | null {
+  // Guard: skip digest when WATCHDOG_ISSUE is not configured
+  if (!ctx.watchdogIssue) {
+    ctx.log.warn('WATCHDOG_ISSUE not configured — skipping digest')
+    return null
+  }
+
   const healthCounts: Record<TaskHealth, number> = {
     healthy: 0,
     completed: 0,
@@ -261,7 +280,7 @@ function createDigestAction(tasks: EvaluatedTask[], ctx: InspectorContext): Acti
       }
 
       ctx.github.postComment(
-        Number(process.env.WATCHDOG_ISSUE) || 0,
+        ctx.watchdogIssue!,
         `## 🐕 Inspector Digest\n\n${table}\n\n_Cycle ${ctx.cycleNumber}_`,
       )
       return { success: true, message: 'Digest posted' }

--- a/tests/unit/scripts/inspector/github-client.test.ts
+++ b/tests/unit/scripts/inspector/github-client.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import * as childProcess from 'child_process'
+
+// Mock child_process before importing the module
+vi.mock('child_process', () => ({
+  execFileSync: vi.fn().mockReturnValue(''),
+}))
+
+// Mock fs (used by readTaskFile)
+vi.mock('fs', () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  readFileSync: vi.fn().mockReturnValue(''),
+}))
+
+import { createGitHubClient } from '../../../../scripts/inspector/clients/github'
+
+describe('createGitHubClient', () => {
+  const mockExecFileSync = childProcess.execFileSync as ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockExecFileSync.mockReturnValue('')
+  })
+
+  describe('postComment', () => {
+    it('should include --repo flag in gh CLI args', () => {
+      const client = createGitHubClient('owner/repo', 'fake-token')
+
+      client.postComment(42, 'Hello world')
+
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        'gh',
+        expect.arrayContaining([
+          'issue',
+          'comment',
+          '42',
+          '--repo',
+          'owner/repo',
+          '--body-file',
+          '-',
+        ]),
+        expect.objectContaining({ input: 'Hello world' }),
+      )
+    })
+
+    it('should pass body as stdin input', () => {
+      const client = createGitHubClient('owner/repo', 'fake-token')
+
+      client.postComment(10, 'Test body')
+
+      const call = mockExecFileSync.mock.calls[0]
+      expect(call[2].input).toBe('Test body')
+    })
+  })
+
+  describe('addLabel', () => {
+    it('should include --repo flag in gh CLI args', () => {
+      const client = createGitHubClient('owner/repo', 'fake-token')
+
+      client.addLabel(42, 'bug')
+
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        'gh',
+        expect.arrayContaining(['issue', 'add-label', '42', '--repo', 'owner/repo', 'bug']),
+        expect.any(Object),
+      )
+    })
+  })
+
+  describe('removeLabel', () => {
+    it('should include --repo flag in gh CLI args', () => {
+      const client = createGitHubClient('owner/repo', 'fake-token')
+
+      client.removeLabel(42, 'bug')
+
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        'gh',
+        expect.arrayContaining(['issue', 'remove-label', '42', '--repo', 'owner/repo', 'bug']),
+        expect.any(Object),
+      )
+    })
+  })
+
+  describe('closeIssue', () => {
+    it('should include --repo flag in gh CLI args (regression)', () => {
+      const client = createGitHubClient('owner/repo', 'fake-token')
+
+      client.closeIssue(42)
+
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        'gh',
+        expect.arrayContaining(['issue', 'close', '42']),
+        expect.any(Object),
+      )
+      // Verify --repo is present (already was before this fix, regression test)
+      const args = mockExecFileSync.mock.calls[0][1] as string[]
+      const hasRepo = args.some((arg: string) => arg.includes('--repo'))
+      expect(hasRepo).toBe(true)
+    })
+  })
+
+  describe('triggerWorkflow', () => {
+    it('should include --repo flag in gh CLI args (regression)', () => {
+      const client = createGitHubClient('owner/repo', 'fake-token')
+
+      // triggerWorkflow uses execFileSync directly (not the gh helper)
+      client.triggerWorkflow('cody.yml', { task: 'test' })
+
+      // triggerWorkflow has its own execFileSync call
+      const calls = mockExecFileSync.mock.calls
+      const workflowCall = calls.find((call: unknown[]) => {
+        const args = call[1] as string[]
+        return args.includes('workflow')
+      })
+      expect(workflowCall).toBeDefined()
+      const args = workflowCall![1] as string[]
+      const hasRepo = args.some((arg: string) => arg.includes('--repo'))
+      expect(hasRepo).toBe(true)
+    })
+  })
+
+  describe('error handling', () => {
+    it('should return empty string when gh command fails', () => {
+      mockExecFileSync.mockImplementation(() => {
+        throw new Error('gh command failed')
+      })
+
+      const client = createGitHubClient('owner/repo', 'fake-token')
+
+      // Should not throw — fire-and-forget
+      expect(() => client.postComment(42, 'test')).not.toThrow()
+    })
+  })
+})

--- a/tests/unit/scripts/inspector/health-check.test.ts
+++ b/tests/unit/scripts/inspector/health-check.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type {
+  InspectorContext,
+  EvaluatedTask,
+  GitHubClient,
+  StateStore,
+} from '../../../../scripts/inspector/core/types'
+import {
+  createNudgeAction,
+  createDigestAction,
+} from '../../../../scripts/inspector/plugins/cody/health-check/index'
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createMockContext(overrides?: Partial<InspectorContext>): InspectorContext {
+  return {
+    repo: 'owner/repo',
+    dryRun: false,
+    state: {
+      get: vi.fn(),
+      set: vi.fn(),
+      save: vi.fn(),
+    } as unknown as StateStore,
+    github: {
+      postComment: vi.fn(),
+      getIssue: vi.fn().mockReturnValue({ body: null, title: null }),
+      getOpenIssues: vi.fn().mockReturnValue([]),
+      triggerWorkflow: vi.fn(),
+      addLabel: vi.fn(),
+      removeLabel: vi.fn(),
+      setLifecycleLabel: vi.fn(),
+      closeIssue: vi.fn(),
+      getIssueComments: vi.fn().mockReturnValue([]),
+    } as unknown as GitHubClient,
+    log: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as InspectorContext['log'],
+    runTimestamp: new Date().toISOString(),
+    cycleNumber: 1,
+    ...overrides,
+  }
+}
+
+function createEvaluatedTask(overrides?: Partial<EvaluatedTask>): EvaluatedTask {
+  return {
+    taskId: '260312-test-task',
+    issueNumber: 42,
+    issueTitle: 'Test task',
+    labels: ['cody:building'],
+    status: null,
+    issueUpdatedAt: new Date().toISOString(),
+    statusUpdatedAt: null,
+    health: 'healthy',
+    healthDetail: 'Pipeline running normally',
+    ...overrides,
+  }
+}
+
+// ============================================================================
+// createDigestAction
+// ============================================================================
+
+describe('createDigestAction', () => {
+  let ctx: InspectorContext
+
+  beforeEach(() => {
+    ctx = createMockContext()
+  })
+
+  it('should return null when ctx.watchdogIssue is undefined', () => {
+    // No watchdogIssue on context
+    const tasks = [createEvaluatedTask({ health: 'failed', healthDetail: 'Pipeline failed' })]
+
+    const action = createDigestAction(tasks, ctx)
+
+    expect(action).toBeNull()
+    expect(ctx.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('WATCHDOG_ISSUE not configured'),
+    )
+  })
+
+  it('should return null when ctx.watchdogIssue is 0', () => {
+    ctx = createMockContext({ watchdogIssue: 0 })
+    const tasks = [createEvaluatedTask({ health: 'failed', healthDetail: 'Pipeline failed' })]
+
+    const action = createDigestAction(tasks, ctx)
+
+    expect(action).toBeNull()
+  })
+
+  it('should return action that posts to correct issue number when ctx.watchdogIssue is set', async () => {
+    ctx = createMockContext({ watchdogIssue: 99 })
+    const tasks = [createEvaluatedTask({ health: 'failed', healthDetail: 'Pipeline failed' })]
+
+    const action = createDigestAction(tasks, ctx)
+
+    expect(action).not.toBeNull()
+    expect(action!.type).toBe('digest')
+    expect(action!.plugin).toBe('cody-health-check')
+
+    // Execute the action and verify postComment is called with correct issue number
+    const result = await action!.execute(ctx)
+    expect(result.success).toBe(true)
+    expect(ctx.github.postComment).toHaveBeenCalledWith(
+      99,
+      expect.stringContaining('Inspector Digest'),
+    )
+  })
+
+  it('should return null when all tasks are healthy', () => {
+    ctx = createMockContext({ watchdogIssue: 42 })
+    const tasks = [
+      createEvaluatedTask({ health: 'healthy' }),
+      createEvaluatedTask({ health: 'completed' }),
+    ]
+
+    const action = createDigestAction(tasks, ctx)
+
+    expect(action).toBeNull()
+  })
+
+  it('should return null when there are no tasks', () => {
+    ctx = createMockContext({ watchdogIssue: 42 })
+
+    const action = createDigestAction([], ctx)
+
+    expect(action).toBeNull()
+  })
+
+  it('should include task details in digest table', async () => {
+    ctx = createMockContext({ watchdogIssue: 42 })
+    const tasks = [
+      createEvaluatedTask({
+        taskId: '260312-task-a',
+        health: 'failed',
+        healthDetail: 'Pipeline failed at build',
+      }),
+      createEvaluatedTask({
+        taskId: '260312-task-b',
+        health: 'gated',
+        healthDetail: 'Pipeline paused at review',
+      }),
+    ]
+
+    const action = createDigestAction(tasks, ctx)
+    expect(action).not.toBeNull()
+
+    await action!.execute(ctx)
+
+    const body = (ctx.github.postComment as ReturnType<typeof vi.fn>).mock.calls[0][1] as string
+    expect(body).toContain('260312-task-a')
+    expect(body).toContain('260312-task-b')
+    expect(body).toContain('❌ failed')
+    expect(body).toContain('🚧 gated')
+  })
+})
+
+// ============================================================================
+// createNudgeAction
+// ============================================================================
+
+describe('createNudgeAction', () => {
+  let ctx: InspectorContext
+
+  beforeEach(() => {
+    ctx = createMockContext()
+  })
+
+  it('should return null when task.issueNumber is 0', () => {
+    const task = createEvaluatedTask({
+      health: 'gated',
+      gatedMinutes: 60,
+      issueNumber: 0,
+    })
+
+    const action = createNudgeAction(task, ctx)
+
+    expect(action).toBeNull()
+  })
+
+  it('should return null when task.issueNumber is negative', () => {
+    const task = createEvaluatedTask({
+      health: 'gated',
+      gatedMinutes: 60,
+      issueNumber: -1,
+    })
+
+    const action = createNudgeAction(task, ctx)
+
+    expect(action).toBeNull()
+  })
+
+  it('should return null when task health is not gated', () => {
+    const task = createEvaluatedTask({
+      health: 'healthy',
+      issueNumber: 42,
+    })
+
+    const action = createNudgeAction(task, ctx)
+
+    expect(action).toBeNull()
+  })
+
+  it('should return null when gated for less than 30 minutes', () => {
+    const task = createEvaluatedTask({
+      health: 'gated',
+      gatedMinutes: 15,
+      issueNumber: 42,
+    })
+
+    const action = createNudgeAction(task, ctx)
+
+    expect(action).toBeNull()
+  })
+
+  it('should return action for valid gated task with issueNumber', async () => {
+    const task = createEvaluatedTask({
+      health: 'gated',
+      gatedMinutes: 60,
+      issueNumber: 123,
+      taskId: '260312-gated-task',
+    })
+
+    const action = createNudgeAction(task, ctx)
+
+    expect(action).not.toBeNull()
+    expect(action!.type).toBe('nudge')
+    expect(action!.urgency).toBe('warning')
+    expect(action!.target).toBe('260312-gated-task')
+
+    // Execute and verify postComment is called with the correct issue number
+    const result = await action!.execute(ctx)
+    expect(result.success).toBe(true)
+    expect(ctx.github.postComment).toHaveBeenCalledWith(
+      123,
+      expect.stringContaining('Gate Approval Needed'),
+    )
+  })
+
+  it('should set critical urgency when gated for more than 120 minutes', () => {
+    const task = createEvaluatedTask({
+      health: 'gated',
+      gatedMinutes: 150,
+      issueNumber: 42,
+    })
+
+    const action = createNudgeAction(task, ctx)
+
+    expect(action).not.toBeNull()
+    expect(action!.urgency).toBe('critical')
+  })
+})

--- a/tests/unit/scripts/inspector/inspector.test.ts
+++ b/tests/unit/scripts/inspector/inspector.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Mock all external dependencies before importing
+vi.mock('pino', () => ({
+  default: vi.fn().mockReturnValue({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  }),
+}))
+
+vi.mock('../../../../scripts/inspector/core/state', () => ({
+  JsonStateStore: {
+    load: vi.fn().mockReturnValue({
+      get: vi.fn().mockReturnValue(0),
+      set: vi.fn(),
+      save: vi.fn(),
+    }),
+  },
+}))
+
+vi.mock('../../../../scripts/inspector/clients/github', () => ({
+  createGitHubClient: vi.fn().mockReturnValue({
+    postComment: vi.fn(),
+    getIssue: vi.fn().mockReturnValue({ body: null, title: null }),
+    getOpenIssues: vi.fn().mockReturnValue([]),
+    triggerWorkflow: vi.fn(),
+    addLabel: vi.fn(),
+    removeLabel: vi.fn(),
+    setLifecycleLabel: vi.fn(),
+    closeIssue: vi.fn(),
+    getIssueComments: vi.fn().mockReturnValue([]),
+  }),
+}))
+
+vi.mock('../../../../scripts/inspector/clients/slack', () => ({
+  createSlackClient: vi.fn().mockReturnValue(undefined),
+}))
+
+vi.mock('../../../../scripts/inspector/core/dedup', () => ({
+  shouldDedup: vi.fn().mockReturnValue(false),
+  markExecuted: vi.fn(),
+  cleanupExpiredDedup: vi.fn().mockReturnValue(0),
+}))
+
+import { runInspector } from '../../../../scripts/inspector/core/inspector'
+import type {
+  InspectorConfig,
+  InspectorContext,
+  InspectorPlugin,
+} from '../../../../scripts/inspector/core/types'
+
+describe('runInspector', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env = {
+      ...originalEnv,
+      GH_TOKEN: 'fake-token',
+    }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('should include watchdogIssue on context when configured', async () => {
+    let capturedCtx: InspectorContext | undefined
+
+    const spyPlugin: InspectorPlugin = {
+      name: 'spy-plugin',
+      description: 'Captures context for testing',
+      domain: 'test',
+      async run(ctx) {
+        capturedCtx = ctx
+        return []
+      },
+    }
+
+    const config: InspectorConfig = {
+      repo: 'owner/repo',
+      dryRun: false,
+      stateFile: '/tmp/test-state.json',
+      plugins: [spyPlugin],
+      watchdogIssue: 42,
+    }
+
+    await runInspector(config)
+
+    expect(capturedCtx).toBeDefined()
+    expect(capturedCtx!.watchdogIssue).toBe(42)
+  })
+
+  it('should have watchdogIssue undefined on context when not configured', async () => {
+    let capturedCtx: InspectorContext | undefined
+
+    const spyPlugin: InspectorPlugin = {
+      name: 'spy-plugin',
+      description: 'Captures context for testing',
+      domain: 'test',
+      async run(ctx) {
+        capturedCtx = ctx
+        return []
+      },
+    }
+
+    const config: InspectorConfig = {
+      repo: 'owner/repo',
+      dryRun: false,
+      stateFile: '/tmp/test-state.json',
+      plugins: [spyPlugin],
+      // No watchdogIssue
+    }
+
+    await runInspector(config)
+
+    expect(capturedCtx).toBeDefined()
+    expect(capturedCtx!.watchdogIssue).toBeUndefined()
+  })
+
+  it('should return correct result summary', async () => {
+    const config: InspectorConfig = {
+      repo: 'owner/repo',
+      dryRun: false,
+      stateFile: '/tmp/test-state.json',
+      plugins: [],
+      watchdogIssue: 42,
+    }
+
+    const result = await runInspector(config)
+
+    expect(result.cycleNumber).toBe(1)
+    expect(result.pluginsRun).toBe(0)
+    expect(result.actionsProduced).toBe(0)
+    expect(result.actionsExecuted).toBe(0)
+    expect(result.actionsDeduplicated).toBe(0)
+    expect(result.errors).toEqual([])
+  })
+
+  it('should isolate plugin errors without crashing', async () => {
+    const failingPlugin: InspectorPlugin = {
+      name: 'failing-plugin',
+      description: 'Always throws',
+      domain: 'test',
+      async run() {
+        throw new Error('Plugin exploded')
+      },
+    }
+
+    const config: InspectorConfig = {
+      repo: 'owner/repo',
+      dryRun: false,
+      stateFile: '/tmp/test-state.json',
+      plugins: [failingPlugin],
+    }
+
+    const result = await runInspector(config)
+
+    expect(result.pluginsRun).toBe(1)
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toContain('Plugin exploded')
+  })
+
+  it('should skip action execution in dry run mode', async () => {
+    const executeAction = vi.fn().mockResolvedValue({ success: true })
+
+    const actionPlugin: InspectorPlugin = {
+      name: 'action-plugin',
+      description: 'Returns an action',
+      domain: 'test',
+      async run() {
+        return [
+          {
+            plugin: 'action-plugin',
+            type: 'test-action',
+            urgency: 'info' as const,
+            title: 'Test action',
+            detail: 'Test detail',
+            execute: executeAction,
+          },
+        ]
+      },
+    }
+
+    const config: InspectorConfig = {
+      repo: 'owner/repo',
+      dryRun: true,
+      stateFile: '/tmp/test-state.json',
+      plugins: [actionPlugin],
+    }
+
+    const result = await runInspector(config)
+
+    expect(result.actionsProduced).toBe(1)
+    expect(result.actionsExecuted).toBe(0)
+    expect(executeAction).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What / Why

The Inspector workflow runs successfully every ~30-60 minutes (216 runs, 100% success rate), but its **digest action silently fails** because the `WATCHDOG_ISSUE` environment variable is empty — causing `postComment(0, ...)` to fire against a nonexistent issue #0. Additionally, nudge actions could post to invalid issue numbers, and several `gh issue` CLI subcommands were missing the `--repo` flag (relying on fragile CWD detection).

This PR fixes 4 bugs:

- **B1/B2** (Critical): Digest posts to issue #0 when `WATCHDOG_ISSUE` is unset → now guarded with early return + warning log
- **B3** (Medium): `createNudgeAction` doesn't validate `task.issueNumber` → now guarded for 0/negative values
- **B4** (Medium): `postComment`, `addLabel`, `removeLabel` missing `--repo` flag → added for CI robustness
- **B5** (Startup): No visibility into degraded config → added startup warnings for `WATCHDOG_ISSUE` and `MINIMAX_API_KEY`

## Scope of Changes

### Source files (5 modified)
- `scripts/inspector/core/types.ts` — Add `watchdogIssue?: number` to `InspectorConfig` and `InspectorContext`
- `scripts/inspector/index.ts` — Parse `WATCHDOG_ISSUE` env var, add startup warnings, pass to config
- `scripts/inspector/core/inspector.ts` — Flow `watchdogIssue` from config to context
- `scripts/inspector/plugins/cody/health-check/index.ts` — Guard digest + nudge actions, use `ctx.watchdogIssue` instead of `process.env`
- `scripts/inspector/clients/github.ts` — Add `--repo` flag to `postComment`, `addLabel`, `removeLabel`

### Test files (3 new)
- `tests/unit/scripts/inspector/health-check.test.ts` — 12 tests for digest/nudge guards
- `tests/unit/scripts/inspector/github-client.test.ts` — 7 tests for `--repo` flag verification
- `tests/unit/scripts/inspector/inspector.test.ts` — 5 tests for config→context flow

## How It Was Tested

```
✓ pnpm -s tsc --noEmit - PASSED
✓ pnpm -s lint - PASSED
✓ pnpm -s format - PASSED
✓ pnpm test:unit - PASSED (3270 tests, 201 test files)
```

All 24 new inspector tests pass. No existing tests broken.

## Operational Follow-up (Manual)

After merge, the repo admin should:
1. Create a "Inspector Digest Reports" issue in the repo
2. Set `WATCHDOG_ISSUE` repo variable: Settings → Variables → Actions → `WATCHDOG_ISSUE` = `<issue-number>`

## Definition of Done Checklist

- [x] All quality gates pass (typecheck, lint, format, tests)
- [x] No new dependencies
- [x] Tests added for all bug fixes (24 new tests)
- [x] No `process.env` reads inside plugin execute closures
- [x] All `gh issue` subcommands pass `--repo` explicitly

## Risks / Rollback Notes

- Low risk — all changes are additive guards and optional fields
- If `WATCHDOG_ISSUE` is not set, digest is simply skipped (graceful degradation)
- Rollback: revert commit, no data migration needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)