### PR TITLE
feat: Redesign Google login page with vibrant UI

### DIFF
--- a/src/app/(frontend)/login/LoginForm.tsx
+++ b/src/app/(frontend)/login/LoginForm.tsx
@@ -69,7 +69,7 @@ function LoginFormContent() {
             <div className="flex justify-center">
               <SystemLink
                 href="/signup"
-                className="bg-gray-100 text-red-700 font-bold rounded-full px-6 py-2 text-sm hover:bg-gray-200 transition-colors inline-block"
+                className="bg-muted text-primary font-bold rounded-full px-6 py-2 text-sm hover:bg-primary-soft transition-colors inline-block"
               >
                 {t('freeRegistration')}
               </SystemLink>
@@ -122,7 +122,7 @@ function LoginFormContent() {
             <div className="flex flex-col items-center gap-2 pt-2">
               <SystemLink
                 href="/signup"
-                className="bg-gray-100 text-red-700 font-bold rounded-full px-6 py-2 text-sm hover:bg-gray-200 transition-colors inline-block"
+                className="bg-muted text-primary font-bold rounded-full px-6 py-2 text-sm hover:bg-primary-soft transition-colors inline-block"
               >
                 {t('freeRegistration')}
               </SystemLink>

--- a/src/app/(frontend)/login/LoginForm.tsx
+++ b/src/app/(frontend)/login/LoginForm.tsx
@@ -3,6 +3,8 @@
 import { useSearchParams } from 'next/navigation'
 import { Suspense, useState } from 'react'
 
+import Image from 'next/image'
+
 import { GoogleLoginButton } from '@/ui/web/auth/GoogleLoginButton'
 import { Button } from '@/ui/web/components/button'
 import { Card, CardContent, CardHeader } from '@/ui/web/components/card'
@@ -12,6 +14,7 @@ import { SystemLink } from '@/infra/loading/components/SystemLink'
 import { usePasswordLogin } from '@/ui/web/providers/PasswordLoginProvider'
 import { useTranslations } from '@/ui/web/providers/I18n'
 import { loginAction } from './login_authenticate-action'
+import telescopeSvg from '@/ui/web/TelescopeLogo/telescope.svg'
 
 function LoginFormContent() {
   const t = useTranslations('auth.login')
@@ -40,17 +43,28 @@ function LoginFormContent() {
   }
 
   return (
-    <Card className="rounded-2xl shadow-lg border-0 bg-card p-8">
-      <CardHeader className="pb-4">
+    <Card className="rounded-2xl shadow-lg border-0 bg-card px-8 py-6">
+      <CardHeader className="pb-3">
+        {/* Logo */}
+        <div className="flex flex-col items-center gap-1">
+          <Image
+            src={telescopeSvg}
+            alt="A-Guy"
+            className="h-24 w-auto"
+            width={224}
+            height={204}
+          />
+          <p className="text-primary font-semibold">{t('heroSubtitle')}</p>
+        </div>
         {/* Section label with decorative line */}
-        <div className="flex flex-col items-center">
-          <div className="w-8 h-px bg-border mb-3" />
+        <div className="flex flex-col items-center mt-3">
+          <div className="w-8 h-px bg-border mb-2" />
           <p className="text-sm text-muted-foreground">{t('quickLogin')}</p>
         </div>
       </CardHeader>
       <CardContent className="space-y-4">
         {/* Google SSO Button */}
-        <GoogleLoginButton returnTo={returnTo} className="w-full h-14 rounded-xl" />
+        <GoogleLoginButton returnTo={returnTo} className="w-full h-14 rounded-xl text-base font-semibold" />
 
         {/* Registration Link - appears below Google button when password is disabled */}
         {!passwordEnabled && (
@@ -58,13 +72,15 @@ function LoginFormContent() {
             <div className="flex justify-center">
               <SystemLink
                 href="/signup"
-                className="border border-primary text-primary rounded-full px-6 py-2 text-sm hover:bg-primary/5 transition-colors inline-block"
+                className="bg-gray-100 text-red-700 font-bold rounded-full px-6 py-2 text-sm hover:bg-gray-200 transition-colors inline-block"
               >
                 {t('freeRegistration')}
               </SystemLink>
             </div>
             <p className="text-sm text-muted-foreground text-center pt-2">
-              {t('secureAccess')} {t('oneClickEntry')}
+              {t('secureAccess')}
+              <br />
+              {t('oneClickEntry')}
             </p>
           </>
         )}
@@ -109,12 +125,14 @@ function LoginFormContent() {
             <div className="flex flex-col items-center gap-2 pt-2">
               <SystemLink
                 href="/signup"
-                className="border border-primary text-primary rounded-full px-6 py-2 text-sm hover:bg-primary/5 transition-colors inline-block"
+                className="bg-gray-100 text-red-700 font-bold rounded-full px-6 py-2 text-sm hover:bg-gray-200 transition-colors inline-block"
               >
                 {t('freeRegistration')}
               </SystemLink>
               <p className="text-sm text-muted-foreground text-center">
-                {t('secureAccess')} {t('oneClickEntry')}
+                {t('secureAccess')}
+              <br />
+              {t('oneClickEntry')}
               </p>
             </div>
           </>
@@ -134,9 +152,13 @@ export function LoginForm() {
 
 function LoginFormSkeleton() {
   return (
-    <Card className="rounded-2xl shadow-lg border-0 bg-card p-8">
-      <CardHeader className="pb-4">
-        <div className="flex flex-col items-center">
+    <Card className="rounded-2xl shadow-lg border-0 bg-card px-8 py-6">
+      <CardHeader className="pb-3">
+        <div className="flex flex-col items-center gap-1">
+          <div className="h-24 w-24 bg-muted animate-pulse rounded-full" />
+          <div className="h-4 w-40 bg-muted animate-pulse rounded" />
+        </div>
+        <div className="flex flex-col items-center mt-4">
           <div className="w-8 h-px bg-border mb-3" />
           <div className="h-4 w-24 mx-auto bg-muted animate-pulse rounded" />
         </div>

--- a/src/app/(frontend)/login/LoginForm.tsx
+++ b/src/app/(frontend)/login/LoginForm.tsx
@@ -47,13 +47,7 @@ function LoginFormContent() {
       <CardHeader className="pb-3">
         {/* Logo */}
         <div className="flex flex-col items-center gap-1">
-          <Image
-            src={telescopeSvg}
-            alt="A-Guy"
-            className="h-24 w-auto"
-            width={224}
-            height={204}
-          />
+          <Image src={telescopeSvg} alt="A-Guy" className="h-24 w-auto" width={224} height={204} />
           <p className="text-primary font-semibold">{t('heroSubtitle')}</p>
         </div>
         {/* Section label with decorative line */}
@@ -64,7 +58,10 @@ function LoginFormContent() {
       </CardHeader>
       <CardContent className="space-y-4">
         {/* Google SSO Button */}
-        <GoogleLoginButton returnTo={returnTo} className="w-full h-14 rounded-xl text-base font-semibold" />
+        <GoogleLoginButton
+          returnTo={returnTo}
+          className="w-full h-14 rounded-xl text-base font-semibold"
+        />
 
         {/* Registration Link - appears below Google button when password is disabled */}
         {!passwordEnabled && (
@@ -131,8 +128,8 @@ function LoginFormContent() {
               </SystemLink>
               <p className="text-sm text-muted-foreground text-center">
                 {t('secureAccess')}
-              <br />
-              {t('oneClickEntry')}
+                <br />
+                {t('oneClickEntry')}
               </p>
             </div>
           </>

--- a/src/app/(frontend)/login/LoginPageContent.tsx
+++ b/src/app/(frontend)/login/LoginPageContent.tsx
@@ -12,16 +12,14 @@ export function LoginPageContent() {
   return (
     <div className="min-h-[calc(100vh-200px)] flex flex-col items-center justify-center bg-gradient-to-b from-background to-muted/30 py-12">
       {/* Hero Section */}
-      <div className="text-center mb-8 px-4">
-        <h1 className="text-4xl md:text-5xl font-extrabold mb-2">
-          <span className="text-foreground">{t('headingBold')}</span>{' '}
-          <span className="text-foreground/70 font-normal">{t('headingRest')}</span>
+      <div className="text-center mb-6 px-4">
+        <h1 className="text-4xl md:text-5xl font-extrabold bg-gradient-to-r from-blue-600 to-blue-400 bg-clip-text text-transparent">
+          {t('headingRest')}
         </h1>
-        <p className="text-base text-muted-foreground">{t('heroSubtitle')}</p>
       </div>
 
       {/* Login Card */}
-      <div className="w-full max-w-sm px-4">
+      <div className="w-full max-w-lg px-4">
         <LoginForm />
       </div>
 

--- a/src/app/(frontend)/login/LoginPageContent.tsx
+++ b/src/app/(frontend)/login/LoginPageContent.tsx
@@ -13,7 +13,7 @@ export function LoginPageContent() {
     <div className="min-h-[calc(100vh-200px)] flex flex-col items-center justify-center bg-gradient-to-b from-background to-muted/30 py-12">
       {/* Hero Section */}
       <div className="text-center mb-6 px-4">
-        <h1 className="text-4xl md:text-5xl font-extrabold bg-gradient-to-r from-blue-600 to-blue-400 bg-clip-text text-transparent">
+        <h1 className="text-4xl md:text-5xl font-extrabold bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent">
           {t('headingRest')}
         </h1>
       </div>

--- a/src/ui/web/auth/AccessGateProvider.tsx
+++ b/src/ui/web/auth/AccessGateProvider.tsx
@@ -85,7 +85,7 @@ export function AccessGateProvider({
             </DialogDescription>
           </DialogHeader>
           <div className="mt-4 flex justify-center">
-            <GoogleLoginButton returnTo={pathname} variant="default" className="w-full" />
+            <GoogleLoginButton returnTo={pathname} className="w-full" />
           </div>
         </DialogContent>
       </Dialog>

--- a/src/ui/web/auth/AuthGateModal.tsx
+++ b/src/ui/web/auth/AuthGateModal.tsx
@@ -30,7 +30,7 @@ export function AuthGateModal({ isOpen, title, description, returnTo }: AuthGate
           <DialogDescription className="mt-2">{description}</DialogDescription>
         </DialogHeader>
         <div className="mt-4 flex flex-col items-center gap-3">
-          <GoogleLoginButton returnTo={returnTo} variant="default" className="w-full" />
+          <GoogleLoginButton returnTo={returnTo} className="w-full" />
           <Link
             href="/courses"
             className="text-sm text-muted-foreground underline hover:text-foreground"

--- a/src/ui/web/auth/GoogleLoginButton.tsx
+++ b/src/ui/web/auth/GoogleLoginButton.tsx
@@ -1,19 +1,16 @@
 'use client'
 
 import { useState } from 'react'
-import { Button } from '@/ui/web/components/button'
 import { useTranslations } from '@/ui/web/providers/I18n'
 import { cn } from '@/infra/utils/ui'
 
 interface GoogleLoginButtonProps {
   returnTo?: string
-  variant?: 'default' | 'outline'
   className?: string
 }
 
 export function GoogleLoginButton({
   returnTo = '/',
-  variant = 'outline',
   className,
 }: GoogleLoginButtonProps) {
   const t = useTranslations('auth.oauth')
@@ -27,31 +24,42 @@ export function GoogleLoginButton({
   }
 
   return (
-    <Button
-      variant={variant}
+    <button
       className={cn(
-        className,
+        'inline-flex items-center justify-center rounded text-sm font-medium',
+        'bg-white text-gray-700 border border-gray-300',
+        'transition-all duration-150 hover:scale-[1.03] hover:shadow-lg hover:bg-gray-50',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
         isNavigating && 'opacity-60 pointer-events-none',
-        'transition-opacity duration-150',
+        className,
       )}
       onClick={handleGoogleLogin}
     >
       <svg
-        className="mr-2 h-4 w-4"
+        className="me-2 h-5 w-5"
         aria-hidden="true"
         focusable="false"
-        data-prefix="fab"
-        data-icon="google"
-        role="img"
         xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 488 512"
+        viewBox="0 0 48 48"
       >
         <path
-          fill="currentColor"
-          d="M488 261.8C488 403.3 391.1 504 248 504 110.8 504 0 393.2 0 256S110.8 8 248 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9C258.5 52.6 94.3 116.6 94.3 256c0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9H248v-85.3h236.1c2.3 12.7 3.9 24.9 3.9 41.4z"
+          fill="#FFC107"
+          d="M43.611 20.083H42V20H24v8h11.303c-1.649 4.657-6.08 8-11.303 8-6.627 0-12-5.373-12-12s5.373-12 12-12c3.059 0 5.842 1.154 7.961 3.039l5.657-5.657C34.046 6.053 29.268 4 24 4 12.955 4 4 12.955 4 24s8.955 20 20 20 20-8.955 20-20c0-1.341-.138-2.65-.389-3.917z"
+        />
+        <path
+          fill="#FF3D00"
+          d="m6.306 14.691 6.571 4.819C14.655 15.108 18.961 12 24 12c3.059 0 5.842 1.154 7.961 3.039l5.657-5.657C34.046 6.053 29.268 4 24 4 16.318 4 9.656 8.337 6.306 14.691z"
+        />
+        <path
+          fill="#4CAF50"
+          d="M24 44c5.166 0 9.86-1.977 13.409-5.192l-6.19-5.238A11.91 11.91 0 0 1 24 36c-5.202 0-9.619-3.317-11.283-7.946l-6.522 5.025C9.505 39.556 16.227 44 24 44z"
+        />
+        <path
+          fill="#1976D2"
+          d="M43.611 20.083H42V20H24v8h11.303a12.04 12.04 0 0 1-4.087 5.571l.003-.002 6.19 5.238C36.971 39.205 44 34 44 24c0-1.341-.138-2.65-.389-3.917z"
         />
       </svg>
       {t('continueWithGoogle')}
-    </Button>
+    </button>
   )
 }

--- a/src/ui/web/auth/GoogleLoginButton.tsx
+++ b/src/ui/web/auth/GoogleLoginButton.tsx
@@ -24,8 +24,8 @@ export function GoogleLoginButton({ returnTo = '/', className }: GoogleLoginButt
     <button
       className={cn(
         'inline-flex items-center justify-center rounded text-sm font-medium',
-        'bg-white text-gray-700 border border-gray-300',
-        'transition-all duration-150 hover:scale-[1.03] hover:shadow-lg hover:bg-gray-50',
+        'bg-card text-card-foreground border border-border',
+        'transition-all duration-150 hover:scale-[1.03] hover:shadow-lg hover:bg-muted',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
         isNavigating && 'opacity-60 pointer-events-none',
         className,

--- a/src/ui/web/auth/GoogleLoginButton.tsx
+++ b/src/ui/web/auth/GoogleLoginButton.tsx
@@ -9,10 +9,7 @@ interface GoogleLoginButtonProps {
   className?: string
 }
 
-export function GoogleLoginButton({
-  returnTo = '/',
-  className,
-}: GoogleLoginButtonProps) {
+export function GoogleLoginButton({ returnTo = '/', className }: GoogleLoginButtonProps) {
   const t = useTranslations('auth.oauth')
   const [isNavigating, setIsNavigating] = useState(false)
 

--- a/tests/unit/login-page-redesign.test.tsx
+++ b/tests/unit/login-page-redesign.test.tsx
@@ -50,30 +50,16 @@ describe('Login Page Redesign - i18n translations', () => {
 })
 
 describe('LoginPageContent', () => {
-  it('renders hero heading with split bold/regular text in Hebrew', () => {
+  it('renders hero heading as gradient text in Hebrew', () => {
     renderWithI18n('he', <LoginPageContent />)
 
-    expect(screen.getByText('שלום,')).toBeTruthy()
     expect(screen.getByText('מוכנים להצליח?')).toBeTruthy()
   })
 
-  it('renders hero heading in English', () => {
+  it('renders hero heading as gradient text in English', () => {
     renderWithI18n('en', <LoginPageContent />)
 
-    expect(screen.getByText('Hello,')).toBeTruthy()
     expect(screen.getByText('Ready to Succeed?')).toBeTruthy()
-  })
-
-  it('renders subtitle "A-Guy המורה הפרטי שלכם" in Hebrew', () => {
-    renderWithI18n('he', <LoginPageContent />)
-
-    expect(screen.getByText('A-Guy המורה הפרטי שלכם')).toBeTruthy()
-  })
-
-  it('renders subtitle in English', () => {
-    renderWithI18n('en', <LoginPageContent />)
-
-    expect(screen.getByText('A-Guy Your Personal Tutor')).toBeTruthy()
   })
 
   it('renders help link "זקוקים לעזרה?"', () => {


### PR DESCRIPTION
Add telescope logo and brand text inside login card. Use colored Google icon with white button background. Blue gradient heading. Dark red registration pill on grey background. RTL-aware layout with logical margins.