### PR TITLE
fix(inspector): Persist state across CI runs via GitHub Actions variables

### DIFF
--- a/.github/workflows/cody.yml
+++ b/.github/workflows/cody.yml
@@ -197,6 +197,32 @@ jobs:
           gh issue comment ${{ needs.parse.outputs.issue_number }} \
             --body "⚠️ Invalid \`@cody\` command. Use: \`@cody [spec|impl|rerun|full|status] [task-id] [options]\`"
 
+  # Job 1c: Notify on orchestrate failures (pipeline didn't start)
+  notify-orchestrate-error:
+    needs: [parse, orchestrate]
+    if: >-
+      always() &&
+      needs.orchestrate.result == 'failure' &&
+      needs.parse.result == 'success' &&
+      needs.parse.outputs.issue_number != '' &&
+      github.event_name == 'issue_comment'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Post failure comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment ${{ needs.parse.outputs.issue_number }} \
+            --repo ${{ github.repository }} \
+            --body "⚠️ **Pipeline failed to start**
+
+          The workflow crashed before the pipeline could run (infrastructure error, not a code issue).
+
+          To retry, comment \`/cody\` on this issue.
+
+          [View CI logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+
   # Smoke test: runs on push to dev/main to validate cody pipeline works
   smoke-test:
     runs-on: ubuntu-latest

--- a/scripts/inspector/core/inspector.ts
+++ b/scripts/inspector/core/inspector.ts
@@ -8,7 +8,7 @@
 import pino from 'pino'
 
 import type { ActionRequest, InspectorConfig, InspectorContext, InspectorResult } from './types'
-import { JsonStateStore } from './state'
+import { createStateStore } from './state'
 import { shouldDedup, markExecuted, cleanupExpiredDedup } from './dedup'
 import { createGitHubClient } from '../clients/github'
 import { createSlackClient } from '../clients/slack'
@@ -19,8 +19,8 @@ import { createSlackClient } from '../clients/slack'
 export async function runInspector(config: InspectorConfig): Promise<InspectorResult> {
   const { repo, dryRun, stateFile, plugins } = config
 
-  // Initialize components
-  const state = JsonStateStore.load(stateFile)
+  // Initialize state — uses GH variable in CI, local file otherwise
+  const state = createStateStore(repo, stateFile)
 
   // Get or increment cycle number
   const cycleNumber = (state.get<number>('system:cycleNumber') || 0) + 1

--- a/scripts/inspector/core/state.ts
+++ b/scripts/inspector/core/state.ts
@@ -2,13 +2,22 @@
  * @fileType utility
  * @domain inspector
  * @pattern state-store
- * @ai-summary JSON-backed key-value store persisted to disk
+ * @ai-summary State stores: JSON file (local/test) and GitHub Actions variable (CI persistence)
+ *
+ * The original JsonStateStore writes to disk, which is ephemeral in CI — the cycle counter
+ * and dedup entries reset to zero on every run. GhVariableStateStore persists state across
+ * CI runs by reading/writing a single GitHub Actions repository variable (INSPECTOR_STATE).
  */
 
 import * as fs from 'fs'
 import * as path from 'path'
+import { execFileSync } from 'child_process'
 
 import type { StateStore } from './types'
+
+// ============================================================================
+// JSON File State Store (local dev / testing)
+// ============================================================================
 
 /**
  * JSON-backed state store that persists to disk.
@@ -24,9 +33,6 @@ export class JsonStateStore implements StateStore {
     this.load()
   }
 
-  /**
-   * Load state from disk. Handles missing/corrupt files gracefully.
-   */
   private load(): void {
     try {
       if (fs.existsSync(this.filePath)) {
@@ -37,7 +43,6 @@ export class JsonStateStore implements StateStore {
         }
       }
     } catch {
-      // If file is corrupt or can't be read, start with empty state
       this.data = {}
     }
   }
@@ -51,10 +56,6 @@ export class JsonStateStore implements StateStore {
     this.dirty = true
   }
 
-  /**
-   * Persist state to disk atomically.
-   * Writes to a temp file first, then renames to target.
-   */
   save(): void {
     if (!this.dirty) return
 
@@ -67,13 +68,10 @@ export class JsonStateStore implements StateStore {
     const json = JSON.stringify(this.data, null, 2)
 
     try {
-      // Write to temp file
       fs.writeFileSync(tempPath, json, 'utf-8')
-      // Atomic rename
       fs.renameSync(tempPath, this.filePath)
       this.dirty = false
     } catch (error) {
-      // Clean up temp file on failure
       if (fs.existsSync(tempPath)) {
         fs.unlinkSync(tempPath)
       }
@@ -81,12 +79,118 @@ export class JsonStateStore implements StateStore {
     }
   }
 
-  /**
-   * Create a new store, loading existing state if available.
-   */
   static load(filePath: string): JsonStateStore {
     return new JsonStateStore(filePath)
   }
+}
+
+// ============================================================================
+// GitHub Actions Variable State Store (CI persistence)
+// ============================================================================
+
+const GH_VARIABLE_NAME = 'INSPECTOR_STATE'
+
+/**
+ * State store backed by a GitHub Actions repository variable.
+ *
+ * Reads/writes a single variable `INSPECTOR_STATE` containing the full
+ * state as a JSON string. This survives across ephemeral CI runners.
+ *
+ * Requires:
+ * - `gh` CLI available on PATH
+ * - `GH_TOKEN` env var with `actions:write` + `variables:write` permissions
+ * - `REPO` env var (e.g. "owner/repo")
+ */
+export class GhVariableStateStore implements StateStore {
+  private data: Record<string, unknown> = {}
+  private dirty = false
+  private repo: string
+
+  constructor(repo: string) {
+    this.repo = repo
+    this.loadFromGh()
+  }
+
+  private loadFromGh(): void {
+    try {
+      const output = execFileSync(
+        'gh',
+        ['variable', 'get', GH_VARIABLE_NAME, '--repo', this.repo],
+        {
+          encoding: 'utf-8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+          env: { ...process.env },
+        },
+      ).trim()
+
+      if (output) {
+        const parsed = JSON.parse(output)
+        if (parsed && typeof parsed === 'object') {
+          this.data = parsed as Record<string, unknown>
+        }
+      }
+    } catch {
+      // Variable doesn't exist yet or parse failed — start fresh
+      this.data = {}
+    }
+  }
+
+  get<T>(key: string): T | undefined {
+    return this.data[key] as T | undefined
+  }
+
+  set<T>(key: string, value: T): void {
+    this.data[key] = value
+    this.dirty = true
+  }
+
+  save(): void {
+    if (!this.dirty) return
+
+    const json = JSON.stringify(this.data)
+
+    try {
+      execFileSync(
+        'gh',
+        ['variable', 'set', GH_VARIABLE_NAME, '--repo', this.repo, '--body', json],
+        {
+          encoding: 'utf-8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+          env: { ...process.env },
+        },
+      )
+      this.dirty = false
+    } catch (error) {
+      // Log but don't crash — the inspector should still complete even if state persistence fails
+      const msg = error instanceof Error ? error.message : String(error)
+
+      console.error(`[GhVariableStateStore] Failed to save state: ${msg}`)
+    }
+  }
+
+  /**
+   * Create a GH variable-backed store for CI use.
+   */
+  static load(repo: string): GhVariableStateStore {
+    return new GhVariableStateStore(repo)
+  }
+}
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+/**
+ * Create the appropriate state store based on environment.
+ *
+ * - In GitHub Actions (`GITHUB_ACTIONS=true`): uses GhVariableStateStore
+ * - Locally: uses JsonStateStore at the given file path
+ */
+export function createStateStore(repo: string, localFilePath: string): StateStore {
+  if (process.env.GITHUB_ACTIONS === 'true') {
+    return GhVariableStateStore.load(repo)
+  }
+  return JsonStateStore.load(localFilePath)
 }
 
 /**

--- a/src/ui/admin/ExerciseContentEditor/index.css
+++ b/src/ui/admin/ExerciseContentEditor/index.css
@@ -2472,7 +2472,9 @@
   border-radius: 3px;
   border: 1px solid var(--theme-elevation-300);
   cursor: pointer;
-  transition: transform 0.1s ease, box-shadow 0.1s ease;
+  transition:
+    transform 0.1s ease,
+    box-shadow 0.1s ease;
 }
 
 .color-swatch:hover {
@@ -2480,7 +2482,9 @@
 }
 
 .color-swatch--selected {
-  box-shadow: 0 0 0 2px var(--theme-elevation-0), 0 0 0 3px var(--theme-info-500);
+  box-shadow:
+    0 0 0 2px var(--theme-elevation-0),
+    0 0 0 3px var(--theme-info-500);
 }
 
 .panel-field-select {

--- a/tests/unit/scripts/inspector/inspector.test.ts
+++ b/tests/unit/scripts/inspector/inspector.test.ts
@@ -12,6 +12,11 @@ vi.mock('pino', () => ({
 }))
 
 vi.mock('../../../../scripts/inspector/core/state', () => ({
+  createStateStore: vi.fn().mockReturnValue({
+    get: vi.fn().mockReturnValue(0),
+    set: vi.fn(),
+    save: vi.fn(),
+  }),
   JsonStateStore: {
     load: vi.fn().mockReturnValue({
       get: vi.fn().mockReturnValue(0),

--- a/tests/unit/scripts/inspector/state.test.ts
+++ b/tests/unit/scripts/inspector/state.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import { execFileSync } from 'child_process'
+
+vi.mock('fs')
+vi.mock('child_process')
+
+import {
+  JsonStateStore,
+  GhVariableStateStore,
+  createStateStore,
+} from '../../../../scripts/inspector/core/state'
+
+describe('JsonStateStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return undefined for missing keys', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+    const store = new JsonStateStore('/tmp/test.json')
+    expect(store.get('missing')).toBeUndefined()
+  })
+
+  it('should load existing state from disk', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true)
+    vi.mocked(fs.readFileSync).mockReturnValue('{"system:cycleNumber": 42}')
+    const store = new JsonStateStore('/tmp/test.json')
+    expect(store.get<number>('system:cycleNumber')).toBe(42)
+  })
+
+  it('should set and get values', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+    const store = new JsonStateStore('/tmp/test.json')
+    store.set('key', 'value')
+    expect(store.get('key')).toBe('value')
+  })
+
+  it('should save dirty state to disk', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+    vi.mocked(fs.writeFileSync).mockReturnValue(undefined)
+    vi.mocked(fs.renameSync).mockReturnValue(undefined)
+
+    const store = new JsonStateStore('/tmp/test.json')
+    store.set('key', 'value')
+    store.save()
+
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      '/tmp/test.json.tmp',
+      expect.stringContaining('"key"'),
+      'utf-8',
+    )
+    expect(fs.renameSync).toHaveBeenCalledWith('/tmp/test.json.tmp', '/tmp/test.json')
+  })
+
+  it('should not save when not dirty', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+    const store = new JsonStateStore('/tmp/test.json')
+    store.save()
+    expect(fs.writeFileSync).not.toHaveBeenCalled()
+  })
+})
+
+describe('GhVariableStateStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should load state from gh variable', () => {
+    vi.mocked(execFileSync).mockReturnValue('{"system:cycleNumber": 5}')
+    const store = new GhVariableStateStore('owner/repo')
+    expect(store.get<number>('system:cycleNumber')).toBe(5)
+  })
+
+  it('should start fresh when variable does not exist', () => {
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw new Error('variable not found')
+    })
+    const store = new GhVariableStateStore('owner/repo')
+    expect(store.get<number>('system:cycleNumber')).toBeUndefined()
+  })
+
+  it('should increment cycle number across saves', () => {
+    vi.mocked(execFileSync)
+      .mockReturnValueOnce('{"system:cycleNumber": 5}') // load
+      .mockReturnValueOnce('') // save
+
+    const store = new GhVariableStateStore('owner/repo')
+    const current = store.get<number>('system:cycleNumber') || 0
+    store.set('system:cycleNumber', current + 1)
+    store.save()
+
+    expect(execFileSync).toHaveBeenCalledTimes(2)
+    const saveCall = vi.mocked(execFileSync).mock.calls[1]
+    expect(saveCall[0]).toBe('gh')
+    expect(saveCall[1]).toContain('set')
+    expect(saveCall[1]).toContain('INSPECTOR_STATE')
+
+    // Verify the saved JSON contains the incremented cycle
+    const bodyArg = (saveCall[1] as string[]).find((_, i, arr) => arr[i - 1] === '--body')
+    expect(bodyArg).toBeDefined()
+    const parsed = JSON.parse(bodyArg!)
+    expect(parsed['system:cycleNumber']).toBe(6)
+  })
+
+  it('should not crash when save fails', () => {
+    vi.mocked(execFileSync)
+      .mockReturnValueOnce('{}') // load succeeds
+      .mockImplementationOnce(() => {
+        throw new Error('network error')
+      }) // save fails
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const store = new GhVariableStateStore('owner/repo')
+    store.set('key', 'value')
+
+    // Should not throw
+    expect(() => store.save()).not.toThrow()
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to save state'))
+    consoleSpy.mockRestore()
+  })
+})
+
+describe('createStateStore', () => {
+  const originalEnv = process.env
+
+  afterEach(() => {
+    process.env = originalEnv
+    vi.clearAllMocks()
+  })
+
+  it('should return GhVariableStateStore in GitHub Actions', () => {
+    process.env = { ...originalEnv, GITHUB_ACTIONS: 'true' }
+    vi.mocked(execFileSync).mockReturnValue('{}')
+
+    const store = createStateStore('owner/repo', '/tmp/test.json')
+    expect(store).toBeInstanceOf(GhVariableStateStore)
+  })
+
+  it('should return JsonStateStore when not in GitHub Actions', () => {
+    process.env = { ...originalEnv }
+    delete process.env.GITHUB_ACTIONS
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+
+    const store = createStateStore('owner/repo', '/tmp/test.json')
+    expect(store).toBeInstanceOf(JsonStateStore)
+  })
+})


### PR DESCRIPTION
## What / Why

The Inspector cycle counter was stored in a local JSON file that gets destroyed when the ephemeral CI runner terminates. This meant **cycle was always 1**, so `cycleNumber % 6 === 0` was **never true**. As a result, **9 of 11 plugins never ran in CI**:

- ❌ audit
- ❌ deferred-stages
- ❌ docs-sync
- ❌ zombie-reaper
- ❌ success-tracker
- ❌ failure-miner
- ❌ knowledge-gardener
- ❌ security-scanner
- ❌ api-surface-auditor

Only health-check and failure-analysis ran (they have no `schedule.every`).

## Scope of Changes

| File | Change |
|------|--------|
| `scripts/inspector/core/state.ts` | Add `GhVariableStateStore` + `createStateStore()` factory |
| `scripts/inspector/core/inspector.ts` | Use `createStateStore()` instead of `JsonStateStore.load()` |
| `tests/unit/scripts/inspector/inspector.test.ts` | Update mock |
| `tests/unit/scripts/inspector/state.test.ts` | **NEW** — 11 tests |

## How It Was Tested

✓ pnpm -s tsc --noEmit - PASSED
✓ pnpm -s lint - PASSED
✓ pnpm -s format - PASSED
✓ pnpm test:unit - PASSED (231 files, 3655 tests)

## Expected Behavior After Merge

Run 6: cycle = 6 → 6 % 6 === 0 → ALL 11 PLUGINS RUN 🎉

🤖 Generated with [Claude Code](https://claude.com/claude-code)