### PR TITLE
feat(inspector): Add queue manager plugin for autonomous task processing

### DIFF
--- a/.ai-docs/indexes/pattern-index.json
+++ b/.ai-docs/indexes/pattern-index.json
@@ -3,7 +3,9 @@
     "client-provider": {
       "pattern": "client-provider",
       "description": "No description available",
-      "files": ["src/app/(cody)/CodyProviders.tsx"]
+      "files": [
+        "src/app/(cody)/CodyProviders.tsx"
+      ]
     },
     "client-component": {
       "pattern": "client-component",
@@ -339,17 +341,23 @@
     "next-error-boundary": {
       "pattern": "next-error-boundary",
       "description": "No description available",
-      "files": ["src/app/(cody)/cody/error.tsx"]
+      "files": [
+        "src/app/(cody)/cody/error.tsx"
+      ]
     },
     "metadata-helper": {
       "pattern": "metadata-helper",
       "description": "No description available",
-      "files": ["src/app/(cody)/cody/metadata.ts"]
+      "files": [
+        "src/app/(cody)/cody/metadata.ts"
+      ]
     },
     "route-group": {
       "pattern": "route-group",
       "description": "No description available",
-      "files": ["src/app/(cody)/layout.tsx"]
+      "files": [
+        "src/app/(cody)/layout.tsx"
+      ]
     },
     "tailwind-component": {
       "pattern": "tailwind-component",
@@ -694,117 +702,163 @@
     "boards-api": {
       "pattern": "boards-api",
       "description": "No description available",
-      "files": ["src/app/api/cody/boards/route.ts"]
+      "files": [
+        "src/app/api/cody/boards/route.ts"
+      ]
     },
     "branches-api": {
       "pattern": "branches-api",
       "description": "No description available",
-      "files": ["src/app/api/cody/branches/route.ts"]
+      "files": [
+        "src/app/api/cody/branches/route.ts"
+      ]
     },
     "chat-load-api": {
       "pattern": "chat-load-api",
       "description": "No description available",
-      "files": ["src/app/api/cody/chat/load/route.ts"]
+      "files": [
+        "src/app/api/cody/chat/load/route.ts"
+      ]
     },
     "ai-chat-streaming": {
       "pattern": "ai-chat-streaming",
       "description": "No description available",
-      "files": ["src/app/api/cody/chat/route.ts"]
+      "files": [
+        "src/app/api/cody/chat/route.ts"
+      ]
     },
     "chat-save-api": {
       "pattern": "chat-save-api",
       "description": "No description available",
-      "files": ["src/app/api/cody/chat/save/route.ts"]
+      "files": [
+        "src/app/api/cody/chat/save/route.ts"
+      ]
     },
     "collaborators-api": {
       "pattern": "collaborators-api",
       "description": "No description available",
-      "files": ["src/app/api/cody/collaborators/route.ts"]
+      "files": [
+        "src/app/api/cody/collaborators/route.ts"
+      ]
     },
     "inspector-health-api": {
       "pattern": "inspector-health-api",
       "description": "No description available",
-      "files": ["src/app/api/cody/inspector/health/route.ts"]
+      "files": [
+        "src/app/api/cody/inspector/health/route.ts"
+      ]
     },
     "pipeline-api": {
       "pattern": "pipeline-api",
       "description": "No description available",
-      "files": ["src/app/api/cody/pipeline/[taskId]/route.ts"]
+      "files": [
+        "src/app/api/cody/pipeline/[taskId]/route.ts"
+      ]
     },
     "prs-comments-api": {
       "pattern": "prs-comments-api",
       "description": "No description available",
-      "files": ["src/app/api/cody/prs/comments/route.ts"]
+      "files": [
+        "src/app/api/cody/prs/comments/route.ts"
+      ]
     },
     "pr-files-api": {
       "pattern": "pr-files-api",
       "description": "No description available",
-      "files": ["src/app/api/cody/prs/files/route.ts"]
+      "files": [
+        "src/app/api/cody/prs/files/route.ts"
+      ]
     },
     "prs-api": {
       "pattern": "prs-api",
       "description": "No description available",
-      "files": ["src/app/api/cody/prs/route.ts"]
+      "files": [
+        "src/app/api/cody/prs/route.ts"
+      ]
     },
     "pr-ci-status": {
       "pattern": "pr-ci-status",
       "description": "No description available",
-      "files": ["src/app/api/cody/prs/status/route.ts"]
+      "files": [
+        "src/app/api/cody/prs/status/route.ts"
+      ]
     },
     "publish": {
       "pattern": "publish",
       "description": "No description available",
-      "files": ["src/app/api/cody/publish/route.ts"]
+      "files": [
+        "src/app/api/cody/publish/route.ts"
+      ]
     },
     "proxy-endpoint": {
       "pattern": "proxy-endpoint",
       "description": "No description available",
-      "files": ["src/app/api/cody/remote/exec/route.ts"]
+      "files": [
+        "src/app/api/cody/remote/exec/route.ts"
+      ]
     },
     "health-check": {
       "pattern": "health-check",
       "description": "No description available",
-      "files": ["src/app/api/cody/remote/status/route.ts"]
+      "files": [
+        "src/app/api/cody/remote/status/route.ts"
+      ]
     },
     "task-actions-api": {
       "pattern": "task-actions-api",
       "description": "No description available",
-      "files": ["src/app/api/cody/tasks/[taskId]/actions/route.ts"]
+      "files": [
+        "src/app/api/cody/tasks/[taskId]/actions/route.ts"
+      ]
     },
     "task-docs-api": {
       "pattern": "task-docs-api",
       "description": "No description available",
-      "files": ["src/app/api/cody/tasks/[taskId]/docs/route.ts"]
+      "files": [
+        "src/app/api/cody/tasks/[taskId]/docs/route.ts"
+      ]
     },
     "task-detail-api": {
       "pattern": "task-detail-api",
       "description": "No description available",
-      "files": ["src/app/api/cody/tasks/[taskId]/route.ts"]
+      "files": [
+        "src/app/api/cody/tasks/[taskId]/route.ts"
+      ]
     },
     "approve-gate": {
       "pattern": "approve-gate",
       "description": "No description available",
-      "files": ["src/app/api/cody/tasks/approve/route.ts"]
+      "files": [
+        "src/app/api/cody/tasks/approve/route.ts"
+      ]
     },
     "approve-review": {
       "pattern": "approve-review",
       "description": "No description available",
-      "files": ["src/app/api/cody/tasks/approve-review/route.ts"]
+      "files": [
+        "src/app/api/cody/tasks/approve-review/route.ts"
+      ]
     },
     "tasks-api": {
       "pattern": "tasks-api",
       "description": "No description available",
-      "files": ["src/app/api/cody/tasks/route.ts"]
+      "files": [
+        "src/app/api/cody/tasks/route.ts"
+      ]
     },
     "workflows-api": {
       "pattern": "workflows-api",
       "description": "No description available",
-      "files": ["src/app/api/cody/workflows/route.ts"]
+      "files": [
+        "src/app/api/cody/workflows/route.ts"
+      ]
     },
     "copilotkit-runtime": {
       "pattern": "copilotkit-runtime",
       "description": "No description available",
-      "files": ["src/app/api/copilotkit/route.ts"]
+      "files": [
+        "src/app/api/copilotkit/route.ts"
+      ]
     },
     "endpoint": {
       "pattern": "endpoint",
@@ -818,7 +872,9 @@
     "queue": {
       "pattern": "queue",
       "description": "No description available",
-      "files": ["src/app/api/exercises/convert/queue-v2/route.ts"]
+      "files": [
+        "src/app/api/exercises/convert/queue-v2/route.ts"
+      ]
     },
     "validation": {
       "pattern": "validation",
@@ -832,7 +888,9 @@
     "zod-schema": {
       "pattern": "zod-schema",
       "description": "No description available",
-      "files": ["src/app/api/exercises/convert/queue-v2/schema.ts"]
+      "files": [
+        "src/app/api/exercises/convert/queue-v2/schema.ts"
+      ]
     },
     "oauth": {
       "pattern": "oauth",
@@ -866,7 +924,10 @@
     "constants": {
       "pattern": "constants",
       "description": "No description available",
-      "files": ["src/infra/config/config-constants.ts", "src/ui/cody/constants.ts"]
+      "files": [
+        "src/infra/config/config-constants.ts",
+        "src/ui/cody/constants.ts"
+      ]
     },
     "singleton": {
       "pattern": "singleton",
@@ -888,7 +949,9 @@
     "domain-config-loader": {
       "pattern": "domain-config-loader",
       "description": "No description available",
-      "files": ["src/infra/config/runtime/config-values.ts"]
+      "files": [
+        "src/infra/config/runtime/config-values.ts"
+      ]
     },
     "error-handling": {
       "pattern": "error-handling",
@@ -901,27 +964,38 @@
     "config-loader": {
       "pattern": "config-loader",
       "description": "No description available",
-      "files": ["src/infra/config/runtime/runtime-config.ts"]
+      "files": [
+        "src/infra/config/runtime/runtime-config.ts"
+      ]
     },
     "types": {
       "pattern": "types",
       "description": "No description available",
-      "files": ["src/infra/config/runtime/types.ts", "src/ui/cody/types.ts"]
+      "files": [
+        "src/infra/config/runtime/types.ts",
+        "src/ui/cody/types.ts"
+      ]
     },
     "runtime-validation": {
       "pattern": "runtime-validation",
       "description": "No description available",
-      "files": ["src/infra/config/runtime/validate-chat-config.ts"]
+      "files": [
+        "src/infra/config/runtime/validate-chat-config.ts"
+      ]
     },
     "config-sanity-check": {
       "pattern": "config-sanity-check",
       "description": "No description available",
-      "files": ["src/infra/config/runtime/validate-chat-config.ts"]
+      "files": [
+        "src/infra/config/runtime/validate-chat-config.ts"
+      ]
     },
     "type-safe-accessor": {
       "pattern": "type-safe-accessor",
       "description": "No description available",
-      "files": ["src/infra/config/system-params.ts"]
+      "files": [
+        "src/infra/config/system-params.ts"
+      ]
     },
     "genkit": {
       "pattern": "genkit",
@@ -946,42 +1020,59 @@
     "provider-abstraction": {
       "pattern": "provider-abstraction",
       "description": "No description available",
-      "files": ["src/infra/llm/genkit/adapters/unified-adapter.ts", "src/infra/llm/genkit/index.ts"]
+      "files": [
+        "src/infra/llm/genkit/adapters/unified-adapter.ts",
+        "src/infra/llm/genkit/index.ts"
+      ]
     },
     "config-mapping": {
       "pattern": "config-mapping",
       "description": "No description available",
-      "files": ["src/infra/llm/genkit/config-resolver.ts"]
+      "files": [
+        "src/infra/llm/genkit/config-resolver.ts"
+      ]
     },
     "lazy-loading": {
       "pattern": "lazy-loading",
       "description": "No description available",
-      "files": ["src/infra/llm/genkit/genkit-instance.ts"]
+      "files": [
+        "src/infra/llm/genkit/genkit-instance.ts"
+      ]
     },
     "genkit-tools": {
       "pattern": "genkit-tools",
       "description": "No description available",
-      "files": ["src/infra/llm/genkit/tools/genkit-tools.ts"]
+      "files": [
+        "src/infra/llm/genkit/tools/genkit-tools.ts"
+      ]
     },
     "tool-calling": {
       "pattern": "tool-calling",
       "description": "No description available",
-      "files": ["src/infra/llm/genkit/tools/genkit-tools.ts"]
+      "files": [
+        "src/infra/llm/genkit/tools/genkit-tools.ts"
+      ]
     },
     "mcp-integration": {
       "pattern": "mcp-integration",
       "description": "No description available",
-      "files": ["src/infra/llm/genkit/tools/genkit-tools.ts"]
+      "files": [
+        "src/infra/llm/genkit/tools/genkit-tools.ts"
+      ]
     },
     "single-responsibility": {
       "pattern": "single-responsibility",
       "description": "No description available",
-      "files": ["src/infra/llm/lesson-context.ts"]
+      "files": [
+        "src/infra/llm/lesson-context.ts"
+      ]
     },
     "runtime-injection": {
       "pattern": "runtime-injection",
       "description": "No description available",
-      "files": ["src/infra/llm/lesson-context.ts"]
+      "files": [
+        "src/infra/llm/lesson-context.ts"
+      ]
     },
     "server-only": {
       "pattern": "server-only",
@@ -995,47 +1086,66 @@
     "provider-factory": {
       "pattern": "provider-factory",
       "description": "No description available",
-      "files": ["src/infra/llm/providers/factory.ts"]
+      "files": [
+        "src/infra/llm/providers/factory.ts"
+      ]
     },
     "dependency-injection": {
       "pattern": "dependency-injection",
       "description": "No description available",
-      "files": ["src/infra/llm/providers/factory.ts"]
+      "files": [
+        "src/infra/llm/providers/factory.ts"
+      ]
     },
     "circuit-breaker": {
       "pattern": "circuit-breaker",
       "description": "No description available",
-      "files": ["src/infra/llm/providers/shared/circuit-breaker.ts"]
+      "files": [
+        "src/infra/llm/providers/shared/circuit-breaker.ts"
+      ]
     },
     "resilience": {
       "pattern": "resilience",
       "description": "No description available",
-      "files": ["src/infra/llm/providers/shared/circuit-breaker.ts"]
+      "files": [
+        "src/infra/llm/providers/shared/circuit-breaker.ts"
+      ]
     },
     "data-transformation": {
       "pattern": "data-transformation",
       "description": "No description available",
-      "files": ["src/infra/llm/providers/shared/media-reader.ts"]
+      "files": [
+        "src/infra/llm/providers/shared/media-reader.ts"
+      ]
     },
     "retry": {
       "pattern": "retry",
       "description": "No description available",
-      "files": ["src/infra/llm/providers/shared/retry.ts"]
+      "files": [
+        "src/infra/llm/providers/shared/retry.ts"
+      ]
     },
     "timeout": {
       "pattern": "timeout",
       "description": "No description available",
-      "files": ["src/infra/llm/providers/shared/timeout.ts"]
+      "files": [
+        "src/infra/llm/providers/shared/timeout.ts"
+      ]
     },
     "context-aware-loading": {
       "pattern": "context-aware-loading",
       "description": "No description available",
-      "files": ["src/infra/llm/smart-doc-loader.ts"]
+      "files": [
+        "src/infra/llm/smart-doc-loader.ts"
+      ]
     },
     "vector-search": {
       "pattern": "vector-search",
       "description": "No description available",
-      "files": ["src/infra/llm/vector-search.ts", "src/server/payload/collections/MemoryItems.ts"]
+      "files": [
+        "src/infra/llm/vector-search.ts",
+        "src/server/payload/collections/MemoryItems.ts"
+      ]
     },
     "context-scoped": {
       "pattern": "context-scoped",
@@ -1097,27 +1207,37 @@
     "youtube-detection": {
       "pattern": "youtube-detection",
       "description": "No description available",
-      "files": ["src/infra/media/youtube.ts"]
+      "files": [
+        "src/infra/media/youtube.ts"
+      ]
     },
     "type-exports": {
       "pattern": "type-exports",
       "description": "No description available",
-      "files": ["src/infra/types/index.ts"]
+      "files": [
+        "src/infra/types/index.ts"
+      ]
     },
     "viewport-calculation": {
       "pattern": "viewport-calculation",
       "description": "No description available",
-      "files": ["src/infra/utils/graphics/viewport-utils.ts"]
+      "files": [
+        "src/infra/utils/graphics/viewport-utils.ts"
+      ]
     },
     "typed-config-accessor": {
       "pattern": "typed-config-accessor",
       "description": "No description available",
-      "files": ["src/server/config/guest-chat-config.ts"]
+      "files": [
+        "src/server/config/guest-chat-config.ts"
+      ]
     },
     "admin-only": {
       "pattern": "admin-only",
       "description": "No description available",
-      "files": ["src/server/payload/access/configAdminOnly.ts"]
+      "files": [
+        "src/server/payload/access/configAdminOnly.ts"
+      ]
     },
     "access-control": {
       "pattern": "access-control",
@@ -1172,22 +1292,30 @@
     "key-value-store": {
       "pattern": "key-value-store",
       "description": "No description available",
-      "files": ["src/server/payload/collections/ConfigSecrets.ts"]
+      "files": [
+        "src/server/payload/collections/ConfigSecrets.ts"
+      ]
     },
     "encrypted-values": {
       "pattern": "encrypted-values",
       "description": "No description available",
-      "files": ["src/server/payload/collections/ConfigSecrets.ts"]
+      "files": [
+        "src/server/payload/collections/ConfigSecrets.ts"
+      ]
     },
     "domain-scoped-config": {
       "pattern": "domain-scoped-config",
       "description": "No description available",
-      "files": ["src/server/payload/collections/ConfigValues.ts"]
+      "files": [
+        "src/server/payload/collections/ConfigValues.ts"
+      ]
     },
     "json-storage": {
       "pattern": "json-storage",
       "description": "No description available",
-      "files": ["src/server/payload/collections/ConfigValues.ts"]
+      "files": [
+        "src/server/payload/collections/ConfigValues.ts"
+      ]
     },
     "user-owned": {
       "pattern": "user-owned",
@@ -1219,7 +1347,9 @@
     "append-only-log": {
       "pattern": "append-only-log",
       "description": "No description available",
-      "files": ["src/server/payload/collections/ExtractionLogs.ts"]
+      "files": [
+        "src/server/payload/collections/ExtractionLogs.ts"
+      ]
     },
     "session-management": {
       "pattern": "session-management",
@@ -1232,22 +1362,30 @@
     "expiring-records": {
       "pattern": "expiring-records",
       "description": "No description available",
-      "files": ["src/server/payload/collections/GuestSessions.ts"]
+      "files": [
+        "src/server/payload/collections/GuestSessions.ts"
+      ]
     },
     "teacher-profile": {
       "pattern": "teacher-profile",
       "description": "No description available",
-      "files": ["src/server/payload/collections/TeacherProfiles.ts"]
+      "files": [
+        "src/server/payload/collections/TeacherProfiles.ts"
+      ]
     },
     "progress-tracking": {
       "pattern": "progress-tracking",
       "description": "No description available",
-      "files": ["src/server/payload/collections/UserProgress.ts"]
+      "files": [
+        "src/server/payload/collections/UserProgress.ts"
+      ]
     },
     "user-settings": {
       "pattern": "user-settings",
       "description": "No description available",
-      "files": ["src/server/payload/collections/UserSettings/index.ts"]
+      "files": [
+        "src/server/payload/collections/UserSettings/index.ts"
+      ]
     },
     "guest-session": {
       "pattern": "guest-session",
@@ -1262,37 +1400,51 @@
     "rate-limiting": {
       "pattern": "rate-limiting",
       "description": "No description available",
-      "files": ["src/server/payload/endpoints/agent/auth-middleware.ts"]
+      "files": [
+        "src/server/payload/endpoints/agent/auth-middleware.ts"
+      ]
     },
     "pipeline": {
       "pattern": "pipeline",
       "description": "No description available",
-      "files": ["src/server/payload/endpoints/agent/chat/pipeline.ts"]
+      "files": [
+        "src/server/payload/endpoints/agent/chat/pipeline.ts"
+      ]
     },
     "extraction": {
       "pattern": "extraction",
       "description": "No description available",
-      "files": ["src/server/payload/endpoints/agent/chat/pipeline.ts"]
+      "files": [
+        "src/server/payload/endpoints/agent/chat/pipeline.ts"
+      ]
     },
     "streaming": {
       "pattern": "streaming",
       "description": "No description available",
-      "files": ["src/server/payload/endpoints/agent/chat-stream.ts"]
+      "files": [
+        "src/server/payload/endpoints/agent/chat-stream.ts"
+      ]
     },
     "sse": {
       "pattern": "sse",
       "description": "No description available",
-      "files": ["src/server/payload/endpoints/agent/chat-stream.ts"]
+      "files": [
+        "src/server/payload/endpoints/agent/chat-stream.ts"
+      ]
     },
     "server-sent-events": {
       "pattern": "server-sent-events",
       "description": "No description available",
-      "files": ["src/server/payload/endpoints/agent/chat-stream.ts"]
+      "files": [
+        "src/server/payload/endpoints/agent/chat-stream.ts"
+      ]
     },
     "admin-mode": {
       "pattern": "admin-mode",
       "description": "No description available",
-      "files": ["src/server/payload/endpoints/agent/chat.ts"]
+      "files": [
+        "src/server/payload/endpoints/agent/chat.ts"
+      ]
     },
     "cron-endpoint": {
       "pattern": "cron-endpoint",
@@ -1313,42 +1465,58 @@
     "write-only-ux": {
       "pattern": "write-only-ux",
       "description": "No description available",
-      "files": ["src/server/payload/hooks/configSecrets/afterRead-hook.ts"]
+      "files": [
+        "src/server/payload/hooks/configSecrets/afterRead-hook.ts"
+      ]
     },
     "secret-detection": {
       "pattern": "secret-detection",
       "description": "No description available",
-      "files": ["src/server/payload/hooks/configValues/beforeChange-hook.ts"]
+      "files": [
+        "src/server/payload/hooks/configValues/beforeChange-hook.ts"
+      ]
     },
     "job-handler": {
       "pattern": "job-handler",
       "description": "No description available",
-      "files": ["src/server/payload/jobs/pdf-to-exercises-v2-task.ts"]
+      "files": [
+        "src/server/payload/jobs/pdf-to-exercises-v2-task.ts"
+      ]
     },
     "pipeline-orchestration": {
       "pattern": "pipeline-orchestration",
       "description": "No description available",
-      "files": ["src/server/payload/jobs/pdf-to-exercises-v2-task.ts"]
+      "files": [
+        "src/server/payload/jobs/pdf-to-exercises-v2-task.ts"
+      ]
     },
     "plugin-configuration": {
       "pattern": "plugin-configuration",
       "description": "No description available",
-      "files": ["src/server/payload/plugins/mcp/index.ts"]
+      "files": [
+        "src/server/payload/plugins/mcp/index.ts"
+      ]
     },
     "read-only-access": {
       "pattern": "read-only-access",
       "description": "No description available",
-      "files": ["src/server/payload/plugins/mcp/index.ts"]
+      "files": [
+        "src/server/payload/plugins/mcp/index.ts"
+      ]
     },
     "tenant-scoped": {
       "pattern": "tenant-scoped",
       "description": "No description available",
-      "files": ["src/server/payload/plugins/mcp/index.ts"]
+      "files": [
+        "src/server/payload/plugins/mcp/index.ts"
+      ]
     },
     "service-layer": {
       "pattern": "service-layer",
       "description": "No description available",
-      "files": ["src/server/services/conversation-service.ts"]
+      "files": [
+        "src/server/services/conversation-service.ts"
+      ]
     },
     "image-processing": {
       "pattern": "image-processing",
@@ -1361,12 +1529,16 @@
     "cropping": {
       "pattern": "cropping",
       "description": "No description available",
-      "files": ["src/server/services/exercise-conversion/v2/image-crop-service.ts"]
+      "files": [
+        "src/server/services/exercise-conversion/v2/image-crop-service.ts"
+      ]
     },
     "ocr": {
       "pattern": "ocr",
       "description": "No description available",
-      "files": ["src/server/services/exercise-conversion/v2/ocr-detection-service.ts"]
+      "files": [
+        "src/server/services/exercise-conversion/v2/ocr-detection-service.ts"
+      ]
     },
     "pattern-matching": {
       "pattern": "pattern-matching",
@@ -1387,47 +1559,65 @@
     "text-extraction": {
       "pattern": "text-extraction",
       "description": "No description available",
-      "files": ["src/server/services/exercise-conversion/v2/text-detection-service.ts"]
+      "files": [
+        "src/server/services/exercise-conversion/v2/text-detection-service.ts"
+      ]
     },
     "vision-detection": {
       "pattern": "vision-detection",
       "description": "No description available",
-      "files": ["src/server/services/exercise-conversion/v2/vision-detection-service.ts"]
+      "files": [
+        "src/server/services/exercise-conversion/v2/vision-detection-service.ts"
+      ]
     },
     "combo-detection": {
       "pattern": "combo-detection",
       "description": "No description available",
-      "files": ["src/server/services/exercise-conversion/v2/vision-text-combo-service.ts"]
+      "files": [
+        "src/server/services/exercise-conversion/v2/vision-text-combo-service.ts"
+      ]
     },
     "vision+text": {
       "pattern": "vision+text",
       "description": "No description available",
-      "files": ["src/server/services/exercise-conversion/v2/vision-text-combo-service.ts"]
+      "files": [
+        "src/server/services/exercise-conversion/v2/vision-text-combo-service.ts"
+      ]
     },
     "orchestrator": {
       "pattern": "orchestrator",
       "description": "No description available",
-      "files": ["src/server/services/exercise-conversion/v3/extract-single.ts"]
+      "files": [
+        "src/server/services/exercise-conversion/v3/extract-single.ts"
+      ]
     },
     "prompt-resolution": {
       "pattern": "prompt-resolution",
       "description": "No description available",
-      "files": ["src/server/services/exercise-conversion/v3/prompt-resolver.ts"]
+      "files": [
+        "src/server/services/exercise-conversion/v3/prompt-resolver.ts"
+      ]
     },
     "transform": {
       "pattern": "transform",
       "description": "No description available",
-      "files": ["src/server/services/exercise-conversion/v3/transform.ts"]
+      "files": [
+        "src/server/services/exercise-conversion/v3/transform.ts"
+      ]
     },
     "ownership-transfer": {
       "pattern": "ownership-transfer",
       "description": "No description available",
-      "files": ["src/server/services/guest-session-upgrade.ts"]
+      "files": [
+        "src/server/services/guest-session-upgrade.ts"
+      ]
     },
     "admin-dashboard-widget": {
       "pattern": "admin-dashboard-widget",
       "description": "No description available",
-      "files": ["src/ui/admin/AdminChat/DashboardWidget/index.tsx"]
+      "files": [
+        "src/ui/admin/AdminChat/DashboardWidget/index.tsx"
+      ]
     },
     "admin-sidebar-link": {
       "pattern": "admin-sidebar-link",
@@ -1440,187 +1630,262 @@
     "form": {
       "pattern": "form",
       "description": "No description available",
-      "files": ["src/ui/admin/PdfConversion/ConversionForm/index.tsx"]
+      "files": [
+        "src/ui/admin/PdfConversion/ConversionForm/index.tsx"
+      ]
     },
     "exercise-list": {
       "pattern": "exercise-list",
       "description": "No description available",
-      "files": ["src/ui/admin/PdfConversion/ExerciseReview/index.tsx"]
+      "files": [
+        "src/ui/admin/PdfConversion/ExerciseReview/index.tsx"
+      ]
     },
     "job-list": {
       "pattern": "job-list",
       "description": "No description available",
-      "files": ["src/ui/admin/PdfConversion/JobHistory/index.tsx"]
+      "files": [
+        "src/ui/admin/PdfConversion/JobHistory/index.tsx"
+      ]
     },
     "searchable-select": {
       "pattern": "searchable-select",
       "description": "No description available",
-      "files": ["src/ui/admin/PdfConversion/LessonSelector/index.tsx"]
+      "files": [
+        "src/ui/admin/PdfConversion/LessonSelector/index.tsx"
+      ]
     },
     "admin-page-layout": {
       "pattern": "admin-page-layout",
       "description": "No description available",
-      "files": ["src/ui/admin/PdfConversion/PdfConversionPage/index.tsx"]
+      "files": [
+        "src/ui/admin/PdfConversion/PdfConversionPage/index.tsx"
+      ]
     },
     "file-selector": {
       "pattern": "file-selector",
       "description": "No description available",
-      "files": ["src/ui/admin/PdfConversion/PdfSelector/index.tsx"]
+      "files": [
+        "src/ui/admin/PdfConversion/PdfSelector/index.tsx"
+      ]
     },
     "agent-config": {
       "pattern": "agent-config",
       "description": "No description available",
-      "files": ["src/ui/cody/agents.ts"]
+      "files": [
+        "src/ui/cody/agents.ts"
+      ]
     },
     "api-client": {
       "pattern": "api-client",
       "description": "No description available",
-      "files": ["src/ui/cody/api.ts"]
+      "files": [
+        "src/ui/cody/api.ts"
+      ]
     },
     "auth": {
       "pattern": "auth",
       "description": "No description available",
-      "files": ["src/ui/cody/auth.ts"]
+      "files": [
+        "src/ui/cody/auth.ts"
+      ]
     },
     "chat-persistence": {
       "pattern": "chat-persistence",
       "description": "No description available",
-      "files": ["src/ui/cody/chat-types.ts"]
+      "files": [
+        "src/ui/cody/chat-types.ts"
+      ]
     },
     "add-comment-dialog": {
       "pattern": "add-comment-dialog",
       "description": "No description available",
-      "files": ["src/ui/cody/components/AddCommentDialog.tsx"]
+      "files": [
+        "src/ui/cody/components/AddCommentDialog.tsx"
+      ]
     },
     "assignee-picker": {
       "pattern": "assignee-picker",
       "description": "No description available",
-      "files": ["src/ui/cody/components/AssigneePicker.tsx"]
+      "files": [
+        "src/ui/cody/components/AssigneePicker.tsx"
+      ]
     },
     "branch-cleanup-dialog": {
       "pattern": "branch-cleanup-dialog",
       "description": "No description available",
-      "files": ["src/ui/cody/components/BranchCleanupDialog.tsx"]
+      "files": [
+        "src/ui/cody/components/BranchCleanupDialog.tsx"
+      ]
     },
     "bug-report-dialog": {
       "pattern": "bug-report-dialog",
       "description": "No description available",
-      "files": ["src/ui/cody/components/BugReportDialog.tsx"]
+      "files": [
+        "src/ui/cody/components/BugReportDialog.tsx"
+      ]
     },
     "ci-status-badge": {
       "pattern": "ci-status-badge",
       "description": "No description available",
-      "files": ["src/ui/cody/components/CIStatusBadge.tsx"]
+      "files": [
+        "src/ui/cody/components/CIStatusBadge.tsx"
+      ]
     },
     "cody-dashboard": {
       "pattern": "cody-dashboard",
       "description": "No description available",
-      "files": ["src/ui/cody/components/CodyDashboard.tsx"]
+      "files": [
+        "src/ui/cody/components/CodyDashboard.tsx"
+      ]
     },
     "cody-status-banner": {
       "pattern": "cody-status-banner",
       "description": "No description available",
-      "files": ["src/ui/cody/components/CodyStatusBanner.tsx"]
+      "files": [
+        "src/ui/cody/components/CodyStatusBanner.tsx"
+      ]
     },
     "comment-box": {
       "pattern": "comment-box",
       "description": "No description available",
-      "files": ["src/ui/cody/components/CommentBox.tsx"]
+      "files": [
+        "src/ui/cody/components/CommentBox.tsx"
+      ]
     },
     "comment-editor": {
       "pattern": "comment-editor",
       "description": "No description available",
-      "files": ["src/ui/cody/components/CommentEditor.tsx"]
+      "files": [
+        "src/ui/cody/components/CommentEditor.tsx"
+      ]
     },
     "comment-list": {
       "pattern": "comment-list",
       "description": "No description available",
-      "files": ["src/ui/cody/components/CommentList.tsx"]
+      "files": [
+        "src/ui/cody/components/CommentList.tsx"
+      ]
     },
     "confirm-dialog": {
       "pattern": "confirm-dialog",
       "description": "No description available",
-      "files": ["src/ui/cody/components/ConfirmDialog.tsx"]
+      "files": [
+        "src/ui/cody/components/ConfirmDialog.tsx"
+      ]
     },
     "create-task-dialog": {
       "pattern": "create-task-dialog",
       "description": "No description available",
-      "files": ["src/ui/cody/components/CreateTaskDialog.tsx"]
+      "files": [
+        "src/ui/cody/components/CreateTaskDialog.tsx"
+      ]
     },
     "edit-task-dialog": {
       "pattern": "edit-task-dialog",
       "description": "No description available",
-      "files": ["src/ui/cody/components/EditTaskDialog.tsx"]
+      "files": [
+        "src/ui/cody/components/EditTaskDialog.tsx"
+      ]
     },
     "environment-toolbar": {
       "pattern": "environment-toolbar",
       "description": "No description available",
-      "files": ["src/ui/cody/components/EnvironmentToolbar.tsx"]
+      "files": [
+        "src/ui/cody/components/EnvironmentToolbar.tsx"
+      ]
     },
     "error-boundary": {
       "pattern": "error-boundary",
       "description": "No description available",
-      "files": ["src/ui/cody/components/ErrorBoundary.tsx"]
+      "files": [
+        "src/ui/cody/components/ErrorBoundary.tsx"
+      ]
     },
     "filter-bar": {
       "pattern": "filter-bar",
       "description": "No description available",
-      "files": ["src/ui/cody/components/FilterBar.tsx"]
+      "files": [
+        "src/ui/cody/components/FilterBar.tsx"
+      ]
     },
     "fix-request-dialog": {
       "pattern": "fix-request-dialog",
       "description": "No description available",
-      "files": ["src/ui/cody/components/FixRequestDialog.tsx"]
+      "files": [
+        "src/ui/cody/components/FixRequestDialog.tsx"
+      ]
     },
     "keyboard-shortcuts-dialog": {
       "pattern": "keyboard-shortcuts-dialog",
       "description": "No description available",
-      "files": ["src/ui/cody/components/KeyboardShortcutsDialog.tsx"]
+      "files": [
+        "src/ui/cody/components/KeyboardShortcutsDialog.tsx"
+      ]
     },
     "label-picker": {
       "pattern": "label-picker",
       "description": "No description available",
-      "files": ["src/ui/cody/components/LabelPicker.tsx"]
+      "files": [
+        "src/ui/cody/components/LabelPicker.tsx"
+      ]
     },
     "markdown-viewer": {
       "pattern": "markdown-viewer",
       "description": "No description available",
-      "files": ["src/ui/cody/components/MarkdownViewer.tsx"]
+      "files": [
+        "src/ui/cody/components/MarkdownViewer.tsx"
+      ]
     },
     "merge-approval-dialog": {
       "pattern": "merge-approval-dialog",
       "description": "No description available",
-      "files": ["src/ui/cody/components/MergeApprovalDialog.tsx"]
+      "files": [
+        "src/ui/cody/components/MergeApprovalDialog.tsx"
+      ]
     },
     "merge-button": {
       "pattern": "merge-button",
       "description": "No description available",
-      "files": ["src/ui/cody/components/MergeButton.tsx"]
+      "files": [
+        "src/ui/cody/components/MergeButton.tsx"
+      ]
     },
     "pipeline-progress": {
       "pattern": "pipeline-progress",
       "description": "No description available",
-      "files": ["src/ui/cody/components/MiniPipelineProgress.tsx", "src/ui/cody/pipeline-utils.ts"]
+      "files": [
+        "src/ui/cody/components/MiniPipelineProgress.tsx",
+        "src/ui/cody/pipeline-utils.ts"
+      ]
     },
     "pr-comment-list": {
       "pattern": "pr-comment-list",
       "description": "No description available",
-      "files": ["src/ui/cody/components/PRCommentList.tsx"]
+      "files": [
+        "src/ui/cody/components/PRCommentList.tsx"
+      ]
     },
     "pipeline-status": {
       "pattern": "pipeline-status",
       "description": "No description available",
-      "files": ["src/ui/cody/components/PipelineStatus.tsx"]
+      "files": [
+        "src/ui/cody/components/PipelineStatus.tsx"
+      ]
     },
     "preview-actions": {
       "pattern": "preview-actions",
       "description": "No description available",
-      "files": ["src/ui/cody/components/PreviewActions.tsx"]
+      "files": [
+        "src/ui/cody/components/PreviewActions.tsx"
+      ]
     },
     "preview-modal": {
       "pattern": "preview-modal",
       "description": "No description available",
-      "files": ["src/ui/cody/components/PreviewModal.tsx"]
+      "files": [
+        "src/ui/cody/components/PreviewModal.tsx"
+      ]
     },
     "badge": {
       "pattern": "badge",
@@ -1634,87 +1899,122 @@
     "simple-tooltip": {
       "pattern": "simple-tooltip",
       "description": "No description available",
-      "files": ["src/ui/cody/components/SimpleTooltip.tsx"]
+      "files": [
+        "src/ui/cody/components/SimpleTooltip.tsx"
+      ]
     },
     "stage-error-detail": {
       "pattern": "stage-error-detail",
       "description": "No description available",
-      "files": ["src/ui/cody/components/StageErrorDetail.tsx"]
+      "files": [
+        "src/ui/cody/components/StageErrorDetail.tsx"
+      ]
     },
     "task-detail": {
       "pattern": "task-detail",
       "description": "No description available",
-      "files": ["src/ui/cody/components/TaskDetail.tsx"]
+      "files": [
+        "src/ui/cody/components/TaskDetail.tsx"
+      ]
     },
     "task-detail-dialog": {
       "pattern": "task-detail-dialog",
       "description": "No description available",
-      "files": ["src/ui/cody/components/TaskDetailDialog.tsx"]
+      "files": [
+        "src/ui/cody/components/TaskDetailDialog.tsx"
+      ]
     },
     "task-list": {
       "pattern": "task-list",
       "description": "No description available",
-      "files": ["src/ui/cody/components/TaskList.tsx"]
+      "files": [
+        "src/ui/cody/components/TaskList.tsx"
+      ]
     },
     "popover": {
       "pattern": "popover",
       "description": "No description available",
-      "files": ["src/ui/cody/components/WorkflowRunsPopover.tsx"]
+      "files": [
+        "src/ui/cody/components/WorkflowRunsPopover.tsx"
+      ]
     },
     "tooltip-content": {
       "pattern": "tooltip-content",
       "description": "No description available",
-      "files": ["src/ui/cody/components/tooltip-content.tsx"]
+      "files": [
+        "src/ui/cody/components/tooltip-content.tsx"
+      ]
     },
     "github-client": {
       "pattern": "github-client",
       "description": "No description available",
-      "files": ["src/ui/cody/github-client.ts"]
+      "files": [
+        "src/ui/cody/github-client.ts"
+      ]
     },
     "custom-hooks": {
       "pattern": "custom-hooks",
       "description": "No description available",
-      "files": ["src/ui/cody/hooks/index.ts", "src/ui/cody/hooks/useRemoteStatus.ts"]
+      "files": [
+        "src/ui/cody/hooks/index.ts",
+        "src/ui/cody/hooks/useRemoteStatus.ts"
+      ]
     },
     "browser-notifications": {
       "pattern": "browser-notifications",
       "description": "No description available",
-      "files": ["src/ui/cody/hooks/useBrowserNotifications.ts"]
+      "files": [
+        "src/ui/cody/hooks/useBrowserNotifications.ts"
+      ]
     },
     "github-identity": {
       "pattern": "github-identity",
       "description": "No description available",
-      "files": ["src/ui/cody/hooks/useGitHubIdentity.ts"]
+      "files": [
+        "src/ui/cody/hooks/useGitHubIdentity.ts"
+      ]
     },
     "keyboard-shortcuts": {
       "pattern": "keyboard-shortcuts",
       "description": "No description available",
-      "files": ["src/ui/cody/hooks/useKeyboardShortcuts.ts"]
+      "files": [
+        "src/ui/cody/hooks/useKeyboardShortcuts.ts"
+      ]
     },
     "usePRCIStatus": {
       "pattern": "usePRCIStatus",
       "description": "No description available",
-      "files": ["src/ui/cody/hooks/usePRCIStatus.ts"]
+      "files": [
+        "src/ui/cody/hooks/usePRCIStatus.ts"
+      ]
     },
     "usePublish": {
       "pattern": "usePublish",
       "description": "No description available",
-      "files": ["src/ui/cody/hooks/usePublish.ts"]
+      "files": [
+        "src/ui/cody/hooks/usePublish.ts"
+      ]
     },
     "config": {
       "pattern": "config",
       "description": "No description available",
-      "files": ["src/ui/cody/remote-config.ts"]
+      "files": [
+        "src/ui/cody/remote-config.ts"
+      ]
     },
     "task-parser": {
       "pattern": "task-parser",
       "description": "No description available",
-      "files": ["src/ui/cody/task-parser.ts"]
+      "files": [
+        "src/ui/cody/task-parser.ts"
+      ]
     },
     "utilities": {
       "pattern": "utilities",
       "description": "No description available",
-      "files": ["src/ui/cody/utils.ts"]
+      "files": [
+        "src/ui/cody/utils.ts"
+      ]
     },
     "variant-component": {
       "pattern": "variant-component",
@@ -1737,17 +2037,23 @@
     "shared-markdown": {
       "pattern": "shared-markdown",
       "description": "No description available",
-      "files": ["src/ui/web/shared/MathMarkdown/index.tsx"]
+      "files": [
+        "src/ui/web/shared/MathMarkdown/index.tsx"
+      ]
     },
     "rtl-isolation": {
       "pattern": "rtl-isolation",
       "description": "No description available",
-      "files": ["src/ui/web/shared/MathMarkdown/rehype-math-wrapper.ts"]
+      "files": [
+        "src/ui/web/shared/MathMarkdown/rehype-math-wrapper.ts"
+      ]
     },
     "remark-plugin": {
       "pattern": "remark-plugin",
       "description": "No description available",
-      "files": ["src/ui/web/shared/MathMarkdown/remark-color-syntax.ts"]
+      "files": [
+        "src/ui/web/shared/MathMarkdown/remark-color-syntax.ts"
+      ]
     }
   },
   "fileMetadata": {
@@ -1755,135 +2061,227 @@
       "path": "src/app/(cody)/CodyProviders.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["client-provider", "client-component"],
+      "patterns": [
+        "client-provider",
+        "client-component"
+      ],
       "aiSummary": "Client-side providers wrapper for Cody dashboard (QueryClientProvider)",
-      "dependencies": ["@tanstack/react-query", "react"]
+      "dependencies": [
+        "@tanstack/react-query",
+        "react"
+      ]
     },
     "src/app/(cody)/cody/[issueNumber]/comments/page.tsx": {
       "path": "src/app/(cody)/cody/[issueNumber]/comments/page.tsx",
       "type": "page",
       "domain": "cody",
-      "patterns": ["dashboard-page"],
+      "patterns": [
+        "dashboard-page"
+      ],
       "aiSummary": "Cody dashboard with task detail on Comments tab via URL /cody/[n]/comments",
-      "dependencies": ["next/headers", "next/navigation", "next"]
+      "dependencies": [
+        "next/headers",
+        "next/navigation",
+        "next"
+      ]
     },
     "src/app/(cody)/cody/[issueNumber]/page.tsx": {
       "path": "src/app/(cody)/cody/[issueNumber]/page.tsx",
       "type": "page",
       "domain": "cody",
-      "patterns": ["dashboard-page"],
+      "patterns": [
+        "dashboard-page"
+      ],
       "aiSummary": "Cody dashboard with a specific task pre-selected via URL",
-      "dependencies": ["next/headers", "next/navigation", "next"]
+      "dependencies": [
+        "next/headers",
+        "next/navigation",
+        "next"
+      ]
     },
     "src/app/(cody)/cody/[issueNumber]/preview/comments/page.tsx": {
       "path": "src/app/(cody)/cody/[issueNumber]/preview/comments/page.tsx",
       "type": "page",
       "domain": "cody",
-      "patterns": ["dashboard-page"],
+      "patterns": [
+        "dashboard-page"
+      ],
       "aiSummary": "Cody dashboard with preview modal on Comments tab via URL /cody/[n]/preview/comments",
-      "dependencies": ["next/headers", "next/navigation", "next"]
+      "dependencies": [
+        "next/headers",
+        "next/navigation",
+        "next"
+      ]
     },
     "src/app/(cody)/cody/[issueNumber]/preview/docs/page.tsx": {
       "path": "src/app/(cody)/cody/[issueNumber]/preview/docs/page.tsx",
       "type": "page",
       "domain": "cody",
-      "patterns": ["dashboard-page"],
+      "patterns": [
+        "dashboard-page"
+      ],
       "aiSummary": "Cody dashboard with preview modal on Docs tab via URL /cody/[n]/preview/docs",
-      "dependencies": ["next/headers", "next/navigation", "next"]
+      "dependencies": [
+        "next/headers",
+        "next/navigation",
+        "next"
+      ]
     },
     "src/app/(cody)/cody/[issueNumber]/preview/page.tsx": {
       "path": "src/app/(cody)/cody/[issueNumber]/preview/page.tsx",
       "type": "page",
       "domain": "cody",
-      "patterns": ["dashboard-page"],
+      "patterns": [
+        "dashboard-page"
+      ],
       "aiSummary": "Cody dashboard with preview modal pre-opened via URL /cody/[n]/preview",
-      "dependencies": ["next/headers", "next/navigation", "next"]
+      "dependencies": [
+        "next/headers",
+        "next/navigation",
+        "next"
+      ]
     },
     "src/app/(cody)/cody/bug/page.tsx": {
       "path": "src/app/(cody)/cody/bug/page.tsx",
       "type": "page",
       "domain": "cody",
-      "patterns": ["dashboard-page"],
+      "patterns": [
+        "dashboard-page"
+      ],
       "aiSummary": "Cody dashboard with bug report dialog pre-opened via URL /cody/bug",
-      "dependencies": ["next/headers", "next/navigation"]
+      "dependencies": [
+        "next/headers",
+        "next/navigation"
+      ]
     },
     "src/app/(cody)/cody/chat/page.tsx": {
       "path": "src/app/(cody)/cody/chat/page.tsx",
       "type": "page",
       "domain": "cody",
-      "patterns": ["dashboard-page"],
+      "patterns": [
+        "dashboard-page"
+      ],
       "aiSummary": "Cody dashboard with chat panel pre-opened via URL /cody/chat",
-      "dependencies": ["next/headers", "next/navigation"]
+      "dependencies": [
+        "next/headers",
+        "next/navigation"
+      ]
     },
     "src/app/(cody)/cody/error.tsx": {
       "path": "src/app/(cody)/cody/error.tsx",
       "type": "error-boundary",
       "domain": "cody",
-      "patterns": ["next-error-boundary", "client-component"],
+      "patterns": [
+        "next-error-boundary",
+        "client-component"
+      ],
       "aiSummary": "Error boundary for the Cody dashboard — catches runtime errors and lets the user retry",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/app/(cody)/cody/metadata.ts": {
       "path": "src/app/(cody)/cody/metadata.ts",
       "type": "utility",
       "domain": "cody",
-      "patterns": ["metadata-helper"],
+      "patterns": [
+        "metadata-helper"
+      ],
       "aiSummary": "Shared metadata builders for Cody dashboard routes with OG/Twitter tags",
-      "dependencies": ["next"]
+      "dependencies": [
+        "next"
+      ]
     },
     "src/app/(cody)/cody/new/page.tsx": {
       "path": "src/app/(cody)/cody/new/page.tsx",
       "type": "page",
       "domain": "cody",
-      "patterns": ["dashboard-page"],
+      "patterns": [
+        "dashboard-page"
+      ],
       "aiSummary": "Cody dashboard with create task dialog pre-opened via URL /cody/new",
-      "dependencies": ["next/headers", "next/navigation"]
+      "dependencies": [
+        "next/headers",
+        "next/navigation"
+      ]
     },
     "src/app/(cody)/cody/page.tsx": {
       "path": "src/app/(cody)/cody/page.tsx",
       "type": "page",
       "domain": "cody",
-      "patterns": ["dashboard-page"],
+      "patterns": [
+        "dashboard-page"
+      ],
       "aiSummary": "Main Cody dashboard page. Auth gate: GitHub OAuth session (any repo collaborator).",
-      "dependencies": ["next/headers", "next/navigation"]
+      "dependencies": [
+        "next/headers",
+        "next/navigation"
+      ]
     },
     "src/app/(cody)/layout.tsx": {
       "path": "src/app/(cody)/layout.tsx",
       "type": "layout",
       "domain": "cody",
-      "patterns": ["route-group", "tailwind-component"],
+      "patterns": [
+        "route-group",
+        "tailwind-component"
+      ],
       "aiSummary": "Root layout for Cody dashboard — reuses frontend fonts, theme, and CSS without Header/Footer/i18n",
-      "dependencies": ["react", "next", "geist/font/mono", "geist/font/sans", "next/font/google"]
+      "dependencies": [
+        "react",
+        "next",
+        "geist/font/mono",
+        "geist/font/sans",
+        "next/font/google"
+      ]
     },
     "src/app/(frontend)/LayoutClient.tsx": {
       "path": "src/app/(frontend)/LayoutClient.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/app/(frontend)/[slug]/page.client.tsx": {
       "path": "src/app/(frontend)/[slug]/page.client.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/app/(frontend)/_components/HomePage/index.tsx": {
       "path": "src/app/(frontend)/_components/HomePage/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "next/navigation"]
+      "dependencies": [
+        "react",
+        "next/navigation"
+      ]
     },
     "src/app/(frontend)/account/AccountPageContent.tsx": {
       "path": "src/app/(frontend)/account/AccountPageContent.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -1891,15 +2289,23 @@
       "path": "src/app/(frontend)/account/_components/AccountHub.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/app/(frontend)/account/_components/DetailsSection.tsx": {
       "path": "src/app/(frontend)/account/_components/DetailsSection.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -1907,127 +2313,224 @@
       "path": "src/app/(frontend)/account/_components/PreferencesSection.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/link"]
+      "dependencies": [
+        "next/link"
+      ]
     },
     "src/app/(frontend)/account/_components/SelectedCourseCard.tsx": {
       "path": "src/app/(frontend)/account/_components/SelectedCourseCard.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/link", "next/navigation", "react"]
+      "dependencies": [
+        "next/link",
+        "next/navigation",
+        "react"
+      ]
     },
     "src/app/(frontend)/account/_components/TeachersProfileSection.tsx": {
       "path": "src/app/(frontend)/account/_components/TeachersProfileSection.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "sonner"]
+      "dependencies": [
+        "react",
+        "sonner"
+      ]
     },
     "src/app/(frontend)/ask/_components/AskContent/index.tsx": {
       "path": "src/app/(frontend)/ask/_components/AskContent/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/app/(frontend)/ask/_components/AskConversationGrid/index.tsx": {
       "path": "src/app/(frontend)/ask/_components/AskConversationGrid/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "i18n-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "next/navigation", "lucide-react"]
+      "dependencies": [
+        "react",
+        "next/navigation",
+        "lucide-react"
+      ]
     },
     "src/app/(frontend)/ask/_components/AskDrawingCanvas/index.tsx": {
       "path": "src/app/(frontend)/ask/_components/AskDrawingCanvas/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "i18n-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react", "react"]
+      "dependencies": [
+        "lucide-react",
+        "react"
+      ]
     },
     "src/app/(frontend)/ask/_components/AskExerciseCard/index.tsx": {
       "path": "src/app/(frontend)/ask/_components/AskExerciseCard/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "i18n-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react", "react"]
+      "dependencies": [
+        "lucide-react",
+        "react"
+      ]
     },
     "src/app/(frontend)/ask/_components/AskPageClient/index.tsx": {
       "path": "src/app/(frontend)/ask/_components/AskPageClient/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/navigation", "react"]
+      "dependencies": [
+        "next/navigation",
+        "react"
+      ]
     },
     "src/app/(frontend)/ask/_components/AskPrimaryContent/index.tsx": {
       "path": "src/app/(frontend)/ask/_components/AskPrimaryContent/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react", "react", "sonner"]
+      "dependencies": [
+        "lucide-react",
+        "react",
+        "sonner"
+      ]
     },
     "src/app/(frontend)/courses/[courseSlug]/_components/AddExamDialog/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/AddExamDialog/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/app/(frontend)/courses/[courseSlug]/_components/AskTab/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/AskTab/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "i18n-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "next/navigation", "lucide-react"]
+      "dependencies": [
+        "react",
+        "next/navigation",
+        "lucide-react"
+      ]
     },
     "src/app/(frontend)/courses/[courseSlug]/_components/ConversationCard/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/ConversationCard/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "i18n-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react"]
+      "dependencies": [
+        "lucide-react"
+      ]
     },
     "src/app/(frontend)/courses/[courseSlug]/_components/CourseAnalytics.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/CourseAnalytics.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/app/(frontend)/courses/[courseSlug]/_components/CourseLessonCard/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/CourseLessonCard/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "i18n-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react"]
+      "dependencies": [
+        "lucide-react"
+      ]
     },
     "src/app/(frontend)/courses/[courseSlug]/_components/CoursePageContent/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/CoursePageContent/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react", "react"]
+      "dependencies": [
+        "lucide-react",
+        "react"
+      ]
     },
     "src/app/(frontend)/courses/[courseSlug]/_components/CourseTabs/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/CourseTabs/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "i18n-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2035,7 +2538,10 @@
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/ExamReminderBubble/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2043,15 +2549,23 @@
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/ExamsTab/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react"]
+      "dependencies": [
+        "lucide-react"
+      ]
     },
     "src/app/(frontend)/courses/[courseSlug]/_components/LearnTab/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/LearnTab/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2059,7 +2573,10 @@
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/PracticeTab/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2067,63 +2584,100 @@
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/ConvertButton.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "next/navigation"]
+      "dependencies": [
+        "react",
+        "next/navigation"
+      ]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/ExercisesPager/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/ExercisesPager/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react"]
+      "dependencies": [
+        "lucide-react"
+      ]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/LessonAnalytics.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/LessonAnalytics.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/LessonContent.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/LessonContent.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/ViewToggle.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/ViewToggle.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/complete/CompleteContent.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/complete/CompleteContent.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react"]
+      "dependencies": [
+        "lucide-react"
+      ]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/ExerciseHeader/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/ExerciseHeader/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "i18n-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react"]
+      "dependencies": [
+        "lucide-react"
+      ]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/ExercisePageContent/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/ExercisePageContent/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2131,7 +2685,10 @@
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/ExercisePageHeader/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2139,47 +2696,78 @@
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/ExerciseWorkspace/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/navigation", "react"]
+      "dependencies": [
+        "next/navigation",
+        "react"
+      ]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/FormulaPanel/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/FormulaPanel/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/MathPalette/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/MathPalette/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/NotebookNotes/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/NotebookNotes/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/NotebookWorkspace/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/NotebookWorkspace/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "i18n-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "next/link", "lucide-react"]
+      "dependencies": [
+        "react",
+        "next/link",
+        "lucide-react"
+      ]
     },
     "src/app/(frontend)/courses/_components/BackToChapter/index.tsx": {
       "path": "src/app/(frontend)/courses/_components/BackToChapter/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2187,7 +2775,10 @@
       "path": "src/app/(frontend)/courses/_components/BackToCourses/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2195,7 +2786,10 @@
       "path": "src/app/(frontend)/courses/_components/ChapterCard/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2203,7 +2797,9 @@
       "path": "src/app/(frontend)/courses/_components/ChapterHeader/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2211,7 +2807,10 @@
       "path": "src/app/(frontend)/courses/_components/ChapterPageBreadcrumb/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2219,7 +2818,10 @@
       "path": "src/app/(frontend)/courses/_components/ChaptersSectionTitle/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2227,15 +2829,25 @@
       "path": "src/app/(frontend)/courses/_components/CourseCard/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "i18n-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react", "react"]
+      "dependencies": [
+        "lucide-react",
+        "react"
+      ]
     },
     "src/app/(frontend)/courses/_components/CourseCatalogHeader/index.tsx": {
       "path": "src/app/(frontend)/courses/_components/CourseCatalogHeader/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2243,7 +2855,10 @@
       "path": "src/app/(frontend)/courses/_components/CourseShopHeader/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2251,7 +2866,10 @@
       "path": "src/app/(frontend)/courses/_components/CoursesHero/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2259,7 +2877,10 @@
       "path": "src/app/(frontend)/courses/_components/CoursesPageTitle/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2267,7 +2888,10 @@
       "path": "src/app/(frontend)/courses/_components/EmptyState/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2275,7 +2899,10 @@
       "path": "src/app/(frontend)/courses/_components/ExerciseCard/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2283,7 +2910,10 @@
       "path": "src/app/(frontend)/courses/_components/LessonCard/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2291,15 +2921,25 @@
       "path": "src/app/(frontend)/courses/_components/LessonHeader/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "i18n-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react", "next/navigation"]
+      "dependencies": [
+        "lucide-react",
+        "next/navigation"
+      ]
     },
     "src/app/(frontend)/courses/_components/LessonsSectionTitle/index.tsx": {
       "path": "src/app/(frontend)/courses/_components/LessonsSectionTitle/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2307,7 +2947,10 @@
       "path": "src/app/(frontend)/courses/_components/MembershipPlans/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2315,15 +2958,22 @@
       "path": "src/app/(frontend)/courses/_components/PlanCard/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react"]
+      "dependencies": [
+        "lucide-react"
+      ]
     },
     "src/app/(frontend)/layout.tsx": {
       "path": "src/app/(frontend)/layout.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component"],
+      "patterns": [
+        "tailwind-component"
+      ],
       "aiSummary": "",
       "dependencies": [
         "next",
@@ -2339,23 +2989,37 @@
       "path": "src/app/(frontend)/login/LoginForm.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/navigation", "react", "next/image"]
+      "dependencies": [
+        "next/navigation",
+        "react",
+        "next/image"
+      ]
     },
     "src/app/(frontend)/login/LoginPageContent.tsx": {
       "path": "src/app/(frontend)/login/LoginPageContent.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react"]
+      "dependencies": [
+        "lucide-react"
+      ]
     },
     "src/app/(frontend)/next/preview/route.ts": {
       "path": "src/app/(frontend)/next/preview/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["authenticated-endpoint"],
+      "patterns": [
+        "authenticated-endpoint"
+      ],
       "aiSummary": "",
       "dependencies": [
         "payload",
@@ -2369,119 +3033,195 @@
       "path": "src/app/(frontend)/next/seed/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["authenticated-endpoint"],
+      "patterns": [
+        "authenticated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload", "@payload-config", "next/headers"]
+      "dependencies": [
+        "payload",
+        "@payload-config",
+        "next/headers"
+      ]
     },
     "src/app/(frontend)/not-found.tsx": {
       "path": "src/app/(frontend)/not-found.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/link", "react"]
+      "dependencies": [
+        "next/link",
+        "react"
+      ]
     },
     "src/app/(frontend)/onboarding/persona/PersonaSelectionStep.tsx": {
       "path": "src/app/(frontend)/onboarding/persona/PersonaSelectionStep.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "sonner"]
+      "dependencies": [
+        "react",
+        "sonner"
+      ]
     },
     "src/app/(frontend)/posts/[slug]/page.client.tsx": {
       "path": "src/app/(frontend)/posts/[slug]/page.client.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/app/(frontend)/posts/page/[pageNumber]/page.client.tsx": {
       "path": "src/app/(frontend)/posts/page/[pageNumber]/page.client.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/app/(frontend)/posts/page.client.tsx": {
       "path": "src/app/(frontend)/posts/page.client.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/app/(frontend)/search/page.client.tsx": {
       "path": "src/app/(frontend)/search/page.client.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/app/(frontend)/signup/SignupForm.tsx": {
       "path": "src/app/(frontend)/signup/SignupForm.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/navigation", "react", "sonner"]
+      "dependencies": [
+        "next/navigation",
+        "react",
+        "sonner"
+      ]
     },
     "src/app/(frontend)/signup/SignupPageContent.tsx": {
       "path": "src/app/(frontend)/signup/SignupPageContent.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/app/(frontend)/study/_components/StudyContent/index.tsx": {
       "path": "src/app/(frontend)/study/_components/StudyContent/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "i18n-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react", "react"]
+      "dependencies": [
+        "lucide-react",
+        "react"
+      ]
     },
     "src/app/(frontend)/study-plan/_components/DayCard.tsx": {
       "path": "src/app/(frontend)/study-plan/_components/DayCard.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/app/(frontend)/study-plan/_components/EmptyPlanState.tsx": {
       "path": "src/app/(frontend)/study-plan/_components/EmptyPlanState.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component"],
+      "patterns": [
+        "i18n-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react"]
+      "dependencies": [
+        "lucide-react"
+      ]
     },
     "src/app/(frontend)/study-plan/_components/StudyPlanPage.tsx": {
       "path": "src/app/(frontend)/study-plan/_components/StudyPlanPage.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react", "react"]
+      "dependencies": [
+        "lucide-react",
+        "react"
+      ]
     },
     "src/app/(frontend)/study-plan/_components/useStudyPlan.ts": {
       "path": "src/app/(frontend)/study-plan/_components/useStudyPlan.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/app/(payload)/admin/chat/page.tsx": {
       "path": "src/app/(payload)/admin/chat/page.tsx",
       "type": "page",
       "domain": "admin",
-      "patterns": ["admin-page", "client-component"],
+      "patterns": [
+        "admin-page",
+        "client-component"
+      ],
       "aiSummary": "Dedicated admin chat interface for querying content via MCP tools",
       "dependencies": []
     },
@@ -2489,7 +3229,10 @@
       "path": "src/app/(payload)/admin/pdf-conversion/page.tsx",
       "type": "page",
       "domain": "admin",
-      "patterns": ["admin-page", "client-component"],
+      "patterns": [
+        "admin-page",
+        "client-component"
+      ],
       "aiSummary": "Dedicated admin page for PDF-to-exercise conversion",
       "dependencies": []
     },
@@ -2497,487 +3240,859 @@
       "path": "src/app/api/agent/chat/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["api-endpoint", "authenticated-endpoint"],
+      "patterns": [
+        "api-endpoint",
+        "authenticated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payload-config", "next/server", "payload"]
+      "dependencies": [
+        "@payload-config",
+        "next/server",
+        "payload"
+      ]
     },
     "src/app/api/agent/chat/stream/route.ts": {
       "path": "src/app/api/agent/chat/stream/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["api-endpoint", "authenticated-endpoint"],
+      "patterns": [
+        "api-endpoint",
+        "authenticated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payload-config", "next/server", "payload"]
+      "dependencies": [
+        "@payload-config",
+        "next/server",
+        "payload"
+      ]
     },
     "src/app/api/agent/conversation/route.ts": {
       "path": "src/app/api/agent/conversation/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["api-endpoint", "authenticated-endpoint"],
+      "patterns": [
+        "api-endpoint",
+        "authenticated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/server", "payload", "@payload-config"]
+      "dependencies": [
+        "next/server",
+        "payload",
+        "@payload-config"
+      ]
     },
     "src/app/api/agent/message/persist/route.ts": {
       "path": "src/app/api/agent/message/persist/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["api-endpoint", "authenticated-endpoint", "validated-endpoint"],
+      "patterns": [
+        "api-endpoint",
+        "authenticated-endpoint",
+        "validated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payload-config", "next/server", "payload", "zod"]
+      "dependencies": [
+        "@payload-config",
+        "next/server",
+        "payload",
+        "zod"
+      ]
     },
     "src/app/api/agent/reset-chat/route.ts": {
       "path": "src/app/api/agent/reset-chat/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["api-endpoint", "authenticated-endpoint"],
+      "patterns": [
+        "api-endpoint",
+        "authenticated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payload-config", "next/server", "payload"]
+      "dependencies": [
+        "@payload-config",
+        "next/server",
+        "payload"
+      ]
     },
     "src/app/api/blob/upload-token/route.ts": {
       "path": "src/app/api/blob/upload-token/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["authenticated-endpoint", "validated-endpoint"],
+      "patterns": [
+        "authenticated-endpoint",
+        "validated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["@vercel/blob/client", "payload", "zod", "@payload-config"]
+      "dependencies": [
+        "@vercel/blob/client",
+        "payload",
+        "zod",
+        "@payload-config"
+      ]
     },
     "src/app/api/chapters/by-grade/route.ts": {
       "path": "src/app/api/chapters/by-grade/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["api-endpoint"],
+      "patterns": [
+        "api-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/server", "payload", "@payload-config"]
+      "dependencies": [
+        "next/server",
+        "payload",
+        "@payload-config"
+      ]
     },
     "src/app/api/chat-assets/finalize/route.ts": {
       "path": "src/app/api/chat-assets/finalize/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["authenticated-endpoint"],
+      "patterns": [
+        "authenticated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload", "zod", "@payload-config"]
+      "dependencies": [
+        "payload",
+        "zod",
+        "@payload-config"
+      ]
     },
     "src/app/api/cody/auth/logout/route.ts": {
       "path": "src/app/api/cody/auth/logout/route.ts",
       "type": "api-route",
       "domain": "cody",
-      "patterns": ["auth-api", "api-endpoint"],
+      "patterns": [
+        "auth-api",
+        "api-endpoint"
+      ],
       "aiSummary": "Clears the Cody GitHub session cookie (logout).",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/cody/auth/me/route.ts": {
       "path": "src/app/api/cody/auth/me/route.ts",
       "type": "api-route",
       "domain": "cody",
-      "patterns": ["auth-api", "api-endpoint"],
+      "patterns": [
+        "auth-api",
+        "api-endpoint"
+      ],
       "aiSummary": "Returns the current GitHub identity from the Cody session cookie.",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/cody/auth/route.ts": {
       "path": "src/app/api/cody/auth/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["auth-api", "api-endpoint"],
+      "patterns": [
+        "auth-api",
+        "api-endpoint"
+      ],
       "aiSummary": "API route for dashboard auth status",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/cody/boards/route.ts": {
       "path": "src/app/api/cody/boards/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["boards-api", "api-endpoint"],
+      "patterns": [
+        "boards-api",
+        "api-endpoint"
+      ],
       "aiSummary": "API route to fetch boards (labels + milestones)",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/cody/branches/route.ts": {
       "path": "src/app/api/cody/branches/route.ts",
       "type": "endpoint",
       "domain": "cody",
-      "patterns": ["branches-api", "api-endpoint", "validated-endpoint"],
+      "patterns": [
+        "branches-api",
+        "api-endpoint",
+        "validated-endpoint"
+      ],
       "aiSummary": "API route for listing and deleting branches from GitHub",
-      "dependencies": ["next/server", "zod"]
+      "dependencies": [
+        "next/server",
+        "zod"
+      ]
     },
     "src/app/api/cody/chat/load/route.ts": {
       "path": "src/app/api/cody/chat/load/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["chat-load-api", "api-endpoint"],
+      "patterns": [
+        "chat-load-api",
+        "api-endpoint"
+      ],
       "aiSummary": "API route to load chat history for a task from GitHub",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/cody/chat/route.ts": {
       "path": "src/app/api/cody/chat/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["ai-chat-streaming", "api-endpoint", "validated-endpoint"],
+      "patterns": [
+        "ai-chat-streaming",
+        "api-endpoint",
+        "validated-endpoint"
+      ],
       "aiSummary": "Streaming AI chat endpoint with GitHub MCP tools for repo browsing",
-      "dependencies": ["@ai-sdk/mcp", "@ai-sdk/google", "ai", "zod", "next/server"]
+      "dependencies": [
+        "@ai-sdk/mcp",
+        "@ai-sdk/google",
+        "ai",
+        "zod",
+        "next/server"
+      ]
     },
     "src/app/api/cody/chat/save/route.ts": {
       "path": "src/app/api/cody/chat/save/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["chat-save-api", "api-endpoint", "validated-endpoint"],
+      "patterns": [
+        "chat-save-api",
+        "api-endpoint",
+        "validated-endpoint"
+      ],
       "aiSummary": "API route to save chat history for a task to GitHub",
-      "dependencies": ["next/server", "zod"]
+      "dependencies": [
+        "next/server",
+        "zod"
+      ]
     },
     "src/app/api/cody/collaborators/route.ts": {
       "path": "src/app/api/cody/collaborators/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["collaborators-api", "api-endpoint"],
+      "patterns": [
+        "collaborators-api",
+        "api-endpoint"
+      ],
       "aiSummary": "API route to fetch repository collaborators for assignee picker",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/cody/inspector/health/route.ts": {
       "path": "src/app/api/cody/inspector/health/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["inspector-health-api", "api-endpoint"],
+      "patterns": [
+        "inspector-health-api",
+        "api-endpoint"
+      ],
       "aiSummary": "API route to fetch inspector health status and metrics",
-      "dependencies": ["next/server", "child_process", "fs", "path"]
+      "dependencies": [
+        "next/server",
+        "child_process",
+        "fs",
+        "path"
+      ]
     },
     "src/app/api/cody/pipeline/[taskId]/route.ts": {
       "path": "src/app/api/cody/pipeline/[taskId]/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["pipeline-api", "api-endpoint"],
+      "patterns": [
+        "pipeline-api",
+        "api-endpoint"
+      ],
       "aiSummary": "API route to fetch pipeline status for a task",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/cody/prs/comments/route.ts": {
       "path": "src/app/api/cody/prs/comments/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["prs-comments-api", "api-endpoint", "validated-endpoint"],
+      "patterns": [
+        "prs-comments-api",
+        "api-endpoint",
+        "validated-endpoint"
+      ],
       "aiSummary": "API route to fetch and post PR comments",
-      "dependencies": ["next/server", "zod"]
+      "dependencies": [
+        "next/server",
+        "zod"
+      ]
     },
     "src/app/api/cody/prs/files/route.ts": {
       "path": "src/app/api/cody/prs/files/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["pr-files-api", "api-endpoint"],
+      "patterns": [
+        "pr-files-api",
+        "api-endpoint"
+      ],
       "aiSummary": "API route to fetch file changes for a PR",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/cody/prs/route.ts": {
       "path": "src/app/api/cody/prs/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["prs-api", "api-endpoint"],
+      "patterns": [
+        "prs-api",
+        "api-endpoint"
+      ],
       "aiSummary": "API route to fetch PRs",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/cody/prs/status/route.ts": {
       "path": "src/app/api/cody/prs/status/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["pr-ci-status", "api-endpoint"],
+      "patterns": [
+        "pr-ci-status",
+        "api-endpoint"
+      ],
       "aiSummary": "Fetch CI status and mergeability for a PR",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/cody/publish/route.ts": {
       "path": "src/app/api/cody/publish/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["publish", "api-endpoint"],
+      "patterns": [
+        "publish",
+        "api-endpoint"
+      ],
       "aiSummary": "Create a GitHub issue with 'publish' label to trigger dev→main PR workflow",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/cody/remote/exec/route.ts": {
       "path": "src/app/api/cody/remote/exec/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["proxy-endpoint", "api-endpoint"],
+      "patterns": [
+        "proxy-endpoint",
+        "api-endpoint"
+      ],
       "aiSummary": "Proxy endpoint that forwards exec/read/write/ls actions to the remote dev agent",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/cody/remote/status/route.ts": {
       "path": "src/app/api/cody/remote/status/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["health-check", "api-endpoint"],
+      "patterns": [
+        "health-check",
+        "api-endpoint"
+      ],
       "aiSummary": "Health check for the remote dev agent — returns online/offline status",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/cody/tasks/[taskId]/actions/route.ts": {
       "path": "src/app/api/cody/tasks/[taskId]/actions/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["task-actions-api", "api-endpoint", "validated-endpoint"],
+      "patterns": [
+        "task-actions-api",
+        "api-endpoint",
+        "validated-endpoint"
+      ],
       "aiSummary": "API route for task actions (approve, reject, rerun, abort, execute)",
-      "dependencies": ["next/server", "zod"]
+      "dependencies": [
+        "next/server",
+        "zod"
+      ]
     },
     "src/app/api/cody/tasks/[taskId]/docs/route.ts": {
       "path": "src/app/api/cody/tasks/[taskId]/docs/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["task-docs-api", "api-endpoint"],
+      "patterns": [
+        "task-docs-api",
+        "api-endpoint"
+      ],
       "aiSummary": "API route to fetch task documents from the task's branch",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/cody/tasks/[taskId]/route.ts": {
       "path": "src/app/api/cody/tasks/[taskId]/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["task-detail-api", "api-endpoint"],
+      "patterns": [
+        "task-detail-api",
+        "api-endpoint"
+      ],
       "aiSummary": "API route to fetch detailed task info",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/cody/tasks/approve/route.ts": {
       "path": "src/app/api/cody/tasks/approve/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["approve-gate", "api-endpoint", "validated-endpoint"],
+      "patterns": [
+        "approve-gate",
+        "api-endpoint",
+        "validated-endpoint"
+      ],
       "aiSummary": "Approve a gate - merge PR, delete branch, close issue, remove labels via GitHub API",
-      "dependencies": ["next/server", "zod"]
+      "dependencies": [
+        "next/server",
+        "zod"
+      ]
     },
     "src/app/api/cody/tasks/approve-review/route.ts": {
       "path": "src/app/api/cody/tasks/approve-review/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["approve-review", "api-endpoint"],
+      "patterns": [
+        "approve-review",
+        "api-endpoint"
+      ],
       "aiSummary": "Approve a PR review and merge it via GitHub API (Octokit).",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/cody/tasks/route.ts": {
       "path": "src/app/api/cody/tasks/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["tasks-api", "api-endpoint"],
+      "patterns": [
+        "tasks-api",
+        "api-endpoint"
+      ],
       "aiSummary": "API route to fetch and create tasks (GitHub issues)",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/cody/workflows/route.ts": {
       "path": "src/app/api/cody/workflows/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["workflows-api", "api-endpoint"],
+      "patterns": [
+        "workflows-api",
+        "api-endpoint"
+      ],
       "aiSummary": "API route to fetch workflow runs",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/conversations/by-context/route.ts": {
       "path": "src/app/api/conversations/by-context/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["api-endpoint", "authenticated-endpoint"],
+      "patterns": [
+        "api-endpoint",
+        "authenticated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/server", "payload", "@payload-config"]
+      "dependencies": [
+        "next/server",
+        "payload",
+        "@payload-config"
+      ]
     },
     "src/app/api/copilotkit/route.ts": {
       "path": "src/app/api/copilotkit/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": ["copilotkit-runtime", "api-endpoint"],
+      "patterns": [
+        "copilotkit-runtime",
+        "api-endpoint"
+      ],
       "aiSummary": "Simple AI chat endpoint for Cody dashboard",
-      "dependencies": ["@google/generative-ai", "next/server"]
+      "dependencies": [
+        "@google/generative-ai",
+        "next/server"
+      ]
     },
     "src/app/api/example/route.ts": {
       "path": "src/app/api/example/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["api-endpoint"],
+      "patterns": [
+        "api-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/server", "zod", "@sentry/nextjs", "crypto"]
+      "dependencies": [
+        "next/server",
+        "zod",
+        "@sentry/nextjs",
+        "crypto"
+      ]
     },
     "src/app/api/exercises/[id]/blocks/[blockId]/route.ts": {
       "path": "src/app/api/exercises/[id]/blocks/[blockId]/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["api-endpoint", "authenticated-endpoint", "validated-endpoint"],
+      "patterns": [
+        "api-endpoint",
+        "authenticated-endpoint",
+        "validated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/server", "payload", "zod", "@payload-config"]
+      "dependencies": [
+        "next/server",
+        "payload",
+        "zod",
+        "@payload-config"
+      ]
     },
     "src/app/api/exercises/convert/queue/route.ts": {
       "path": "src/app/api/exercises/convert/queue/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["api-endpoint", "authenticated-endpoint", "validated-endpoint"],
+      "patterns": [
+        "api-endpoint",
+        "authenticated-endpoint",
+        "validated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload", "@payload-config", "next/server", "zod"]
+      "dependencies": [
+        "payload",
+        "@payload-config",
+        "next/server",
+        "zod"
+      ]
     },
     "src/app/api/exercises/convert/queue-v2/route.ts": {
       "path": "src/app/api/exercises/convert/queue-v2/route.ts",
       "type": "api-route",
       "domain": "conversion",
-      "patterns": ["endpoint", "queue", "api-endpoint", "authenticated-endpoint"],
+      "patterns": [
+        "endpoint",
+        "queue",
+        "api-endpoint",
+        "authenticated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload", "@payload-config", "next/server"]
+      "dependencies": [
+        "payload",
+        "@payload-config",
+        "next/server"
+      ]
     },
     "src/app/api/exercises/convert/queue-v2/schema.ts": {
       "path": "src/app/api/exercises/convert/queue-v2/schema.ts",
       "type": "utility",
       "domain": "conversion",
-      "patterns": ["validation", "zod-schema"],
+      "patterns": [
+        "validation",
+        "zod-schema"
+      ],
       "aiSummary": "",
-      "dependencies": ["zod"]
+      "dependencies": [
+        "zod"
+      ]
     },
     "src/app/api/exercises/convert/runner/route.ts": {
       "path": "src/app/api/exercises/convert/runner/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["api-endpoint"],
+      "patterns": [
+        "api-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payload-config", "mongodb", "next/server", "payload"]
+      "dependencies": [
+        "@payload-config",
+        "mongodb",
+        "next/server",
+        "payload"
+      ]
     },
     "src/app/api/exercises/convert/single/create/route.ts": {
       "path": "src/app/api/exercises/convert/single/create/route.ts",
       "type": "api-route",
       "domain": "conversion",
-      "patterns": ["endpoint", "validated-endpoint"],
+      "patterns": [
+        "endpoint",
+        "validated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/server", "zod"]
+      "dependencies": [
+        "next/server",
+        "zod"
+      ]
     },
     "src/app/api/exercises/convert/single/route.ts": {
       "path": "src/app/api/exercises/convert/single/route.ts",
       "type": "api-route",
       "domain": "conversion",
-      "patterns": ["endpoint"],
+      "patterns": [
+        "endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/server", "zod"]
+      "dependencies": [
+        "next/server",
+        "zod"
+      ]
     },
     "src/app/api/exercises/import/route.ts": {
       "path": "src/app/api/exercises/import/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["api-endpoint", "authenticated-endpoint"],
+      "patterns": [
+        "api-endpoint",
+        "authenticated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/server", "payload", "@payload-config"]
+      "dependencies": [
+        "next/server",
+        "payload",
+        "@payload-config"
+      ]
     },
     "src/app/api/exercises/validate-answer/route.ts": {
       "path": "src/app/api/exercises/validate-answer/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["authenticated-endpoint"],
+      "patterns": [
+        "authenticated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/server", "payload", "@payload-config"]
+      "dependencies": [
+        "next/server",
+        "payload",
+        "@payload-config"
+      ]
     },
     "src/app/api/jobs/run-immediate/route.ts": {
       "path": "src/app/api/jobs/run-immediate/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["api-endpoint", "authenticated-endpoint"],
+      "patterns": [
+        "api-endpoint",
+        "authenticated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payload-config", "mongodb", "next/server", "payload"]
+      "dependencies": [
+        "@payload-config",
+        "mongodb",
+        "next/server",
+        "payload"
+      ]
     },
     "src/app/api/oauth/github/callback/route.ts": {
       "path": "src/app/api/oauth/github/callback/route.ts",
       "type": "api-route",
       "domain": "auth",
-      "patterns": ["oauth", "api-endpoint"],
+      "patterns": [
+        "oauth",
+        "api-endpoint"
+      ],
       "aiSummary": "Handles GitHub OAuth callback for the Cody Operations Dashboard.",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/oauth/github/route.ts": {
       "path": "src/app/api/oauth/github/route.ts",
       "type": "api-route",
       "domain": "auth",
-      "patterns": ["oauth", "api-endpoint"],
+      "patterns": [
+        "oauth",
+        "api-endpoint"
+      ],
       "aiSummary": "Initiates GitHub OAuth flow for the Cody Operations Dashboard.",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/oauth/google/callback/oauth_callback_helpers.ts": {
       "path": "src/app/api/oauth/google/callback/oauth_callback_helpers.ts",
       "type": "utility",
       "domain": "auth",
-      "patterns": ["oauth", "api-endpoint"],
+      "patterns": [
+        "oauth",
+        "api-endpoint"
+      ],
       "aiSummary": "Helper functions for OAuth callback to handle user lookup and creation",
-      "dependencies": ["next/server", "payload"]
+      "dependencies": [
+        "next/server",
+        "payload"
+      ]
     },
     "src/app/api/oauth/google/callback/route.ts": {
       "path": "src/app/api/oauth/google/callback/route.ts",
       "type": "api-route",
       "domain": "auth",
-      "patterns": ["oauth", "api-endpoint"],
+      "patterns": [
+        "oauth",
+        "api-endpoint"
+      ],
       "aiSummary": "Handles Google OAuth callback, creates/updates users, issues sessions",
-      "dependencies": ["next/server", "payload", "@payload-config"]
+      "dependencies": [
+        "next/server",
+        "payload",
+        "@payload-config"
+      ]
     },
     "src/app/api/oauth/google/route.ts": {
       "path": "src/app/api/oauth/google/route.ts",
       "type": "api-route",
       "domain": "auth",
-      "patterns": ["oauth", "api-endpoint"],
+      "patterns": [
+        "oauth",
+        "api-endpoint"
+      ],
       "aiSummary": "Initiates Google OAuth flow by redirecting to Google consent screen",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/pdfjs-viewer/route.ts": {
       "path": "src/app/api/pdfjs-viewer/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["api-endpoint"],
+      "patterns": [
+        "api-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/app/api/prompts/for-conversion/route.ts": {
       "path": "src/app/api/prompts/for-conversion/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["api-endpoint", "authenticated-endpoint"],
+      "patterns": [
+        "api-endpoint",
+        "authenticated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payload-config", "next/server", "payload"]
+      "dependencies": [
+        "@payload-config",
+        "next/server",
+        "payload"
+      ]
     },
     "src/app/api/study-plan/route.ts": {
       "path": "src/app/api/study-plan/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["api-endpoint", "authenticated-endpoint", "validated-endpoint"],
+      "patterns": [
+        "api-endpoint",
+        "authenticated-endpoint",
+        "validated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payload-config", "date-fns", "nanoid", "next/server", "payload", "zod"]
+      "dependencies": [
+        "@payload-config",
+        "date-fns",
+        "nanoid",
+        "next/server",
+        "payload",
+        "zod"
+      ]
     },
     "src/app/api/teacher-profiles/route.ts": {
       "path": "src/app/api/teacher-profiles/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["authenticated-endpoint"],
+      "patterns": [
+        "authenticated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload", "@payload-config"]
+      "dependencies": [
+        "payload",
+        "@payload-config"
+      ]
     },
     "src/app/api/user-settings/route.ts": {
       "path": "src/app/api/user-settings/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["authenticated-endpoint"],
+      "patterns": [
+        "authenticated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload", "zod", "@payload-config"]
+      "dependencies": [
+        "payload",
+        "zod",
+        "@payload-config"
+      ]
     },
     "src/app/global-error.tsx": {
       "path": "src/app/global-error.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["@sentry/nextjs", "next/error", "react"]
+      "dependencies": [
+        "@sentry/nextjs",
+        "next/error",
+        "react"
+      ]
     },
     "src/client/hooks/useAccessGate.ts": {
       "path": "src/client/hooks/useAccessGate.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/client/hooks/useCurrentUser.ts": {
       "path": "src/client/hooks/useCurrentUser.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/client/hooks/useExamCountdown.ts": {
       "path": "src/client/hooks/useExamCountdown.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/infra/analytics/adapters/ga4/adapter.ts": {
       "path": "src/infra/analytics/adapters/ga4/adapter.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2985,15 +4100,21 @@
       "path": "src/infra/analytics/adapters/ga4/scripts.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/script"]
+      "dependencies": [
+        "next/script"
+      ]
     },
     "src/infra/analytics/adapters/mixpanel/adapter.ts": {
       "path": "src/infra/analytics/adapters/mixpanel/adapter.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -3001,23 +4122,33 @@
       "path": "src/infra/analytics/adapters/mixpanel/scripts.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/script"]
+      "dependencies": [
+        "next/script"
+      ]
     },
     "src/infra/analytics/components/UserIdentificationTracker.tsx": {
       "path": "src/infra/analytics/components/UserIdentificationTracker.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/infra/analytics/core/tracker.ts": {
       "path": "src/infra/analytics/core/tracker.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -3025,39 +4156,60 @@
       "path": "src/infra/analytics/hooks/usePageAbandonment.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "next/navigation"]
+      "dependencies": [
+        "react",
+        "next/navigation"
+      ]
     },
     "src/infra/analytics/hooks/usePageView.ts": {
       "path": "src/infra/analytics/hooks/usePageView.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/navigation", "react"]
+      "dependencies": [
+        "next/navigation",
+        "react"
+      ]
     },
     "src/infra/analytics/hooks/useSessionDuration.ts": {
       "path": "src/infra/analytics/hooks/useSessionDuration.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "next/navigation"]
+      "dependencies": [
+        "react",
+        "next/navigation"
+      ]
     },
     "src/infra/analytics/providers/AnalyticsProvider.tsx": {
       "path": "src/infra/analytics/providers/AnalyticsProvider.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/infra/analytics/system-events-subscriber.ts": {
       "path": "src/infra/analytics/system-events-subscriber.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["authenticated-endpoint"],
+      "patterns": [
+        "authenticated-endpoint"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -3065,47 +4217,73 @@
       "path": "src/infra/auth/cody_session.ts",
       "type": "utility",
       "domain": "auth",
-      "patterns": ["oauth", "api-endpoint"],
+      "patterns": [
+        "oauth",
+        "api-endpoint"
+      ],
       "aiSummary": "Standalone GitHub identity session for the Cody Operations Dashboard.",
-      "dependencies": ["jose", "next/server"]
+      "dependencies": [
+        "jose",
+        "next/server"
+      ]
     },
     "src/infra/auth/oauth_constants.ts": {
       "path": "src/infra/auth/oauth_constants.ts",
       "type": "constants",
       "domain": "auth",
-      "patterns": ["oauth"],
+      "patterns": [
+        "oauth"
+      ],
       "aiSummary": "Cookie configuration and constants for OAuth authentication",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/infra/auth/oauth_cookies.ts": {
       "path": "src/infra/auth/oauth_cookies.ts",
       "type": "utility",
       "domain": "auth",
-      "patterns": ["oauth", "api-endpoint"],
+      "patterns": [
+        "oauth",
+        "api-endpoint"
+      ],
       "aiSummary": "Cookie read/write/delete utilities for OAuth flow",
-      "dependencies": ["next/server", "payload"]
+      "dependencies": [
+        "next/server",
+        "payload"
+      ]
     },
     "src/infra/auth/oauth_crypto.ts": {
       "path": "src/infra/auth/oauth_crypto.ts",
       "type": "utility",
       "domain": "auth",
-      "patterns": ["encryption"],
+      "patterns": [
+        "encryption"
+      ],
       "aiSummary": "AES-256-GCM encryption for OAuth login secrets",
-      "dependencies": ["crypto"]
+      "dependencies": [
+        "crypto"
+      ]
     },
     "src/infra/auth/oauth_logger.ts": {
       "path": "src/infra/auth/oauth_logger.ts",
       "type": "utility",
       "domain": "auth",
-      "patterns": ["oauth"],
+      "patterns": [
+        "oauth"
+      ],
       "aiSummary": "PII-safe logging for OAuth events with email hashing",
-      "dependencies": ["crypto"]
+      "dependencies": [
+        "crypto"
+      ]
     },
     "src/infra/auth/oauth_nonce.ts": {
       "path": "src/infra/auth/oauth_nonce.ts",
       "type": "utility",
       "domain": "auth",
-      "patterns": ["oauth"],
+      "patterns": [
+        "oauth"
+      ],
       "aiSummary": "Generate cryptographically secure random nonces for CSRF protection",
       "dependencies": []
     },
@@ -3113,7 +4291,9 @@
       "path": "src/infra/auth/oauth_sanitize.ts",
       "type": "utility",
       "domain": "auth",
-      "patterns": ["oauth"],
+      "patterns": [
+        "oauth"
+      ],
       "aiSummary": "Sanitize returnTo URLs to prevent open redirect vulnerabilities",
       "dependencies": []
     },
@@ -3121,31 +4301,47 @@
       "path": "src/infra/auth/oauth_session.ts",
       "type": "utility",
       "domain": "auth",
-      "patterns": ["oauth"],
+      "patterns": [
+        "oauth"
+      ],
       "aiSummary": "Issue Payload auth sessions using payload.login() for OAuth users",
-      "dependencies": ["payload", "@payload-config"]
+      "dependencies": [
+        "payload",
+        "@payload-config"
+      ]
     },
     "src/infra/auth/oauth_state.ts": {
       "path": "src/infra/auth/oauth_state.ts",
       "type": "utility",
       "domain": "auth",
-      "patterns": ["oauth", "api-endpoint"],
+      "patterns": [
+        "oauth",
+        "api-endpoint"
+      ],
       "aiSummary": "Manage OAuth state nonces and returnTo URLs for CSRF protection",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/infra/auth/oauth_url.ts": {
       "path": "src/infra/auth/oauth_url.ts",
       "type": "utility",
       "domain": "auth",
-      "patterns": ["oauth"],
+      "patterns": [
+        "oauth"
+      ],
       "aiSummary": "Build canonical public base URLs for OAuth callbacks",
-      "dependencies": ["next/server"]
+      "dependencies": [
+        "next/server"
+      ]
     },
     "src/infra/config/config-constants.ts": {
       "path": "src/infra/config/config-constants.ts",
       "type": "utility",
       "domain": "config",
-      "patterns": ["constants"],
+      "patterns": [
+        "constants"
+      ],
       "aiSummary": "Configuration constants for the config manager",
       "dependencies": []
     },
@@ -3153,23 +4349,36 @@
       "path": "src/infra/config/config-crypto.ts",
       "type": "utility",
       "domain": "config",
-      "patterns": ["encryption"],
+      "patterns": [
+        "encryption"
+      ],
       "aiSummary": "AES-256-GCM encryption for config secrets",
-      "dependencies": ["crypto"]
+      "dependencies": [
+        "crypto"
+      ]
     },
     "src/infra/config/runtime/config-values.ts": {
       "path": "src/infra/config/runtime/config-values.ts",
       "type": "implementation",
       "domain": "config.runtime",
-      "patterns": ["singleton", "in-memory-cache", "domain-config-loader"],
+      "patterns": [
+        "singleton",
+        "in-memory-cache",
+        "domain-config-loader"
+      ],
       "aiSummary": "Server-side runtime config values loader with DB→memory caching (tenant-scoped, domain-grouped)",
-      "dependencies": ["payload", "@payload-config"]
+      "dependencies": [
+        "payload",
+        "@payload-config"
+      ]
     },
     "src/infra/config/runtime/errors.ts": {
       "path": "src/infra/config/runtime/errors.ts",
       "type": "error-definition",
       "domain": "config.runtime",
-      "patterns": ["error-handling"],
+      "patterns": [
+        "error-handling"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -3177,15 +4386,24 @@
       "path": "src/infra/config/runtime/runtime-config.ts",
       "type": "implementation",
       "domain": "config.runtime",
-      "patterns": ["singleton", "in-memory-cache", "config-loader"],
+      "patterns": [
+        "singleton",
+        "in-memory-cache",
+        "config-loader"
+      ],
       "aiSummary": "Server-side runtime config loader for secrets only (DB→memory caching, tenant-scoped)",
-      "dependencies": ["payload", "@payload-config"]
+      "dependencies": [
+        "payload",
+        "@payload-config"
+      ]
     },
     "src/infra/config/runtime/types.ts": {
       "path": "src/infra/config/runtime/types.ts",
       "type": "type-definition",
       "domain": "config.runtime",
-      "patterns": ["types"],
+      "patterns": [
+        "types"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -3193,7 +4411,10 @@
       "path": "src/infra/config/runtime/validate-chat-config.ts",
       "type": "implementation",
       "domain": "config.validation",
-      "patterns": ["runtime-validation", "config-sanity-check"],
+      "patterns": [
+        "runtime-validation",
+        "config-sanity-check"
+      ],
       "aiSummary": "Validates chat configuration values at runtime to ensure required paths exist and values are within expected ranges",
       "dependencies": []
     },
@@ -3201,7 +4422,9 @@
       "path": "src/infra/config/system-params.ts",
       "type": "wrapper",
       "domain": "config.system-params",
-      "patterns": ["type-safe-accessor"],
+      "patterns": [
+        "type-safe-accessor"
+      ],
       "aiSummary": "Type-safe accessors for system parameters stored in ConfigValues",
       "dependencies": []
     },
@@ -3209,7 +4432,10 @@
       "path": "src/infra/llm/genkit/adapters/error-adapter.ts",
       "type": "adapter",
       "domain": "ai",
-      "patterns": ["error-handling", "genkit"],
+      "patterns": [
+        "error-handling",
+        "genkit"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -3217,31 +4443,56 @@
       "path": "src/infra/llm/genkit/adapters/unified-adapter.ts",
       "type": "adapter",
       "domain": "ai",
-      "patterns": ["abstraction", "genkit", "provider-abstraction"],
+      "patterns": [
+        "abstraction",
+        "genkit",
+        "provider-abstraction"
+      ],
       "aiSummary": "",
-      "dependencies": ["genkit", "payload"]
+      "dependencies": [
+        "genkit",
+        "payload"
+      ]
     },
     "src/infra/llm/genkit/config-resolver.ts": {
       "path": "src/infra/llm/genkit/config-resolver.ts",
       "type": "implementation",
       "domain": "ai",
-      "patterns": ["config-mapping", "genkit"],
+      "patterns": [
+        "config-mapping",
+        "genkit"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/infra/llm/genkit/genkit-instance.ts": {
       "path": "src/infra/llm/genkit/genkit-instance.ts",
       "type": "implementation",
       "domain": "ai",
-      "patterns": ["singleton", "genkit", "lazy-loading"],
+      "patterns": [
+        "singleton",
+        "genkit",
+        "lazy-loading"
+      ],
       "aiSummary": "",
-      "dependencies": ["@genkit-ai/googleai", "genkit", "genkitx-openai", "payload"]
+      "dependencies": [
+        "@genkit-ai/googleai",
+        "genkit",
+        "genkitx-openai",
+        "payload"
+      ]
     },
     "src/infra/llm/genkit/index.ts": {
       "path": "src/infra/llm/genkit/index.ts",
       "type": "index",
       "domain": "ai",
-      "patterns": ["abstraction", "genkit", "provider-abstraction"],
+      "patterns": [
+        "abstraction",
+        "genkit",
+        "provider-abstraction"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -3249,15 +4500,24 @@
       "path": "src/infra/llm/genkit/tools/genkit-tools.ts",
       "type": "module",
       "domain": "ai",
-      "patterns": ["genkit-tools", "tool-calling", "mcp-integration"],
+      "patterns": [
+        "genkit-tools",
+        "tool-calling",
+        "mcp-integration"
+      ],
       "aiSummary": "",
-      "dependencies": ["genkit"]
+      "dependencies": [
+        "genkit"
+      ]
     },
     "src/infra/llm/lesson-context.ts": {
       "path": "src/infra/llm/lesson-context.ts",
       "type": "ai-utility",
       "domain": "chat",
-      "patterns": ["single-responsibility", "runtime-injection"],
+      "patterns": [
+        "single-responsibility",
+        "runtime-injection"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -3265,7 +4525,9 @@
       "path": "src/infra/llm/prompt-composer.server.ts",
       "type": "ai-utility",
       "domain": "chat",
-      "patterns": ["server-only"],
+      "patterns": [
+        "server-only"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -3273,15 +4535,24 @@
       "path": "src/infra/llm/providers/factory.ts",
       "type": "factory",
       "domain": "ai",
-      "patterns": ["provider-factory", "abstraction", "dependency-injection"],
+      "patterns": [
+        "provider-factory",
+        "abstraction",
+        "dependency-injection"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/infra/llm/providers/shared/circuit-breaker.ts": {
       "path": "src/infra/llm/providers/shared/circuit-breaker.ts",
       "type": "utility",
       "domain": "ai",
-      "patterns": ["circuit-breaker", "resilience"],
+      "patterns": [
+        "circuit-breaker",
+        "resilience"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -3289,15 +4560,21 @@
       "path": "src/infra/llm/providers/shared/media-reader.ts",
       "type": "utility",
       "domain": "ai",
-      "patterns": ["data-transformation"],
+      "patterns": [
+        "data-transformation"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/infra/llm/providers/shared/retry.ts": {
       "path": "src/infra/llm/providers/shared/retry.ts",
       "type": "utility",
       "domain": "ai",
-      "patterns": ["retry"],
+      "patterns": [
+        "retry"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -3305,7 +4582,9 @@
       "path": "src/infra/llm/providers/shared/timeout.ts",
       "type": "utility",
       "domain": "ai",
-      "patterns": ["timeout"],
+      "patterns": [
+        "timeout"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -3313,7 +4592,9 @@
       "path": "src/infra/llm/smart-doc-loader.ts",
       "type": "utility",
       "domain": "ai",
-      "patterns": ["context-aware-loading"],
+      "patterns": [
+        "context-aware-loading"
+      ],
       "aiSummary": "Context-aware documentation loader that minimizes token usage",
       "dependencies": []
     },
@@ -3321,15 +4602,21 @@
       "path": "src/infra/llm/system-prompts.server.ts",
       "type": "ai-utility",
       "domain": "chat",
-      "patterns": ["server-only"],
+      "patterns": [
+        "server-only"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/infra/llm/teacher-profile-block.ts": {
       "path": "src/infra/llm/teacher-profile-block.ts",
       "type": "ai-utility",
       "domain": "chat",
-      "patterns": ["server-only"],
+      "patterns": [
+        "server-only"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -3337,23 +4624,39 @@
       "path": "src/infra/llm/vector-search.ts",
       "type": "service",
       "domain": "ai",
-      "patterns": ["vector-search", "context-scoped"],
+      "patterns": [
+        "vector-search",
+        "context-scoped"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payloadcms/db-mongodb", "mongodb", "payload"]
+      "dependencies": [
+        "@payloadcms/db-mongodb",
+        "mongodb",
+        "payload"
+      ]
     },
     "src/infra/loading/components/RouteLoadingIndicator.tsx": {
       "path": "src/infra/loading/components/RouteLoadingIndicator.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "next/navigation"]
+      "dependencies": [
+        "react",
+        "next/navigation"
+      ]
     },
     "src/infra/loading/components/Spinner.tsx": {
       "path": "src/infra/loading/components/Spinner.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -3361,39 +4664,61 @@
       "path": "src/infra/loading/components/SystemLink.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "next/link", "next/navigation"]
+      "dependencies": [
+        "react",
+        "next/link",
+        "next/navigation"
+      ]
     },
     "src/infra/loading/hooks/useAsyncAction.ts": {
       "path": "src/infra/loading/hooks/useAsyncAction.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/infra/loading/hooks/useLoadingState.ts": {
       "path": "src/infra/loading/hooks/useLoadingState.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/infra/loading/hooks/useRouterWithLoading.ts": {
       "path": "src/infra/loading/hooks/useRouterWithLoading.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/navigation", "react"]
+      "dependencies": [
+        "next/navigation",
+        "react"
+      ]
     },
     "src/infra/media/embed/resolve.ts": {
       "path": "src/infra/media/embed/resolve.ts",
       "type": "utility",
       "domain": "media",
-      "patterns": ["embed-provider"],
+      "patterns": [
+        "embed-provider"
+      ],
       "aiSummary": "Main entry point for resolving external URLs to embed metadata.",
       "dependencies": []
     },
@@ -3401,7 +4726,9 @@
       "path": "src/infra/media/embed/types.ts",
       "type": "utility",
       "domain": "media",
-      "patterns": ["embed-provider"],
+      "patterns": [
+        "embed-provider"
+      ],
       "aiSummary": "Type definitions for external media embed providers",
       "dependencies": []
     },
@@ -3409,7 +4736,10 @@
       "path": "src/infra/media/embed/vimeo.ts",
       "type": "utility",
       "domain": "media",
-      "patterns": ["embed-provider", "payload-hooks"],
+      "patterns": [
+        "embed-provider",
+        "payload-hooks"
+      ],
       "aiSummary": "Vimeo URL detection, video ID extraction, and oEmbed metadata fetching",
       "dependencies": []
     },
@@ -3417,7 +4747,9 @@
       "path": "src/infra/media/embed/youtube.ts",
       "type": "utility",
       "domain": "media",
-      "patterns": ["embed-provider"],
+      "patterns": [
+        "embed-provider"
+      ],
       "aiSummary": "YouTube URL detection, video ID extraction, and oEmbed metadata fetching",
       "dependencies": []
     },
@@ -3425,7 +4757,9 @@
       "path": "src/infra/media/youtube.ts",
       "type": "utility",
       "domain": "media",
-      "patterns": ["youtube-detection"],
+      "patterns": [
+        "youtube-detection"
+      ],
       "aiSummary": "Client-side YouTube URL detection and embed URL generation (no API calls)",
       "dependencies": []
     },
@@ -3433,7 +4767,9 @@
       "path": "src/infra/types/index.ts",
       "type": "utility",
       "domain": "general",
-      "patterns": ["type-exports"],
+      "patterns": [
+        "type-exports"
+      ],
       "aiSummary": "Centralized type exports for easy discovery by AI agents",
       "dependencies": []
     },
@@ -3441,7 +4777,9 @@
       "path": "src/infra/utils/graphics/viewport-utils.ts",
       "type": "utility",
       "domain": "graphics",
-      "patterns": ["viewport-calculation"],
+      "patterns": [
+        "viewport-calculation"
+      ],
       "aiSummary": "Viewport utility functions for auto-calculating, validating, and resolving graph display ranges",
       "dependencies": []
     },
@@ -3449,31 +4787,52 @@
       "path": "src/infra/utils/useClickableCard.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "next/navigation"]
+      "dependencies": [
+        "react",
+        "next/navigation"
+      ]
     },
     "src/server/api/responses.ts": {
       "path": "src/server/api/responses.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["api-endpoint"],
+      "patterns": [
+        "api-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/server", "zod"]
+      "dependencies": [
+        "next/server",
+        "zod"
+      ]
     },
     "src/server/api/with-api-handler.ts": {
       "path": "src/server/api/with-api-handler.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["api-endpoint", "authenticated-endpoint"],
+      "patterns": [
+        "api-endpoint",
+        "authenticated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["@sentry/nextjs", "@payload-config", "next/server", "payload", "zod"]
+      "dependencies": [
+        "@sentry/nextjs",
+        "@payload-config",
+        "next/server",
+        "payload",
+        "zod"
+      ]
     },
     "src/server/config/guest-chat-config.ts": {
       "path": "src/server/config/guest-chat-config.ts",
       "type": "utility",
       "domain": "config",
-      "patterns": ["typed-config-accessor"],
+      "patterns": [
+        "typed-config-accessor"
+      ],
       "aiSummary": "Typed getter for guest_chat domain config values with hardcoded fallbacks",
       "dependencies": []
     },
@@ -3481,47 +4840,72 @@
       "path": "src/server/payload/access/configAdminOnly.ts",
       "type": "access-control",
       "domain": "config",
-      "patterns": ["admin-only"],
+      "patterns": [
+        "admin-only"
+      ],
       "aiSummary": "Access control that restricts config operations to admins only",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/blocks/Banner/Component.tsx": {
       "path": "src/server/payload/blocks/Banner/Component.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component"],
+      "patterns": [
+        "tailwind-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["src/payload-types", "react"]
+      "dependencies": [
+        "src/payload-types",
+        "react"
+      ]
     },
     "src/server/payload/blocks/Code/Component.client.tsx": {
       "path": "src/server/payload/blocks/Code/Component.client.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["prism-react-renderer", "react"]
+      "dependencies": [
+        "prism-react-renderer",
+        "react"
+      ]
     },
     "src/server/payload/blocks/Code/CopyButton.tsx": {
       "path": "src/server/payload/blocks/Code/CopyButton.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payloadcms/ui/icons/Copy", "react"]
+      "dependencies": [
+        "@payloadcms/ui/icons/Copy",
+        "react"
+      ]
     },
     "src/server/payload/blocks/Content/Component.tsx": {
       "path": "src/server/payload/blocks/Content/Component.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component"],
+      "patterns": [
+        "tailwind-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/server/payload/blocks/Form/Component.tsx": {
       "path": "src/server/payload/blocks/Form/Component.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": [
         "@payloadcms/plugin-form-builder/types",
@@ -3535,297 +4919,496 @@
       "path": "src/server/payload/blocks/Form/Error/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "react-hook-form"]
+      "dependencies": [
+        "react",
+        "react-hook-form"
+      ]
     },
     "src/server/payload/blocks/MediaBlock/Component.tsx": {
       "path": "src/server/payload/blocks/MediaBlock/Component.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component"],
+      "patterns": [
+        "tailwind-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/image", "react"]
+      "dependencies": [
+        "next/image",
+        "react"
+      ]
     },
     "src/server/payload/collections/Categories.ts": {
       "path": "src/server/payload/collections/Categories.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["access-control", "payload-hooks"],
+      "patterns": [
+        "access-control",
+        "payload-hooks"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/Chapters.ts": {
       "path": "src/server/payload/collections/Chapters.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["hierarchical-data", "access-control", "payload-hooks"],
+      "patterns": [
+        "hierarchical-data",
+        "access-control",
+        "payload-hooks"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/ChatAssets/index.ts": {
       "path": "src/server/payload/collections/ChatAssets/index.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["access-control"],
+      "patterns": [
+        "access-control"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/ConfigAuditLogs.ts": {
       "path": "src/server/payload/collections/ConfigAuditLogs.ts",
       "type": "collection-config",
       "domain": "config",
-      "patterns": ["audit-log", "access-control"],
+      "patterns": [
+        "audit-log",
+        "access-control"
+      ],
       "aiSummary": "Append-only audit log for config secret mutations",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/ConfigSecrets.ts": {
       "path": "src/server/payload/collections/ConfigSecrets.ts",
       "type": "collection-config",
       "domain": "config",
-      "patterns": ["key-value-store", "encrypted-values", "access-control", "payload-hooks"],
+      "patterns": [
+        "key-value-store",
+        "encrypted-values",
+        "access-control",
+        "payload-hooks"
+      ],
       "aiSummary": "Tenant-scoped encrypted secrets. All values are always encrypted.",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/ConfigValues.ts": {
       "path": "src/server/payload/collections/ConfigValues.ts",
       "type": "collection-config",
       "domain": "config",
-      "patterns": ["domain-scoped-config", "json-storage", "access-control", "payload-hooks"],
+      "patterns": [
+        "domain-scoped-config",
+        "json-storage",
+        "access-control",
+        "payload-hooks"
+      ],
       "aiSummary": "Domain-based configuration values stored as JSON, tenant-scoped",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/Conversations.ts": {
       "path": "src/server/payload/collections/Conversations.ts",
       "type": "collection-config",
       "domain": "chat",
-      "patterns": ["user-owned", "context-scoped", "access-control", "payload-hooks"],
+      "patterns": [
+        "user-owned",
+        "context-scoped",
+        "access-control",
+        "payload-hooks"
+      ],
       "aiSummary": "Context-scoped conversations with polymorphic context references",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/Courses.ts": {
       "path": "src/server/payload/collections/Courses.ts",
       "type": "collection-config",
       "domain": "courses",
-      "patterns": ["published-content", "hierarchical-data", "access-control", "payload-hooks"],
+      "patterns": [
+        "published-content",
+        "hierarchical-data",
+        "access-control",
+        "payload-hooks"
+      ],
       "aiSummary": "Courses collection with chapters relationship and published state",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/ExerciseAssets.ts": {
       "path": "src/server/payload/collections/ExerciseAssets.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["access-control"],
+      "patterns": [
+        "access-control"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/Exercises/index.ts": {
       "path": "src/server/payload/collections/Exercises/index.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["rbac", "hierarchical-data", "access-control"],
+      "patterns": [
+        "rbac",
+        "hierarchical-data",
+        "access-control"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/ExtractionLogs.ts": {
       "path": "src/server/payload/collections/ExtractionLogs.ts",
       "type": "collection-config",
       "domain": "conversion",
-      "patterns": ["append-only-log", "access-control"],
+      "patterns": [
+        "append-only-log",
+        "access-control"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/GuestSessions.ts": {
       "path": "src/server/payload/collections/GuestSessions.ts",
       "type": "collection-config",
       "domain": "auth",
-      "patterns": ["session-management", "expiring-records", "access-control"],
+      "patterns": [
+        "session-management",
+        "expiring-records",
+        "access-control"
+      ],
       "aiSummary": "Expiring guest sessions for anonymous chat persistence",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/Lessons.ts": {
       "path": "src/server/payload/collections/Lessons.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["hierarchical-data", "access-control", "payload-hooks"],
+      "patterns": [
+        "hierarchical-data",
+        "access-control",
+        "payload-hooks"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/MCPAuditLogs.ts": {
       "path": "src/server/payload/collections/MCPAuditLogs.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["access-control"],
+      "patterns": [
+        "access-control"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/Media/hooks/enforceRetentionPolicy.ts": {
       "path": "src/server/payload/collections/Media/hooks/enforceRetentionPolicy.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["payload-hooks"],
+      "patterns": [
+        "payload-hooks"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/Media/hooks/resolveEmbed.ts": {
       "path": "src/server/payload/collections/Media/hooks/resolveEmbed.ts",
       "type": "hook",
       "domain": "media",
-      "patterns": ["embed-provider", "payload-hooks"],
+      "patterns": [
+        "embed-provider",
+        "payload-hooks"
+      ],
       "aiSummary": "beforeChange hook that resolves external URLs to embed metadata.",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/Media/index.ts": {
       "path": "src/server/payload/collections/Media/index.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["access-control", "payload-hooks"],
+      "patterns": [
+        "access-control",
+        "payload-hooks"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/MemoryItems.ts": {
       "path": "src/server/payload/collections/MemoryItems.ts",
       "type": "collection-config",
       "domain": "chat",
-      "patterns": ["user-owned", "vector-search", "context-scoped", "rbac", "access-control"],
+      "patterns": [
+        "user-owned",
+        "vector-search",
+        "context-scoped",
+        "rbac",
+        "access-control"
+      ],
       "aiSummary": "Memory items with context hierarchy for semantic retrieval",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/Pages/index.ts": {
       "path": "src/server/payload/collections/Pages/index.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["access-control", "payload-hooks"],
+      "patterns": [
+        "access-control",
+        "payload-hooks"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/Posts/index.ts": {
       "path": "src/server/payload/collections/Posts/index.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["access-control", "payload-hooks"],
+      "patterns": [
+        "access-control",
+        "payload-hooks"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/PricingPlans.ts": {
       "path": "src/server/payload/collections/PricingPlans.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["access-control"],
+      "patterns": [
+        "access-control"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/Prompts.ts": {
       "path": "src/server/payload/collections/Prompts.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["access-control", "payload-hooks"],
+      "patterns": [
+        "access-control",
+        "payload-hooks"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/TeacherProfiles.ts": {
       "path": "src/server/payload/collections/TeacherProfiles.ts",
       "type": "collection-config",
       "domain": "ai",
-      "patterns": ["teacher-profile", "access-control"],
+      "patterns": [
+        "teacher-profile",
+        "access-control"
+      ],
       "aiSummary": "Collection for managing teacher profiles that define AI chat behavior",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/Tenants.ts": {
       "path": "src/server/payload/collections/Tenants.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["access-control"],
+      "patterns": [
+        "access-control"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/UploadSessions/index.ts": {
       "path": "src/server/payload/collections/UploadSessions/index.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["access-control"],
+      "patterns": [
+        "access-control"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/UserProgress.ts": {
       "path": "src/server/payload/collections/UserProgress.ts",
       "type": "collection-config",
       "domain": "progress-tracking",
-      "patterns": ["user-owned", "progress-tracking", "access-control"],
+      "patterns": [
+        "user-owned",
+        "progress-tracking",
+        "access-control"
+      ],
       "aiSummary": "User progress tracking for chapters, lessons, and exercises",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/UserSettings/index.ts": {
       "path": "src/server/payload/collections/UserSettings/index.ts",
       "type": "collection-config",
       "domain": "user",
-      "patterns": ["user-settings", "access-control"],
+      "patterns": [
+        "user-settings",
+        "access-control"
+      ],
       "aiSummary": "Collection for storing per-user settings including teacher profile selection",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/Users/hooks/auditRoleChange-hook.ts": {
       "path": "src/server/payload/collections/Users/hooks/auditRoleChange-hook.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["payload-hooks"],
+      "patterns": [
+        "payload-hooks"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/Users/hooks/ensureRoleOnSignup-hook.ts": {
       "path": "src/server/payload/collections/Users/hooks/ensureRoleOnSignup-hook.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["payload-hooks"],
+      "patterns": [
+        "payload-hooks"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/Users/hooks/preventLastAdminDemotion-hook.ts": {
       "path": "src/server/payload/collections/Users/hooks/preventLastAdminDemotion-hook.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["payload-hooks"],
+      "patterns": [
+        "payload-hooks"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/collections/Users/index.ts": {
       "path": "src/server/payload/collections/Users/index.ts",
       "type": "collection-config",
       "domain": "auth",
-      "patterns": ["rbac", "user-owned", "access-control", "payload-hooks"],
+      "patterns": [
+        "rbac",
+        "user-owned",
+        "access-control",
+        "payload-hooks"
+      ],
       "aiSummary": "Users collection with authentication, RBAC roles, and audit hooks",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/endpoints/agent/auth-middleware.ts": {
       "path": "src/server/payload/endpoints/agent/auth-middleware.ts",
       "type": "middleware",
       "domain": "auth",
-      "patterns": ["guest-session", "rate-limiting", "authenticated-endpoint"],
+      "patterns": [
+        "guest-session",
+        "rate-limiting",
+        "authenticated-endpoint"
+      ],
       "aiSummary": "Shared resolver for authenticated users and guest sessions",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/endpoints/agent/chat/pipeline.ts": {
       "path": "src/server/payload/endpoints/agent/chat/pipeline.ts",
       "type": "module",
       "domain": "chat",
-      "patterns": ["pipeline", "extraction"],
+      "patterns": [
+        "pipeline",
+        "extraction"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload", "pino", "zod"]
+      "dependencies": [
+        "payload",
+        "pino",
+        "zod"
+      ]
     },
     "src/server/payload/endpoints/agent/chat/request-validation.ts": {
       "path": "src/server/payload/endpoints/agent/chat/request-validation.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["validated-endpoint"],
+      "patterns": [
+        "validated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["zod"]
+      "dependencies": [
+        "zod"
+      ]
     },
     "src/server/payload/endpoints/agent/chat-stream.ts": {
       "path": "src/server/payload/endpoints/agent/chat-stream.ts",
       "type": "endpoint",
       "domain": "chat",
-      "patterns": ["streaming", "sse", "server-sent-events", "authenticated-endpoint"],
+      "patterns": [
+        "streaming",
+        "sse",
+        "server-sent-events",
+        "authenticated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["pino", "payload", "zod"]
+      "dependencies": [
+        "pino",
+        "payload",
+        "zod"
+      ]
     },
     "src/server/payload/endpoints/agent/chat.ts": {
       "path": "src/server/payload/endpoints/agent/chat.ts",
@@ -3839,7 +5422,11 @@
         "guest-session"
       ],
       "aiSummary": "Chat endpoint with context scoping, memory retrieval, MCP tools for admins, guest sessions, and automatic maintenance",
-      "dependencies": ["payload", "pino", "zod"]
+      "dependencies": [
+        "payload",
+        "pino",
+        "zod"
+      ]
     },
     "src/server/payload/endpoints/agent/get-conversation.ts": {
       "path": "src/server/payload/endpoints/agent/get-conversation.ts",
@@ -3852,7 +5439,10 @@
         "guest-session"
       ],
       "aiSummary": "Get conversation endpoint with explicit user/guest isolation",
-      "dependencies": ["payload", "zod"]
+      "dependencies": [
+        "payload",
+        "zod"
+      ]
     },
     "src/server/payload/endpoints/agent/reset-chat.ts": {
       "path": "src/server/payload/endpoints/agent/reset-chat.ts",
@@ -3865,133 +5455,216 @@
         "validated-endpoint"
       ],
       "aiSummary": "Reset endpoint for context-scoped conversations with guest support",
-      "dependencies": ["payload", "zod"]
+      "dependencies": [
+        "payload",
+        "zod"
+      ]
     },
     "src/server/payload/endpoints/cron/guest-sessions-cleanup.ts": {
       "path": "src/server/payload/endpoints/cron/guest-sessions-cleanup.ts",
       "type": "endpoint",
       "domain": "auth",
-      "patterns": ["cron-endpoint", "authenticated-endpoint"],
+      "patterns": [
+        "cron-endpoint",
+        "authenticated-endpoint"
+      ],
       "aiSummary": "Deletes expired guest sessions and their associated orphaned conversations",
-      "dependencies": ["payload", "pino"]
+      "dependencies": [
+        "payload",
+        "pino"
+      ]
     },
     "src/server/payload/endpoints/cron/media-expiry.ts": {
       "path": "src/server/payload/endpoints/cron/media-expiry.ts",
       "type": "endpoint",
       "domain": "media",
-      "patterns": ["cron-endpoint", "authenticated-endpoint"],
+      "patterns": [
+        "cron-endpoint",
+        "authenticated-endpoint"
+      ],
       "aiSummary": "Deletes expired ephemeral media files and database records",
-      "dependencies": ["fs/promises", "payload", "pino"]
+      "dependencies": [
+        "fs/promises",
+        "payload",
+        "pino"
+      ]
     },
     "src/server/payload/endpoints/exercises/validate-answer.ts": {
       "path": "src/server/payload/endpoints/exercises/validate-answer.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["validated-endpoint"],
+      "patterns": [
+        "validated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload", "zod"]
+      "dependencies": [
+        "payload",
+        "zod"
+      ]
     },
     "src/server/payload/endpoints/seed/guest-chat-config.ts": {
       "path": "src/server/payload/endpoints/seed/guest-chat-config.ts",
       "type": "seed-function",
       "domain": "config.seed",
-      "patterns": ["data-seeding"],
+      "patterns": [
+        "data-seeding"
+      ],
       "aiSummary": "Seeds guest_chat domain defaults into config_values collection",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/endpoints/seed/intro-page.ts": {
       "path": "src/server/payload/endpoints/seed/intro-page.ts",
       "type": "seed-data",
       "domain": "pages",
-      "patterns": ["published-content"],
+      "patterns": [
+        "published-content"
+      ],
       "aiSummary": "Seed data for the A-Guy platform introduction page, converted from docs/a-guy/intro.md",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/endpoints/seed/system-params.ts": {
       "path": "src/server/payload/endpoints/seed/system-params.ts",
       "type": "seed-function",
       "domain": "config.seed",
-      "patterns": ["data-seeding"],
+      "patterns": [
+        "data-seeding"
+      ],
       "aiSummary": "Seeds default system parameters into ConfigValues (global domain)",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/fields/createdBy.ts": {
       "path": "src/server/payload/fields/createdBy.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["payload-hooks"],
+      "patterns": [
+        "payload-hooks"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/hooks/configSecrets/afterChange-hook.ts": {
       "path": "src/server/payload/hooks/configSecrets/afterChange-hook.ts",
       "type": "hook",
       "domain": "config",
-      "patterns": ["audit-log", "payload-hooks"],
+      "patterns": [
+        "audit-log",
+        "payload-hooks"
+      ],
       "aiSummary": "Creates audit log entries after config secret mutations",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/hooks/configSecrets/afterRead-hook.ts": {
       "path": "src/server/payload/hooks/configSecrets/afterRead-hook.ts",
       "type": "hook",
       "domain": "config",
-      "patterns": ["write-only-ux"],
+      "patterns": [
+        "write-only-ux"
+      ],
       "aiSummary": "Clears all values in Admin UI responses (secrets-only collection), but skips for internal runtime load",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/hooks/configSecrets/beforeChange-hook.ts": {
       "path": "src/server/payload/hooks/configSecrets/beforeChange-hook.ts",
       "type": "hook",
       "domain": "config",
-      "patterns": ["validation", "encryption", "payload-hooks"],
+      "patterns": [
+        "validation",
+        "encryption",
+        "payload-hooks"
+      ],
       "aiSummary": "Encrypts secrets and validates config entries before save",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/hooks/configValues/beforeChange-hook.ts": {
       "path": "src/server/payload/hooks/configValues/beforeChange-hook.ts",
       "type": "hook",
       "domain": "config",
-      "patterns": ["validation", "secret-detection", "payload-hooks"],
+      "patterns": [
+        "validation",
+        "secret-detection",
+        "payload-hooks"
+      ],
       "aiSummary": "Validates config values and detects secret-like keys before save",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/hooks/validateLocaleUniqueness.ts": {
       "path": "src/server/payload/hooks/validateLocaleUniqueness.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["payload-hooks"],
+      "patterns": [
+        "payload-hooks"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/jobs/pdf-to-exercises-task.ts": {
       "path": "src/server/payload/jobs/pdf-to-exercises-task.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["validated-endpoint"],
+      "patterns": [
+        "validated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payload-config", "mongodb", "payload", "zod"]
+      "dependencies": [
+        "@payload-config",
+        "mongodb",
+        "payload",
+        "zod"
+      ]
     },
     "src/server/payload/jobs/pdf-to-exercises-v2-task.ts": {
       "path": "src/server/payload/jobs/pdf-to-exercises-v2-task.ts",
       "type": "job-task",
       "domain": "conversion",
-      "patterns": ["job-handler", "pipeline-orchestration"],
+      "patterns": [
+        "job-handler",
+        "pipeline-orchestration"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payload-config", "mongodb", "payload", "nanoid"]
+      "dependencies": [
+        "@payload-config",
+        "mongodb",
+        "payload",
+        "nanoid"
+      ]
     },
     "src/server/payload/migrations/backfillAdminTitle.ts": {
       "path": "src/server/payload/migrations/backfillAdminTitle.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["payload-hooks"],
+      "patterns": [
+        "payload-hooks"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/payload/plugins/index.ts": {
       "path": "src/server/payload/plugins/index.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["payload-hooks"],
+      "patterns": [
+        "payload-hooks"
+      ],
       "aiSummary": "",
       "dependencies": [
         "@payloadcms/plugin-form-builder",
@@ -4009,23 +5682,38 @@
       "path": "src/server/payload/plugins/mcp/index.ts",
       "type": "plugin-config",
       "domain": "mcp",
-      "patterns": ["plugin-configuration", "read-only-access", "tenant-scoped"],
+      "patterns": [
+        "plugin-configuration",
+        "read-only-access",
+        "tenant-scoped"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payloadcms/plugin-mcp", "payload"]
+      "dependencies": [
+        "@payloadcms/plugin-mcp",
+        "payload"
+      ]
     },
     "src/server/services/conversation-service.ts": {
       "path": "src/server/services/conversation-service.ts",
       "type": "service",
       "domain": "chat",
-      "patterns": ["service-layer", "context-scoped"],
+      "patterns": [
+        "service-layer",
+        "context-scoped"
+      ],
       "aiSummary": "Service for managing conversations with context scoping and access control",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/services/exercise-conversion/v2/image-crop-service.ts": {
       "path": "src/server/services/exercise-conversion/v2/image-crop-service.ts",
       "type": "service",
       "domain": "ai",
-      "patterns": ["image-processing", "cropping"],
+      "patterns": [
+        "image-processing",
+        "cropping"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -4033,7 +5721,9 @@
       "path": "src/server/services/exercise-conversion/v2/image-strip-service.ts",
       "type": "service",
       "domain": "conversion",
-      "patterns": ["image-processing"],
+      "patterns": [
+        "image-processing"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -4041,7 +5731,10 @@
       "path": "src/server/services/exercise-conversion/v2/ocr-detection-service.ts",
       "type": "service",
       "domain": "conversion",
-      "patterns": ["ocr", "pattern-matching"],
+      "patterns": [
+        "ocr",
+        "pattern-matching"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -4049,7 +5742,9 @@
       "path": "src/server/services/exercise-conversion/v2/pdf-render-service.ts",
       "type": "service",
       "domain": "conversion",
-      "patterns": ["pdf-processing"],
+      "patterns": [
+        "pdf-processing"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -4057,7 +5752,10 @@
       "path": "src/server/services/exercise-conversion/v2/text-detection-service.ts",
       "type": "service",
       "domain": "conversion",
-      "patterns": ["text-extraction", "pattern-matching"],
+      "patterns": [
+        "text-extraction",
+        "pattern-matching"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -4065,687 +5763,1104 @@
       "path": "src/server/services/exercise-conversion/v2/vision-detection-service.ts",
       "type": "service",
       "domain": "ai",
-      "patterns": ["vision-detection", "pdf-processing"],
+      "patterns": [
+        "vision-detection",
+        "pdf-processing"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/services/exercise-conversion/v2/vision-text-combo-service.ts": {
       "path": "src/server/services/exercise-conversion/v2/vision-text-combo-service.ts",
       "type": "service",
       "domain": "conversion",
-      "patterns": ["combo-detection", "vision+text"],
+      "patterns": [
+        "combo-detection",
+        "vision+text"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/services/exercise-conversion/v3/extract-single.ts": {
       "path": "src/server/services/exercise-conversion/v3/extract-single.ts",
       "type": "service",
       "domain": "conversion",
-      "patterns": ["orchestrator"],
+      "patterns": [
+        "orchestrator"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/services/exercise-conversion/v3/prompt-resolver.ts": {
       "path": "src/server/services/exercise-conversion/v3/prompt-resolver.ts",
       "type": "service",
       "domain": "conversion",
-      "patterns": ["prompt-resolution"],
+      "patterns": [
+        "prompt-resolution"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/services/exercise-conversion/v3/transform.ts": {
       "path": "src/server/services/exercise-conversion/v3/transform.ts",
       "type": "service",
       "domain": "conversion",
-      "patterns": ["transform"],
+      "patterns": [
+        "transform"
+      ],
       "aiSummary": "",
-      "dependencies": ["nanoid"]
+      "dependencies": [
+        "nanoid"
+      ]
     },
     "src/server/services/guest-session-upgrade.ts": {
       "path": "src/server/services/guest-session-upgrade.ts",
       "type": "service",
       "domain": "auth",
-      "patterns": ["ownership-transfer"],
+      "patterns": [
+        "ownership-transfer"
+      ],
       "aiSummary": "Atomic transfer of guest conversations to user account",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/server/services/guest-session.ts": {
       "path": "src/server/services/guest-session.ts",
       "type": "service",
       "domain": "auth",
-      "patterns": ["session-management"],
+      "patterns": [
+        "session-management"
+      ],
       "aiSummary": "Guest session lifecycle: create, validate, extend, revoke",
-      "dependencies": ["payload", "crypto"]
+      "dependencies": [
+        "payload",
+        "crypto"
+      ]
     },
     "src/server/utils/access-gate-server.ts": {
       "path": "src/server/utils/access-gate-server.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["authenticated-endpoint"],
+      "patterns": [
+        "authenticated-endpoint"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/headers", "payload"]
+      "dependencies": [
+        "next/headers",
+        "payload"
+      ]
     },
     "src/ui/admin/AdminChat/DashboardWidget/index.tsx": {
       "path": "src/ui/admin/AdminChat/DashboardWidget/index.tsx",
       "type": "component",
       "domain": "admin",
-      "patterns": ["admin-dashboard-widget", "client-component"],
+      "patterns": [
+        "admin-dashboard-widget",
+        "client-component"
+      ],
       "aiSummary": "Quick access widget for admin chat on the dashboard",
-      "dependencies": ["next/link", "react"]
+      "dependencies": [
+        "next/link",
+        "react"
+      ]
     },
     "src/ui/admin/AdminChat/SidebarLink/index.tsx": {
       "path": "src/ui/admin/AdminChat/SidebarLink/index.tsx",
       "type": "component",
       "domain": "admin",
-      "patterns": ["admin-sidebar-link", "client-component"],
+      "patterns": [
+        "admin-sidebar-link",
+        "client-component"
+      ],
       "aiSummary": "Navigation link for admin chat in the sidebar",
-      "dependencies": ["next/link", "react"]
+      "dependencies": [
+        "next/link",
+        "react"
+      ]
     },
     "src/ui/admin/AnswerSpecJsonField/index.tsx": {
       "path": "src/ui/admin/AnswerSpecJsonField/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "@payloadcms/ui", "prism-react-renderer", "payload"]
+      "dependencies": [
+        "react",
+        "@payloadcms/ui",
+        "prism-react-renderer",
+        "payload"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/BlockTypeSelector.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/BlockTypeSelector.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/JSONInspector.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/JSONInspector.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react", "prism-react-renderer", "react"]
+      "dependencies": [
+        "lucide-react",
+        "prism-react-renderer",
+        "react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/RichTextEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/RichTextEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/axis/AsymptotesPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/axis/AsymptotesPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/axis/AxisCanvas.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/axis/AxisCanvas.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "jsxgraph"]
+      "dependencies": [
+        "react",
+        "jsxgraph"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/axis/AxisConfigPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/axis/AxisConfigPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/axis/AxisPointsPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/axis/AxisPointsPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/axis/GraphsPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/axis/GraphsPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/axis/LineBetweenPointsPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/axis/LineBetweenPointsPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/axis/LociPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/axis/LociPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/axis/PaintPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/axis/PaintPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/AnglesPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/AnglesPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/CanvasConfigPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/CanvasConfigPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/CirclesPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/CirclesPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/GeometryCanvas.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/GeometryCanvas.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["jsxgraph", "react"]
+      "dependencies": [
+        "jsxgraph",
+        "react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/GeometryCanvasWithToolbar.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/GeometryCanvasWithToolbar.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/GeometryToolbar.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/GeometryToolbar.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/LinesPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/LinesPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/PointsPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/PointsPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/ShapesPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/ShapesPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/TextsPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/TextsPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react", "react"]
+      "dependencies": [
+        "lucide-react",
+        "react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/VectorsPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/VectorsPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/matching/ColumnEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/matching/ColumnEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/matching/MatchingPairsList.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/matching/MatchingPairsList.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/components/shared/JSXGraphBoard.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/shared/JSXGraphBoard.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "jsxgraph"]
+      "dependencies": [
+        "react",
+        "jsxgraph"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/editors/AxisEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/AxisEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/editors/FreeResponseEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/FreeResponseEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/editors/GeometryEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/GeometryEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/editors/HintSolutionPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/HintSolutionPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/editors/HtmlBlockEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/HtmlBlockEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["dompurify", "next/dynamic", "react"]
+      "dependencies": [
+        "dompurify",
+        "next/dynamic",
+        "react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/editors/InlineRichTextEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/InlineRichTextEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "@payloadcms/ui", "next/image"]
+      "dependencies": [
+        "react",
+        "@payloadcms/ui",
+        "next/image"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/editors/MatchingEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/MatchingEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/editors/McqEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/McqEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/editors/MediaBlockEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/MediaBlockEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payloadcms/ui", "next/image", "react", "lucide-react"]
+      "dependencies": [
+        "@payloadcms/ui",
+        "next/image",
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/editors/QuestionBlockWrapper.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/QuestionBlockWrapper.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/editors/SvgEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/SvgEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/editors/TableEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/TableEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/editors/TrueFalseEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/TrueFalseEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/ExerciseContentEditor/index.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payloadcms/ui", "lucide-react", "react"]
+      "dependencies": [
+        "@payloadcms/ui",
+        "lucide-react",
+        "react"
+      ]
     },
     "src/ui/admin/ExercisePreview/index.tsx": {
       "path": "src/ui/admin/ExercisePreview/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payloadcms/ui"]
+      "dependencies": [
+        "@payloadcms/ui"
+      ]
     },
     "src/ui/admin/Footer/index.tsx": {
       "path": "src/ui/admin/Footer/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payloadcms/ui"]
+      "dependencies": [
+        "@payloadcms/ui"
+      ]
     },
     "src/ui/admin/Header/index.tsx": {
       "path": "src/ui/admin/Header/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payloadcms/ui"]
+      "dependencies": [
+        "@payloadcms/ui"
+      ]
     },
     "src/ui/admin/MediaPreview/AudioPreview.tsx": {
       "path": "src/ui/admin/MediaPreview/AudioPreview.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "@payloadcms/ui"]
+      "dependencies": [
+        "react",
+        "@payloadcms/ui"
+      ]
     },
     "src/ui/admin/MediaPreview/DocumentPreview.tsx": {
       "path": "src/ui/admin/MediaPreview/DocumentPreview.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "@payloadcms/ui"]
+      "dependencies": [
+        "react",
+        "@payloadcms/ui"
+      ]
     },
     "src/ui/admin/MediaPreview/ExternalPreview.tsx": {
       "path": "src/ui/admin/MediaPreview/ExternalPreview.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "@payloadcms/ui"]
+      "dependencies": [
+        "react",
+        "@payloadcms/ui"
+      ]
     },
     "src/ui/admin/MediaPreview/ImagePreview.tsx": {
       "path": "src/ui/admin/MediaPreview/ImagePreview.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "@payloadcms/ui", "next/image"]
+      "dependencies": [
+        "react",
+        "@payloadcms/ui",
+        "next/image"
+      ]
     },
     "src/ui/admin/MediaPreview/OtherPreview.tsx": {
       "path": "src/ui/admin/MediaPreview/OtherPreview.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "@payloadcms/ui"]
+      "dependencies": [
+        "react",
+        "@payloadcms/ui"
+      ]
     },
     "src/ui/admin/MediaPreview/PDFPreview.tsx": {
       "path": "src/ui/admin/MediaPreview/PDFPreview.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/dynamic", "react", "@payloadcms/ui"]
+      "dependencies": [
+        "next/dynamic",
+        "react",
+        "@payloadcms/ui"
+      ]
     },
     "src/ui/admin/MediaPreview/SVGPreview.tsx": {
       "path": "src/ui/admin/MediaPreview/SVGPreview.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "@payloadcms/ui", "next/image"]
+      "dependencies": [
+        "react",
+        "@payloadcms/ui",
+        "next/image"
+      ]
     },
     "src/ui/admin/MediaPreview/VideoPreview.tsx": {
       "path": "src/ui/admin/MediaPreview/VideoPreview.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "@payloadcms/ui"]
+      "dependencies": [
+        "react",
+        "@payloadcms/ui"
+      ]
     },
     "src/ui/admin/MediaPreview/index.tsx": {
       "path": "src/ui/admin/MediaPreview/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payloadcms/ui", "payload"]
+      "dependencies": [
+        "@payloadcms/ui",
+        "payload"
+      ]
     },
     "src/ui/admin/PdfConversion/ConversionForm/index.tsx": {
       "path": "src/ui/admin/PdfConversion/ConversionForm/index.tsx",
       "type": "component",
       "domain": "admin",
-      "patterns": ["form", "client-component"],
+      "patterns": [
+        "form",
+        "client-component"
+      ],
       "aiSummary": "Form for configuring and starting PDF-to-exercise conversion",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/PdfConversion/ExerciseReview/index.tsx": {
       "path": "src/ui/admin/PdfConversion/ExerciseReview/index.tsx",
       "type": "component",
       "domain": "admin",
-      "patterns": ["exercise-list", "client-component"],
+      "patterns": [
+        "exercise-list",
+        "client-component"
+      ],
       "aiSummary": "Displays exercises created by a conversion job with links to editor",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/PdfConversion/JobHistory/index.tsx": {
       "path": "src/ui/admin/PdfConversion/JobHistory/index.tsx",
       "type": "component",
       "domain": "admin",
-      "patterns": ["job-list", "client-component"],
+      "patterns": [
+        "job-list",
+        "client-component"
+      ],
       "aiSummary": "Displays list of PDF conversion jobs with status and actions",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/PdfConversion/LessonSelector/index.tsx": {
       "path": "src/ui/admin/PdfConversion/LessonSelector/index.tsx",
       "type": "component",
       "domain": "admin",
-      "patterns": ["searchable-select", "client-component"],
+      "patterns": [
+        "searchable-select",
+        "client-component"
+      ],
       "aiSummary": "Searchable dropdown to select a lesson for PDF conversion",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/PdfConversion/PdfConversionPage/index.tsx": {
       "path": "src/ui/admin/PdfConversion/PdfConversionPage/index.tsx",
       "type": "component",
       "domain": "admin",
-      "patterns": ["admin-page-layout", "client-component"],
+      "patterns": [
+        "admin-page-layout",
+        "client-component"
+      ],
       "aiSummary": "Main two-column layout for PDF conversion page",
-      "dependencies": ["next/link", "react"]
+      "dependencies": [
+        "next/link",
+        "react"
+      ]
     },
     "src/ui/admin/PdfConversion/PdfSelector/index.tsx": {
       "path": "src/ui/admin/PdfConversion/PdfSelector/index.tsx",
       "type": "component",
       "domain": "admin",
-      "patterns": ["file-selector", "client-component"],
+      "patterns": [
+        "file-selector",
+        "client-component"
+      ],
       "aiSummary": "Dropdown to select a PDF file from a lesson's content files",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/PdfConversion/SidebarLink/index.tsx": {
       "path": "src/ui/admin/PdfConversion/SidebarLink/index.tsx",
       "type": "component",
       "domain": "admin",
-      "patterns": ["admin-sidebar-link", "client-component"],
+      "patterns": [
+        "admin-sidebar-link",
+        "client-component"
+      ],
       "aiSummary": "Navigation link for PDF conversion in the admin sidebar",
-      "dependencies": ["next/link", "react"]
+      "dependencies": [
+        "next/link",
+        "react"
+      ]
     },
     "src/ui/admin/QuillField/index.tsx": {
       "path": "src/ui/admin/QuillField/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["dompurify", "@payloadcms/ui", "next/dynamic", "react"]
+      "dependencies": [
+        "dompurify",
+        "@payloadcms/ui",
+        "next/dynamic",
+        "react"
+      ]
     },
     "src/ui/admin/VersionInfo/index.tsx": {
       "path": "src/ui/admin/VersionInfo/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "Version/build date display for admin footer",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/exercise-conversion/ConversionStatusPanel/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/ConversionStatusPanel/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/exercise-conversion/ConvertContextButton/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/ConvertContextButton/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/exercise-conversion/ConvertContextModal/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/ConvertContextModal/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payloadcms/ui", "react"]
+      "dependencies": [
+        "@payloadcms/ui",
+        "react"
+      ]
     },
     "src/ui/admin/exercise-conversion/ConvertForm/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/ConvertForm/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/exercise-conversion/ConvertV2Button/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/ConvertV2Button/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/exercise-conversion/ConvertV3Button/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/ConvertV3Button/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/exercise-conversion/DraftExercisesList/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/DraftExercisesList/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/navigation", "react"]
+      "dependencies": [
+        "next/navigation",
+        "react"
+      ]
     },
     "src/ui/admin/exercise-conversion/LessonConversionPanel/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/LessonConversionPanel/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payloadcms/ui", "react"]
+      "dependencies": [
+        "@payloadcms/ui",
+        "react"
+      ]
     },
     "src/ui/admin/exercise-conversion/LessonMediaActions/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/LessonMediaActions/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payloadcms/ui", "react"]
+      "dependencies": [
+        "@payloadcms/ui",
+        "react"
+      ]
     },
     "src/ui/admin/exercise-conversion/V2StatusPanel/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/V2StatusPanel/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/exercise-conversion/V3PreviewPanel/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/V3PreviewPanel/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/shared/AdvancedJsonPanel.tsx": {
       "path": "src/ui/admin/shared/AdvancedJsonPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/shared/CollapsibleSection.tsx": {
       "path": "src/ui/admin/shared/CollapsibleSection.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/admin/shared/ErrorDisplay.tsx": {
       "path": "src/ui/admin/shared/ErrorDisplay.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/cody/agents.ts": {
       "path": "src/ui/cody/agents.ts",
       "type": "config",
       "domain": "cody",
-      "patterns": ["agent-config"],
+      "patterns": [
+        "agent-config"
+      ],
       "aiSummary": "Shared agent definitions for Cody chat — single source of truth",
       "dependencies": []
     },
@@ -4753,7 +6868,9 @@
       "path": "src/ui/cody/api.ts",
       "type": "utility",
       "domain": "cody",
-      "patterns": ["api-client"],
+      "patterns": [
+        "api-client"
+      ],
       "aiSummary": "Typed API client for Cody dashboard",
       "dependencies": []
     },
@@ -4761,15 +6878,25 @@
       "path": "src/ui/cody/auth.ts",
       "type": "utility",
       "domain": "cody",
-      "patterns": ["auth", "api-endpoint", "authenticated-endpoint"],
+      "patterns": [
+        "auth",
+        "api-endpoint",
+        "authenticated-endpoint"
+      ],
       "aiSummary": "Dashboard authentication middleware.",
-      "dependencies": ["next/server", "payload", "@payload-config"]
+      "dependencies": [
+        "next/server",
+        "payload",
+        "@payload-config"
+      ]
     },
     "src/ui/cody/chat-types.ts": {
       "path": "src/ui/cody/chat-types.ts",
       "type": "types",
       "domain": "cody | dashboard",
-      "patterns": ["chat-persistence"],
+      "patterns": [
+        "chat-persistence"
+      ],
       "aiSummary": "Shared types for chat persistence across dashboard and pipeline",
       "dependencies": []
     },
@@ -4777,95 +6904,178 @@
       "path": "src/ui/cody/components/AddCommentDialog.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["add-comment-dialog", "client-component"],
+      "patterns": [
+        "add-comment-dialog",
+        "client-component"
+      ],
       "aiSummary": "Dialog with markdown editor to add a simple comment on a PR (without @cody action)",
-      "dependencies": ["react", "lucide-react", "react-markdown", "remark-gfm"]
+      "dependencies": [
+        "react",
+        "lucide-react",
+        "react-markdown",
+        "remark-gfm"
+      ]
     },
     "src/ui/cody/components/AssigneePicker.tsx": {
       "path": "src/ui/cody/components/AssigneePicker.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["assignee-picker", "client-component"],
+      "patterns": [
+        "assignee-picker",
+        "client-component"
+      ],
       "aiSummary": "Inline assignee management with cached collaborators, loading states, and remove buttons",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/cody/components/BranchCleanupDialog.tsx": {
       "path": "src/ui/cody/components/BranchCleanupDialog.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["branch-cleanup-dialog", "tailwind-component", "client-component"],
+      "patterns": [
+        "branch-cleanup-dialog",
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "Dialog to view and delete branches associated with closed/done tasks",
-      "dependencies": ["react", "lucide-react", "@tanstack/react-query", "sonner"]
+      "dependencies": [
+        "react",
+        "lucide-react",
+        "@tanstack/react-query",
+        "sonner"
+      ]
     },
     "src/ui/cody/components/BugReportDialog.tsx": {
       "path": "src/ui/cody/components/BugReportDialog.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["bug-report-dialog", "tailwind-component", "client-component"],
+      "patterns": [
+        "bug-report-dialog",
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "Dialog to report bugs with structured template",
-      "dependencies": ["react", "@tanstack/react-query", "lucide-react"]
+      "dependencies": [
+        "react",
+        "@tanstack/react-query",
+        "lucide-react"
+      ]
     },
     "src/ui/cody/components/CIStatusBadge.tsx": {
       "path": "src/ui/cody/components/CIStatusBadge.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["ci-status-badge", "tailwind-component", "client-component"],
+      "patterns": [
+        "ci-status-badge",
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "Shows CI status indicator for a PR and controls merge button state",
-      "dependencies": ["lucide-react"]
+      "dependencies": [
+        "lucide-react"
+      ]
     },
     "src/ui/cody/components/CodyChat.tsx": {
       "path": "src/ui/cody/components/CodyChat.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "react-markdown", "lucide-react"]
+      "dependencies": [
+        "react",
+        "react-markdown",
+        "lucide-react"
+      ]
     },
     "src/ui/cody/components/CodyDashboard.tsx": {
       "path": "src/ui/cody/components/CodyDashboard.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["cody-dashboard", "client-component"],
+      "patterns": [
+        "cody-dashboard",
+        "client-component"
+      ],
       "aiSummary": "Main dashboard component with responsive layout — Sheet for mobile controls and task detail",
-      "dependencies": ["react", "@tanstack/react-query", "sonner"]
+      "dependencies": [
+        "react",
+        "@tanstack/react-query",
+        "sonner"
+      ]
     },
     "src/ui/cody/components/CodyStatusBanner.tsx": {
       "path": "src/ui/cody/components/CodyStatusBanner.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["cody-status-banner", "tailwind-component", "client-component"],
+      "patterns": [
+        "cody-status-banner",
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "Banner showing Cody's current state: idle, working, failed, or gate-waiting",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/cody/components/CommentBox.tsx": {
       "path": "src/ui/cody/components/CommentBox.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["comment-box", "client-component"],
+      "patterns": [
+        "comment-box",
+        "client-component"
+      ],
       "aiSummary": "Comment input component for writing comments on issues",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/cody/components/CommentEditor.tsx": {
       "path": "src/ui/cody/components/CommentEditor.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["comment-editor", "tailwind-component", "client-component"],
+      "patterns": [
+        "comment-editor",
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "Simplified comment editor with markdown preview and @mention support",
-      "dependencies": ["react", "lucide-react", "react-markdown", "next/image"]
+      "dependencies": [
+        "react",
+        "lucide-react",
+        "react-markdown",
+        "next/image"
+      ]
     },
     "src/ui/cody/components/CommentList.tsx": {
       "path": "src/ui/cody/components/CommentList.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["comment-list", "tailwind-component", "client-component"],
+      "patterns": [
+        "comment-list",
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "Component to display comments with markdown rendering",
-      "dependencies": ["react", "react-markdown", "remark-gfm"]
+      "dependencies": [
+        "react",
+        "react-markdown",
+        "remark-gfm"
+      ]
     },
     "src/ui/cody/components/ConfirmDialog.tsx": {
       "path": "src/ui/cody/components/ConfirmDialog.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["confirm-dialog", "tailwind-component", "client-component"],
+      "patterns": [
+        "confirm-dialog",
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "Reusable confirmation dialog replacing native confirm() calls with accessible modal",
       "dependencies": []
     },
@@ -4873,55 +7083,100 @@
       "path": "src/ui/cody/components/CreateTaskDialog.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["create-task-dialog", "tailwind-component", "client-component"],
+      "patterns": [
+        "create-task-dialog",
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "Dialog to create new tasks with useCreateTask hook",
-      "dependencies": ["react", "next/image", "react-markdown"]
+      "dependencies": [
+        "react",
+        "next/image",
+        "react-markdown"
+      ]
     },
     "src/ui/cody/components/EditTaskDialog.tsx": {
       "path": "src/ui/cody/components/EditTaskDialog.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["edit-task-dialog", "tailwind-component", "client-component"],
+      "patterns": [
+        "edit-task-dialog",
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "Dialog to edit existing tasks with title, description, labels, and assignees",
-      "dependencies": ["react", "react-markdown"]
+      "dependencies": [
+        "react",
+        "react-markdown"
+      ]
     },
     "src/ui/cody/components/EnvironmentToolbar.tsx": {
       "path": "src/ui/cody/components/EnvironmentToolbar.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["environment-toolbar", "client-component"],
+      "patterns": [
+        "environment-toolbar",
+        "client-component"
+      ],
       "aiSummary": "Toolbar with Dev/Prod site links and Publish button with confirmation dialog",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/cody/components/ErrorBoundary.tsx": {
       "path": "src/ui/cody/components/ErrorBoundary.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["error-boundary", "client-component"],
+      "patterns": [
+        "error-boundary",
+        "client-component"
+      ],
       "aiSummary": "React error boundary that catches render errors and shows a \"Something went wrong\" fallback",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/cody/components/FilterBar.tsx": {
       "path": "src/ui/cody/components/FilterBar.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["filter-bar", "tailwind-component", "client-component"],
+      "patterns": [
+        "filter-bar",
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "Dedicated filter sub-header bar for Cody dashboard with view toggle, date, status, and label filters",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/cody/components/FixRequestDialog.tsx": {
       "path": "src/ui/cody/components/FixRequestDialog.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["fix-request-dialog", "client-component"],
+      "patterns": [
+        "fix-request-dialog",
+        "client-component"
+      ],
       "aiSummary": "Dialog with markdown editor to request fixes on a PR via @cody fix",
-      "dependencies": ["react", "lucide-react", "react-markdown", "remark-gfm"]
+      "dependencies": [
+        "react",
+        "lucide-react",
+        "react-markdown",
+        "remark-gfm"
+      ]
     },
     "src/ui/cody/components/KeyboardShortcutsDialog.tsx": {
       "path": "src/ui/cody/components/KeyboardShortcutsDialog.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["keyboard-shortcuts-dialog", "client-component"],
+      "patterns": [
+        "keyboard-shortcuts-dialog",
+        "client-component"
+      ],
       "aiSummary": "Dialog showing keyboard shortcuts available in Cody dashboard",
       "dependencies": []
     },
@@ -4929,79 +7184,143 @@
       "path": "src/ui/cody/components/LabelPicker.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["label-picker", "client-component"],
+      "patterns": [
+        "label-picker",
+        "client-component"
+      ],
       "aiSummary": "Dropdown component for adding/removing labels on issues",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/cody/components/MarkdownViewer.tsx": {
       "path": "src/ui/cody/components/MarkdownViewer.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["markdown-viewer", "client-component"],
+      "patterns": [
+        "markdown-viewer",
+        "client-component"
+      ],
       "aiSummary": "Renders markdown content with syntax highlighting",
-      "dependencies": ["react-markdown", "lucide-react", "react"]
+      "dependencies": [
+        "react-markdown",
+        "lucide-react",
+        "react"
+      ]
     },
     "src/ui/cody/components/MergeApprovalDialog.tsx": {
       "path": "src/ui/cody/components/MergeApprovalDialog.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["merge-approval-dialog", "tailwind-component", "client-component"],
+      "patterns": [
+        "merge-approval-dialog",
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "Dialog for approving and merging a PR with CI status and file changes",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/cody/components/MergeButton.tsx": {
       "path": "src/ui/cody/components/MergeButton.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["merge-button", "tailwind-component", "client-component"],
+      "patterns": [
+        "merge-button",
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "Merge button that opens approval dialog with CI status and file changes",
-      "dependencies": ["react", "lucide-react", "sonner"]
+      "dependencies": [
+        "react",
+        "lucide-react",
+        "sonner"
+      ]
     },
     "src/ui/cody/components/MiniPipelineProgress.tsx": {
       "path": "src/ui/cody/components/MiniPipelineProgress.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["pipeline-progress", "tailwind-component", "client-component"],
+      "patterns": [
+        "pipeline-progress",
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "Compact pipeline progress indicator with two variants: \"inline\" (dot-separated text for metadata line) and \"bar\" (full progress bar for dedicated row). Both variants always render 12 dots — one per stage — for visual consistency across all tasks.",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/cody/components/PRCommentList.tsx": {
       "path": "src/ui/cody/components/PRCommentList.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["pr-comment-list", "client-component"],
+      "patterns": [
+        "pr-comment-list",
+        "client-component"
+      ],
       "aiSummary": "Renders PR comments with markdown and author avatars",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/cody/components/PipelineStatus.tsx": {
       "path": "src/ui/cody/components/PipelineStatus.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["pipeline-status", "tailwind-component", "client-component"],
+      "patterns": [
+        "pipeline-status",
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "Vertical stepper pipeline status for narrow sidebar",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/cody/components/PreviewActions.tsx": {
       "path": "src/ui/cody/components/PreviewActions.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["preview-actions", "tailwind-component", "client-component"],
+      "patterns": [
+        "preview-actions",
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "Sticky action bar for Preview: Approve UI, Approve PR, Merge, Fix, Cancel PR",
-      "dependencies": ["react", "lucide-react", "sonner"]
+      "dependencies": [
+        "react",
+        "lucide-react",
+        "sonner"
+      ]
     },
     "src/ui/cody/components/PreviewModal.tsx": {
       "path": "src/ui/cody/components/PreviewModal.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["preview-modal", "tailwind-component", "client-component"],
+      "patterns": [
+        "preview-modal",
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "Full-screen modal overlay showing PR preview: iframe, changes, docs, comments, actions",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/cody/components/RiskBadge.tsx": {
       "path": "src/ui/cody/components/RiskBadge.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["badge", "tailwind-component"],
+      "patterns": [
+        "badge",
+        "tailwind-component"
+      ],
       "aiSummary": "Risk level badge",
       "dependencies": []
     },
@@ -5009,23 +7328,37 @@
       "path": "src/ui/cody/components/SimpleTooltip.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["simple-tooltip", "client-component"],
+      "patterns": [
+        "simple-tooltip",
+        "client-component"
+      ],
       "aiSummary": "Convenience wrapper around shadcn Tooltip for Cody dashboard — supports string or ReactNode content",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/cody/components/StageErrorDetail.tsx": {
       "path": "src/ui/cody/components/StageErrorDetail.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["stage-error-detail", "client-component"],
+      "patterns": [
+        "stage-error-detail",
+        "client-component"
+      ],
       "aiSummary": "Shows detailed error information for failed pipeline stages",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/cody/components/StatusBadge.tsx": {
       "path": "src/ui/cody/components/StatusBadge.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["badge", "tailwind-component"],
+      "patterns": [
+        "badge",
+        "tailwind-component"
+      ],
       "aiSummary": "Status badge for pipeline state",
       "dependencies": []
     },
@@ -5033,15 +7366,27 @@
       "path": "src/ui/cody/components/TaskDetail.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["task-detail", "tailwind-component", "client-component"],
+      "patterns": [
+        "task-detail",
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "Task detail — v2 with header quick-links, consolidated sidebar, contextual actions, inline pipeline timeline",
-      "dependencies": ["react", "react-markdown", "remark-gfm", "@tanstack/react-query"]
+      "dependencies": [
+        "react",
+        "react-markdown",
+        "remark-gfm",
+        "@tanstack/react-query"
+      ]
     },
     "src/ui/cody/components/TaskDetailDialog.tsx": {
       "path": "src/ui/cody/components/TaskDetailDialog.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["task-detail-dialog", "client-component"],
+      "patterns": [
+        "task-detail-dialog",
+        "client-component"
+      ],
       "aiSummary": "Wide dialog wrapper for TaskDetail on desktop, ~85vw centered",
       "dependencies": []
     },
@@ -5049,15 +7394,24 @@
       "path": "src/ui/cody/components/TaskList.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["task-list", "tailwind-component", "client-component"],
+      "patterns": [
+        "task-list",
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "Three-zone task list: color bar | title + inline metadata + assignees | actions. Pipeline progress gets its own row only when active.",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/cody/components/TaskTypeBadge.tsx": {
       "path": "src/ui/cody/components/TaskTypeBadge.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["badge", "tailwind-component"],
+      "patterns": [
+        "badge",
+        "tailwind-component"
+      ],
       "aiSummary": "Task type badge",
       "dependencies": []
     },
@@ -5065,23 +7419,36 @@
       "path": "src/ui/cody/components/WorkflowRunsPopover.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["popover", "tailwind-component", "client-component"],
+      "patterns": [
+        "popover",
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "Popover pill listing all workflow runs for a task with status icon, relative time, branch, and external link",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/cody/components/tooltip-content.tsx": {
       "path": "src/ui/cody/components/tooltip-content.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": ["tooltip-content"],
+      "patterns": [
+        "tooltip-content"
+      ],
       "aiSummary": "Pre-built tooltip content blocks for common dashboard elements",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/cody/constants.ts": {
       "path": "src/ui/cody/constants.ts",
       "type": "constants",
       "domain": "cody",
-      "patterns": ["constants"],
+      "patterns": [
+        "constants"
+      ],
       "aiSummary": "Constants for Cody dashboard pipeline and configuration",
       "dependencies": []
     },
@@ -5089,71 +7456,116 @@
       "path": "src/ui/cody/github-client.ts",
       "type": "utility",
       "domain": "cody",
-      "patterns": ["github-client"],
+      "patterns": [
+        "github-client"
+      ],
       "aiSummary": "GitHub API client with caching and manual rate limit handling",
-      "dependencies": ["@octokit/plugin-throttling", "@octokit/rest"]
+      "dependencies": [
+        "@octokit/plugin-throttling",
+        "@octokit/rest"
+      ]
     },
     "src/ui/cody/hooks/index.ts": {
       "path": "src/ui/cody/hooks/index.ts",
       "type": "hooks",
       "domain": "cody",
-      "patterns": ["custom-hooks", "client-component"],
+      "patterns": [
+        "custom-hooks",
+        "client-component"
+      ],
       "aiSummary": "React Query hooks for Cody dashboard data fetching",
-      "dependencies": ["@tanstack/react-query", "sonner"]
+      "dependencies": [
+        "@tanstack/react-query",
+        "sonner"
+      ]
     },
     "src/ui/cody/hooks/useBrowserNotifications.ts": {
       "path": "src/ui/cody/hooks/useBrowserNotifications.ts",
       "type": "hooks",
       "domain": "cody",
-      "patterns": ["browser-notifications", "client-component"],
+      "patterns": [
+        "browser-notifications",
+        "client-component"
+      ],
       "aiSummary": "Browser notification hook for task state changes.",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/cody/hooks/useGitHubIdentity.ts": {
       "path": "src/ui/cody/hooks/useGitHubIdentity.ts",
       "type": "hook",
       "domain": "cody",
-      "patterns": ["github-identity", "client-component"],
+      "patterns": [
+        "github-identity",
+        "client-component"
+      ],
       "aiSummary": "Hook to read the authenticated GitHub identity from the Cody session cookie.",
-      "dependencies": ["react", "@tanstack/react-query"]
+      "dependencies": [
+        "react",
+        "@tanstack/react-query"
+      ]
     },
     "src/ui/cody/hooks/useKeyboardShortcuts.ts": {
       "path": "src/ui/cody/hooks/useKeyboardShortcuts.ts",
       "type": "hook",
       "domain": "cody",
-      "patterns": ["keyboard-shortcuts", "client-component"],
+      "patterns": [
+        "keyboard-shortcuts",
+        "client-component"
+      ],
       "aiSummary": "Hook for keyboard navigation shortcuts in Cody dashboard",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/cody/hooks/usePRCIStatus.ts": {
       "path": "src/ui/cody/hooks/usePRCIStatus.ts",
       "type": "hook",
       "domain": "cody",
-      "patterns": ["usePRCIStatus", "client-component"],
+      "patterns": [
+        "usePRCIStatus",
+        "client-component"
+      ],
       "aiSummary": "Hook to poll CI status for a PR using GitHub's mergeable_state",
-      "dependencies": ["@tanstack/react-query"]
+      "dependencies": [
+        "@tanstack/react-query"
+      ]
     },
     "src/ui/cody/hooks/usePublish.ts": {
       "path": "src/ui/cody/hooks/usePublish.ts",
       "type": "hook",
       "domain": "cody",
-      "patterns": ["usePublish", "client-component"],
+      "patterns": [
+        "usePublish",
+        "client-component"
+      ],
       "aiSummary": "Hook for publishing dev to production (creates issue with publish label)",
-      "dependencies": ["@tanstack/react-query", "sonner"]
+      "dependencies": [
+        "@tanstack/react-query",
+        "sonner"
+      ]
     },
     "src/ui/cody/hooks/useRemoteStatus.ts": {
       "path": "src/ui/cody/hooks/useRemoteStatus.ts",
       "type": "hooks",
       "domain": "cody",
-      "patterns": ["custom-hooks", "client-component"],
+      "patterns": [
+        "custom-hooks",
+        "client-component"
+      ],
       "aiSummary": "React Query hook for polling remote dev agent status",
-      "dependencies": ["@tanstack/react-query"]
+      "dependencies": [
+        "@tanstack/react-query"
+      ]
     },
     "src/ui/cody/pipeline-utils.ts": {
       "path": "src/ui/cody/pipeline-utils.ts",
       "type": "utility",
       "domain": "cody",
-      "patterns": ["pipeline-progress"],
+      "patterns": [
+        "pipeline-progress"
+      ],
       "aiSummary": "Shared pipeline progress utilities — stage labels, progress calculation, elapsed formatting, tooltips",
       "dependencies": []
     },
@@ -5161,7 +7573,9 @@
       "path": "src/ui/cody/remote-config.ts",
       "type": "utility",
       "domain": "cody",
-      "patterns": ["config"],
+      "patterns": [
+        "config"
+      ],
       "aiSummary": "Parses REMOTE_DEV_USERS env var to enable per-user remote dev agent access",
       "dependencies": []
     },
@@ -5169,7 +7583,9 @@
       "path": "src/ui/cody/task-parser.ts",
       "type": "utility",
       "domain": "cody",
-      "patterns": ["task-parser"],
+      "patterns": [
+        "task-parser"
+      ],
       "aiSummary": "Parse GitHub bot comments to extract Cody task status",
       "dependencies": []
     },
@@ -5177,7 +7593,9 @@
       "path": "src/ui/cody/types.ts",
       "type": "types",
       "domain": "cody",
-      "patterns": ["types"],
+      "patterns": [
+        "types"
+      ],
       "aiSummary": "Core TypeScript types for Cody dashboard",
       "dependencies": []
     },
@@ -5185,7 +7603,10 @@
       "path": "src/ui/cody/utils.ts",
       "type": "utility",
       "domain": "cody",
-      "patterns": ["utilities", "tailwind-component"],
+      "patterns": [
+        "utilities",
+        "tailwind-component"
+      ],
       "aiSummary": "Utility functions for Cody dashboard",
       "dependencies": []
     },
@@ -5193,79 +7614,131 @@
       "path": "src/ui/web/AdminBar/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payloadcms/admin-bar", "next/navigation", "react"]
+      "dependencies": [
+        "@payloadcms/admin-bar",
+        "next/navigation",
+        "react"
+      ]
     },
     "src/ui/web/Card/index.tsx": {
       "path": "src/ui/web/Card/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/CollectionArchive/index.tsx": {
       "path": "src/ui/web/CollectionArchive/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component"],
+      "patterns": [
+        "tailwind-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/CommandPalette.tsx": {
       "path": "src/ui/web/CommandPalette.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "next/navigation", "lucide-react"]
+      "dependencies": [
+        "react",
+        "next/navigation",
+        "lucide-react"
+      ]
     },
     "src/ui/web/ExampleForm.tsx": {
       "path": "src/ui/web/ExampleForm.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "sonner"]
+      "dependencies": [
+        "react",
+        "sonner"
+      ]
     },
     "src/ui/web/LanguageSwitcher/index.tsx": {
       "path": "src/ui/web/LanguageSwitcher/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react", "next/navigation", "react"]
+      "dependencies": [
+        "lucide-react",
+        "next/navigation",
+        "react"
+      ]
     },
     "src/ui/web/Link/index.tsx": {
       "path": "src/ui/web/Link/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component"],
+      "patterns": [
+        "tailwind-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/LivePreviewListener/index.tsx": {
       "path": "src/ui/web/LivePreviewListener/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payloadcms/live-preview-react", "next/navigation", "react"]
+      "dependencies": [
+        "@payloadcms/live-preview-react",
+        "next/navigation",
+        "react"
+      ]
     },
     "src/ui/web/Pagination/index.tsx": {
       "path": "src/ui/web/Pagination/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/navigation", "react"]
+      "dependencies": [
+        "next/navigation",
+        "react"
+      ]
     },
     "src/ui/web/RichText/index.tsx": {
       "path": "src/ui/web/RichText/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component"],
+      "patterns": [
+        "tailwind-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -5273,239 +7746,411 @@
       "path": "src/ui/web/SafeHtml/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["dompurify", "react"]
+      "dependencies": [
+        "dompurify",
+        "react"
+      ]
     },
     "src/ui/web/UserDropdown/index.tsx": {
       "path": "src/ui/web/UserDropdown/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "next/navigation", "lucide-react"]
+      "dependencies": [
+        "react",
+        "next/navigation",
+        "lucide-react"
+      ]
     },
     "src/ui/web/auth/AccessGateProvider.tsx": {
       "path": "src/ui/web/auth/AccessGateProvider.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "next/navigation"]
+      "dependencies": [
+        "react",
+        "next/navigation"
+      ]
     },
     "src/ui/web/auth/AuthGateModal.tsx": {
       "path": "src/ui/web/auth/AuthGateModal.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/link"]
+      "dependencies": [
+        "next/link"
+      ]
     },
     "src/ui/web/auth/GoogleLoginButton.tsx": {
       "path": "src/ui/web/auth/GoogleLoginButton.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "i18n-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/chat/ChatErrorSurface/index.tsx": {
       "path": "src/ui/web/chat/ChatErrorSurface/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "i18n-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react", "next/navigation"]
+      "dependencies": [
+        "lucide-react",
+        "next/navigation"
+      ]
     },
     "src/ui/web/chat/ChatInterface/index.tsx": {
       "path": "src/ui/web/chat/ChatInterface/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "i18n-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/web/chat/ChatMessageContent/index.tsx": {
       "path": "src/ui/web/chat/ChatMessageContent/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react-markdown"]
+      "dependencies": [
+        "react-markdown"
+      ]
     },
     "src/ui/web/chat/TTSButton/index.tsx": {
       "path": "src/ui/web/chat/TTSButton/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react"]
+      "dependencies": [
+        "lucide-react"
+      ]
     },
     "src/ui/web/chat/hooks/useNotebookChat.ts": {
       "path": "src/ui/web/chat/hooks/useNotebookChat.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "sonner"]
+      "dependencies": [
+        "react",
+        "sonner"
+      ]
     },
     "src/ui/web/chat/hooks/useTTS.ts": {
       "path": "src/ui/web/chat/hooks/useTTS.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/chat/hooks/useTeacherProfileLabel.ts": {
       "path": "src/ui/web/chat/hooks/useTeacherProfileLabel.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/components/HealthBadge.tsx": {
       "path": "src/ui/web/components/HealthBadge.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/components/accordion.tsx": {
       "path": "src/ui/web/components/accordion.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "@radix-ui/react-accordion", "lucide-react"]
+      "dependencies": [
+        "react",
+        "@radix-ui/react-accordion",
+        "lucide-react"
+      ]
     },
     "src/ui/web/components/avatar.tsx": {
       "path": "src/ui/web/components/avatar.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "@radix-ui/react-avatar"]
+      "dependencies": [
+        "react",
+        "@radix-ui/react-avatar"
+      ]
     },
     "src/ui/web/components/badge.tsx": {
       "path": "src/ui/web/components/badge.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "variant-component"],
+      "patterns": [
+        "tailwind-component",
+        "variant-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "class-variance-authority"]
+      "dependencies": [
+        "react",
+        "class-variance-authority"
+      ]
     },
     "src/ui/web/components/breadcrumb.tsx": {
       "path": "src/ui/web/components/breadcrumb.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component"],
+      "patterns": [
+        "tailwind-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "@radix-ui/react-slot", "lucide-react"]
+      "dependencies": [
+        "react",
+        "@radix-ui/react-slot",
+        "lucide-react"
+      ]
     },
     "src/ui/web/components/button.tsx": {
       "path": "src/ui/web/components/button.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "variant-component"],
+      "patterns": [
+        "tailwind-component",
+        "variant-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["@radix-ui/react-slot", "class-variance-authority", "react"]
+      "dependencies": [
+        "@radix-ui/react-slot",
+        "class-variance-authority",
+        "react"
+      ]
     },
     "src/ui/web/components/card.tsx": {
       "path": "src/ui/web/components/card.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component"],
+      "patterns": [
+        "tailwind-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/components/checkbox.tsx": {
       "path": "src/ui/web/components/checkbox.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["@radix-ui/react-checkbox", "lucide-react", "react"]
+      "dependencies": [
+        "@radix-ui/react-checkbox",
+        "lucide-react",
+        "react"
+      ]
     },
     "src/ui/web/components/command.tsx": {
       "path": "src/ui/web/components/command.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "cmdk", "lucide-react"]
+      "dependencies": [
+        "react",
+        "cmdk",
+        "lucide-react"
+      ]
     },
     "src/ui/web/components/dialog.tsx": {
       "path": "src/ui/web/components/dialog.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["@radix-ui/react-dialog", "lucide-react", "react"]
+      "dependencies": [
+        "@radix-ui/react-dialog",
+        "lucide-react",
+        "react"
+      ]
     },
     "src/ui/web/components/dropdown-menu.tsx": {
       "path": "src/ui/web/components/dropdown-menu.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "@radix-ui/react-dropdown-menu", "lucide-react"]
+      "dependencies": [
+        "react",
+        "@radix-ui/react-dropdown-menu",
+        "lucide-react"
+      ]
     },
     "src/ui/web/components/input.tsx": {
       "path": "src/ui/web/components/input.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component"],
+      "patterns": [
+        "tailwind-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/components/label.tsx": {
       "path": "src/ui/web/components/label.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "variant-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "variant-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["@radix-ui/react-label", "class-variance-authority", "react"]
+      "dependencies": [
+        "@radix-ui/react-label",
+        "class-variance-authority",
+        "react"
+      ]
     },
     "src/ui/web/components/pagination.tsx": {
       "path": "src/ui/web/components/pagination.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component"],
+      "patterns": [
+        "tailwind-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["lucide-react", "react"]
+      "dependencies": [
+        "lucide-react",
+        "react"
+      ]
     },
     "src/ui/web/components/progress.tsx": {
       "path": "src/ui/web/components/progress.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component"],
+      "patterns": [
+        "tailwind-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/components/resizable-pane.tsx": {
       "path": "src/ui/web/components/resizable-pane.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/components/select.tsx": {
       "path": "src/ui/web/components/select.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["@radix-ui/react-select", "lucide-react", "react"]
+      "dependencies": [
+        "@radix-ui/react-select",
+        "lucide-react",
+        "react"
+      ]
     },
     "src/ui/web/components/sheet.tsx": {
       "path": "src/ui/web/components/sheet.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "variant-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "variant-component",
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": [
         "@radix-ui/react-dialog",
@@ -5518,39 +8163,60 @@
       "path": "src/ui/web/components/split-pane-layout.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/components/textarea.tsx": {
       "path": "src/ui/web/components/textarea.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component"],
+      "patterns": [
+        "tailwind-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/components/toaster.tsx": {
       "path": "src/ui/web/components/toaster.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["sonner"]
+      "dependencies": [
+        "sonner"
+      ]
     },
     "src/ui/web/components/tooltip.tsx": {
       "path": "src/ui/web/components/tooltip.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "@radix-ui/react-tooltip"]
+      "dependencies": [
+        "react",
+        "@radix-ui/react-tooltip"
+      ]
     },
     "src/ui/web/courses/PDFViewer/PDFEmbed.tsx": {
       "path": "src/ui/web/courses/PDFViewer/PDFEmbed.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -5558,15 +8224,24 @@
       "path": "src/ui/web/exerciserenderer/ExerciseRenderer/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "i18n-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/web/exerciserenderer/answers/McqAnswerUI/index.tsx": {
       "path": "src/ui/web/exerciserenderer/answers/McqAnswerUI/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component"],
+      "patterns": [
+        "tailwind-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -5574,7 +8249,9 @@
       "path": "src/ui/web/exerciserenderer/answers/TrueFalseAnswerUI/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component"],
+      "patterns": [
+        "tailwind-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -5582,311 +8259,504 @@
       "path": "src/ui/web/exerciserenderer/blocks/AxisRenderer/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "next/dynamic"]
+      "dependencies": [
+        "react",
+        "next/dynamic"
+      ]
     },
     "src/ui/web/exerciserenderer/blocks/GeometryRenderer/index.tsx": {
       "path": "src/ui/web/exerciserenderer/blocks/GeometryRenderer/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "next/dynamic"]
+      "dependencies": [
+        "react",
+        "next/dynamic"
+      ]
     },
     "src/ui/web/exerciserenderer/blocks/GraphWithPrompt/index.tsx": {
       "path": "src/ui/web/exerciserenderer/blocks/GraphWithPrompt/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component"],
+      "patterns": [
+        "tailwind-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/exerciserenderer/blocks/HtmlBlockRenderer/index.tsx": {
       "path": "src/ui/web/exerciserenderer/blocks/HtmlBlockRenderer/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["dompurify", "react"]
+      "dependencies": [
+        "dompurify",
+        "react"
+      ]
     },
     "src/ui/web/exerciserenderer/blocks/MultiAxisRenderer/index.tsx": {
       "path": "src/ui/web/exerciserenderer/blocks/MultiAxisRenderer/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/exerciserenderer/blocks/SvgRenderer/index.tsx": {
       "path": "src/ui/web/exerciserenderer/blocks/SvgRenderer/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/exerciserenderer/components/FeedbackDisplay/index.tsx": {
       "path": "src/ui/web/exerciserenderer/components/FeedbackDisplay/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/web/exerciserenderer/components/HelpSystem/HelpSystemButtons.tsx": {
       "path": "src/ui/web/exerciserenderer/components/HelpSystem/HelpSystemButtons.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/web/exerciserenderer/components/HelpSystem/HelpSystemContent.tsx": {
       "path": "src/ui/web/exerciserenderer/components/HelpSystem/HelpSystemContent.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/web/exerciserenderer/components/HelpSystem/index.tsx": {
       "path": "src/ui/web/exerciserenderer/components/HelpSystem/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/exerciserenderer/components/MediaAttachments/index.tsx": {
       "path": "src/ui/web/exerciserenderer/components/MediaAttachments/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/exerciserenderer/components/QuestionCard/index.tsx": {
       "path": "src/ui/web/exerciserenderer/components/QuestionCard/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/web/exerciserenderer/components/VideoPlayer/index.tsx": {
       "path": "src/ui/web/exerciserenderer/components/VideoPlayer/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "i18n-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/exerciserenderer/context/MediaMapContext.tsx": {
       "path": "src/ui/web/exerciserenderer/context/MediaMapContext.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/exerciserenderer/graphics/JSXGraphBoard.tsx": {
       "path": "src/ui/web/exerciserenderer/graphics/JSXGraphBoard.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/exerciserenderer/hooks/useHelpSystem.ts": {
       "path": "src/ui/web/exerciserenderer/hooks/useHelpSystem.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/exerciserenderer/questions/FreeResponseQuestion/index.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/FreeResponseQuestion/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingColumn.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingColumn.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingItem.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingItem.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingLines.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingLines.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/exerciserenderer/questions/MatchingQuestion/index.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/MatchingQuestion/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/web/exerciserenderer/questions/McqQuestion/index.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/McqQuestion/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/web/exerciserenderer/questions/TableQuestion/ExerciseTable.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/TableQuestion/ExerciseTable.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/exerciserenderer/questions/TableQuestion/index.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/TableQuestion/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/web/exerciserenderer/questions/TrueFalseQuestion/index.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/TrueFalseQuestion/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/web/footer/RowLabel.tsx": {
       "path": "src/ui/web/footer/RowLabel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payloadcms/ui"]
+      "dependencies": [
+        "@payloadcms/ui"
+      ]
     },
     "src/ui/web/footer/config.ts": {
       "path": "src/ui/web/footer/config.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["payload-hooks"],
+      "patterns": [
+        "payload-hooks"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/ui/web/guards/RequireCourseSelection.tsx": {
       "path": "src/ui/web/guards/RequireCourseSelection.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/navigation", "react"]
+      "dependencies": [
+        "next/navigation",
+        "react"
+      ]
     },
     "src/ui/web/header/Component.client.tsx": {
       "path": "src/ui/web/header/Component.client.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/navigation", "react"]
+      "dependencies": [
+        "next/navigation",
+        "react"
+      ]
     },
     "src/ui/web/header/MobileMenu/MobileMenuAuthSection.tsx": {
       "path": "src/ui/web/header/MobileMenu/MobileMenuAuthSection.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "next/navigation", "lucide-react"]
+      "dependencies": [
+        "react",
+        "next/navigation",
+        "lucide-react"
+      ]
     },
     "src/ui/web/header/MobileMenu/index.tsx": {
       "path": "src/ui/web/header/MobileMenu/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/web/header/Nav/index.tsx": {
       "path": "src/ui/web/header/Nav/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/web/header/RowLabel.tsx": {
       "path": "src/ui/web/header/RowLabel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["@payloadcms/ui"]
+      "dependencies": [
+        "@payloadcms/ui"
+      ]
     },
     "src/ui/web/header/config.ts": {
       "path": "src/ui/web/header/config.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["payload-hooks"],
+      "patterns": [
+        "payload-hooks"
+      ],
       "aiSummary": "",
-      "dependencies": ["payload"]
+      "dependencies": [
+        "payload"
+      ]
     },
     "src/ui/web/heros/HighImpact/index.tsx": {
       "path": "src/ui/web/heros/HighImpact/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/heros/PostHero/index.tsx": {
       "path": "src/ui/web/heros/PostHero/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/homepage/GreetingFlow/index.tsx": {
       "path": "src/ui/web/homepage/GreetingFlow/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/homepage/NavigationBar/index.tsx": {
       "path": "src/ui/web/homepage/NavigationBar/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "i18n-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/navigation"]
+      "dependencies": [
+        "next/navigation"
+      ]
     },
     "src/ui/web/homepage/TopicCard/index.tsx": {
       "path": "src/ui/web/homepage/TopicCard/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
       "dependencies": []
     },
@@ -5894,261 +8764,434 @@
       "path": "src/ui/web/media/AudioMedia/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/media/DocumentMedia/index.tsx": {
       "path": "src/ui/web/media/DocumentMedia/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/media/ExternalMedia/index.tsx": {
       "path": "src/ui/web/media/ExternalMedia/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/media/ImageMedia/index.tsx": {
       "path": "src/ui/web/media/ImageMedia/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["next/image", "react"]
+      "dependencies": [
+        "next/image",
+        "react"
+      ]
     },
     "src/ui/web/media/OtherMedia/index.tsx": {
       "path": "src/ui/web/media/OtherMedia/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/media/PDFMedia/index.tsx": {
       "path": "src/ui/web/media/PDFMedia/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/media/SVGMedia/index.tsx": {
       "path": "src/ui/web/media/SVGMedia/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "next/image"]
+      "dependencies": [
+        "react",
+        "next/image"
+      ]
     },
     "src/ui/web/media/VideoMedia/index.tsx": {
       "path": "src/ui/web/media/VideoMedia/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/providers/HeaderTheme/index.tsx": {
       "path": "src/ui/web/providers/HeaderTheme/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/providers/I18n/index.tsx": {
       "path": "src/ui/web/providers/I18n/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": [
+        "i18n-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/providers/PasswordLoginProvider.tsx": {
       "path": "src/ui/web/providers/PasswordLoginProvider.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/providers/Theme/ThemeSelector/index.tsx": {
       "path": "src/ui/web/providers/Theme/ThemeSelector/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/providers/Theme/index.tsx": {
       "path": "src/ui/web/providers/Theme/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/search/Component.tsx": {
       "path": "src/ui/web/search/Component.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "next/navigation"]
+      "dependencies": [
+        "react",
+        "next/navigation"
+      ]
     },
     "src/ui/web/shared/EmptyState/EmptyState.tsx": {
       "path": "src/ui/web/shared/EmptyState/EmptyState.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component"],
+      "patterns": [
+        "tailwind-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/web/shared/EmptyState/ErrorState.tsx": {
       "path": "src/ui/web/shared/EmptyState/ErrorState.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component"],
+      "patterns": [
+        "tailwind-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": [
+        "react",
+        "lucide-react"
+      ]
     },
     "src/ui/web/shared/Icon/Icon.tsx": {
       "path": "src/ui/web/shared/Icon/Icon.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "variant-component"],
+      "patterns": [
+        "tailwind-component",
+        "variant-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "class-variance-authority", "lucide-react"]
+      "dependencies": [
+        "react",
+        "class-variance-authority",
+        "lucide-react"
+      ]
     },
     "src/ui/web/shared/Layout/Grid.tsx": {
       "path": "src/ui/web/shared/Layout/Grid.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "variant-component"],
+      "patterns": [
+        "tailwind-component",
+        "variant-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "class-variance-authority"]
+      "dependencies": [
+        "react",
+        "class-variance-authority"
+      ]
     },
     "src/ui/web/shared/Layout/Section.tsx": {
       "path": "src/ui/web/shared/Layout/Section.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "variant-component"],
+      "patterns": [
+        "tailwind-component",
+        "variant-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "class-variance-authority"]
+      "dependencies": [
+        "react",
+        "class-variance-authority"
+      ]
     },
     "src/ui/web/shared/Layout/Stack.tsx": {
       "path": "src/ui/web/shared/Layout/Stack.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "variant-component"],
+      "patterns": [
+        "tailwind-component",
+        "variant-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "class-variance-authority"]
+      "dependencies": [
+        "react",
+        "class-variance-authority"
+      ]
     },
     "src/ui/web/shared/Loading/Skeleton.tsx": {
       "path": "src/ui/web/shared/Loading/Skeleton.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "variant-component"],
+      "patterns": [
+        "tailwind-component",
+        "variant-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "class-variance-authority"]
+      "dependencies": [
+        "react",
+        "class-variance-authority"
+      ]
     },
     "src/ui/web/shared/Loading/Spinner.tsx": {
       "path": "src/ui/web/shared/Loading/Spinner.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "variant-component"],
+      "patterns": [
+        "tailwind-component",
+        "variant-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "class-variance-authority"]
+      "dependencies": [
+        "react",
+        "class-variance-authority"
+      ]
     },
     "src/ui/web/shared/MathInput/FormulaComposer.tsx": {
       "path": "src/ui/web/shared/MathInput/FormulaComposer.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react", "mathlive"]
+      "dependencies": [
+        "react",
+        "lucide-react",
+        "mathlive"
+      ]
     },
     "src/ui/web/shared/MathInput/MathField.tsx": {
       "path": "src/ui/web/shared/MathInput/MathField.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "mathlive"]
+      "dependencies": [
+        "react",
+        "mathlive"
+      ]
     },
     "src/ui/web/shared/MathInput/MathFieldToolbar.tsx": {
       "path": "src/ui/web/shared/MathInput/MathFieldToolbar.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "mathlive"]
+      "dependencies": [
+        "react",
+        "mathlive"
+      ]
     },
     "src/ui/web/shared/MathMarkdown/index.tsx": {
       "path": "src/ui/web/shared/MathMarkdown/index.tsx",
       "type": "component",
       "domain": "ui",
-      "patterns": ["shared-markdown", "tailwind-component", "client-component"],
+      "patterns": [
+        "shared-markdown",
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "Shared markdown renderer with KaTeX math support and RTL isolation",
-      "dependencies": ["react-markdown", "rehype-katex", "remark-gfm", "remark-math"]
+      "dependencies": [
+        "react-markdown",
+        "rehype-katex",
+        "remark-gfm",
+        "remark-math"
+      ]
     },
     "src/ui/web/shared/MathMarkdown/rehype-math-wrapper.ts": {
       "path": "src/ui/web/shared/MathMarkdown/rehype-math-wrapper.ts",
       "type": "utility",
       "domain": "ui",
-      "patterns": ["rtl-isolation"],
+      "patterns": [
+        "rtl-isolation"
+      ],
       "aiSummary": "Rehype plugin that wraps KaTeX math output with dir=\"ltr\" for RTL language support",
-      "dependencies": ["hast", "unist-util-visit"]
+      "dependencies": [
+        "hast",
+        "unist-util-visit"
+      ]
     },
     "src/ui/web/shared/MathMarkdown/remark-color-syntax.ts": {
       "path": "src/ui/web/shared/MathMarkdown/remark-color-syntax.ts",
       "type": "utility",
       "domain": "ui",
-      "patterns": ["remark-plugin"],
+      "patterns": [
+        "remark-plugin"
+      ],
       "aiSummary": "Simplified remark plugin to transform ::text-highlight-N{text} syntax (single-node only)",
-      "dependencies": ["unist-util-visit"]
+      "dependencies": [
+        "unist-util-visit"
+      ]
     },
     "src/ui/web/shared/ProgressCircle/index.tsx": {
       "path": "src/ui/web/shared/ProgressCircle/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": [
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/shared/TypingAnimation/index.tsx": {
       "path": "src/ui/web/shared/TypingAnimation/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "client-component"],
+      "patterns": [
+        "tailwind-component",
+        "client-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": [
+        "react"
+      ]
     },
     "src/ui/web/shared/Typography/Heading.tsx": {
       "path": "src/ui/web/shared/Typography/Heading.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "variant-component"],
+      "patterns": [
+        "tailwind-component",
+        "variant-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "class-variance-authority"]
+      "dependencies": [
+        "react",
+        "class-variance-authority"
+      ]
     },
     "src/ui/web/shared/Typography/Text.tsx": {
       "path": "src/ui/web/shared/Typography/Text.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "variant-component"],
+      "patterns": [
+        "tailwind-component",
+        "variant-component"
+      ],
       "aiSummary": "",
-      "dependencies": ["react", "class-variance-authority"]
+      "dependencies": [
+        "react",
+        "class-variance-authority"
+      ]
     }
   },
   "metadata": {
-    "generatedAt": "2026-03-15T21:22:14.457Z",
+    "generatedAt": "2026-03-15T21:46:49.251Z",
     "totalFiles": 543,
     "totalPatterns": 188
   }

--- a/.ai-docs/indexes/pattern-index.json
+++ b/.ai-docs/indexes/pattern-index.json
@@ -3,9 +3,7 @@
     "client-provider": {
       "pattern": "client-provider",
       "description": "No description available",
-      "files": [
-        "src/app/(cody)/CodyProviders.tsx"
-      ]
+      "files": ["src/app/(cody)/CodyProviders.tsx"]
     },
     "client-component": {
       "pattern": "client-component",
@@ -217,6 +215,7 @@
         "src/ui/cody/components/PipelineStatus.tsx",
         "src/ui/cody/components/PreviewActions.tsx",
         "src/ui/cody/components/PreviewModal.tsx",
+        "src/ui/cody/components/QueueView.tsx",
         "src/ui/cody/components/SimpleTooltip.tsx",
         "src/ui/cody/components/StageErrorDetail.tsx",
         "src/ui/cody/components/TaskDetail.tsx",
@@ -341,23 +340,17 @@
     "next-error-boundary": {
       "pattern": "next-error-boundary",
       "description": "No description available",
-      "files": [
-        "src/app/(cody)/cody/error.tsx"
-      ]
+      "files": ["src/app/(cody)/cody/error.tsx"]
     },
     "metadata-helper": {
       "pattern": "metadata-helper",
       "description": "No description available",
-      "files": [
-        "src/app/(cody)/cody/metadata.ts"
-      ]
+      "files": ["src/app/(cody)/cody/metadata.ts"]
     },
     "route-group": {
       "pattern": "route-group",
       "description": "No description available",
-      "files": [
-        "src/app/(cody)/layout.tsx"
-      ]
+      "files": ["src/app/(cody)/layout.tsx"]
     },
     "tailwind-component": {
       "pattern": "tailwind-component",
@@ -401,6 +394,7 @@
         "src/ui/cody/components/PipelineStatus.tsx",
         "src/ui/cody/components/PreviewActions.tsx",
         "src/ui/cody/components/PreviewModal.tsx",
+        "src/ui/cody/components/QueueView.tsx",
         "src/ui/cody/components/RiskBadge.tsx",
         "src/ui/cody/components/StatusBadge.tsx",
         "src/ui/cody/components/TaskDetail.tsx",
@@ -702,163 +696,117 @@
     "boards-api": {
       "pattern": "boards-api",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/boards/route.ts"
-      ]
+      "files": ["src/app/api/cody/boards/route.ts"]
     },
     "branches-api": {
       "pattern": "branches-api",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/branches/route.ts"
-      ]
+      "files": ["src/app/api/cody/branches/route.ts"]
     },
     "chat-load-api": {
       "pattern": "chat-load-api",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/chat/load/route.ts"
-      ]
+      "files": ["src/app/api/cody/chat/load/route.ts"]
     },
     "ai-chat-streaming": {
       "pattern": "ai-chat-streaming",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/chat/route.ts"
-      ]
+      "files": ["src/app/api/cody/chat/route.ts"]
     },
     "chat-save-api": {
       "pattern": "chat-save-api",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/chat/save/route.ts"
-      ]
+      "files": ["src/app/api/cody/chat/save/route.ts"]
     },
     "collaborators-api": {
       "pattern": "collaborators-api",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/collaborators/route.ts"
-      ]
+      "files": ["src/app/api/cody/collaborators/route.ts"]
     },
     "inspector-health-api": {
       "pattern": "inspector-health-api",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/inspector/health/route.ts"
-      ]
+      "files": ["src/app/api/cody/inspector/health/route.ts"]
     },
     "pipeline-api": {
       "pattern": "pipeline-api",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/pipeline/[taskId]/route.ts"
-      ]
+      "files": ["src/app/api/cody/pipeline/[taskId]/route.ts"]
     },
     "prs-comments-api": {
       "pattern": "prs-comments-api",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/prs/comments/route.ts"
-      ]
+      "files": ["src/app/api/cody/prs/comments/route.ts"]
     },
     "pr-files-api": {
       "pattern": "pr-files-api",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/prs/files/route.ts"
-      ]
+      "files": ["src/app/api/cody/prs/files/route.ts"]
     },
     "prs-api": {
       "pattern": "prs-api",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/prs/route.ts"
-      ]
+      "files": ["src/app/api/cody/prs/route.ts"]
     },
     "pr-ci-status": {
       "pattern": "pr-ci-status",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/prs/status/route.ts"
-      ]
+      "files": ["src/app/api/cody/prs/status/route.ts"]
     },
     "publish": {
       "pattern": "publish",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/publish/route.ts"
-      ]
+      "files": ["src/app/api/cody/publish/route.ts"]
     },
     "proxy-endpoint": {
       "pattern": "proxy-endpoint",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/remote/exec/route.ts"
-      ]
+      "files": ["src/app/api/cody/remote/exec/route.ts"]
     },
     "health-check": {
       "pattern": "health-check",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/remote/status/route.ts"
-      ]
+      "files": ["src/app/api/cody/remote/status/route.ts"]
     },
     "task-actions-api": {
       "pattern": "task-actions-api",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/tasks/[taskId]/actions/route.ts"
-      ]
+      "files": ["src/app/api/cody/tasks/[taskId]/actions/route.ts"]
     },
     "task-docs-api": {
       "pattern": "task-docs-api",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/tasks/[taskId]/docs/route.ts"
-      ]
+      "files": ["src/app/api/cody/tasks/[taskId]/docs/route.ts"]
     },
     "task-detail-api": {
       "pattern": "task-detail-api",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/tasks/[taskId]/route.ts"
-      ]
+      "files": ["src/app/api/cody/tasks/[taskId]/route.ts"]
     },
     "approve-gate": {
       "pattern": "approve-gate",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/tasks/approve/route.ts"
-      ]
+      "files": ["src/app/api/cody/tasks/approve/route.ts"]
     },
     "approve-review": {
       "pattern": "approve-review",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/tasks/approve-review/route.ts"
-      ]
+      "files": ["src/app/api/cody/tasks/approve-review/route.ts"]
     },
     "tasks-api": {
       "pattern": "tasks-api",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/tasks/route.ts"
-      ]
+      "files": ["src/app/api/cody/tasks/route.ts"]
     },
     "workflows-api": {
       "pattern": "workflows-api",
       "description": "No description available",
-      "files": [
-        "src/app/api/cody/workflows/route.ts"
-      ]
+      "files": ["src/app/api/cody/workflows/route.ts"]
     },
     "copilotkit-runtime": {
       "pattern": "copilotkit-runtime",
       "description": "No description available",
-      "files": [
-        "src/app/api/copilotkit/route.ts"
-      ]
+      "files": ["src/app/api/copilotkit/route.ts"]
     },
     "endpoint": {
       "pattern": "endpoint",
@@ -872,9 +820,7 @@
     "queue": {
       "pattern": "queue",
       "description": "No description available",
-      "files": [
-        "src/app/api/exercises/convert/queue-v2/route.ts"
-      ]
+      "files": ["src/app/api/exercises/convert/queue-v2/route.ts"]
     },
     "validation": {
       "pattern": "validation",
@@ -888,9 +834,7 @@
     "zod-schema": {
       "pattern": "zod-schema",
       "description": "No description available",
-      "files": [
-        "src/app/api/exercises/convert/queue-v2/schema.ts"
-      ]
+      "files": ["src/app/api/exercises/convert/queue-v2/schema.ts"]
     },
     "oauth": {
       "pattern": "oauth",
@@ -924,10 +868,7 @@
     "constants": {
       "pattern": "constants",
       "description": "No description available",
-      "files": [
-        "src/infra/config/config-constants.ts",
-        "src/ui/cody/constants.ts"
-      ]
+      "files": ["src/infra/config/config-constants.ts", "src/ui/cody/constants.ts"]
     },
     "singleton": {
       "pattern": "singleton",
@@ -949,9 +890,7 @@
     "domain-config-loader": {
       "pattern": "domain-config-loader",
       "description": "No description available",
-      "files": [
-        "src/infra/config/runtime/config-values.ts"
-      ]
+      "files": ["src/infra/config/runtime/config-values.ts"]
     },
     "error-handling": {
       "pattern": "error-handling",
@@ -964,38 +903,27 @@
     "config-loader": {
       "pattern": "config-loader",
       "description": "No description available",
-      "files": [
-        "src/infra/config/runtime/runtime-config.ts"
-      ]
+      "files": ["src/infra/config/runtime/runtime-config.ts"]
     },
     "types": {
       "pattern": "types",
       "description": "No description available",
-      "files": [
-        "src/infra/config/runtime/types.ts",
-        "src/ui/cody/types.ts"
-      ]
+      "files": ["src/infra/config/runtime/types.ts", "src/ui/cody/types.ts"]
     },
     "runtime-validation": {
       "pattern": "runtime-validation",
       "description": "No description available",
-      "files": [
-        "src/infra/config/runtime/validate-chat-config.ts"
-      ]
+      "files": ["src/infra/config/runtime/validate-chat-config.ts"]
     },
     "config-sanity-check": {
       "pattern": "config-sanity-check",
       "description": "No description available",
-      "files": [
-        "src/infra/config/runtime/validate-chat-config.ts"
-      ]
+      "files": ["src/infra/config/runtime/validate-chat-config.ts"]
     },
     "type-safe-accessor": {
       "pattern": "type-safe-accessor",
       "description": "No description available",
-      "files": [
-        "src/infra/config/system-params.ts"
-      ]
+      "files": ["src/infra/config/system-params.ts"]
     },
     "genkit": {
       "pattern": "genkit",
@@ -1020,59 +948,42 @@
     "provider-abstraction": {
       "pattern": "provider-abstraction",
       "description": "No description available",
-      "files": [
-        "src/infra/llm/genkit/adapters/unified-adapter.ts",
-        "src/infra/llm/genkit/index.ts"
-      ]
+      "files": ["src/infra/llm/genkit/adapters/unified-adapter.ts", "src/infra/llm/genkit/index.ts"]
     },
     "config-mapping": {
       "pattern": "config-mapping",
       "description": "No description available",
-      "files": [
-        "src/infra/llm/genkit/config-resolver.ts"
-      ]
+      "files": ["src/infra/llm/genkit/config-resolver.ts"]
     },
     "lazy-loading": {
       "pattern": "lazy-loading",
       "description": "No description available",
-      "files": [
-        "src/infra/llm/genkit/genkit-instance.ts"
-      ]
+      "files": ["src/infra/llm/genkit/genkit-instance.ts"]
     },
     "genkit-tools": {
       "pattern": "genkit-tools",
       "description": "No description available",
-      "files": [
-        "src/infra/llm/genkit/tools/genkit-tools.ts"
-      ]
+      "files": ["src/infra/llm/genkit/tools/genkit-tools.ts"]
     },
     "tool-calling": {
       "pattern": "tool-calling",
       "description": "No description available",
-      "files": [
-        "src/infra/llm/genkit/tools/genkit-tools.ts"
-      ]
+      "files": ["src/infra/llm/genkit/tools/genkit-tools.ts"]
     },
     "mcp-integration": {
       "pattern": "mcp-integration",
       "description": "No description available",
-      "files": [
-        "src/infra/llm/genkit/tools/genkit-tools.ts"
-      ]
+      "files": ["src/infra/llm/genkit/tools/genkit-tools.ts"]
     },
     "single-responsibility": {
       "pattern": "single-responsibility",
       "description": "No description available",
-      "files": [
-        "src/infra/llm/lesson-context.ts"
-      ]
+      "files": ["src/infra/llm/lesson-context.ts"]
     },
     "runtime-injection": {
       "pattern": "runtime-injection",
       "description": "No description available",
-      "files": [
-        "src/infra/llm/lesson-context.ts"
-      ]
+      "files": ["src/infra/llm/lesson-context.ts"]
     },
     "server-only": {
       "pattern": "server-only",
@@ -1086,66 +997,47 @@
     "provider-factory": {
       "pattern": "provider-factory",
       "description": "No description available",
-      "files": [
-        "src/infra/llm/providers/factory.ts"
-      ]
+      "files": ["src/infra/llm/providers/factory.ts"]
     },
     "dependency-injection": {
       "pattern": "dependency-injection",
       "description": "No description available",
-      "files": [
-        "src/infra/llm/providers/factory.ts"
-      ]
+      "files": ["src/infra/llm/providers/factory.ts"]
     },
     "circuit-breaker": {
       "pattern": "circuit-breaker",
       "description": "No description available",
-      "files": [
-        "src/infra/llm/providers/shared/circuit-breaker.ts"
-      ]
+      "files": ["src/infra/llm/providers/shared/circuit-breaker.ts"]
     },
     "resilience": {
       "pattern": "resilience",
       "description": "No description available",
-      "files": [
-        "src/infra/llm/providers/shared/circuit-breaker.ts"
-      ]
+      "files": ["src/infra/llm/providers/shared/circuit-breaker.ts"]
     },
     "data-transformation": {
       "pattern": "data-transformation",
       "description": "No description available",
-      "files": [
-        "src/infra/llm/providers/shared/media-reader.ts"
-      ]
+      "files": ["src/infra/llm/providers/shared/media-reader.ts"]
     },
     "retry": {
       "pattern": "retry",
       "description": "No description available",
-      "files": [
-        "src/infra/llm/providers/shared/retry.ts"
-      ]
+      "files": ["src/infra/llm/providers/shared/retry.ts"]
     },
     "timeout": {
       "pattern": "timeout",
       "description": "No description available",
-      "files": [
-        "src/infra/llm/providers/shared/timeout.ts"
-      ]
+      "files": ["src/infra/llm/providers/shared/timeout.ts"]
     },
     "context-aware-loading": {
       "pattern": "context-aware-loading",
       "description": "No description available",
-      "files": [
-        "src/infra/llm/smart-doc-loader.ts"
-      ]
+      "files": ["src/infra/llm/smart-doc-loader.ts"]
     },
     "vector-search": {
       "pattern": "vector-search",
       "description": "No description available",
-      "files": [
-        "src/infra/llm/vector-search.ts",
-        "src/server/payload/collections/MemoryItems.ts"
-      ]
+      "files": ["src/infra/llm/vector-search.ts", "src/server/payload/collections/MemoryItems.ts"]
     },
     "context-scoped": {
       "pattern": "context-scoped",
@@ -1207,37 +1099,27 @@
     "youtube-detection": {
       "pattern": "youtube-detection",
       "description": "No description available",
-      "files": [
-        "src/infra/media/youtube.ts"
-      ]
+      "files": ["src/infra/media/youtube.ts"]
     },
     "type-exports": {
       "pattern": "type-exports",
       "description": "No description available",
-      "files": [
-        "src/infra/types/index.ts"
-      ]
+      "files": ["src/infra/types/index.ts"]
     },
     "viewport-calculation": {
       "pattern": "viewport-calculation",
       "description": "No description available",
-      "files": [
-        "src/infra/utils/graphics/viewport-utils.ts"
-      ]
+      "files": ["src/infra/utils/graphics/viewport-utils.ts"]
     },
     "typed-config-accessor": {
       "pattern": "typed-config-accessor",
       "description": "No description available",
-      "files": [
-        "src/server/config/guest-chat-config.ts"
-      ]
+      "files": ["src/server/config/guest-chat-config.ts"]
     },
     "admin-only": {
       "pattern": "admin-only",
       "description": "No description available",
-      "files": [
-        "src/server/payload/access/configAdminOnly.ts"
-      ]
+      "files": ["src/server/payload/access/configAdminOnly.ts"]
     },
     "access-control": {
       "pattern": "access-control",
@@ -1292,30 +1174,22 @@
     "key-value-store": {
       "pattern": "key-value-store",
       "description": "No description available",
-      "files": [
-        "src/server/payload/collections/ConfigSecrets.ts"
-      ]
+      "files": ["src/server/payload/collections/ConfigSecrets.ts"]
     },
     "encrypted-values": {
       "pattern": "encrypted-values",
       "description": "No description available",
-      "files": [
-        "src/server/payload/collections/ConfigSecrets.ts"
-      ]
+      "files": ["src/server/payload/collections/ConfigSecrets.ts"]
     },
     "domain-scoped-config": {
       "pattern": "domain-scoped-config",
       "description": "No description available",
-      "files": [
-        "src/server/payload/collections/ConfigValues.ts"
-      ]
+      "files": ["src/server/payload/collections/ConfigValues.ts"]
     },
     "json-storage": {
       "pattern": "json-storage",
       "description": "No description available",
-      "files": [
-        "src/server/payload/collections/ConfigValues.ts"
-      ]
+      "files": ["src/server/payload/collections/ConfigValues.ts"]
     },
     "user-owned": {
       "pattern": "user-owned",
@@ -1347,9 +1221,7 @@
     "append-only-log": {
       "pattern": "append-only-log",
       "description": "No description available",
-      "files": [
-        "src/server/payload/collections/ExtractionLogs.ts"
-      ]
+      "files": ["src/server/payload/collections/ExtractionLogs.ts"]
     },
     "session-management": {
       "pattern": "session-management",
@@ -1362,30 +1234,22 @@
     "expiring-records": {
       "pattern": "expiring-records",
       "description": "No description available",
-      "files": [
-        "src/server/payload/collections/GuestSessions.ts"
-      ]
+      "files": ["src/server/payload/collections/GuestSessions.ts"]
     },
     "teacher-profile": {
       "pattern": "teacher-profile",
       "description": "No description available",
-      "files": [
-        "src/server/payload/collections/TeacherProfiles.ts"
-      ]
+      "files": ["src/server/payload/collections/TeacherProfiles.ts"]
     },
     "progress-tracking": {
       "pattern": "progress-tracking",
       "description": "No description available",
-      "files": [
-        "src/server/payload/collections/UserProgress.ts"
-      ]
+      "files": ["src/server/payload/collections/UserProgress.ts"]
     },
     "user-settings": {
       "pattern": "user-settings",
       "description": "No description available",
-      "files": [
-        "src/server/payload/collections/UserSettings/index.ts"
-      ]
+      "files": ["src/server/payload/collections/UserSettings/index.ts"]
     },
     "guest-session": {
       "pattern": "guest-session",
@@ -1400,51 +1264,37 @@
     "rate-limiting": {
       "pattern": "rate-limiting",
       "description": "No description available",
-      "files": [
-        "src/server/payload/endpoints/agent/auth-middleware.ts"
-      ]
+      "files": ["src/server/payload/endpoints/agent/auth-middleware.ts"]
     },
     "pipeline": {
       "pattern": "pipeline",
       "description": "No description available",
-      "files": [
-        "src/server/payload/endpoints/agent/chat/pipeline.ts"
-      ]
+      "files": ["src/server/payload/endpoints/agent/chat/pipeline.ts"]
     },
     "extraction": {
       "pattern": "extraction",
       "description": "No description available",
-      "files": [
-        "src/server/payload/endpoints/agent/chat/pipeline.ts"
-      ]
+      "files": ["src/server/payload/endpoints/agent/chat/pipeline.ts"]
     },
     "streaming": {
       "pattern": "streaming",
       "description": "No description available",
-      "files": [
-        "src/server/payload/endpoints/agent/chat-stream.ts"
-      ]
+      "files": ["src/server/payload/endpoints/agent/chat-stream.ts"]
     },
     "sse": {
       "pattern": "sse",
       "description": "No description available",
-      "files": [
-        "src/server/payload/endpoints/agent/chat-stream.ts"
-      ]
+      "files": ["src/server/payload/endpoints/agent/chat-stream.ts"]
     },
     "server-sent-events": {
       "pattern": "server-sent-events",
       "description": "No description available",
-      "files": [
-        "src/server/payload/endpoints/agent/chat-stream.ts"
-      ]
+      "files": ["src/server/payload/endpoints/agent/chat-stream.ts"]
     },
     "admin-mode": {
       "pattern": "admin-mode",
       "description": "No description available",
-      "files": [
-        "src/server/payload/endpoints/agent/chat.ts"
-      ]
+      "files": ["src/server/payload/endpoints/agent/chat.ts"]
     },
     "cron-endpoint": {
       "pattern": "cron-endpoint",
@@ -1465,58 +1315,42 @@
     "write-only-ux": {
       "pattern": "write-only-ux",
       "description": "No description available",
-      "files": [
-        "src/server/payload/hooks/configSecrets/afterRead-hook.ts"
-      ]
+      "files": ["src/server/payload/hooks/configSecrets/afterRead-hook.ts"]
     },
     "secret-detection": {
       "pattern": "secret-detection",
       "description": "No description available",
-      "files": [
-        "src/server/payload/hooks/configValues/beforeChange-hook.ts"
-      ]
+      "files": ["src/server/payload/hooks/configValues/beforeChange-hook.ts"]
     },
     "job-handler": {
       "pattern": "job-handler",
       "description": "No description available",
-      "files": [
-        "src/server/payload/jobs/pdf-to-exercises-v2-task.ts"
-      ]
+      "files": ["src/server/payload/jobs/pdf-to-exercises-v2-task.ts"]
     },
     "pipeline-orchestration": {
       "pattern": "pipeline-orchestration",
       "description": "No description available",
-      "files": [
-        "src/server/payload/jobs/pdf-to-exercises-v2-task.ts"
-      ]
+      "files": ["src/server/payload/jobs/pdf-to-exercises-v2-task.ts"]
     },
     "plugin-configuration": {
       "pattern": "plugin-configuration",
       "description": "No description available",
-      "files": [
-        "src/server/payload/plugins/mcp/index.ts"
-      ]
+      "files": ["src/server/payload/plugins/mcp/index.ts"]
     },
     "read-only-access": {
       "pattern": "read-only-access",
       "description": "No description available",
-      "files": [
-        "src/server/payload/plugins/mcp/index.ts"
-      ]
+      "files": ["src/server/payload/plugins/mcp/index.ts"]
     },
     "tenant-scoped": {
       "pattern": "tenant-scoped",
       "description": "No description available",
-      "files": [
-        "src/server/payload/plugins/mcp/index.ts"
-      ]
+      "files": ["src/server/payload/plugins/mcp/index.ts"]
     },
     "service-layer": {
       "pattern": "service-layer",
       "description": "No description available",
-      "files": [
-        "src/server/services/conversation-service.ts"
-      ]
+      "files": ["src/server/services/conversation-service.ts"]
     },
     "image-processing": {
       "pattern": "image-processing",
@@ -1529,16 +1363,12 @@
     "cropping": {
       "pattern": "cropping",
       "description": "No description available",
-      "files": [
-        "src/server/services/exercise-conversion/v2/image-crop-service.ts"
-      ]
+      "files": ["src/server/services/exercise-conversion/v2/image-crop-service.ts"]
     },
     "ocr": {
       "pattern": "ocr",
       "description": "No description available",
-      "files": [
-        "src/server/services/exercise-conversion/v2/ocr-detection-service.ts"
-      ]
+      "files": ["src/server/services/exercise-conversion/v2/ocr-detection-service.ts"]
     },
     "pattern-matching": {
       "pattern": "pattern-matching",
@@ -1559,65 +1389,47 @@
     "text-extraction": {
       "pattern": "text-extraction",
       "description": "No description available",
-      "files": [
-        "src/server/services/exercise-conversion/v2/text-detection-service.ts"
-      ]
+      "files": ["src/server/services/exercise-conversion/v2/text-detection-service.ts"]
     },
     "vision-detection": {
       "pattern": "vision-detection",
       "description": "No description available",
-      "files": [
-        "src/server/services/exercise-conversion/v2/vision-detection-service.ts"
-      ]
+      "files": ["src/server/services/exercise-conversion/v2/vision-detection-service.ts"]
     },
     "combo-detection": {
       "pattern": "combo-detection",
       "description": "No description available",
-      "files": [
-        "src/server/services/exercise-conversion/v2/vision-text-combo-service.ts"
-      ]
+      "files": ["src/server/services/exercise-conversion/v2/vision-text-combo-service.ts"]
     },
     "vision+text": {
       "pattern": "vision+text",
       "description": "No description available",
-      "files": [
-        "src/server/services/exercise-conversion/v2/vision-text-combo-service.ts"
-      ]
+      "files": ["src/server/services/exercise-conversion/v2/vision-text-combo-service.ts"]
     },
     "orchestrator": {
       "pattern": "orchestrator",
       "description": "No description available",
-      "files": [
-        "src/server/services/exercise-conversion/v3/extract-single.ts"
-      ]
+      "files": ["src/server/services/exercise-conversion/v3/extract-single.ts"]
     },
     "prompt-resolution": {
       "pattern": "prompt-resolution",
       "description": "No description available",
-      "files": [
-        "src/server/services/exercise-conversion/v3/prompt-resolver.ts"
-      ]
+      "files": ["src/server/services/exercise-conversion/v3/prompt-resolver.ts"]
     },
     "transform": {
       "pattern": "transform",
       "description": "No description available",
-      "files": [
-        "src/server/services/exercise-conversion/v3/transform.ts"
-      ]
+      "files": ["src/server/services/exercise-conversion/v3/transform.ts"]
     },
     "ownership-transfer": {
       "pattern": "ownership-transfer",
       "description": "No description available",
-      "files": [
-        "src/server/services/guest-session-upgrade.ts"
-      ]
+      "files": ["src/server/services/guest-session-upgrade.ts"]
     },
     "admin-dashboard-widget": {
       "pattern": "admin-dashboard-widget",
       "description": "No description available",
-      "files": [
-        "src/ui/admin/AdminChat/DashboardWidget/index.tsx"
-      ]
+      "files": ["src/ui/admin/AdminChat/DashboardWidget/index.tsx"]
     },
     "admin-sidebar-link": {
       "pattern": "admin-sidebar-link",
@@ -1630,262 +1442,192 @@
     "form": {
       "pattern": "form",
       "description": "No description available",
-      "files": [
-        "src/ui/admin/PdfConversion/ConversionForm/index.tsx"
-      ]
+      "files": ["src/ui/admin/PdfConversion/ConversionForm/index.tsx"]
     },
     "exercise-list": {
       "pattern": "exercise-list",
       "description": "No description available",
-      "files": [
-        "src/ui/admin/PdfConversion/ExerciseReview/index.tsx"
-      ]
+      "files": ["src/ui/admin/PdfConversion/ExerciseReview/index.tsx"]
     },
     "job-list": {
       "pattern": "job-list",
       "description": "No description available",
-      "files": [
-        "src/ui/admin/PdfConversion/JobHistory/index.tsx"
-      ]
+      "files": ["src/ui/admin/PdfConversion/JobHistory/index.tsx"]
     },
     "searchable-select": {
       "pattern": "searchable-select",
       "description": "No description available",
-      "files": [
-        "src/ui/admin/PdfConversion/LessonSelector/index.tsx"
-      ]
+      "files": ["src/ui/admin/PdfConversion/LessonSelector/index.tsx"]
     },
     "admin-page-layout": {
       "pattern": "admin-page-layout",
       "description": "No description available",
-      "files": [
-        "src/ui/admin/PdfConversion/PdfConversionPage/index.tsx"
-      ]
+      "files": ["src/ui/admin/PdfConversion/PdfConversionPage/index.tsx"]
     },
     "file-selector": {
       "pattern": "file-selector",
       "description": "No description available",
-      "files": [
-        "src/ui/admin/PdfConversion/PdfSelector/index.tsx"
-      ]
+      "files": ["src/ui/admin/PdfConversion/PdfSelector/index.tsx"]
     },
     "agent-config": {
       "pattern": "agent-config",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/agents.ts"
-      ]
+      "files": ["src/ui/cody/agents.ts"]
     },
     "api-client": {
       "pattern": "api-client",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/api.ts"
-      ]
+      "files": ["src/ui/cody/api.ts"]
     },
     "auth": {
       "pattern": "auth",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/auth.ts"
-      ]
+      "files": ["src/ui/cody/auth.ts"]
     },
     "chat-persistence": {
       "pattern": "chat-persistence",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/chat-types.ts"
-      ]
+      "files": ["src/ui/cody/chat-types.ts"]
     },
     "add-comment-dialog": {
       "pattern": "add-comment-dialog",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/AddCommentDialog.tsx"
-      ]
+      "files": ["src/ui/cody/components/AddCommentDialog.tsx"]
     },
     "assignee-picker": {
       "pattern": "assignee-picker",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/AssigneePicker.tsx"
-      ]
+      "files": ["src/ui/cody/components/AssigneePicker.tsx"]
     },
     "branch-cleanup-dialog": {
       "pattern": "branch-cleanup-dialog",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/BranchCleanupDialog.tsx"
-      ]
+      "files": ["src/ui/cody/components/BranchCleanupDialog.tsx"]
     },
     "bug-report-dialog": {
       "pattern": "bug-report-dialog",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/BugReportDialog.tsx"
-      ]
+      "files": ["src/ui/cody/components/BugReportDialog.tsx"]
     },
     "ci-status-badge": {
       "pattern": "ci-status-badge",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/CIStatusBadge.tsx"
-      ]
+      "files": ["src/ui/cody/components/CIStatusBadge.tsx"]
     },
     "cody-dashboard": {
       "pattern": "cody-dashboard",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/CodyDashboard.tsx"
-      ]
+      "files": ["src/ui/cody/components/CodyDashboard.tsx"]
     },
     "cody-status-banner": {
       "pattern": "cody-status-banner",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/CodyStatusBanner.tsx"
-      ]
+      "files": ["src/ui/cody/components/CodyStatusBanner.tsx"]
     },
     "comment-box": {
       "pattern": "comment-box",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/CommentBox.tsx"
-      ]
+      "files": ["src/ui/cody/components/CommentBox.tsx"]
     },
     "comment-editor": {
       "pattern": "comment-editor",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/CommentEditor.tsx"
-      ]
+      "files": ["src/ui/cody/components/CommentEditor.tsx"]
     },
     "comment-list": {
       "pattern": "comment-list",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/CommentList.tsx"
-      ]
+      "files": ["src/ui/cody/components/CommentList.tsx"]
     },
     "confirm-dialog": {
       "pattern": "confirm-dialog",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/ConfirmDialog.tsx"
-      ]
+      "files": ["src/ui/cody/components/ConfirmDialog.tsx"]
     },
     "create-task-dialog": {
       "pattern": "create-task-dialog",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/CreateTaskDialog.tsx"
-      ]
+      "files": ["src/ui/cody/components/CreateTaskDialog.tsx"]
     },
     "edit-task-dialog": {
       "pattern": "edit-task-dialog",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/EditTaskDialog.tsx"
-      ]
+      "files": ["src/ui/cody/components/EditTaskDialog.tsx"]
     },
     "environment-toolbar": {
       "pattern": "environment-toolbar",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/EnvironmentToolbar.tsx"
-      ]
+      "files": ["src/ui/cody/components/EnvironmentToolbar.tsx"]
     },
     "error-boundary": {
       "pattern": "error-boundary",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/ErrorBoundary.tsx"
-      ]
+      "files": ["src/ui/cody/components/ErrorBoundary.tsx"]
     },
     "filter-bar": {
       "pattern": "filter-bar",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/FilterBar.tsx"
-      ]
+      "files": ["src/ui/cody/components/FilterBar.tsx"]
     },
     "fix-request-dialog": {
       "pattern": "fix-request-dialog",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/FixRequestDialog.tsx"
-      ]
+      "files": ["src/ui/cody/components/FixRequestDialog.tsx"]
     },
     "keyboard-shortcuts-dialog": {
       "pattern": "keyboard-shortcuts-dialog",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/KeyboardShortcutsDialog.tsx"
-      ]
+      "files": ["src/ui/cody/components/KeyboardShortcutsDialog.tsx"]
     },
     "label-picker": {
       "pattern": "label-picker",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/LabelPicker.tsx"
-      ]
+      "files": ["src/ui/cody/components/LabelPicker.tsx"]
     },
     "markdown-viewer": {
       "pattern": "markdown-viewer",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/MarkdownViewer.tsx"
-      ]
+      "files": ["src/ui/cody/components/MarkdownViewer.tsx"]
     },
     "merge-approval-dialog": {
       "pattern": "merge-approval-dialog",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/MergeApprovalDialog.tsx"
-      ]
+      "files": ["src/ui/cody/components/MergeApprovalDialog.tsx"]
     },
     "merge-button": {
       "pattern": "merge-button",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/MergeButton.tsx"
-      ]
+      "files": ["src/ui/cody/components/MergeButton.tsx"]
     },
     "pipeline-progress": {
       "pattern": "pipeline-progress",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/MiniPipelineProgress.tsx",
-        "src/ui/cody/pipeline-utils.ts"
-      ]
+      "files": ["src/ui/cody/components/MiniPipelineProgress.tsx", "src/ui/cody/pipeline-utils.ts"]
     },
     "pr-comment-list": {
       "pattern": "pr-comment-list",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/PRCommentList.tsx"
-      ]
+      "files": ["src/ui/cody/components/PRCommentList.tsx"]
     },
     "pipeline-status": {
       "pattern": "pipeline-status",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/PipelineStatus.tsx"
-      ]
+      "files": ["src/ui/cody/components/PipelineStatus.tsx"]
     },
     "preview-actions": {
       "pattern": "preview-actions",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/PreviewActions.tsx"
-      ]
+      "files": ["src/ui/cody/components/PreviewActions.tsx"]
     },
     "preview-modal": {
       "pattern": "preview-modal",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/PreviewModal.tsx"
-      ]
+      "files": ["src/ui/cody/components/PreviewModal.tsx"]
+    },
+    "queue-view": {
+      "pattern": "queue-view",
+      "description": "No description available",
+      "files": ["src/ui/cody/components/QueueView.tsx"]
     },
     "badge": {
       "pattern": "badge",
@@ -1899,122 +1641,87 @@
     "simple-tooltip": {
       "pattern": "simple-tooltip",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/SimpleTooltip.tsx"
-      ]
+      "files": ["src/ui/cody/components/SimpleTooltip.tsx"]
     },
     "stage-error-detail": {
       "pattern": "stage-error-detail",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/StageErrorDetail.tsx"
-      ]
+      "files": ["src/ui/cody/components/StageErrorDetail.tsx"]
     },
     "task-detail": {
       "pattern": "task-detail",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/TaskDetail.tsx"
-      ]
+      "files": ["src/ui/cody/components/TaskDetail.tsx"]
     },
     "task-detail-dialog": {
       "pattern": "task-detail-dialog",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/TaskDetailDialog.tsx"
-      ]
+      "files": ["src/ui/cody/components/TaskDetailDialog.tsx"]
     },
     "task-list": {
       "pattern": "task-list",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/TaskList.tsx"
-      ]
+      "files": ["src/ui/cody/components/TaskList.tsx"]
     },
     "popover": {
       "pattern": "popover",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/WorkflowRunsPopover.tsx"
-      ]
+      "files": ["src/ui/cody/components/WorkflowRunsPopover.tsx"]
     },
     "tooltip-content": {
       "pattern": "tooltip-content",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/components/tooltip-content.tsx"
-      ]
+      "files": ["src/ui/cody/components/tooltip-content.tsx"]
     },
     "github-client": {
       "pattern": "github-client",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/github-client.ts"
-      ]
+      "files": ["src/ui/cody/github-client.ts"]
     },
     "custom-hooks": {
       "pattern": "custom-hooks",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/hooks/index.ts",
-        "src/ui/cody/hooks/useRemoteStatus.ts"
-      ]
+      "files": ["src/ui/cody/hooks/index.ts", "src/ui/cody/hooks/useRemoteStatus.ts"]
     },
     "browser-notifications": {
       "pattern": "browser-notifications",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/hooks/useBrowserNotifications.ts"
-      ]
+      "files": ["src/ui/cody/hooks/useBrowserNotifications.ts"]
     },
     "github-identity": {
       "pattern": "github-identity",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/hooks/useGitHubIdentity.ts"
-      ]
+      "files": ["src/ui/cody/hooks/useGitHubIdentity.ts"]
     },
     "keyboard-shortcuts": {
       "pattern": "keyboard-shortcuts",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/hooks/useKeyboardShortcuts.ts"
-      ]
+      "files": ["src/ui/cody/hooks/useKeyboardShortcuts.ts"]
     },
     "usePRCIStatus": {
       "pattern": "usePRCIStatus",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/hooks/usePRCIStatus.ts"
-      ]
+      "files": ["src/ui/cody/hooks/usePRCIStatus.ts"]
     },
     "usePublish": {
       "pattern": "usePublish",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/hooks/usePublish.ts"
-      ]
+      "files": ["src/ui/cody/hooks/usePublish.ts"]
     },
     "config": {
       "pattern": "config",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/remote-config.ts"
-      ]
+      "files": ["src/ui/cody/remote-config.ts"]
     },
     "task-parser": {
       "pattern": "task-parser",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/task-parser.ts"
-      ]
+      "files": ["src/ui/cody/task-parser.ts"]
     },
     "utilities": {
       "pattern": "utilities",
       "description": "No description available",
-      "files": [
-        "src/ui/cody/utils.ts"
-      ]
+      "files": ["src/ui/cody/utils.ts"]
     },
     "variant-component": {
       "pattern": "variant-component",
@@ -2037,23 +1744,17 @@
     "shared-markdown": {
       "pattern": "shared-markdown",
       "description": "No description available",
-      "files": [
-        "src/ui/web/shared/MathMarkdown/index.tsx"
-      ]
+      "files": ["src/ui/web/shared/MathMarkdown/index.tsx"]
     },
     "rtl-isolation": {
       "pattern": "rtl-isolation",
       "description": "No description available",
-      "files": [
-        "src/ui/web/shared/MathMarkdown/rehype-math-wrapper.ts"
-      ]
+      "files": ["src/ui/web/shared/MathMarkdown/rehype-math-wrapper.ts"]
     },
     "remark-plugin": {
       "pattern": "remark-plugin",
       "description": "No description available",
-      "files": [
-        "src/ui/web/shared/MathMarkdown/remark-color-syntax.ts"
-      ]
+      "files": ["src/ui/web/shared/MathMarkdown/remark-color-syntax.ts"]
     }
   },
   "fileMetadata": {
@@ -2061,227 +1762,135 @@
       "path": "src/app/(cody)/CodyProviders.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "client-provider",
-        "client-component"
-      ],
+      "patterns": ["client-provider", "client-component"],
       "aiSummary": "Client-side providers wrapper for Cody dashboard (QueryClientProvider)",
-      "dependencies": [
-        "@tanstack/react-query",
-        "react"
-      ]
+      "dependencies": ["@tanstack/react-query", "react"]
     },
     "src/app/(cody)/cody/[issueNumber]/comments/page.tsx": {
       "path": "src/app/(cody)/cody/[issueNumber]/comments/page.tsx",
       "type": "page",
       "domain": "cody",
-      "patterns": [
-        "dashboard-page"
-      ],
+      "patterns": ["dashboard-page"],
       "aiSummary": "Cody dashboard with task detail on Comments tab via URL /cody/[n]/comments",
-      "dependencies": [
-        "next/headers",
-        "next/navigation",
-        "next"
-      ]
+      "dependencies": ["next/headers", "next/navigation", "next"]
     },
     "src/app/(cody)/cody/[issueNumber]/page.tsx": {
       "path": "src/app/(cody)/cody/[issueNumber]/page.tsx",
       "type": "page",
       "domain": "cody",
-      "patterns": [
-        "dashboard-page"
-      ],
+      "patterns": ["dashboard-page"],
       "aiSummary": "Cody dashboard with a specific task pre-selected via URL",
-      "dependencies": [
-        "next/headers",
-        "next/navigation",
-        "next"
-      ]
+      "dependencies": ["next/headers", "next/navigation", "next"]
     },
     "src/app/(cody)/cody/[issueNumber]/preview/comments/page.tsx": {
       "path": "src/app/(cody)/cody/[issueNumber]/preview/comments/page.tsx",
       "type": "page",
       "domain": "cody",
-      "patterns": [
-        "dashboard-page"
-      ],
+      "patterns": ["dashboard-page"],
       "aiSummary": "Cody dashboard with preview modal on Comments tab via URL /cody/[n]/preview/comments",
-      "dependencies": [
-        "next/headers",
-        "next/navigation",
-        "next"
-      ]
+      "dependencies": ["next/headers", "next/navigation", "next"]
     },
     "src/app/(cody)/cody/[issueNumber]/preview/docs/page.tsx": {
       "path": "src/app/(cody)/cody/[issueNumber]/preview/docs/page.tsx",
       "type": "page",
       "domain": "cody",
-      "patterns": [
-        "dashboard-page"
-      ],
+      "patterns": ["dashboard-page"],
       "aiSummary": "Cody dashboard with preview modal on Docs tab via URL /cody/[n]/preview/docs",
-      "dependencies": [
-        "next/headers",
-        "next/navigation",
-        "next"
-      ]
+      "dependencies": ["next/headers", "next/navigation", "next"]
     },
     "src/app/(cody)/cody/[issueNumber]/preview/page.tsx": {
       "path": "src/app/(cody)/cody/[issueNumber]/preview/page.tsx",
       "type": "page",
       "domain": "cody",
-      "patterns": [
-        "dashboard-page"
-      ],
+      "patterns": ["dashboard-page"],
       "aiSummary": "Cody dashboard with preview modal pre-opened via URL /cody/[n]/preview",
-      "dependencies": [
-        "next/headers",
-        "next/navigation",
-        "next"
-      ]
+      "dependencies": ["next/headers", "next/navigation", "next"]
     },
     "src/app/(cody)/cody/bug/page.tsx": {
       "path": "src/app/(cody)/cody/bug/page.tsx",
       "type": "page",
       "domain": "cody",
-      "patterns": [
-        "dashboard-page"
-      ],
+      "patterns": ["dashboard-page"],
       "aiSummary": "Cody dashboard with bug report dialog pre-opened via URL /cody/bug",
-      "dependencies": [
-        "next/headers",
-        "next/navigation"
-      ]
+      "dependencies": ["next/headers", "next/navigation"]
     },
     "src/app/(cody)/cody/chat/page.tsx": {
       "path": "src/app/(cody)/cody/chat/page.tsx",
       "type": "page",
       "domain": "cody",
-      "patterns": [
-        "dashboard-page"
-      ],
+      "patterns": ["dashboard-page"],
       "aiSummary": "Cody dashboard with chat panel pre-opened via URL /cody/chat",
-      "dependencies": [
-        "next/headers",
-        "next/navigation"
-      ]
+      "dependencies": ["next/headers", "next/navigation"]
     },
     "src/app/(cody)/cody/error.tsx": {
       "path": "src/app/(cody)/cody/error.tsx",
       "type": "error-boundary",
       "domain": "cody",
-      "patterns": [
-        "next-error-boundary",
-        "client-component"
-      ],
+      "patterns": ["next-error-boundary", "client-component"],
       "aiSummary": "Error boundary for the Cody dashboard — catches runtime errors and lets the user retry",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/app/(cody)/cody/metadata.ts": {
       "path": "src/app/(cody)/cody/metadata.ts",
       "type": "utility",
       "domain": "cody",
-      "patterns": [
-        "metadata-helper"
-      ],
+      "patterns": ["metadata-helper"],
       "aiSummary": "Shared metadata builders for Cody dashboard routes with OG/Twitter tags",
-      "dependencies": [
-        "next"
-      ]
+      "dependencies": ["next"]
     },
     "src/app/(cody)/cody/new/page.tsx": {
       "path": "src/app/(cody)/cody/new/page.tsx",
       "type": "page",
       "domain": "cody",
-      "patterns": [
-        "dashboard-page"
-      ],
+      "patterns": ["dashboard-page"],
       "aiSummary": "Cody dashboard with create task dialog pre-opened via URL /cody/new",
-      "dependencies": [
-        "next/headers",
-        "next/navigation"
-      ]
+      "dependencies": ["next/headers", "next/navigation"]
     },
     "src/app/(cody)/cody/page.tsx": {
       "path": "src/app/(cody)/cody/page.tsx",
       "type": "page",
       "domain": "cody",
-      "patterns": [
-        "dashboard-page"
-      ],
+      "patterns": ["dashboard-page"],
       "aiSummary": "Main Cody dashboard page. Auth gate: GitHub OAuth session (any repo collaborator).",
-      "dependencies": [
-        "next/headers",
-        "next/navigation"
-      ]
+      "dependencies": ["next/headers", "next/navigation"]
     },
     "src/app/(cody)/layout.tsx": {
       "path": "src/app/(cody)/layout.tsx",
       "type": "layout",
       "domain": "cody",
-      "patterns": [
-        "route-group",
-        "tailwind-component"
-      ],
+      "patterns": ["route-group", "tailwind-component"],
       "aiSummary": "Root layout for Cody dashboard — reuses frontend fonts, theme, and CSS without Header/Footer/i18n",
-      "dependencies": [
-        "react",
-        "next",
-        "geist/font/mono",
-        "geist/font/sans",
-        "next/font/google"
-      ]
+      "dependencies": ["react", "next", "geist/font/mono", "geist/font/sans", "next/font/google"]
     },
     "src/app/(frontend)/LayoutClient.tsx": {
       "path": "src/app/(frontend)/LayoutClient.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/app/(frontend)/[slug]/page.client.tsx": {
       "path": "src/app/(frontend)/[slug]/page.client.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/app/(frontend)/_components/HomePage/index.tsx": {
       "path": "src/app/(frontend)/_components/HomePage/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "next/navigation"
-      ]
+      "dependencies": ["react", "next/navigation"]
     },
     "src/app/(frontend)/account/AccountPageContent.tsx": {
       "path": "src/app/(frontend)/account/AccountPageContent.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2289,23 +1898,15 @@
       "path": "src/app/(frontend)/account/_components/AccountHub.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/app/(frontend)/account/_components/DetailsSection.tsx": {
       "path": "src/app/(frontend)/account/_components/DetailsSection.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2313,224 +1914,127 @@
       "path": "src/app/(frontend)/account/_components/PreferencesSection.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "next/link"
-      ]
+      "dependencies": ["next/link"]
     },
     "src/app/(frontend)/account/_components/SelectedCourseCard.tsx": {
       "path": "src/app/(frontend)/account/_components/SelectedCourseCard.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "next/link",
-        "next/navigation",
-        "react"
-      ]
+      "dependencies": ["next/link", "next/navigation", "react"]
     },
     "src/app/(frontend)/account/_components/TeachersProfileSection.tsx": {
       "path": "src/app/(frontend)/account/_components/TeachersProfileSection.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "sonner"
-      ]
+      "dependencies": ["react", "sonner"]
     },
     "src/app/(frontend)/ask/_components/AskContent/index.tsx": {
       "path": "src/app/(frontend)/ask/_components/AskContent/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/app/(frontend)/ask/_components/AskConversationGrid/index.tsx": {
       "path": "src/app/(frontend)/ask/_components/AskConversationGrid/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "next/navigation",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "next/navigation", "lucide-react"]
     },
     "src/app/(frontend)/ask/_components/AskDrawingCanvas/index.tsx": {
       "path": "src/app/(frontend)/ask/_components/AskDrawingCanvas/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react",
-        "react"
-      ]
+      "dependencies": ["lucide-react", "react"]
     },
     "src/app/(frontend)/ask/_components/AskExerciseCard/index.tsx": {
       "path": "src/app/(frontend)/ask/_components/AskExerciseCard/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react",
-        "react"
-      ]
+      "dependencies": ["lucide-react", "react"]
     },
     "src/app/(frontend)/ask/_components/AskPageClient/index.tsx": {
       "path": "src/app/(frontend)/ask/_components/AskPageClient/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "next/navigation",
-        "react"
-      ]
+      "dependencies": ["next/navigation", "react"]
     },
     "src/app/(frontend)/ask/_components/AskPrimaryContent/index.tsx": {
       "path": "src/app/(frontend)/ask/_components/AskPrimaryContent/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react",
-        "react",
-        "sonner"
-      ]
+      "dependencies": ["lucide-react", "react", "sonner"]
     },
     "src/app/(frontend)/courses/[courseSlug]/_components/AddExamDialog/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/AddExamDialog/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/app/(frontend)/courses/[courseSlug]/_components/AskTab/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/AskTab/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "next/navigation",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "next/navigation", "lucide-react"]
     },
     "src/app/(frontend)/courses/[courseSlug]/_components/ConversationCard/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/ConversationCard/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react"
-      ]
+      "dependencies": ["lucide-react"]
     },
     "src/app/(frontend)/courses/[courseSlug]/_components/CourseAnalytics.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/CourseAnalytics.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/app/(frontend)/courses/[courseSlug]/_components/CourseLessonCard/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/CourseLessonCard/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react"
-      ]
+      "dependencies": ["lucide-react"]
     },
     "src/app/(frontend)/courses/[courseSlug]/_components/CoursePageContent/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/CoursePageContent/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react",
-        "react"
-      ]
+      "dependencies": ["lucide-react", "react"]
     },
     "src/app/(frontend)/courses/[courseSlug]/_components/CourseTabs/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/CourseTabs/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2538,10 +2042,7 @@
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/ExamReminderBubble/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2549,23 +2050,15 @@
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/ExamsTab/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react"
-      ]
+      "dependencies": ["lucide-react"]
     },
     "src/app/(frontend)/courses/[courseSlug]/_components/LearnTab/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/LearnTab/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2573,10 +2066,7 @@
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/PracticeTab/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2584,100 +2074,63 @@
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/ConvertButton.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "next/navigation"
-      ]
+      "dependencies": ["react", "next/navigation"]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/ExercisesPager/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/ExercisesPager/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react"
-      ]
+      "dependencies": ["lucide-react"]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/LessonAnalytics.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/LessonAnalytics.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/LessonContent.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/LessonContent.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/ViewToggle.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/ViewToggle.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/complete/CompleteContent.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/complete/CompleteContent.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react"
-      ]
+      "dependencies": ["lucide-react"]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/ExerciseHeader/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/ExerciseHeader/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react"
-      ]
+      "dependencies": ["lucide-react"]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/ExercisePageContent/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/ExercisePageContent/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2685,10 +2138,7 @@
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/ExercisePageHeader/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2696,78 +2146,47 @@
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/ExerciseWorkspace/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "next/navigation",
-        "react"
-      ]
+      "dependencies": ["next/navigation", "react"]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/FormulaPanel/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/FormulaPanel/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/MathPalette/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/MathPalette/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/NotebookNotes/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/NotebookNotes/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/NotebookWorkspace/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/NotebookWorkspace/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "next/link",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "next/link", "lucide-react"]
     },
     "src/app/(frontend)/courses/_components/BackToChapter/index.tsx": {
       "path": "src/app/(frontend)/courses/_components/BackToChapter/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2775,10 +2194,7 @@
       "path": "src/app/(frontend)/courses/_components/BackToCourses/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2786,10 +2202,7 @@
       "path": "src/app/(frontend)/courses/_components/ChapterCard/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2797,9 +2210,7 @@
       "path": "src/app/(frontend)/courses/_components/ChapterHeader/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2807,10 +2218,7 @@
       "path": "src/app/(frontend)/courses/_components/ChapterPageBreadcrumb/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2818,10 +2226,7 @@
       "path": "src/app/(frontend)/courses/_components/ChaptersSectionTitle/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2829,25 +2234,15 @@
       "path": "src/app/(frontend)/courses/_components/CourseCard/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react",
-        "react"
-      ]
+      "dependencies": ["lucide-react", "react"]
     },
     "src/app/(frontend)/courses/_components/CourseCatalogHeader/index.tsx": {
       "path": "src/app/(frontend)/courses/_components/CourseCatalogHeader/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2855,10 +2250,7 @@
       "path": "src/app/(frontend)/courses/_components/CourseShopHeader/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2866,10 +2258,7 @@
       "path": "src/app/(frontend)/courses/_components/CoursesHero/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2877,10 +2266,7 @@
       "path": "src/app/(frontend)/courses/_components/CoursesPageTitle/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2888,10 +2274,7 @@
       "path": "src/app/(frontend)/courses/_components/EmptyState/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2899,10 +2282,7 @@
       "path": "src/app/(frontend)/courses/_components/ExerciseCard/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2910,10 +2290,7 @@
       "path": "src/app/(frontend)/courses/_components/LessonCard/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2921,25 +2298,15 @@
       "path": "src/app/(frontend)/courses/_components/LessonHeader/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react",
-        "next/navigation"
-      ]
+      "dependencies": ["lucide-react", "next/navigation"]
     },
     "src/app/(frontend)/courses/_components/LessonsSectionTitle/index.tsx": {
       "path": "src/app/(frontend)/courses/_components/LessonsSectionTitle/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2947,10 +2314,7 @@
       "path": "src/app/(frontend)/courses/_components/MembershipPlans/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2958,22 +2322,15 @@
       "path": "src/app/(frontend)/courses/_components/PlanCard/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react"
-      ]
+      "dependencies": ["lucide-react"]
     },
     "src/app/(frontend)/layout.tsx": {
       "path": "src/app/(frontend)/layout.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component"
-      ],
+      "patterns": ["tailwind-component"],
       "aiSummary": "",
       "dependencies": [
         "next",
@@ -2989,37 +2346,23 @@
       "path": "src/app/(frontend)/login/LoginForm.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "next/navigation",
-        "react",
-        "next/image"
-      ]
+      "dependencies": ["next/navigation", "react", "next/image"]
     },
     "src/app/(frontend)/login/LoginPageContent.tsx": {
       "path": "src/app/(frontend)/login/LoginPageContent.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react"
-      ]
+      "dependencies": ["lucide-react"]
     },
     "src/app/(frontend)/next/preview/route.ts": {
       "path": "src/app/(frontend)/next/preview/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "authenticated-endpoint"
-      ],
+      "patterns": ["authenticated-endpoint"],
       "aiSummary": "",
       "dependencies": [
         "payload",
@@ -3033,195 +2376,119 @@
       "path": "src/app/(frontend)/next/seed/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "authenticated-endpoint"
-      ],
+      "patterns": ["authenticated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "payload",
-        "@payload-config",
-        "next/headers"
-      ]
+      "dependencies": ["payload", "@payload-config", "next/headers"]
     },
     "src/app/(frontend)/not-found.tsx": {
       "path": "src/app/(frontend)/not-found.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "next/link",
-        "react"
-      ]
+      "dependencies": ["next/link", "react"]
     },
     "src/app/(frontend)/onboarding/persona/PersonaSelectionStep.tsx": {
       "path": "src/app/(frontend)/onboarding/persona/PersonaSelectionStep.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "sonner"
-      ]
+      "dependencies": ["react", "sonner"]
     },
     "src/app/(frontend)/posts/[slug]/page.client.tsx": {
       "path": "src/app/(frontend)/posts/[slug]/page.client.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/app/(frontend)/posts/page/[pageNumber]/page.client.tsx": {
       "path": "src/app/(frontend)/posts/page/[pageNumber]/page.client.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/app/(frontend)/posts/page.client.tsx": {
       "path": "src/app/(frontend)/posts/page.client.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/app/(frontend)/search/page.client.tsx": {
       "path": "src/app/(frontend)/search/page.client.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/app/(frontend)/signup/SignupForm.tsx": {
       "path": "src/app/(frontend)/signup/SignupForm.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "next/navigation",
-        "react",
-        "sonner"
-      ]
+      "dependencies": ["next/navigation", "react", "sonner"]
     },
     "src/app/(frontend)/signup/SignupPageContent.tsx": {
       "path": "src/app/(frontend)/signup/SignupPageContent.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/app/(frontend)/study/_components/StudyContent/index.tsx": {
       "path": "src/app/(frontend)/study/_components/StudyContent/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react",
-        "react"
-      ]
+      "dependencies": ["lucide-react", "react"]
     },
     "src/app/(frontend)/study-plan/_components/DayCard.tsx": {
       "path": "src/app/(frontend)/study-plan/_components/DayCard.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/app/(frontend)/study-plan/_components/EmptyPlanState.tsx": {
       "path": "src/app/(frontend)/study-plan/_components/EmptyPlanState.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component"
-      ],
+      "patterns": ["i18n-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react"
-      ]
+      "dependencies": ["lucide-react"]
     },
     "src/app/(frontend)/study-plan/_components/StudyPlanPage.tsx": {
       "path": "src/app/(frontend)/study-plan/_components/StudyPlanPage.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react",
-        "react"
-      ]
+      "dependencies": ["lucide-react", "react"]
     },
     "src/app/(frontend)/study-plan/_components/useStudyPlan.ts": {
       "path": "src/app/(frontend)/study-plan/_components/useStudyPlan.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/app/(payload)/admin/chat/page.tsx": {
       "path": "src/app/(payload)/admin/chat/page.tsx",
       "type": "page",
       "domain": "admin",
-      "patterns": [
-        "admin-page",
-        "client-component"
-      ],
+      "patterns": ["admin-page", "client-component"],
       "aiSummary": "Dedicated admin chat interface for querying content via MCP tools",
       "dependencies": []
     },
@@ -3229,10 +2496,7 @@
       "path": "src/app/(payload)/admin/pdf-conversion/page.tsx",
       "type": "page",
       "domain": "admin",
-      "patterns": [
-        "admin-page",
-        "client-component"
-      ],
+      "patterns": ["admin-page", "client-component"],
       "aiSummary": "Dedicated admin page for PDF-to-exercise conversion",
       "dependencies": []
     },
@@ -3240,859 +2504,487 @@
       "path": "src/app/api/agent/chat/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "api-endpoint",
-        "authenticated-endpoint"
-      ],
+      "patterns": ["api-endpoint", "authenticated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "@payload-config",
-        "next/server",
-        "payload"
-      ]
+      "dependencies": ["@payload-config", "next/server", "payload"]
     },
     "src/app/api/agent/chat/stream/route.ts": {
       "path": "src/app/api/agent/chat/stream/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "api-endpoint",
-        "authenticated-endpoint"
-      ],
+      "patterns": ["api-endpoint", "authenticated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "@payload-config",
-        "next/server",
-        "payload"
-      ]
+      "dependencies": ["@payload-config", "next/server", "payload"]
     },
     "src/app/api/agent/conversation/route.ts": {
       "path": "src/app/api/agent/conversation/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "api-endpoint",
-        "authenticated-endpoint"
-      ],
+      "patterns": ["api-endpoint", "authenticated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "next/server",
-        "payload",
-        "@payload-config"
-      ]
+      "dependencies": ["next/server", "payload", "@payload-config"]
     },
     "src/app/api/agent/message/persist/route.ts": {
       "path": "src/app/api/agent/message/persist/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "api-endpoint",
-        "authenticated-endpoint",
-        "validated-endpoint"
-      ],
+      "patterns": ["api-endpoint", "authenticated-endpoint", "validated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "@payload-config",
-        "next/server",
-        "payload",
-        "zod"
-      ]
+      "dependencies": ["@payload-config", "next/server", "payload", "zod"]
     },
     "src/app/api/agent/reset-chat/route.ts": {
       "path": "src/app/api/agent/reset-chat/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "api-endpoint",
-        "authenticated-endpoint"
-      ],
+      "patterns": ["api-endpoint", "authenticated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "@payload-config",
-        "next/server",
-        "payload"
-      ]
+      "dependencies": ["@payload-config", "next/server", "payload"]
     },
     "src/app/api/blob/upload-token/route.ts": {
       "path": "src/app/api/blob/upload-token/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "authenticated-endpoint",
-        "validated-endpoint"
-      ],
+      "patterns": ["authenticated-endpoint", "validated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "@vercel/blob/client",
-        "payload",
-        "zod",
-        "@payload-config"
-      ]
+      "dependencies": ["@vercel/blob/client", "payload", "zod", "@payload-config"]
     },
     "src/app/api/chapters/by-grade/route.ts": {
       "path": "src/app/api/chapters/by-grade/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "api-endpoint"
-      ],
+      "patterns": ["api-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "next/server",
-        "payload",
-        "@payload-config"
-      ]
+      "dependencies": ["next/server", "payload", "@payload-config"]
     },
     "src/app/api/chat-assets/finalize/route.ts": {
       "path": "src/app/api/chat-assets/finalize/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "authenticated-endpoint"
-      ],
+      "patterns": ["authenticated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "payload",
-        "zod",
-        "@payload-config"
-      ]
+      "dependencies": ["payload", "zod", "@payload-config"]
     },
     "src/app/api/cody/auth/logout/route.ts": {
       "path": "src/app/api/cody/auth/logout/route.ts",
       "type": "api-route",
       "domain": "cody",
-      "patterns": [
-        "auth-api",
-        "api-endpoint"
-      ],
+      "patterns": ["auth-api", "api-endpoint"],
       "aiSummary": "Clears the Cody GitHub session cookie (logout).",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/cody/auth/me/route.ts": {
       "path": "src/app/api/cody/auth/me/route.ts",
       "type": "api-route",
       "domain": "cody",
-      "patterns": [
-        "auth-api",
-        "api-endpoint"
-      ],
+      "patterns": ["auth-api", "api-endpoint"],
       "aiSummary": "Returns the current GitHub identity from the Cody session cookie.",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/cody/auth/route.ts": {
       "path": "src/app/api/cody/auth/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "auth-api",
-        "api-endpoint"
-      ],
+      "patterns": ["auth-api", "api-endpoint"],
       "aiSummary": "API route for dashboard auth status",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/cody/boards/route.ts": {
       "path": "src/app/api/cody/boards/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "boards-api",
-        "api-endpoint"
-      ],
+      "patterns": ["boards-api", "api-endpoint"],
       "aiSummary": "API route to fetch boards (labels + milestones)",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/cody/branches/route.ts": {
       "path": "src/app/api/cody/branches/route.ts",
       "type": "endpoint",
       "domain": "cody",
-      "patterns": [
-        "branches-api",
-        "api-endpoint",
-        "validated-endpoint"
-      ],
+      "patterns": ["branches-api", "api-endpoint", "validated-endpoint"],
       "aiSummary": "API route for listing and deleting branches from GitHub",
-      "dependencies": [
-        "next/server",
-        "zod"
-      ]
+      "dependencies": ["next/server", "zod"]
     },
     "src/app/api/cody/chat/load/route.ts": {
       "path": "src/app/api/cody/chat/load/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "chat-load-api",
-        "api-endpoint"
-      ],
+      "patterns": ["chat-load-api", "api-endpoint"],
       "aiSummary": "API route to load chat history for a task from GitHub",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/cody/chat/route.ts": {
       "path": "src/app/api/cody/chat/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "ai-chat-streaming",
-        "api-endpoint",
-        "validated-endpoint"
-      ],
+      "patterns": ["ai-chat-streaming", "api-endpoint", "validated-endpoint"],
       "aiSummary": "Streaming AI chat endpoint with GitHub MCP tools for repo browsing",
-      "dependencies": [
-        "@ai-sdk/mcp",
-        "@ai-sdk/google",
-        "ai",
-        "zod",
-        "next/server"
-      ]
+      "dependencies": ["@ai-sdk/mcp", "@ai-sdk/google", "ai", "zod", "next/server"]
     },
     "src/app/api/cody/chat/save/route.ts": {
       "path": "src/app/api/cody/chat/save/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "chat-save-api",
-        "api-endpoint",
-        "validated-endpoint"
-      ],
+      "patterns": ["chat-save-api", "api-endpoint", "validated-endpoint"],
       "aiSummary": "API route to save chat history for a task to GitHub",
-      "dependencies": [
-        "next/server",
-        "zod"
-      ]
+      "dependencies": ["next/server", "zod"]
     },
     "src/app/api/cody/collaborators/route.ts": {
       "path": "src/app/api/cody/collaborators/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "collaborators-api",
-        "api-endpoint"
-      ],
+      "patterns": ["collaborators-api", "api-endpoint"],
       "aiSummary": "API route to fetch repository collaborators for assignee picker",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/cody/inspector/health/route.ts": {
       "path": "src/app/api/cody/inspector/health/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "inspector-health-api",
-        "api-endpoint"
-      ],
+      "patterns": ["inspector-health-api", "api-endpoint"],
       "aiSummary": "API route to fetch inspector health status and metrics",
-      "dependencies": [
-        "next/server",
-        "child_process",
-        "fs",
-        "path"
-      ]
+      "dependencies": ["next/server", "child_process", "fs", "path"]
     },
     "src/app/api/cody/pipeline/[taskId]/route.ts": {
       "path": "src/app/api/cody/pipeline/[taskId]/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "pipeline-api",
-        "api-endpoint"
-      ],
+      "patterns": ["pipeline-api", "api-endpoint"],
       "aiSummary": "API route to fetch pipeline status for a task",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/cody/prs/comments/route.ts": {
       "path": "src/app/api/cody/prs/comments/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "prs-comments-api",
-        "api-endpoint",
-        "validated-endpoint"
-      ],
+      "patterns": ["prs-comments-api", "api-endpoint", "validated-endpoint"],
       "aiSummary": "API route to fetch and post PR comments",
-      "dependencies": [
-        "next/server",
-        "zod"
-      ]
+      "dependencies": ["next/server", "zod"]
     },
     "src/app/api/cody/prs/files/route.ts": {
       "path": "src/app/api/cody/prs/files/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "pr-files-api",
-        "api-endpoint"
-      ],
+      "patterns": ["pr-files-api", "api-endpoint"],
       "aiSummary": "API route to fetch file changes for a PR",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/cody/prs/route.ts": {
       "path": "src/app/api/cody/prs/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "prs-api",
-        "api-endpoint"
-      ],
+      "patterns": ["prs-api", "api-endpoint"],
       "aiSummary": "API route to fetch PRs",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/cody/prs/status/route.ts": {
       "path": "src/app/api/cody/prs/status/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "pr-ci-status",
-        "api-endpoint"
-      ],
+      "patterns": ["pr-ci-status", "api-endpoint"],
       "aiSummary": "Fetch CI status and mergeability for a PR",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/cody/publish/route.ts": {
       "path": "src/app/api/cody/publish/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "publish",
-        "api-endpoint"
-      ],
+      "patterns": ["publish", "api-endpoint"],
       "aiSummary": "Create a GitHub issue with 'publish' label to trigger dev→main PR workflow",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/cody/remote/exec/route.ts": {
       "path": "src/app/api/cody/remote/exec/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "proxy-endpoint",
-        "api-endpoint"
-      ],
+      "patterns": ["proxy-endpoint", "api-endpoint"],
       "aiSummary": "Proxy endpoint that forwards exec/read/write/ls actions to the remote dev agent",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/cody/remote/status/route.ts": {
       "path": "src/app/api/cody/remote/status/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "health-check",
-        "api-endpoint"
-      ],
+      "patterns": ["health-check", "api-endpoint"],
       "aiSummary": "Health check for the remote dev agent — returns online/offline status",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/cody/tasks/[taskId]/actions/route.ts": {
       "path": "src/app/api/cody/tasks/[taskId]/actions/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "task-actions-api",
-        "api-endpoint",
-        "validated-endpoint"
-      ],
+      "patterns": ["task-actions-api", "api-endpoint", "validated-endpoint"],
       "aiSummary": "API route for task actions (approve, reject, rerun, abort, execute)",
-      "dependencies": [
-        "next/server",
-        "zod"
-      ]
+      "dependencies": ["next/server", "zod"]
     },
     "src/app/api/cody/tasks/[taskId]/docs/route.ts": {
       "path": "src/app/api/cody/tasks/[taskId]/docs/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "task-docs-api",
-        "api-endpoint"
-      ],
+      "patterns": ["task-docs-api", "api-endpoint"],
       "aiSummary": "API route to fetch task documents from the task's branch",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/cody/tasks/[taskId]/route.ts": {
       "path": "src/app/api/cody/tasks/[taskId]/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "task-detail-api",
-        "api-endpoint"
-      ],
+      "patterns": ["task-detail-api", "api-endpoint"],
       "aiSummary": "API route to fetch detailed task info",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/cody/tasks/approve/route.ts": {
       "path": "src/app/api/cody/tasks/approve/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "approve-gate",
-        "api-endpoint",
-        "validated-endpoint"
-      ],
+      "patterns": ["approve-gate", "api-endpoint", "validated-endpoint"],
       "aiSummary": "Approve a gate - merge PR, delete branch, close issue, remove labels via GitHub API",
-      "dependencies": [
-        "next/server",
-        "zod"
-      ]
+      "dependencies": ["next/server", "zod"]
     },
     "src/app/api/cody/tasks/approve-review/route.ts": {
       "path": "src/app/api/cody/tasks/approve-review/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "approve-review",
-        "api-endpoint"
-      ],
+      "patterns": ["approve-review", "api-endpoint"],
       "aiSummary": "Approve a PR review and merge it via GitHub API (Octokit).",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/cody/tasks/route.ts": {
       "path": "src/app/api/cody/tasks/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "tasks-api",
-        "api-endpoint"
-      ],
+      "patterns": ["tasks-api", "api-endpoint"],
       "aiSummary": "API route to fetch and create tasks (GitHub issues)",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/cody/workflows/route.ts": {
       "path": "src/app/api/cody/workflows/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "workflows-api",
-        "api-endpoint"
-      ],
+      "patterns": ["workflows-api", "api-endpoint"],
       "aiSummary": "API route to fetch workflow runs",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/conversations/by-context/route.ts": {
       "path": "src/app/api/conversations/by-context/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "api-endpoint",
-        "authenticated-endpoint"
-      ],
+      "patterns": ["api-endpoint", "authenticated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "next/server",
-        "payload",
-        "@payload-config"
-      ]
+      "dependencies": ["next/server", "payload", "@payload-config"]
     },
     "src/app/api/copilotkit/route.ts": {
       "path": "src/app/api/copilotkit/route.ts",
       "type": "api-endpoint",
       "domain": "cody",
-      "patterns": [
-        "copilotkit-runtime",
-        "api-endpoint"
-      ],
+      "patterns": ["copilotkit-runtime", "api-endpoint"],
       "aiSummary": "Simple AI chat endpoint for Cody dashboard",
-      "dependencies": [
-        "@google/generative-ai",
-        "next/server"
-      ]
+      "dependencies": ["@google/generative-ai", "next/server"]
     },
     "src/app/api/example/route.ts": {
       "path": "src/app/api/example/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "api-endpoint"
-      ],
+      "patterns": ["api-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "next/server",
-        "zod",
-        "@sentry/nextjs",
-        "crypto"
-      ]
+      "dependencies": ["next/server", "zod", "@sentry/nextjs", "crypto"]
     },
     "src/app/api/exercises/[id]/blocks/[blockId]/route.ts": {
       "path": "src/app/api/exercises/[id]/blocks/[blockId]/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "api-endpoint",
-        "authenticated-endpoint",
-        "validated-endpoint"
-      ],
+      "patterns": ["api-endpoint", "authenticated-endpoint", "validated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "next/server",
-        "payload",
-        "zod",
-        "@payload-config"
-      ]
+      "dependencies": ["next/server", "payload", "zod", "@payload-config"]
     },
     "src/app/api/exercises/convert/queue/route.ts": {
       "path": "src/app/api/exercises/convert/queue/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "api-endpoint",
-        "authenticated-endpoint",
-        "validated-endpoint"
-      ],
+      "patterns": ["api-endpoint", "authenticated-endpoint", "validated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "payload",
-        "@payload-config",
-        "next/server",
-        "zod"
-      ]
+      "dependencies": ["payload", "@payload-config", "next/server", "zod"]
     },
     "src/app/api/exercises/convert/queue-v2/route.ts": {
       "path": "src/app/api/exercises/convert/queue-v2/route.ts",
       "type": "api-route",
       "domain": "conversion",
-      "patterns": [
-        "endpoint",
-        "queue",
-        "api-endpoint",
-        "authenticated-endpoint"
-      ],
+      "patterns": ["endpoint", "queue", "api-endpoint", "authenticated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "payload",
-        "@payload-config",
-        "next/server"
-      ]
+      "dependencies": ["payload", "@payload-config", "next/server"]
     },
     "src/app/api/exercises/convert/queue-v2/schema.ts": {
       "path": "src/app/api/exercises/convert/queue-v2/schema.ts",
       "type": "utility",
       "domain": "conversion",
-      "patterns": [
-        "validation",
-        "zod-schema"
-      ],
+      "patterns": ["validation", "zod-schema"],
       "aiSummary": "",
-      "dependencies": [
-        "zod"
-      ]
+      "dependencies": ["zod"]
     },
     "src/app/api/exercises/convert/runner/route.ts": {
       "path": "src/app/api/exercises/convert/runner/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "api-endpoint"
-      ],
+      "patterns": ["api-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "@payload-config",
-        "mongodb",
-        "next/server",
-        "payload"
-      ]
+      "dependencies": ["@payload-config", "mongodb", "next/server", "payload"]
     },
     "src/app/api/exercises/convert/single/create/route.ts": {
       "path": "src/app/api/exercises/convert/single/create/route.ts",
       "type": "api-route",
       "domain": "conversion",
-      "patterns": [
-        "endpoint",
-        "validated-endpoint"
-      ],
+      "patterns": ["endpoint", "validated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "next/server",
-        "zod"
-      ]
+      "dependencies": ["next/server", "zod"]
     },
     "src/app/api/exercises/convert/single/route.ts": {
       "path": "src/app/api/exercises/convert/single/route.ts",
       "type": "api-route",
       "domain": "conversion",
-      "patterns": [
-        "endpoint"
-      ],
+      "patterns": ["endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "next/server",
-        "zod"
-      ]
+      "dependencies": ["next/server", "zod"]
     },
     "src/app/api/exercises/import/route.ts": {
       "path": "src/app/api/exercises/import/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "api-endpoint",
-        "authenticated-endpoint"
-      ],
+      "patterns": ["api-endpoint", "authenticated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "next/server",
-        "payload",
-        "@payload-config"
-      ]
+      "dependencies": ["next/server", "payload", "@payload-config"]
     },
     "src/app/api/exercises/validate-answer/route.ts": {
       "path": "src/app/api/exercises/validate-answer/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "authenticated-endpoint"
-      ],
+      "patterns": ["authenticated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "next/server",
-        "payload",
-        "@payload-config"
-      ]
+      "dependencies": ["next/server", "payload", "@payload-config"]
     },
     "src/app/api/jobs/run-immediate/route.ts": {
       "path": "src/app/api/jobs/run-immediate/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "api-endpoint",
-        "authenticated-endpoint"
-      ],
+      "patterns": ["api-endpoint", "authenticated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "@payload-config",
-        "mongodb",
-        "next/server",
-        "payload"
-      ]
+      "dependencies": ["@payload-config", "mongodb", "next/server", "payload"]
     },
     "src/app/api/oauth/github/callback/route.ts": {
       "path": "src/app/api/oauth/github/callback/route.ts",
       "type": "api-route",
       "domain": "auth",
-      "patterns": [
-        "oauth",
-        "api-endpoint"
-      ],
+      "patterns": ["oauth", "api-endpoint"],
       "aiSummary": "Handles GitHub OAuth callback for the Cody Operations Dashboard.",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/oauth/github/route.ts": {
       "path": "src/app/api/oauth/github/route.ts",
       "type": "api-route",
       "domain": "auth",
-      "patterns": [
-        "oauth",
-        "api-endpoint"
-      ],
+      "patterns": ["oauth", "api-endpoint"],
       "aiSummary": "Initiates GitHub OAuth flow for the Cody Operations Dashboard.",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/oauth/google/callback/oauth_callback_helpers.ts": {
       "path": "src/app/api/oauth/google/callback/oauth_callback_helpers.ts",
       "type": "utility",
       "domain": "auth",
-      "patterns": [
-        "oauth",
-        "api-endpoint"
-      ],
+      "patterns": ["oauth", "api-endpoint"],
       "aiSummary": "Helper functions for OAuth callback to handle user lookup and creation",
-      "dependencies": [
-        "next/server",
-        "payload"
-      ]
+      "dependencies": ["next/server", "payload"]
     },
     "src/app/api/oauth/google/callback/route.ts": {
       "path": "src/app/api/oauth/google/callback/route.ts",
       "type": "api-route",
       "domain": "auth",
-      "patterns": [
-        "oauth",
-        "api-endpoint"
-      ],
+      "patterns": ["oauth", "api-endpoint"],
       "aiSummary": "Handles Google OAuth callback, creates/updates users, issues sessions",
-      "dependencies": [
-        "next/server",
-        "payload",
-        "@payload-config"
-      ]
+      "dependencies": ["next/server", "payload", "@payload-config"]
     },
     "src/app/api/oauth/google/route.ts": {
       "path": "src/app/api/oauth/google/route.ts",
       "type": "api-route",
       "domain": "auth",
-      "patterns": [
-        "oauth",
-        "api-endpoint"
-      ],
+      "patterns": ["oauth", "api-endpoint"],
       "aiSummary": "Initiates Google OAuth flow by redirecting to Google consent screen",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/pdfjs-viewer/route.ts": {
       "path": "src/app/api/pdfjs-viewer/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "api-endpoint"
-      ],
+      "patterns": ["api-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/app/api/prompts/for-conversion/route.ts": {
       "path": "src/app/api/prompts/for-conversion/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "api-endpoint",
-        "authenticated-endpoint"
-      ],
+      "patterns": ["api-endpoint", "authenticated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "@payload-config",
-        "next/server",
-        "payload"
-      ]
+      "dependencies": ["@payload-config", "next/server", "payload"]
     },
     "src/app/api/study-plan/route.ts": {
       "path": "src/app/api/study-plan/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "api-endpoint",
-        "authenticated-endpoint",
-        "validated-endpoint"
-      ],
+      "patterns": ["api-endpoint", "authenticated-endpoint", "validated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "@payload-config",
-        "date-fns",
-        "nanoid",
-        "next/server",
-        "payload",
-        "zod"
-      ]
+      "dependencies": ["@payload-config", "date-fns", "nanoid", "next/server", "payload", "zod"]
     },
     "src/app/api/teacher-profiles/route.ts": {
       "path": "src/app/api/teacher-profiles/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "authenticated-endpoint"
-      ],
+      "patterns": ["authenticated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "payload",
-        "@payload-config"
-      ]
+      "dependencies": ["payload", "@payload-config"]
     },
     "src/app/api/user-settings/route.ts": {
       "path": "src/app/api/user-settings/route.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "authenticated-endpoint"
-      ],
+      "patterns": ["authenticated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "payload",
-        "zod",
-        "@payload-config"
-      ]
+      "dependencies": ["payload", "zod", "@payload-config"]
     },
     "src/app/global-error.tsx": {
       "path": "src/app/global-error.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "@sentry/nextjs",
-        "next/error",
-        "react"
-      ]
+      "dependencies": ["@sentry/nextjs", "next/error", "react"]
     },
     "src/client/hooks/useAccessGate.ts": {
       "path": "src/client/hooks/useAccessGate.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/client/hooks/useCurrentUser.ts": {
       "path": "src/client/hooks/useCurrentUser.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/client/hooks/useExamCountdown.ts": {
       "path": "src/client/hooks/useExamCountdown.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/infra/analytics/adapters/ga4/adapter.ts": {
       "path": "src/infra/analytics/adapters/ga4/adapter.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -4100,21 +2992,15 @@
       "path": "src/infra/analytics/adapters/ga4/scripts.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "next/script"
-      ]
+      "dependencies": ["next/script"]
     },
     "src/infra/analytics/adapters/mixpanel/adapter.ts": {
       "path": "src/infra/analytics/adapters/mixpanel/adapter.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -4122,33 +3008,23 @@
       "path": "src/infra/analytics/adapters/mixpanel/scripts.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "next/script"
-      ]
+      "dependencies": ["next/script"]
     },
     "src/infra/analytics/components/UserIdentificationTracker.tsx": {
       "path": "src/infra/analytics/components/UserIdentificationTracker.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/infra/analytics/core/tracker.ts": {
       "path": "src/infra/analytics/core/tracker.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -4156,60 +3032,39 @@
       "path": "src/infra/analytics/hooks/usePageAbandonment.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "next/navigation"
-      ]
+      "dependencies": ["react", "next/navigation"]
     },
     "src/infra/analytics/hooks/usePageView.ts": {
       "path": "src/infra/analytics/hooks/usePageView.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "next/navigation",
-        "react"
-      ]
+      "dependencies": ["next/navigation", "react"]
     },
     "src/infra/analytics/hooks/useSessionDuration.ts": {
       "path": "src/infra/analytics/hooks/useSessionDuration.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "next/navigation"
-      ]
+      "dependencies": ["react", "next/navigation"]
     },
     "src/infra/analytics/providers/AnalyticsProvider.tsx": {
       "path": "src/infra/analytics/providers/AnalyticsProvider.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/infra/analytics/system-events-subscriber.ts": {
       "path": "src/infra/analytics/system-events-subscriber.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "authenticated-endpoint"
-      ],
+      "patterns": ["authenticated-endpoint"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -4217,73 +3072,47 @@
       "path": "src/infra/auth/cody_session.ts",
       "type": "utility",
       "domain": "auth",
-      "patterns": [
-        "oauth",
-        "api-endpoint"
-      ],
+      "patterns": ["oauth", "api-endpoint"],
       "aiSummary": "Standalone GitHub identity session for the Cody Operations Dashboard.",
-      "dependencies": [
-        "jose",
-        "next/server"
-      ]
+      "dependencies": ["jose", "next/server"]
     },
     "src/infra/auth/oauth_constants.ts": {
       "path": "src/infra/auth/oauth_constants.ts",
       "type": "constants",
       "domain": "auth",
-      "patterns": [
-        "oauth"
-      ],
+      "patterns": ["oauth"],
       "aiSummary": "Cookie configuration and constants for OAuth authentication",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/infra/auth/oauth_cookies.ts": {
       "path": "src/infra/auth/oauth_cookies.ts",
       "type": "utility",
       "domain": "auth",
-      "patterns": [
-        "oauth",
-        "api-endpoint"
-      ],
+      "patterns": ["oauth", "api-endpoint"],
       "aiSummary": "Cookie read/write/delete utilities for OAuth flow",
-      "dependencies": [
-        "next/server",
-        "payload"
-      ]
+      "dependencies": ["next/server", "payload"]
     },
     "src/infra/auth/oauth_crypto.ts": {
       "path": "src/infra/auth/oauth_crypto.ts",
       "type": "utility",
       "domain": "auth",
-      "patterns": [
-        "encryption"
-      ],
+      "patterns": ["encryption"],
       "aiSummary": "AES-256-GCM encryption for OAuth login secrets",
-      "dependencies": [
-        "crypto"
-      ]
+      "dependencies": ["crypto"]
     },
     "src/infra/auth/oauth_logger.ts": {
       "path": "src/infra/auth/oauth_logger.ts",
       "type": "utility",
       "domain": "auth",
-      "patterns": [
-        "oauth"
-      ],
+      "patterns": ["oauth"],
       "aiSummary": "PII-safe logging for OAuth events with email hashing",
-      "dependencies": [
-        "crypto"
-      ]
+      "dependencies": ["crypto"]
     },
     "src/infra/auth/oauth_nonce.ts": {
       "path": "src/infra/auth/oauth_nonce.ts",
       "type": "utility",
       "domain": "auth",
-      "patterns": [
-        "oauth"
-      ],
+      "patterns": ["oauth"],
       "aiSummary": "Generate cryptographically secure random nonces for CSRF protection",
       "dependencies": []
     },
@@ -4291,9 +3120,7 @@
       "path": "src/infra/auth/oauth_sanitize.ts",
       "type": "utility",
       "domain": "auth",
-      "patterns": [
-        "oauth"
-      ],
+      "patterns": ["oauth"],
       "aiSummary": "Sanitize returnTo URLs to prevent open redirect vulnerabilities",
       "dependencies": []
     },
@@ -4301,47 +3128,31 @@
       "path": "src/infra/auth/oauth_session.ts",
       "type": "utility",
       "domain": "auth",
-      "patterns": [
-        "oauth"
-      ],
+      "patterns": ["oauth"],
       "aiSummary": "Issue Payload auth sessions using payload.login() for OAuth users",
-      "dependencies": [
-        "payload",
-        "@payload-config"
-      ]
+      "dependencies": ["payload", "@payload-config"]
     },
     "src/infra/auth/oauth_state.ts": {
       "path": "src/infra/auth/oauth_state.ts",
       "type": "utility",
       "domain": "auth",
-      "patterns": [
-        "oauth",
-        "api-endpoint"
-      ],
+      "patterns": ["oauth", "api-endpoint"],
       "aiSummary": "Manage OAuth state nonces and returnTo URLs for CSRF protection",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/infra/auth/oauth_url.ts": {
       "path": "src/infra/auth/oauth_url.ts",
       "type": "utility",
       "domain": "auth",
-      "patterns": [
-        "oauth"
-      ],
+      "patterns": ["oauth"],
       "aiSummary": "Build canonical public base URLs for OAuth callbacks",
-      "dependencies": [
-        "next/server"
-      ]
+      "dependencies": ["next/server"]
     },
     "src/infra/config/config-constants.ts": {
       "path": "src/infra/config/config-constants.ts",
       "type": "utility",
       "domain": "config",
-      "patterns": [
-        "constants"
-      ],
+      "patterns": ["constants"],
       "aiSummary": "Configuration constants for the config manager",
       "dependencies": []
     },
@@ -4349,36 +3160,23 @@
       "path": "src/infra/config/config-crypto.ts",
       "type": "utility",
       "domain": "config",
-      "patterns": [
-        "encryption"
-      ],
+      "patterns": ["encryption"],
       "aiSummary": "AES-256-GCM encryption for config secrets",
-      "dependencies": [
-        "crypto"
-      ]
+      "dependencies": ["crypto"]
     },
     "src/infra/config/runtime/config-values.ts": {
       "path": "src/infra/config/runtime/config-values.ts",
       "type": "implementation",
       "domain": "config.runtime",
-      "patterns": [
-        "singleton",
-        "in-memory-cache",
-        "domain-config-loader"
-      ],
+      "patterns": ["singleton", "in-memory-cache", "domain-config-loader"],
       "aiSummary": "Server-side runtime config values loader with DB→memory caching (tenant-scoped, domain-grouped)",
-      "dependencies": [
-        "payload",
-        "@payload-config"
-      ]
+      "dependencies": ["payload", "@payload-config"]
     },
     "src/infra/config/runtime/errors.ts": {
       "path": "src/infra/config/runtime/errors.ts",
       "type": "error-definition",
       "domain": "config.runtime",
-      "patterns": [
-        "error-handling"
-      ],
+      "patterns": ["error-handling"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -4386,24 +3184,15 @@
       "path": "src/infra/config/runtime/runtime-config.ts",
       "type": "implementation",
       "domain": "config.runtime",
-      "patterns": [
-        "singleton",
-        "in-memory-cache",
-        "config-loader"
-      ],
+      "patterns": ["singleton", "in-memory-cache", "config-loader"],
       "aiSummary": "Server-side runtime config loader for secrets only (DB→memory caching, tenant-scoped)",
-      "dependencies": [
-        "payload",
-        "@payload-config"
-      ]
+      "dependencies": ["payload", "@payload-config"]
     },
     "src/infra/config/runtime/types.ts": {
       "path": "src/infra/config/runtime/types.ts",
       "type": "type-definition",
       "domain": "config.runtime",
-      "patterns": [
-        "types"
-      ],
+      "patterns": ["types"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -4411,10 +3200,7 @@
       "path": "src/infra/config/runtime/validate-chat-config.ts",
       "type": "implementation",
       "domain": "config.validation",
-      "patterns": [
-        "runtime-validation",
-        "config-sanity-check"
-      ],
+      "patterns": ["runtime-validation", "config-sanity-check"],
       "aiSummary": "Validates chat configuration values at runtime to ensure required paths exist and values are within expected ranges",
       "dependencies": []
     },
@@ -4422,9 +3208,7 @@
       "path": "src/infra/config/system-params.ts",
       "type": "wrapper",
       "domain": "config.system-params",
-      "patterns": [
-        "type-safe-accessor"
-      ],
+      "patterns": ["type-safe-accessor"],
       "aiSummary": "Type-safe accessors for system parameters stored in ConfigValues",
       "dependencies": []
     },
@@ -4432,10 +3216,7 @@
       "path": "src/infra/llm/genkit/adapters/error-adapter.ts",
       "type": "adapter",
       "domain": "ai",
-      "patterns": [
-        "error-handling",
-        "genkit"
-      ],
+      "patterns": ["error-handling", "genkit"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -4443,56 +3224,31 @@
       "path": "src/infra/llm/genkit/adapters/unified-adapter.ts",
       "type": "adapter",
       "domain": "ai",
-      "patterns": [
-        "abstraction",
-        "genkit",
-        "provider-abstraction"
-      ],
+      "patterns": ["abstraction", "genkit", "provider-abstraction"],
       "aiSummary": "",
-      "dependencies": [
-        "genkit",
-        "payload"
-      ]
+      "dependencies": ["genkit", "payload"]
     },
     "src/infra/llm/genkit/config-resolver.ts": {
       "path": "src/infra/llm/genkit/config-resolver.ts",
       "type": "implementation",
       "domain": "ai",
-      "patterns": [
-        "config-mapping",
-        "genkit"
-      ],
+      "patterns": ["config-mapping", "genkit"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/infra/llm/genkit/genkit-instance.ts": {
       "path": "src/infra/llm/genkit/genkit-instance.ts",
       "type": "implementation",
       "domain": "ai",
-      "patterns": [
-        "singleton",
-        "genkit",
-        "lazy-loading"
-      ],
+      "patterns": ["singleton", "genkit", "lazy-loading"],
       "aiSummary": "",
-      "dependencies": [
-        "@genkit-ai/googleai",
-        "genkit",
-        "genkitx-openai",
-        "payload"
-      ]
+      "dependencies": ["@genkit-ai/googleai", "genkit", "genkitx-openai", "payload"]
     },
     "src/infra/llm/genkit/index.ts": {
       "path": "src/infra/llm/genkit/index.ts",
       "type": "index",
       "domain": "ai",
-      "patterns": [
-        "abstraction",
-        "genkit",
-        "provider-abstraction"
-      ],
+      "patterns": ["abstraction", "genkit", "provider-abstraction"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -4500,24 +3256,15 @@
       "path": "src/infra/llm/genkit/tools/genkit-tools.ts",
       "type": "module",
       "domain": "ai",
-      "patterns": [
-        "genkit-tools",
-        "tool-calling",
-        "mcp-integration"
-      ],
+      "patterns": ["genkit-tools", "tool-calling", "mcp-integration"],
       "aiSummary": "",
-      "dependencies": [
-        "genkit"
-      ]
+      "dependencies": ["genkit"]
     },
     "src/infra/llm/lesson-context.ts": {
       "path": "src/infra/llm/lesson-context.ts",
       "type": "ai-utility",
       "domain": "chat",
-      "patterns": [
-        "single-responsibility",
-        "runtime-injection"
-      ],
+      "patterns": ["single-responsibility", "runtime-injection"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -4525,9 +3272,7 @@
       "path": "src/infra/llm/prompt-composer.server.ts",
       "type": "ai-utility",
       "domain": "chat",
-      "patterns": [
-        "server-only"
-      ],
+      "patterns": ["server-only"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -4535,24 +3280,15 @@
       "path": "src/infra/llm/providers/factory.ts",
       "type": "factory",
       "domain": "ai",
-      "patterns": [
-        "provider-factory",
-        "abstraction",
-        "dependency-injection"
-      ],
+      "patterns": ["provider-factory", "abstraction", "dependency-injection"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/infra/llm/providers/shared/circuit-breaker.ts": {
       "path": "src/infra/llm/providers/shared/circuit-breaker.ts",
       "type": "utility",
       "domain": "ai",
-      "patterns": [
-        "circuit-breaker",
-        "resilience"
-      ],
+      "patterns": ["circuit-breaker", "resilience"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -4560,21 +3296,15 @@
       "path": "src/infra/llm/providers/shared/media-reader.ts",
       "type": "utility",
       "domain": "ai",
-      "patterns": [
-        "data-transformation"
-      ],
+      "patterns": ["data-transformation"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/infra/llm/providers/shared/retry.ts": {
       "path": "src/infra/llm/providers/shared/retry.ts",
       "type": "utility",
       "domain": "ai",
-      "patterns": [
-        "retry"
-      ],
+      "patterns": ["retry"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -4582,9 +3312,7 @@
       "path": "src/infra/llm/providers/shared/timeout.ts",
       "type": "utility",
       "domain": "ai",
-      "patterns": [
-        "timeout"
-      ],
+      "patterns": ["timeout"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -4592,9 +3320,7 @@
       "path": "src/infra/llm/smart-doc-loader.ts",
       "type": "utility",
       "domain": "ai",
-      "patterns": [
-        "context-aware-loading"
-      ],
+      "patterns": ["context-aware-loading"],
       "aiSummary": "Context-aware documentation loader that minimizes token usage",
       "dependencies": []
     },
@@ -4602,21 +3328,15 @@
       "path": "src/infra/llm/system-prompts.server.ts",
       "type": "ai-utility",
       "domain": "chat",
-      "patterns": [
-        "server-only"
-      ],
+      "patterns": ["server-only"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/infra/llm/teacher-profile-block.ts": {
       "path": "src/infra/llm/teacher-profile-block.ts",
       "type": "ai-utility",
       "domain": "chat",
-      "patterns": [
-        "server-only"
-      ],
+      "patterns": ["server-only"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -4624,39 +3344,23 @@
       "path": "src/infra/llm/vector-search.ts",
       "type": "service",
       "domain": "ai",
-      "patterns": [
-        "vector-search",
-        "context-scoped"
-      ],
+      "patterns": ["vector-search", "context-scoped"],
       "aiSummary": "",
-      "dependencies": [
-        "@payloadcms/db-mongodb",
-        "mongodb",
-        "payload"
-      ]
+      "dependencies": ["@payloadcms/db-mongodb", "mongodb", "payload"]
     },
     "src/infra/loading/components/RouteLoadingIndicator.tsx": {
       "path": "src/infra/loading/components/RouteLoadingIndicator.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "next/navigation"
-      ]
+      "dependencies": ["react", "next/navigation"]
     },
     "src/infra/loading/components/Spinner.tsx": {
       "path": "src/infra/loading/components/Spinner.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -4664,61 +3368,39 @@
       "path": "src/infra/loading/components/SystemLink.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "next/link",
-        "next/navigation"
-      ]
+      "dependencies": ["react", "next/link", "next/navigation"]
     },
     "src/infra/loading/hooks/useAsyncAction.ts": {
       "path": "src/infra/loading/hooks/useAsyncAction.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/infra/loading/hooks/useLoadingState.ts": {
       "path": "src/infra/loading/hooks/useLoadingState.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/infra/loading/hooks/useRouterWithLoading.ts": {
       "path": "src/infra/loading/hooks/useRouterWithLoading.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "next/navigation",
-        "react"
-      ]
+      "dependencies": ["next/navigation", "react"]
     },
     "src/infra/media/embed/resolve.ts": {
       "path": "src/infra/media/embed/resolve.ts",
       "type": "utility",
       "domain": "media",
-      "patterns": [
-        "embed-provider"
-      ],
+      "patterns": ["embed-provider"],
       "aiSummary": "Main entry point for resolving external URLs to embed metadata.",
       "dependencies": []
     },
@@ -4726,9 +3408,7 @@
       "path": "src/infra/media/embed/types.ts",
       "type": "utility",
       "domain": "media",
-      "patterns": [
-        "embed-provider"
-      ],
+      "patterns": ["embed-provider"],
       "aiSummary": "Type definitions for external media embed providers",
       "dependencies": []
     },
@@ -4736,10 +3416,7 @@
       "path": "src/infra/media/embed/vimeo.ts",
       "type": "utility",
       "domain": "media",
-      "patterns": [
-        "embed-provider",
-        "payload-hooks"
-      ],
+      "patterns": ["embed-provider", "payload-hooks"],
       "aiSummary": "Vimeo URL detection, video ID extraction, and oEmbed metadata fetching",
       "dependencies": []
     },
@@ -4747,9 +3424,7 @@
       "path": "src/infra/media/embed/youtube.ts",
       "type": "utility",
       "domain": "media",
-      "patterns": [
-        "embed-provider"
-      ],
+      "patterns": ["embed-provider"],
       "aiSummary": "YouTube URL detection, video ID extraction, and oEmbed metadata fetching",
       "dependencies": []
     },
@@ -4757,9 +3432,7 @@
       "path": "src/infra/media/youtube.ts",
       "type": "utility",
       "domain": "media",
-      "patterns": [
-        "youtube-detection"
-      ],
+      "patterns": ["youtube-detection"],
       "aiSummary": "Client-side YouTube URL detection and embed URL generation (no API calls)",
       "dependencies": []
     },
@@ -4767,9 +3440,7 @@
       "path": "src/infra/types/index.ts",
       "type": "utility",
       "domain": "general",
-      "patterns": [
-        "type-exports"
-      ],
+      "patterns": ["type-exports"],
       "aiSummary": "Centralized type exports for easy discovery by AI agents",
       "dependencies": []
     },
@@ -4777,9 +3448,7 @@
       "path": "src/infra/utils/graphics/viewport-utils.ts",
       "type": "utility",
       "domain": "graphics",
-      "patterns": [
-        "viewport-calculation"
-      ],
+      "patterns": ["viewport-calculation"],
       "aiSummary": "Viewport utility functions for auto-calculating, validating, and resolving graph display ranges",
       "dependencies": []
     },
@@ -4787,52 +3456,31 @@
       "path": "src/infra/utils/useClickableCard.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "next/navigation"
-      ]
+      "dependencies": ["react", "next/navigation"]
     },
     "src/server/api/responses.ts": {
       "path": "src/server/api/responses.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "api-endpoint"
-      ],
+      "patterns": ["api-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "next/server",
-        "zod"
-      ]
+      "dependencies": ["next/server", "zod"]
     },
     "src/server/api/with-api-handler.ts": {
       "path": "src/server/api/with-api-handler.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "api-endpoint",
-        "authenticated-endpoint"
-      ],
+      "patterns": ["api-endpoint", "authenticated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "@sentry/nextjs",
-        "@payload-config",
-        "next/server",
-        "payload",
-        "zod"
-      ]
+      "dependencies": ["@sentry/nextjs", "@payload-config", "next/server", "payload", "zod"]
     },
     "src/server/config/guest-chat-config.ts": {
       "path": "src/server/config/guest-chat-config.ts",
       "type": "utility",
       "domain": "config",
-      "patterns": [
-        "typed-config-accessor"
-      ],
+      "patterns": ["typed-config-accessor"],
       "aiSummary": "Typed getter for guest_chat domain config values with hardcoded fallbacks",
       "dependencies": []
     },
@@ -4840,72 +3488,47 @@
       "path": "src/server/payload/access/configAdminOnly.ts",
       "type": "access-control",
       "domain": "config",
-      "patterns": [
-        "admin-only"
-      ],
+      "patterns": ["admin-only"],
       "aiSummary": "Access control that restricts config operations to admins only",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/blocks/Banner/Component.tsx": {
       "path": "src/server/payload/blocks/Banner/Component.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component"
-      ],
+      "patterns": ["tailwind-component"],
       "aiSummary": "",
-      "dependencies": [
-        "src/payload-types",
-        "react"
-      ]
+      "dependencies": ["src/payload-types", "react"]
     },
     "src/server/payload/blocks/Code/Component.client.tsx": {
       "path": "src/server/payload/blocks/Code/Component.client.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "prism-react-renderer",
-        "react"
-      ]
+      "dependencies": ["prism-react-renderer", "react"]
     },
     "src/server/payload/blocks/Code/CopyButton.tsx": {
       "path": "src/server/payload/blocks/Code/CopyButton.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "@payloadcms/ui/icons/Copy",
-        "react"
-      ]
+      "dependencies": ["@payloadcms/ui/icons/Copy", "react"]
     },
     "src/server/payload/blocks/Content/Component.tsx": {
       "path": "src/server/payload/blocks/Content/Component.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component"
-      ],
+      "patterns": ["tailwind-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/server/payload/blocks/Form/Component.tsx": {
       "path": "src/server/payload/blocks/Form/Component.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
       "dependencies": [
         "@payloadcms/plugin-form-builder/types",
@@ -4919,496 +3542,297 @@
       "path": "src/server/payload/blocks/Form/Error/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "react-hook-form"
-      ]
+      "dependencies": ["react", "react-hook-form"]
     },
     "src/server/payload/blocks/MediaBlock/Component.tsx": {
       "path": "src/server/payload/blocks/MediaBlock/Component.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component"
-      ],
+      "patterns": ["tailwind-component"],
       "aiSummary": "",
-      "dependencies": [
-        "next/image",
-        "react"
-      ]
+      "dependencies": ["next/image", "react"]
     },
     "src/server/payload/collections/Categories.ts": {
       "path": "src/server/payload/collections/Categories.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "access-control",
-        "payload-hooks"
-      ],
+      "patterns": ["access-control", "payload-hooks"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/Chapters.ts": {
       "path": "src/server/payload/collections/Chapters.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "hierarchical-data",
-        "access-control",
-        "payload-hooks"
-      ],
+      "patterns": ["hierarchical-data", "access-control", "payload-hooks"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/ChatAssets/index.ts": {
       "path": "src/server/payload/collections/ChatAssets/index.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "access-control"
-      ],
+      "patterns": ["access-control"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/ConfigAuditLogs.ts": {
       "path": "src/server/payload/collections/ConfigAuditLogs.ts",
       "type": "collection-config",
       "domain": "config",
-      "patterns": [
-        "audit-log",
-        "access-control"
-      ],
+      "patterns": ["audit-log", "access-control"],
       "aiSummary": "Append-only audit log for config secret mutations",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/ConfigSecrets.ts": {
       "path": "src/server/payload/collections/ConfigSecrets.ts",
       "type": "collection-config",
       "domain": "config",
-      "patterns": [
-        "key-value-store",
-        "encrypted-values",
-        "access-control",
-        "payload-hooks"
-      ],
+      "patterns": ["key-value-store", "encrypted-values", "access-control", "payload-hooks"],
       "aiSummary": "Tenant-scoped encrypted secrets. All values are always encrypted.",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/ConfigValues.ts": {
       "path": "src/server/payload/collections/ConfigValues.ts",
       "type": "collection-config",
       "domain": "config",
-      "patterns": [
-        "domain-scoped-config",
-        "json-storage",
-        "access-control",
-        "payload-hooks"
-      ],
+      "patterns": ["domain-scoped-config", "json-storage", "access-control", "payload-hooks"],
       "aiSummary": "Domain-based configuration values stored as JSON, tenant-scoped",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/Conversations.ts": {
       "path": "src/server/payload/collections/Conversations.ts",
       "type": "collection-config",
       "domain": "chat",
-      "patterns": [
-        "user-owned",
-        "context-scoped",
-        "access-control",
-        "payload-hooks"
-      ],
+      "patterns": ["user-owned", "context-scoped", "access-control", "payload-hooks"],
       "aiSummary": "Context-scoped conversations with polymorphic context references",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/Courses.ts": {
       "path": "src/server/payload/collections/Courses.ts",
       "type": "collection-config",
       "domain": "courses",
-      "patterns": [
-        "published-content",
-        "hierarchical-data",
-        "access-control",
-        "payload-hooks"
-      ],
+      "patterns": ["published-content", "hierarchical-data", "access-control", "payload-hooks"],
       "aiSummary": "Courses collection with chapters relationship and published state",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/ExerciseAssets.ts": {
       "path": "src/server/payload/collections/ExerciseAssets.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "access-control"
-      ],
+      "patterns": ["access-control"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/Exercises/index.ts": {
       "path": "src/server/payload/collections/Exercises/index.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "rbac",
-        "hierarchical-data",
-        "access-control"
-      ],
+      "patterns": ["rbac", "hierarchical-data", "access-control"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/ExtractionLogs.ts": {
       "path": "src/server/payload/collections/ExtractionLogs.ts",
       "type": "collection-config",
       "domain": "conversion",
-      "patterns": [
-        "append-only-log",
-        "access-control"
-      ],
+      "patterns": ["append-only-log", "access-control"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/GuestSessions.ts": {
       "path": "src/server/payload/collections/GuestSessions.ts",
       "type": "collection-config",
       "domain": "auth",
-      "patterns": [
-        "session-management",
-        "expiring-records",
-        "access-control"
-      ],
+      "patterns": ["session-management", "expiring-records", "access-control"],
       "aiSummary": "Expiring guest sessions for anonymous chat persistence",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/Lessons.ts": {
       "path": "src/server/payload/collections/Lessons.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "hierarchical-data",
-        "access-control",
-        "payload-hooks"
-      ],
+      "patterns": ["hierarchical-data", "access-control", "payload-hooks"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/MCPAuditLogs.ts": {
       "path": "src/server/payload/collections/MCPAuditLogs.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "access-control"
-      ],
+      "patterns": ["access-control"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/Media/hooks/enforceRetentionPolicy.ts": {
       "path": "src/server/payload/collections/Media/hooks/enforceRetentionPolicy.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "payload-hooks"
-      ],
+      "patterns": ["payload-hooks"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/Media/hooks/resolveEmbed.ts": {
       "path": "src/server/payload/collections/Media/hooks/resolveEmbed.ts",
       "type": "hook",
       "domain": "media",
-      "patterns": [
-        "embed-provider",
-        "payload-hooks"
-      ],
+      "patterns": ["embed-provider", "payload-hooks"],
       "aiSummary": "beforeChange hook that resolves external URLs to embed metadata.",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/Media/index.ts": {
       "path": "src/server/payload/collections/Media/index.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "access-control",
-        "payload-hooks"
-      ],
+      "patterns": ["access-control", "payload-hooks"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/MemoryItems.ts": {
       "path": "src/server/payload/collections/MemoryItems.ts",
       "type": "collection-config",
       "domain": "chat",
-      "patterns": [
-        "user-owned",
-        "vector-search",
-        "context-scoped",
-        "rbac",
-        "access-control"
-      ],
+      "patterns": ["user-owned", "vector-search", "context-scoped", "rbac", "access-control"],
       "aiSummary": "Memory items with context hierarchy for semantic retrieval",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/Pages/index.ts": {
       "path": "src/server/payload/collections/Pages/index.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "access-control",
-        "payload-hooks"
-      ],
+      "patterns": ["access-control", "payload-hooks"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/Posts/index.ts": {
       "path": "src/server/payload/collections/Posts/index.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "access-control",
-        "payload-hooks"
-      ],
+      "patterns": ["access-control", "payload-hooks"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/PricingPlans.ts": {
       "path": "src/server/payload/collections/PricingPlans.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "access-control"
-      ],
+      "patterns": ["access-control"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/Prompts.ts": {
       "path": "src/server/payload/collections/Prompts.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "access-control",
-        "payload-hooks"
-      ],
+      "patterns": ["access-control", "payload-hooks"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/TeacherProfiles.ts": {
       "path": "src/server/payload/collections/TeacherProfiles.ts",
       "type": "collection-config",
       "domain": "ai",
-      "patterns": [
-        "teacher-profile",
-        "access-control"
-      ],
+      "patterns": ["teacher-profile", "access-control"],
       "aiSummary": "Collection for managing teacher profiles that define AI chat behavior",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/Tenants.ts": {
       "path": "src/server/payload/collections/Tenants.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "access-control"
-      ],
+      "patterns": ["access-control"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/UploadSessions/index.ts": {
       "path": "src/server/payload/collections/UploadSessions/index.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "access-control"
-      ],
+      "patterns": ["access-control"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/UserProgress.ts": {
       "path": "src/server/payload/collections/UserProgress.ts",
       "type": "collection-config",
       "domain": "progress-tracking",
-      "patterns": [
-        "user-owned",
-        "progress-tracking",
-        "access-control"
-      ],
+      "patterns": ["user-owned", "progress-tracking", "access-control"],
       "aiSummary": "User progress tracking for chapters, lessons, and exercises",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/UserSettings/index.ts": {
       "path": "src/server/payload/collections/UserSettings/index.ts",
       "type": "collection-config",
       "domain": "user",
-      "patterns": [
-        "user-settings",
-        "access-control"
-      ],
+      "patterns": ["user-settings", "access-control"],
       "aiSummary": "Collection for storing per-user settings including teacher profile selection",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/Users/hooks/auditRoleChange-hook.ts": {
       "path": "src/server/payload/collections/Users/hooks/auditRoleChange-hook.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "payload-hooks"
-      ],
+      "patterns": ["payload-hooks"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/Users/hooks/ensureRoleOnSignup-hook.ts": {
       "path": "src/server/payload/collections/Users/hooks/ensureRoleOnSignup-hook.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "payload-hooks"
-      ],
+      "patterns": ["payload-hooks"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/Users/hooks/preventLastAdminDemotion-hook.ts": {
       "path": "src/server/payload/collections/Users/hooks/preventLastAdminDemotion-hook.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "payload-hooks"
-      ],
+      "patterns": ["payload-hooks"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/collections/Users/index.ts": {
       "path": "src/server/payload/collections/Users/index.ts",
       "type": "collection-config",
       "domain": "auth",
-      "patterns": [
-        "rbac",
-        "user-owned",
-        "access-control",
-        "payload-hooks"
-      ],
+      "patterns": ["rbac", "user-owned", "access-control", "payload-hooks"],
       "aiSummary": "Users collection with authentication, RBAC roles, and audit hooks",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/endpoints/agent/auth-middleware.ts": {
       "path": "src/server/payload/endpoints/agent/auth-middleware.ts",
       "type": "middleware",
       "domain": "auth",
-      "patterns": [
-        "guest-session",
-        "rate-limiting",
-        "authenticated-endpoint"
-      ],
+      "patterns": ["guest-session", "rate-limiting", "authenticated-endpoint"],
       "aiSummary": "Shared resolver for authenticated users and guest sessions",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/endpoints/agent/chat/pipeline.ts": {
       "path": "src/server/payload/endpoints/agent/chat/pipeline.ts",
       "type": "module",
       "domain": "chat",
-      "patterns": [
-        "pipeline",
-        "extraction"
-      ],
+      "patterns": ["pipeline", "extraction"],
       "aiSummary": "",
-      "dependencies": [
-        "payload",
-        "pino",
-        "zod"
-      ]
+      "dependencies": ["payload", "pino", "zod"]
     },
     "src/server/payload/endpoints/agent/chat/request-validation.ts": {
       "path": "src/server/payload/endpoints/agent/chat/request-validation.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "validated-endpoint"
-      ],
+      "patterns": ["validated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "zod"
-      ]
+      "dependencies": ["zod"]
     },
     "src/server/payload/endpoints/agent/chat-stream.ts": {
       "path": "src/server/payload/endpoints/agent/chat-stream.ts",
       "type": "endpoint",
       "domain": "chat",
-      "patterns": [
-        "streaming",
-        "sse",
-        "server-sent-events",
-        "authenticated-endpoint"
-      ],
+      "patterns": ["streaming", "sse", "server-sent-events", "authenticated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "pino",
-        "payload",
-        "zod"
-      ]
+      "dependencies": ["pino", "payload", "zod"]
     },
     "src/server/payload/endpoints/agent/chat.ts": {
       "path": "src/server/payload/endpoints/agent/chat.ts",
@@ -5422,11 +3846,7 @@
         "guest-session"
       ],
       "aiSummary": "Chat endpoint with context scoping, memory retrieval, MCP tools for admins, guest sessions, and automatic maintenance",
-      "dependencies": [
-        "payload",
-        "pino",
-        "zod"
-      ]
+      "dependencies": ["payload", "pino", "zod"]
     },
     "src/server/payload/endpoints/agent/get-conversation.ts": {
       "path": "src/server/payload/endpoints/agent/get-conversation.ts",
@@ -5439,10 +3859,7 @@
         "guest-session"
       ],
       "aiSummary": "Get conversation endpoint with explicit user/guest isolation",
-      "dependencies": [
-        "payload",
-        "zod"
-      ]
+      "dependencies": ["payload", "zod"]
     },
     "src/server/payload/endpoints/agent/reset-chat.ts": {
       "path": "src/server/payload/endpoints/agent/reset-chat.ts",
@@ -5455,216 +3872,133 @@
         "validated-endpoint"
       ],
       "aiSummary": "Reset endpoint for context-scoped conversations with guest support",
-      "dependencies": [
-        "payload",
-        "zod"
-      ]
+      "dependencies": ["payload", "zod"]
     },
     "src/server/payload/endpoints/cron/guest-sessions-cleanup.ts": {
       "path": "src/server/payload/endpoints/cron/guest-sessions-cleanup.ts",
       "type": "endpoint",
       "domain": "auth",
-      "patterns": [
-        "cron-endpoint",
-        "authenticated-endpoint"
-      ],
+      "patterns": ["cron-endpoint", "authenticated-endpoint"],
       "aiSummary": "Deletes expired guest sessions and their associated orphaned conversations",
-      "dependencies": [
-        "payload",
-        "pino"
-      ]
+      "dependencies": ["payload", "pino"]
     },
     "src/server/payload/endpoints/cron/media-expiry.ts": {
       "path": "src/server/payload/endpoints/cron/media-expiry.ts",
       "type": "endpoint",
       "domain": "media",
-      "patterns": [
-        "cron-endpoint",
-        "authenticated-endpoint"
-      ],
+      "patterns": ["cron-endpoint", "authenticated-endpoint"],
       "aiSummary": "Deletes expired ephemeral media files and database records",
-      "dependencies": [
-        "fs/promises",
-        "payload",
-        "pino"
-      ]
+      "dependencies": ["fs/promises", "payload", "pino"]
     },
     "src/server/payload/endpoints/exercises/validate-answer.ts": {
       "path": "src/server/payload/endpoints/exercises/validate-answer.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "validated-endpoint"
-      ],
+      "patterns": ["validated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "payload",
-        "zod"
-      ]
+      "dependencies": ["payload", "zod"]
     },
     "src/server/payload/endpoints/seed/guest-chat-config.ts": {
       "path": "src/server/payload/endpoints/seed/guest-chat-config.ts",
       "type": "seed-function",
       "domain": "config.seed",
-      "patterns": [
-        "data-seeding"
-      ],
+      "patterns": ["data-seeding"],
       "aiSummary": "Seeds guest_chat domain defaults into config_values collection",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/endpoints/seed/intro-page.ts": {
       "path": "src/server/payload/endpoints/seed/intro-page.ts",
       "type": "seed-data",
       "domain": "pages",
-      "patterns": [
-        "published-content"
-      ],
+      "patterns": ["published-content"],
       "aiSummary": "Seed data for the A-Guy platform introduction page, converted from docs/a-guy/intro.md",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/endpoints/seed/system-params.ts": {
       "path": "src/server/payload/endpoints/seed/system-params.ts",
       "type": "seed-function",
       "domain": "config.seed",
-      "patterns": [
-        "data-seeding"
-      ],
+      "patterns": ["data-seeding"],
       "aiSummary": "Seeds default system parameters into ConfigValues (global domain)",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/fields/createdBy.ts": {
       "path": "src/server/payload/fields/createdBy.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "payload-hooks"
-      ],
+      "patterns": ["payload-hooks"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/hooks/configSecrets/afterChange-hook.ts": {
       "path": "src/server/payload/hooks/configSecrets/afterChange-hook.ts",
       "type": "hook",
       "domain": "config",
-      "patterns": [
-        "audit-log",
-        "payload-hooks"
-      ],
+      "patterns": ["audit-log", "payload-hooks"],
       "aiSummary": "Creates audit log entries after config secret mutations",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/hooks/configSecrets/afterRead-hook.ts": {
       "path": "src/server/payload/hooks/configSecrets/afterRead-hook.ts",
       "type": "hook",
       "domain": "config",
-      "patterns": [
-        "write-only-ux"
-      ],
+      "patterns": ["write-only-ux"],
       "aiSummary": "Clears all values in Admin UI responses (secrets-only collection), but skips for internal runtime load",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/hooks/configSecrets/beforeChange-hook.ts": {
       "path": "src/server/payload/hooks/configSecrets/beforeChange-hook.ts",
       "type": "hook",
       "domain": "config",
-      "patterns": [
-        "validation",
-        "encryption",
-        "payload-hooks"
-      ],
+      "patterns": ["validation", "encryption", "payload-hooks"],
       "aiSummary": "Encrypts secrets and validates config entries before save",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/hooks/configValues/beforeChange-hook.ts": {
       "path": "src/server/payload/hooks/configValues/beforeChange-hook.ts",
       "type": "hook",
       "domain": "config",
-      "patterns": [
-        "validation",
-        "secret-detection",
-        "payload-hooks"
-      ],
+      "patterns": ["validation", "secret-detection", "payload-hooks"],
       "aiSummary": "Validates config values and detects secret-like keys before save",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/hooks/validateLocaleUniqueness.ts": {
       "path": "src/server/payload/hooks/validateLocaleUniqueness.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "payload-hooks"
-      ],
+      "patterns": ["payload-hooks"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/jobs/pdf-to-exercises-task.ts": {
       "path": "src/server/payload/jobs/pdf-to-exercises-task.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "validated-endpoint"
-      ],
+      "patterns": ["validated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "@payload-config",
-        "mongodb",
-        "payload",
-        "zod"
-      ]
+      "dependencies": ["@payload-config", "mongodb", "payload", "zod"]
     },
     "src/server/payload/jobs/pdf-to-exercises-v2-task.ts": {
       "path": "src/server/payload/jobs/pdf-to-exercises-v2-task.ts",
       "type": "job-task",
       "domain": "conversion",
-      "patterns": [
-        "job-handler",
-        "pipeline-orchestration"
-      ],
+      "patterns": ["job-handler", "pipeline-orchestration"],
       "aiSummary": "",
-      "dependencies": [
-        "@payload-config",
-        "mongodb",
-        "payload",
-        "nanoid"
-      ]
+      "dependencies": ["@payload-config", "mongodb", "payload", "nanoid"]
     },
     "src/server/payload/migrations/backfillAdminTitle.ts": {
       "path": "src/server/payload/migrations/backfillAdminTitle.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "payload-hooks"
-      ],
+      "patterns": ["payload-hooks"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/payload/plugins/index.ts": {
       "path": "src/server/payload/plugins/index.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "payload-hooks"
-      ],
+      "patterns": ["payload-hooks"],
       "aiSummary": "",
       "dependencies": [
         "@payloadcms/plugin-form-builder",
@@ -5682,38 +4016,23 @@
       "path": "src/server/payload/plugins/mcp/index.ts",
       "type": "plugin-config",
       "domain": "mcp",
-      "patterns": [
-        "plugin-configuration",
-        "read-only-access",
-        "tenant-scoped"
-      ],
+      "patterns": ["plugin-configuration", "read-only-access", "tenant-scoped"],
       "aiSummary": "",
-      "dependencies": [
-        "@payloadcms/plugin-mcp",
-        "payload"
-      ]
+      "dependencies": ["@payloadcms/plugin-mcp", "payload"]
     },
     "src/server/services/conversation-service.ts": {
       "path": "src/server/services/conversation-service.ts",
       "type": "service",
       "domain": "chat",
-      "patterns": [
-        "service-layer",
-        "context-scoped"
-      ],
+      "patterns": ["service-layer", "context-scoped"],
       "aiSummary": "Service for managing conversations with context scoping and access control",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/services/exercise-conversion/v2/image-crop-service.ts": {
       "path": "src/server/services/exercise-conversion/v2/image-crop-service.ts",
       "type": "service",
       "domain": "ai",
-      "patterns": [
-        "image-processing",
-        "cropping"
-      ],
+      "patterns": ["image-processing", "cropping"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -5721,9 +4040,7 @@
       "path": "src/server/services/exercise-conversion/v2/image-strip-service.ts",
       "type": "service",
       "domain": "conversion",
-      "patterns": [
-        "image-processing"
-      ],
+      "patterns": ["image-processing"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -5731,10 +4048,7 @@
       "path": "src/server/services/exercise-conversion/v2/ocr-detection-service.ts",
       "type": "service",
       "domain": "conversion",
-      "patterns": [
-        "ocr",
-        "pattern-matching"
-      ],
+      "patterns": ["ocr", "pattern-matching"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -5742,9 +4056,7 @@
       "path": "src/server/services/exercise-conversion/v2/pdf-render-service.ts",
       "type": "service",
       "domain": "conversion",
-      "patterns": [
-        "pdf-processing"
-      ],
+      "patterns": ["pdf-processing"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -5752,10 +4064,7 @@
       "path": "src/server/services/exercise-conversion/v2/text-detection-service.ts",
       "type": "service",
       "domain": "conversion",
-      "patterns": [
-        "text-extraction",
-        "pattern-matching"
-      ],
+      "patterns": ["text-extraction", "pattern-matching"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -5763,1104 +4072,687 @@
       "path": "src/server/services/exercise-conversion/v2/vision-detection-service.ts",
       "type": "service",
       "domain": "ai",
-      "patterns": [
-        "vision-detection",
-        "pdf-processing"
-      ],
+      "patterns": ["vision-detection", "pdf-processing"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/services/exercise-conversion/v2/vision-text-combo-service.ts": {
       "path": "src/server/services/exercise-conversion/v2/vision-text-combo-service.ts",
       "type": "service",
       "domain": "conversion",
-      "patterns": [
-        "combo-detection",
-        "vision+text"
-      ],
+      "patterns": ["combo-detection", "vision+text"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/services/exercise-conversion/v3/extract-single.ts": {
       "path": "src/server/services/exercise-conversion/v3/extract-single.ts",
       "type": "service",
       "domain": "conversion",
-      "patterns": [
-        "orchestrator"
-      ],
+      "patterns": ["orchestrator"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/services/exercise-conversion/v3/prompt-resolver.ts": {
       "path": "src/server/services/exercise-conversion/v3/prompt-resolver.ts",
       "type": "service",
       "domain": "conversion",
-      "patterns": [
-        "prompt-resolution"
-      ],
+      "patterns": ["prompt-resolution"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/services/exercise-conversion/v3/transform.ts": {
       "path": "src/server/services/exercise-conversion/v3/transform.ts",
       "type": "service",
       "domain": "conversion",
-      "patterns": [
-        "transform"
-      ],
+      "patterns": ["transform"],
       "aiSummary": "",
-      "dependencies": [
-        "nanoid"
-      ]
+      "dependencies": ["nanoid"]
     },
     "src/server/services/guest-session-upgrade.ts": {
       "path": "src/server/services/guest-session-upgrade.ts",
       "type": "service",
       "domain": "auth",
-      "patterns": [
-        "ownership-transfer"
-      ],
+      "patterns": ["ownership-transfer"],
       "aiSummary": "Atomic transfer of guest conversations to user account",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/server/services/guest-session.ts": {
       "path": "src/server/services/guest-session.ts",
       "type": "service",
       "domain": "auth",
-      "patterns": [
-        "session-management"
-      ],
+      "patterns": ["session-management"],
       "aiSummary": "Guest session lifecycle: create, validate, extend, revoke",
-      "dependencies": [
-        "payload",
-        "crypto"
-      ]
+      "dependencies": ["payload", "crypto"]
     },
     "src/server/utils/access-gate-server.ts": {
       "path": "src/server/utils/access-gate-server.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "authenticated-endpoint"
-      ],
+      "patterns": ["authenticated-endpoint"],
       "aiSummary": "",
-      "dependencies": [
-        "next/headers",
-        "payload"
-      ]
+      "dependencies": ["next/headers", "payload"]
     },
     "src/ui/admin/AdminChat/DashboardWidget/index.tsx": {
       "path": "src/ui/admin/AdminChat/DashboardWidget/index.tsx",
       "type": "component",
       "domain": "admin",
-      "patterns": [
-        "admin-dashboard-widget",
-        "client-component"
-      ],
+      "patterns": ["admin-dashboard-widget", "client-component"],
       "aiSummary": "Quick access widget for admin chat on the dashboard",
-      "dependencies": [
-        "next/link",
-        "react"
-      ]
+      "dependencies": ["next/link", "react"]
     },
     "src/ui/admin/AdminChat/SidebarLink/index.tsx": {
       "path": "src/ui/admin/AdminChat/SidebarLink/index.tsx",
       "type": "component",
       "domain": "admin",
-      "patterns": [
-        "admin-sidebar-link",
-        "client-component"
-      ],
+      "patterns": ["admin-sidebar-link", "client-component"],
       "aiSummary": "Navigation link for admin chat in the sidebar",
-      "dependencies": [
-        "next/link",
-        "react"
-      ]
+      "dependencies": ["next/link", "react"]
     },
     "src/ui/admin/AnswerSpecJsonField/index.tsx": {
       "path": "src/ui/admin/AnswerSpecJsonField/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "@payloadcms/ui",
-        "prism-react-renderer",
-        "payload"
-      ]
+      "dependencies": ["react", "@payloadcms/ui", "prism-react-renderer", "payload"]
     },
     "src/ui/admin/ExerciseContentEditor/BlockTypeSelector.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/BlockTypeSelector.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/ExerciseContentEditor/JSONInspector.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/JSONInspector.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react",
-        "prism-react-renderer",
-        "react"
-      ]
+      "dependencies": ["lucide-react", "prism-react-renderer", "react"]
     },
     "src/ui/admin/ExerciseContentEditor/RichTextEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/RichTextEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/components/axis/AsymptotesPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/axis/AsymptotesPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/components/axis/AxisCanvas.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/axis/AxisCanvas.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "jsxgraph"
-      ]
+      "dependencies": ["react", "jsxgraph"]
     },
     "src/ui/admin/ExerciseContentEditor/components/axis/AxisConfigPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/axis/AxisConfigPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/ExerciseContentEditor/components/axis/AxisPointsPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/axis/AxisPointsPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/components/axis/GraphsPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/axis/GraphsPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/components/axis/LineBetweenPointsPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/axis/LineBetweenPointsPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/components/axis/LociPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/axis/LociPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/components/axis/PaintPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/axis/PaintPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/AnglesPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/AnglesPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/CanvasConfigPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/CanvasConfigPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/CirclesPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/CirclesPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/GeometryCanvas.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/GeometryCanvas.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "jsxgraph",
-        "react"
-      ]
+      "dependencies": ["jsxgraph", "react"]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/GeometryCanvasWithToolbar.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/GeometryCanvasWithToolbar.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/GeometryToolbar.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/GeometryToolbar.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/LinesPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/LinesPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/PointsPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/PointsPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/ShapesPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/ShapesPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/TextsPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/TextsPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react",
-        "react"
-      ]
+      "dependencies": ["lucide-react", "react"]
     },
     "src/ui/admin/ExerciseContentEditor/components/geometry/VectorsPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/geometry/VectorsPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/components/matching/ColumnEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/matching/ColumnEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/components/matching/MatchingPairsList.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/matching/MatchingPairsList.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/components/shared/JSXGraphBoard.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/components/shared/JSXGraphBoard.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "jsxgraph"
-      ]
+      "dependencies": ["react", "jsxgraph"]
     },
     "src/ui/admin/ExerciseContentEditor/editors/AxisEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/AxisEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/ExerciseContentEditor/editors/FreeResponseEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/FreeResponseEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/editors/GeometryEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/GeometryEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/ExerciseContentEditor/editors/HintSolutionPanel.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/HintSolutionPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/editors/HtmlBlockEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/HtmlBlockEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "dompurify",
-        "next/dynamic",
-        "react"
-      ]
+      "dependencies": ["dompurify", "next/dynamic", "react"]
     },
     "src/ui/admin/ExerciseContentEditor/editors/InlineRichTextEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/InlineRichTextEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "@payloadcms/ui",
-        "next/image"
-      ]
+      "dependencies": ["react", "@payloadcms/ui", "next/image"]
     },
     "src/ui/admin/ExerciseContentEditor/editors/MatchingEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/MatchingEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/ExerciseContentEditor/editors/McqEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/McqEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/editors/MediaBlockEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/MediaBlockEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "@payloadcms/ui",
-        "next/image",
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["@payloadcms/ui", "next/image", "react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/editors/QuestionBlockWrapper.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/QuestionBlockWrapper.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/editors/SvgEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/SvgEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/ExerciseContentEditor/editors/TableEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/TableEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/admin/ExerciseContentEditor/editors/TrueFalseEditor.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/TrueFalseEditor.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/ExerciseContentEditor/index.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "@payloadcms/ui",
-        "lucide-react",
-        "react"
-      ]
+      "dependencies": ["@payloadcms/ui", "lucide-react", "react"]
     },
     "src/ui/admin/ExercisePreview/index.tsx": {
       "path": "src/ui/admin/ExercisePreview/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "@payloadcms/ui"
-      ]
+      "dependencies": ["@payloadcms/ui"]
     },
     "src/ui/admin/Footer/index.tsx": {
       "path": "src/ui/admin/Footer/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "@payloadcms/ui"
-      ]
+      "dependencies": ["@payloadcms/ui"]
     },
     "src/ui/admin/Header/index.tsx": {
       "path": "src/ui/admin/Header/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "@payloadcms/ui"
-      ]
+      "dependencies": ["@payloadcms/ui"]
     },
     "src/ui/admin/MediaPreview/AudioPreview.tsx": {
       "path": "src/ui/admin/MediaPreview/AudioPreview.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "@payloadcms/ui"
-      ]
+      "dependencies": ["react", "@payloadcms/ui"]
     },
     "src/ui/admin/MediaPreview/DocumentPreview.tsx": {
       "path": "src/ui/admin/MediaPreview/DocumentPreview.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "@payloadcms/ui"
-      ]
+      "dependencies": ["react", "@payloadcms/ui"]
     },
     "src/ui/admin/MediaPreview/ExternalPreview.tsx": {
       "path": "src/ui/admin/MediaPreview/ExternalPreview.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "@payloadcms/ui"
-      ]
+      "dependencies": ["react", "@payloadcms/ui"]
     },
     "src/ui/admin/MediaPreview/ImagePreview.tsx": {
       "path": "src/ui/admin/MediaPreview/ImagePreview.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "@payloadcms/ui",
-        "next/image"
-      ]
+      "dependencies": ["react", "@payloadcms/ui", "next/image"]
     },
     "src/ui/admin/MediaPreview/OtherPreview.tsx": {
       "path": "src/ui/admin/MediaPreview/OtherPreview.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "@payloadcms/ui"
-      ]
+      "dependencies": ["react", "@payloadcms/ui"]
     },
     "src/ui/admin/MediaPreview/PDFPreview.tsx": {
       "path": "src/ui/admin/MediaPreview/PDFPreview.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "next/dynamic",
-        "react",
-        "@payloadcms/ui"
-      ]
+      "dependencies": ["next/dynamic", "react", "@payloadcms/ui"]
     },
     "src/ui/admin/MediaPreview/SVGPreview.tsx": {
       "path": "src/ui/admin/MediaPreview/SVGPreview.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "@payloadcms/ui",
-        "next/image"
-      ]
+      "dependencies": ["react", "@payloadcms/ui", "next/image"]
     },
     "src/ui/admin/MediaPreview/VideoPreview.tsx": {
       "path": "src/ui/admin/MediaPreview/VideoPreview.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "@payloadcms/ui"
-      ]
+      "dependencies": ["react", "@payloadcms/ui"]
     },
     "src/ui/admin/MediaPreview/index.tsx": {
       "path": "src/ui/admin/MediaPreview/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "@payloadcms/ui",
-        "payload"
-      ]
+      "dependencies": ["@payloadcms/ui", "payload"]
     },
     "src/ui/admin/PdfConversion/ConversionForm/index.tsx": {
       "path": "src/ui/admin/PdfConversion/ConversionForm/index.tsx",
       "type": "component",
       "domain": "admin",
-      "patterns": [
-        "form",
-        "client-component"
-      ],
+      "patterns": ["form", "client-component"],
       "aiSummary": "Form for configuring and starting PDF-to-exercise conversion",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/PdfConversion/ExerciseReview/index.tsx": {
       "path": "src/ui/admin/PdfConversion/ExerciseReview/index.tsx",
       "type": "component",
       "domain": "admin",
-      "patterns": [
-        "exercise-list",
-        "client-component"
-      ],
+      "patterns": ["exercise-list", "client-component"],
       "aiSummary": "Displays exercises created by a conversion job with links to editor",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/PdfConversion/JobHistory/index.tsx": {
       "path": "src/ui/admin/PdfConversion/JobHistory/index.tsx",
       "type": "component",
       "domain": "admin",
-      "patterns": [
-        "job-list",
-        "client-component"
-      ],
+      "patterns": ["job-list", "client-component"],
       "aiSummary": "Displays list of PDF conversion jobs with status and actions",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/PdfConversion/LessonSelector/index.tsx": {
       "path": "src/ui/admin/PdfConversion/LessonSelector/index.tsx",
       "type": "component",
       "domain": "admin",
-      "patterns": [
-        "searchable-select",
-        "client-component"
-      ],
+      "patterns": ["searchable-select", "client-component"],
       "aiSummary": "Searchable dropdown to select a lesson for PDF conversion",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/PdfConversion/PdfConversionPage/index.tsx": {
       "path": "src/ui/admin/PdfConversion/PdfConversionPage/index.tsx",
       "type": "component",
       "domain": "admin",
-      "patterns": [
-        "admin-page-layout",
-        "client-component"
-      ],
+      "patterns": ["admin-page-layout", "client-component"],
       "aiSummary": "Main two-column layout for PDF conversion page",
-      "dependencies": [
-        "next/link",
-        "react"
-      ]
+      "dependencies": ["next/link", "react"]
     },
     "src/ui/admin/PdfConversion/PdfSelector/index.tsx": {
       "path": "src/ui/admin/PdfConversion/PdfSelector/index.tsx",
       "type": "component",
       "domain": "admin",
-      "patterns": [
-        "file-selector",
-        "client-component"
-      ],
+      "patterns": ["file-selector", "client-component"],
       "aiSummary": "Dropdown to select a PDF file from a lesson's content files",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/PdfConversion/SidebarLink/index.tsx": {
       "path": "src/ui/admin/PdfConversion/SidebarLink/index.tsx",
       "type": "component",
       "domain": "admin",
-      "patterns": [
-        "admin-sidebar-link",
-        "client-component"
-      ],
+      "patterns": ["admin-sidebar-link", "client-component"],
       "aiSummary": "Navigation link for PDF conversion in the admin sidebar",
-      "dependencies": [
-        "next/link",
-        "react"
-      ]
+      "dependencies": ["next/link", "react"]
     },
     "src/ui/admin/QuillField/index.tsx": {
       "path": "src/ui/admin/QuillField/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "dompurify",
-        "@payloadcms/ui",
-        "next/dynamic",
-        "react"
-      ]
+      "dependencies": ["dompurify", "@payloadcms/ui", "next/dynamic", "react"]
     },
     "src/ui/admin/VersionInfo/index.tsx": {
       "path": "src/ui/admin/VersionInfo/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "Version/build date display for admin footer",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/exercise-conversion/ConversionStatusPanel/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/ConversionStatusPanel/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/exercise-conversion/ConvertContextButton/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/ConvertContextButton/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/exercise-conversion/ConvertContextModal/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/ConvertContextModal/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "@payloadcms/ui",
-        "react"
-      ]
+      "dependencies": ["@payloadcms/ui", "react"]
     },
     "src/ui/admin/exercise-conversion/ConvertForm/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/ConvertForm/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/exercise-conversion/ConvertV2Button/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/ConvertV2Button/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/exercise-conversion/ConvertV3Button/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/ConvertV3Button/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/exercise-conversion/DraftExercisesList/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/DraftExercisesList/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "next/navigation",
-        "react"
-      ]
+      "dependencies": ["next/navigation", "react"]
     },
     "src/ui/admin/exercise-conversion/LessonConversionPanel/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/LessonConversionPanel/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "@payloadcms/ui",
-        "react"
-      ]
+      "dependencies": ["@payloadcms/ui", "react"]
     },
     "src/ui/admin/exercise-conversion/LessonMediaActions/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/LessonMediaActions/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "@payloadcms/ui",
-        "react"
-      ]
+      "dependencies": ["@payloadcms/ui", "react"]
     },
     "src/ui/admin/exercise-conversion/V2StatusPanel/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/V2StatusPanel/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/exercise-conversion/V3PreviewPanel/index.tsx": {
       "path": "src/ui/admin/exercise-conversion/V3PreviewPanel/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/shared/AdvancedJsonPanel.tsx": {
       "path": "src/ui/admin/shared/AdvancedJsonPanel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/shared/CollapsibleSection.tsx": {
       "path": "src/ui/admin/shared/CollapsibleSection.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/admin/shared/ErrorDisplay.tsx": {
       "path": "src/ui/admin/shared/ErrorDisplay.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/cody/agents.ts": {
       "path": "src/ui/cody/agents.ts",
       "type": "config",
       "domain": "cody",
-      "patterns": [
-        "agent-config"
-      ],
+      "patterns": ["agent-config"],
       "aiSummary": "Shared agent definitions for Cody chat — single source of truth",
       "dependencies": []
     },
@@ -6868,9 +4760,7 @@
       "path": "src/ui/cody/api.ts",
       "type": "utility",
       "domain": "cody",
-      "patterns": [
-        "api-client"
-      ],
+      "patterns": ["api-client"],
       "aiSummary": "Typed API client for Cody dashboard",
       "dependencies": []
     },
@@ -6878,25 +4768,15 @@
       "path": "src/ui/cody/auth.ts",
       "type": "utility",
       "domain": "cody",
-      "patterns": [
-        "auth",
-        "api-endpoint",
-        "authenticated-endpoint"
-      ],
+      "patterns": ["auth", "api-endpoint", "authenticated-endpoint"],
       "aiSummary": "Dashboard authentication middleware.",
-      "dependencies": [
-        "next/server",
-        "payload",
-        "@payload-config"
-      ]
+      "dependencies": ["next/server", "payload", "@payload-config"]
     },
     "src/ui/cody/chat-types.ts": {
       "path": "src/ui/cody/chat-types.ts",
       "type": "types",
       "domain": "cody | dashboard",
-      "patterns": [
-        "chat-persistence"
-      ],
+      "patterns": ["chat-persistence"],
       "aiSummary": "Shared types for chat persistence across dashboard and pipeline",
       "dependencies": []
     },
@@ -6904,178 +4784,95 @@
       "path": "src/ui/cody/components/AddCommentDialog.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "add-comment-dialog",
-        "client-component"
-      ],
+      "patterns": ["add-comment-dialog", "client-component"],
       "aiSummary": "Dialog with markdown editor to add a simple comment on a PR (without @cody action)",
-      "dependencies": [
-        "react",
-        "lucide-react",
-        "react-markdown",
-        "remark-gfm"
-      ]
+      "dependencies": ["react", "lucide-react", "react-markdown", "remark-gfm"]
     },
     "src/ui/cody/components/AssigneePicker.tsx": {
       "path": "src/ui/cody/components/AssigneePicker.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "assignee-picker",
-        "client-component"
-      ],
+      "patterns": ["assignee-picker", "client-component"],
       "aiSummary": "Inline assignee management with cached collaborators, loading states, and remove buttons",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/cody/components/BranchCleanupDialog.tsx": {
       "path": "src/ui/cody/components/BranchCleanupDialog.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "branch-cleanup-dialog",
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["branch-cleanup-dialog", "tailwind-component", "client-component"],
       "aiSummary": "Dialog to view and delete branches associated with closed/done tasks",
-      "dependencies": [
-        "react",
-        "lucide-react",
-        "@tanstack/react-query",
-        "sonner"
-      ]
+      "dependencies": ["react", "lucide-react", "@tanstack/react-query", "sonner"]
     },
     "src/ui/cody/components/BugReportDialog.tsx": {
       "path": "src/ui/cody/components/BugReportDialog.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "bug-report-dialog",
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["bug-report-dialog", "tailwind-component", "client-component"],
       "aiSummary": "Dialog to report bugs with structured template",
-      "dependencies": [
-        "react",
-        "@tanstack/react-query",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "@tanstack/react-query", "lucide-react"]
     },
     "src/ui/cody/components/CIStatusBadge.tsx": {
       "path": "src/ui/cody/components/CIStatusBadge.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "ci-status-badge",
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["ci-status-badge", "tailwind-component", "client-component"],
       "aiSummary": "Shows CI status indicator for a PR and controls merge button state",
-      "dependencies": [
-        "lucide-react"
-      ]
+      "dependencies": ["lucide-react"]
     },
     "src/ui/cody/components/CodyChat.tsx": {
       "path": "src/ui/cody/components/CodyChat.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "react-markdown",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "react-markdown", "lucide-react"]
     },
     "src/ui/cody/components/CodyDashboard.tsx": {
       "path": "src/ui/cody/components/CodyDashboard.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "cody-dashboard",
-        "client-component"
-      ],
+      "patterns": ["cody-dashboard", "client-component"],
       "aiSummary": "Main dashboard component with responsive layout — Sheet for mobile controls and task detail",
-      "dependencies": [
-        "react",
-        "@tanstack/react-query",
-        "sonner"
-      ]
+      "dependencies": ["react", "@tanstack/react-query", "sonner"]
     },
     "src/ui/cody/components/CodyStatusBanner.tsx": {
       "path": "src/ui/cody/components/CodyStatusBanner.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "cody-status-banner",
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["cody-status-banner", "tailwind-component", "client-component"],
       "aiSummary": "Banner showing Cody's current state: idle, working, failed, or gate-waiting",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/cody/components/CommentBox.tsx": {
       "path": "src/ui/cody/components/CommentBox.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "comment-box",
-        "client-component"
-      ],
+      "patterns": ["comment-box", "client-component"],
       "aiSummary": "Comment input component for writing comments on issues",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/cody/components/CommentEditor.tsx": {
       "path": "src/ui/cody/components/CommentEditor.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "comment-editor",
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["comment-editor", "tailwind-component", "client-component"],
       "aiSummary": "Simplified comment editor with markdown preview and @mention support",
-      "dependencies": [
-        "react",
-        "lucide-react",
-        "react-markdown",
-        "next/image"
-      ]
+      "dependencies": ["react", "lucide-react", "react-markdown", "next/image"]
     },
     "src/ui/cody/components/CommentList.tsx": {
       "path": "src/ui/cody/components/CommentList.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "comment-list",
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["comment-list", "tailwind-component", "client-component"],
       "aiSummary": "Component to display comments with markdown rendering",
-      "dependencies": [
-        "react",
-        "react-markdown",
-        "remark-gfm"
-      ]
+      "dependencies": ["react", "react-markdown", "remark-gfm"]
     },
     "src/ui/cody/components/ConfirmDialog.tsx": {
       "path": "src/ui/cody/components/ConfirmDialog.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "confirm-dialog",
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["confirm-dialog", "tailwind-component", "client-component"],
       "aiSummary": "Reusable confirmation dialog replacing native confirm() calls with accessible modal",
       "dependencies": []
     },
@@ -7083,100 +4880,55 @@
       "path": "src/ui/cody/components/CreateTaskDialog.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "create-task-dialog",
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["create-task-dialog", "tailwind-component", "client-component"],
       "aiSummary": "Dialog to create new tasks with useCreateTask hook",
-      "dependencies": [
-        "react",
-        "next/image",
-        "react-markdown"
-      ]
+      "dependencies": ["react", "next/image", "react-markdown"]
     },
     "src/ui/cody/components/EditTaskDialog.tsx": {
       "path": "src/ui/cody/components/EditTaskDialog.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "edit-task-dialog",
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["edit-task-dialog", "tailwind-component", "client-component"],
       "aiSummary": "Dialog to edit existing tasks with title, description, labels, and assignees",
-      "dependencies": [
-        "react",
-        "react-markdown"
-      ]
+      "dependencies": ["react", "react-markdown"]
     },
     "src/ui/cody/components/EnvironmentToolbar.tsx": {
       "path": "src/ui/cody/components/EnvironmentToolbar.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "environment-toolbar",
-        "client-component"
-      ],
+      "patterns": ["environment-toolbar", "client-component"],
       "aiSummary": "Toolbar with Dev/Prod site links and Publish button with confirmation dialog",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/cody/components/ErrorBoundary.tsx": {
       "path": "src/ui/cody/components/ErrorBoundary.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "error-boundary",
-        "client-component"
-      ],
+      "patterns": ["error-boundary", "client-component"],
       "aiSummary": "React error boundary that catches render errors and shows a \"Something went wrong\" fallback",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/cody/components/FilterBar.tsx": {
       "path": "src/ui/cody/components/FilterBar.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "filter-bar",
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["filter-bar", "tailwind-component", "client-component"],
       "aiSummary": "Dedicated filter sub-header bar for Cody dashboard with view toggle, date, status, and label filters",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/cody/components/FixRequestDialog.tsx": {
       "path": "src/ui/cody/components/FixRequestDialog.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "fix-request-dialog",
-        "client-component"
-      ],
+      "patterns": ["fix-request-dialog", "client-component"],
       "aiSummary": "Dialog with markdown editor to request fixes on a PR via @cody fix",
-      "dependencies": [
-        "react",
-        "lucide-react",
-        "react-markdown",
-        "remark-gfm"
-      ]
+      "dependencies": ["react", "lucide-react", "react-markdown", "remark-gfm"]
     },
     "src/ui/cody/components/KeyboardShortcutsDialog.tsx": {
       "path": "src/ui/cody/components/KeyboardShortcutsDialog.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "keyboard-shortcuts-dialog",
-        "client-component"
-      ],
+      "patterns": ["keyboard-shortcuts-dialog", "client-component"],
       "aiSummary": "Dialog showing keyboard shortcuts available in Cody dashboard",
       "dependencies": []
     },
@@ -7184,143 +4936,87 @@
       "path": "src/ui/cody/components/LabelPicker.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "label-picker",
-        "client-component"
-      ],
+      "patterns": ["label-picker", "client-component"],
       "aiSummary": "Dropdown component for adding/removing labels on issues",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/cody/components/MarkdownViewer.tsx": {
       "path": "src/ui/cody/components/MarkdownViewer.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "markdown-viewer",
-        "client-component"
-      ],
+      "patterns": ["markdown-viewer", "client-component"],
       "aiSummary": "Renders markdown content with syntax highlighting",
-      "dependencies": [
-        "react-markdown",
-        "lucide-react",
-        "react"
-      ]
+      "dependencies": ["react-markdown", "lucide-react", "react"]
     },
     "src/ui/cody/components/MergeApprovalDialog.tsx": {
       "path": "src/ui/cody/components/MergeApprovalDialog.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "merge-approval-dialog",
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["merge-approval-dialog", "tailwind-component", "client-component"],
       "aiSummary": "Dialog for approving and merging a PR with CI status and file changes",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/cody/components/MergeButton.tsx": {
       "path": "src/ui/cody/components/MergeButton.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "merge-button",
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["merge-button", "tailwind-component", "client-component"],
       "aiSummary": "Merge button that opens approval dialog with CI status and file changes",
-      "dependencies": [
-        "react",
-        "lucide-react",
-        "sonner"
-      ]
+      "dependencies": ["react", "lucide-react", "sonner"]
     },
     "src/ui/cody/components/MiniPipelineProgress.tsx": {
       "path": "src/ui/cody/components/MiniPipelineProgress.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "pipeline-progress",
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["pipeline-progress", "tailwind-component", "client-component"],
       "aiSummary": "Compact pipeline progress indicator with two variants: \"inline\" (dot-separated text for metadata line) and \"bar\" (full progress bar for dedicated row). Both variants always render 12 dots — one per stage — for visual consistency across all tasks.",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/cody/components/PRCommentList.tsx": {
       "path": "src/ui/cody/components/PRCommentList.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "pr-comment-list",
-        "client-component"
-      ],
+      "patterns": ["pr-comment-list", "client-component"],
       "aiSummary": "Renders PR comments with markdown and author avatars",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/cody/components/PipelineStatus.tsx": {
       "path": "src/ui/cody/components/PipelineStatus.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "pipeline-status",
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["pipeline-status", "tailwind-component", "client-component"],
       "aiSummary": "Vertical stepper pipeline status for narrow sidebar",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/cody/components/PreviewActions.tsx": {
       "path": "src/ui/cody/components/PreviewActions.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "preview-actions",
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["preview-actions", "tailwind-component", "client-component"],
       "aiSummary": "Sticky action bar for Preview: Approve UI, Approve PR, Merge, Fix, Cancel PR",
-      "dependencies": [
-        "react",
-        "lucide-react",
-        "sonner"
-      ]
+      "dependencies": ["react", "lucide-react", "sonner"]
     },
     "src/ui/cody/components/PreviewModal.tsx": {
       "path": "src/ui/cody/components/PreviewModal.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "preview-modal",
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["preview-modal", "tailwind-component", "client-component"],
       "aiSummary": "Full-screen modal overlay showing PR preview: iframe, changes, docs, comments, actions",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
+    },
+    "src/ui/cody/components/QueueView.tsx": {
+      "path": "src/ui/cody/components/QueueView.tsx",
+      "type": "component",
+      "domain": "cody",
+      "patterns": ["queue-view", "tailwind-component", "client-component"],
+      "aiSummary": "Queue-specific task list showing queued, active, and failed queue tasks",
+      "dependencies": ["lucide-react"]
     },
     "src/ui/cody/components/RiskBadge.tsx": {
       "path": "src/ui/cody/components/RiskBadge.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "badge",
-        "tailwind-component"
-      ],
+      "patterns": ["badge", "tailwind-component"],
       "aiSummary": "Risk level badge",
       "dependencies": []
     },
@@ -7328,37 +5024,23 @@
       "path": "src/ui/cody/components/SimpleTooltip.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "simple-tooltip",
-        "client-component"
-      ],
+      "patterns": ["simple-tooltip", "client-component"],
       "aiSummary": "Convenience wrapper around shadcn Tooltip for Cody dashboard — supports string or ReactNode content",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/cody/components/StageErrorDetail.tsx": {
       "path": "src/ui/cody/components/StageErrorDetail.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "stage-error-detail",
-        "client-component"
-      ],
+      "patterns": ["stage-error-detail", "client-component"],
       "aiSummary": "Shows detailed error information for failed pipeline stages",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/cody/components/StatusBadge.tsx": {
       "path": "src/ui/cody/components/StatusBadge.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "badge",
-        "tailwind-component"
-      ],
+      "patterns": ["badge", "tailwind-component"],
       "aiSummary": "Status badge for pipeline state",
       "dependencies": []
     },
@@ -7366,27 +5048,15 @@
       "path": "src/ui/cody/components/TaskDetail.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "task-detail",
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["task-detail", "tailwind-component", "client-component"],
       "aiSummary": "Task detail — v2 with header quick-links, consolidated sidebar, contextual actions, inline pipeline timeline",
-      "dependencies": [
-        "react",
-        "react-markdown",
-        "remark-gfm",
-        "@tanstack/react-query"
-      ]
+      "dependencies": ["react", "react-markdown", "remark-gfm", "@tanstack/react-query"]
     },
     "src/ui/cody/components/TaskDetailDialog.tsx": {
       "path": "src/ui/cody/components/TaskDetailDialog.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "task-detail-dialog",
-        "client-component"
-      ],
+      "patterns": ["task-detail-dialog", "client-component"],
       "aiSummary": "Wide dialog wrapper for TaskDetail on desktop, ~85vw centered",
       "dependencies": []
     },
@@ -7394,24 +5064,15 @@
       "path": "src/ui/cody/components/TaskList.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "task-list",
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["task-list", "tailwind-component", "client-component"],
       "aiSummary": "Three-zone task list: color bar | title + inline metadata + assignees | actions. Pipeline progress gets its own row only when active.",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/cody/components/TaskTypeBadge.tsx": {
       "path": "src/ui/cody/components/TaskTypeBadge.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "badge",
-        "tailwind-component"
-      ],
+      "patterns": ["badge", "tailwind-component"],
       "aiSummary": "Task type badge",
       "dependencies": []
     },
@@ -7419,36 +5080,23 @@
       "path": "src/ui/cody/components/WorkflowRunsPopover.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "popover",
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["popover", "tailwind-component", "client-component"],
       "aiSummary": "Popover pill listing all workflow runs for a task with status icon, relative time, branch, and external link",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/cody/components/tooltip-content.tsx": {
       "path": "src/ui/cody/components/tooltip-content.tsx",
       "type": "component",
       "domain": "cody",
-      "patterns": [
-        "tooltip-content"
-      ],
+      "patterns": ["tooltip-content"],
       "aiSummary": "Pre-built tooltip content blocks for common dashboard elements",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/cody/constants.ts": {
       "path": "src/ui/cody/constants.ts",
       "type": "constants",
       "domain": "cody",
-      "patterns": [
-        "constants"
-      ],
+      "patterns": ["constants"],
       "aiSummary": "Constants for Cody dashboard pipeline and configuration",
       "dependencies": []
     },
@@ -7456,116 +5104,71 @@
       "path": "src/ui/cody/github-client.ts",
       "type": "utility",
       "domain": "cody",
-      "patterns": [
-        "github-client"
-      ],
+      "patterns": ["github-client"],
       "aiSummary": "GitHub API client with caching and manual rate limit handling",
-      "dependencies": [
-        "@octokit/plugin-throttling",
-        "@octokit/rest"
-      ]
+      "dependencies": ["@octokit/plugin-throttling", "@octokit/rest"]
     },
     "src/ui/cody/hooks/index.ts": {
       "path": "src/ui/cody/hooks/index.ts",
       "type": "hooks",
       "domain": "cody",
-      "patterns": [
-        "custom-hooks",
-        "client-component"
-      ],
+      "patterns": ["custom-hooks", "client-component"],
       "aiSummary": "React Query hooks for Cody dashboard data fetching",
-      "dependencies": [
-        "@tanstack/react-query",
-        "sonner"
-      ]
+      "dependencies": ["@tanstack/react-query", "sonner"]
     },
     "src/ui/cody/hooks/useBrowserNotifications.ts": {
       "path": "src/ui/cody/hooks/useBrowserNotifications.ts",
       "type": "hooks",
       "domain": "cody",
-      "patterns": [
-        "browser-notifications",
-        "client-component"
-      ],
+      "patterns": ["browser-notifications", "client-component"],
       "aiSummary": "Browser notification hook for task state changes.",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/cody/hooks/useGitHubIdentity.ts": {
       "path": "src/ui/cody/hooks/useGitHubIdentity.ts",
       "type": "hook",
       "domain": "cody",
-      "patterns": [
-        "github-identity",
-        "client-component"
-      ],
+      "patterns": ["github-identity", "client-component"],
       "aiSummary": "Hook to read the authenticated GitHub identity from the Cody session cookie.",
-      "dependencies": [
-        "react",
-        "@tanstack/react-query"
-      ]
+      "dependencies": ["react", "@tanstack/react-query"]
     },
     "src/ui/cody/hooks/useKeyboardShortcuts.ts": {
       "path": "src/ui/cody/hooks/useKeyboardShortcuts.ts",
       "type": "hook",
       "domain": "cody",
-      "patterns": [
-        "keyboard-shortcuts",
-        "client-component"
-      ],
+      "patterns": ["keyboard-shortcuts", "client-component"],
       "aiSummary": "Hook for keyboard navigation shortcuts in Cody dashboard",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/cody/hooks/usePRCIStatus.ts": {
       "path": "src/ui/cody/hooks/usePRCIStatus.ts",
       "type": "hook",
       "domain": "cody",
-      "patterns": [
-        "usePRCIStatus",
-        "client-component"
-      ],
+      "patterns": ["usePRCIStatus", "client-component"],
       "aiSummary": "Hook to poll CI status for a PR using GitHub's mergeable_state",
-      "dependencies": [
-        "@tanstack/react-query"
-      ]
+      "dependencies": ["@tanstack/react-query"]
     },
     "src/ui/cody/hooks/usePublish.ts": {
       "path": "src/ui/cody/hooks/usePublish.ts",
       "type": "hook",
       "domain": "cody",
-      "patterns": [
-        "usePublish",
-        "client-component"
-      ],
+      "patterns": ["usePublish", "client-component"],
       "aiSummary": "Hook for publishing dev to production (creates issue with publish label)",
-      "dependencies": [
-        "@tanstack/react-query",
-        "sonner"
-      ]
+      "dependencies": ["@tanstack/react-query", "sonner"]
     },
     "src/ui/cody/hooks/useRemoteStatus.ts": {
       "path": "src/ui/cody/hooks/useRemoteStatus.ts",
       "type": "hooks",
       "domain": "cody",
-      "patterns": [
-        "custom-hooks",
-        "client-component"
-      ],
+      "patterns": ["custom-hooks", "client-component"],
       "aiSummary": "React Query hook for polling remote dev agent status",
-      "dependencies": [
-        "@tanstack/react-query"
-      ]
+      "dependencies": ["@tanstack/react-query"]
     },
     "src/ui/cody/pipeline-utils.ts": {
       "path": "src/ui/cody/pipeline-utils.ts",
       "type": "utility",
       "domain": "cody",
-      "patterns": [
-        "pipeline-progress"
-      ],
+      "patterns": ["pipeline-progress"],
       "aiSummary": "Shared pipeline progress utilities — stage labels, progress calculation, elapsed formatting, tooltips",
       "dependencies": []
     },
@@ -7573,9 +5176,7 @@
       "path": "src/ui/cody/remote-config.ts",
       "type": "utility",
       "domain": "cody",
-      "patterns": [
-        "config"
-      ],
+      "patterns": ["config"],
       "aiSummary": "Parses REMOTE_DEV_USERS env var to enable per-user remote dev agent access",
       "dependencies": []
     },
@@ -7583,9 +5184,7 @@
       "path": "src/ui/cody/task-parser.ts",
       "type": "utility",
       "domain": "cody",
-      "patterns": [
-        "task-parser"
-      ],
+      "patterns": ["task-parser"],
       "aiSummary": "Parse GitHub bot comments to extract Cody task status",
       "dependencies": []
     },
@@ -7593,9 +5192,7 @@
       "path": "src/ui/cody/types.ts",
       "type": "types",
       "domain": "cody",
-      "patterns": [
-        "types"
-      ],
+      "patterns": ["types"],
       "aiSummary": "Core TypeScript types for Cody dashboard",
       "dependencies": []
     },
@@ -7603,10 +5200,7 @@
       "path": "src/ui/cody/utils.ts",
       "type": "utility",
       "domain": "cody",
-      "patterns": [
-        "utilities",
-        "tailwind-component"
-      ],
+      "patterns": ["utilities", "tailwind-component"],
       "aiSummary": "Utility functions for Cody dashboard",
       "dependencies": []
     },
@@ -7614,131 +5208,79 @@
       "path": "src/ui/web/AdminBar/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "@payloadcms/admin-bar",
-        "next/navigation",
-        "react"
-      ]
+      "dependencies": ["@payloadcms/admin-bar", "next/navigation", "react"]
     },
     "src/ui/web/Card/index.tsx": {
       "path": "src/ui/web/Card/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/CollectionArchive/index.tsx": {
       "path": "src/ui/web/CollectionArchive/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component"
-      ],
+      "patterns": ["tailwind-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/CommandPalette.tsx": {
       "path": "src/ui/web/CommandPalette.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "next/navigation",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "next/navigation", "lucide-react"]
     },
     "src/ui/web/ExampleForm.tsx": {
       "path": "src/ui/web/ExampleForm.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "sonner"
-      ]
+      "dependencies": ["react", "sonner"]
     },
     "src/ui/web/LanguageSwitcher/index.tsx": {
       "path": "src/ui/web/LanguageSwitcher/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react",
-        "next/navigation",
-        "react"
-      ]
+      "dependencies": ["lucide-react", "next/navigation", "react"]
     },
     "src/ui/web/Link/index.tsx": {
       "path": "src/ui/web/Link/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component"
-      ],
+      "patterns": ["tailwind-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/LivePreviewListener/index.tsx": {
       "path": "src/ui/web/LivePreviewListener/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "@payloadcms/live-preview-react",
-        "next/navigation",
-        "react"
-      ]
+      "dependencies": ["@payloadcms/live-preview-react", "next/navigation", "react"]
     },
     "src/ui/web/Pagination/index.tsx": {
       "path": "src/ui/web/Pagination/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "next/navigation",
-        "react"
-      ]
+      "dependencies": ["next/navigation", "react"]
     },
     "src/ui/web/RichText/index.tsx": {
       "path": "src/ui/web/RichText/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component"
-      ],
+      "patterns": ["tailwind-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -7746,411 +5288,239 @@
       "path": "src/ui/web/SafeHtml/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "dompurify",
-        "react"
-      ]
+      "dependencies": ["dompurify", "react"]
     },
     "src/ui/web/UserDropdown/index.tsx": {
       "path": "src/ui/web/UserDropdown/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "next/navigation",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "next/navigation", "lucide-react"]
     },
     "src/ui/web/auth/AccessGateProvider.tsx": {
       "path": "src/ui/web/auth/AccessGateProvider.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "next/navigation"
-      ]
+      "dependencies": ["react", "next/navigation"]
     },
     "src/ui/web/auth/AuthGateModal.tsx": {
       "path": "src/ui/web/auth/AuthGateModal.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "next/link"
-      ]
+      "dependencies": ["next/link"]
     },
     "src/ui/web/auth/GoogleLoginButton.tsx": {
       "path": "src/ui/web/auth/GoogleLoginButton.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/chat/ChatErrorSurface/index.tsx": {
       "path": "src/ui/web/chat/ChatErrorSurface/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react",
-        "next/navigation"
-      ]
+      "dependencies": ["lucide-react", "next/navigation"]
     },
     "src/ui/web/chat/ChatInterface/index.tsx": {
       "path": "src/ui/web/chat/ChatInterface/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/web/chat/ChatMessageContent/index.tsx": {
       "path": "src/ui/web/chat/ChatMessageContent/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react-markdown"
-      ]
+      "dependencies": ["react-markdown"]
     },
     "src/ui/web/chat/TTSButton/index.tsx": {
       "path": "src/ui/web/chat/TTSButton/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react"
-      ]
+      "dependencies": ["lucide-react"]
     },
     "src/ui/web/chat/hooks/useNotebookChat.ts": {
       "path": "src/ui/web/chat/hooks/useNotebookChat.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "sonner"
-      ]
+      "dependencies": ["react", "sonner"]
     },
     "src/ui/web/chat/hooks/useTTS.ts": {
       "path": "src/ui/web/chat/hooks/useTTS.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/chat/hooks/useTeacherProfileLabel.ts": {
       "path": "src/ui/web/chat/hooks/useTeacherProfileLabel.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/components/HealthBadge.tsx": {
       "path": "src/ui/web/components/HealthBadge.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/components/accordion.tsx": {
       "path": "src/ui/web/components/accordion.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "@radix-ui/react-accordion",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "@radix-ui/react-accordion", "lucide-react"]
     },
     "src/ui/web/components/avatar.tsx": {
       "path": "src/ui/web/components/avatar.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "@radix-ui/react-avatar"
-      ]
+      "dependencies": ["react", "@radix-ui/react-avatar"]
     },
     "src/ui/web/components/badge.tsx": {
       "path": "src/ui/web/components/badge.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "variant-component"
-      ],
+      "patterns": ["tailwind-component", "variant-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "class-variance-authority"
-      ]
+      "dependencies": ["react", "class-variance-authority"]
     },
     "src/ui/web/components/breadcrumb.tsx": {
       "path": "src/ui/web/components/breadcrumb.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component"
-      ],
+      "patterns": ["tailwind-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "@radix-ui/react-slot",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "@radix-ui/react-slot", "lucide-react"]
     },
     "src/ui/web/components/button.tsx": {
       "path": "src/ui/web/components/button.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "variant-component"
-      ],
+      "patterns": ["tailwind-component", "variant-component"],
       "aiSummary": "",
-      "dependencies": [
-        "@radix-ui/react-slot",
-        "class-variance-authority",
-        "react"
-      ]
+      "dependencies": ["@radix-ui/react-slot", "class-variance-authority", "react"]
     },
     "src/ui/web/components/card.tsx": {
       "path": "src/ui/web/components/card.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component"
-      ],
+      "patterns": ["tailwind-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/components/checkbox.tsx": {
       "path": "src/ui/web/components/checkbox.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "@radix-ui/react-checkbox",
-        "lucide-react",
-        "react"
-      ]
+      "dependencies": ["@radix-ui/react-checkbox", "lucide-react", "react"]
     },
     "src/ui/web/components/command.tsx": {
       "path": "src/ui/web/components/command.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "cmdk",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "cmdk", "lucide-react"]
     },
     "src/ui/web/components/dialog.tsx": {
       "path": "src/ui/web/components/dialog.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "@radix-ui/react-dialog",
-        "lucide-react",
-        "react"
-      ]
+      "dependencies": ["@radix-ui/react-dialog", "lucide-react", "react"]
     },
     "src/ui/web/components/dropdown-menu.tsx": {
       "path": "src/ui/web/components/dropdown-menu.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "@radix-ui/react-dropdown-menu",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "@radix-ui/react-dropdown-menu", "lucide-react"]
     },
     "src/ui/web/components/input.tsx": {
       "path": "src/ui/web/components/input.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component"
-      ],
+      "patterns": ["tailwind-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/components/label.tsx": {
       "path": "src/ui/web/components/label.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "variant-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "variant-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "@radix-ui/react-label",
-        "class-variance-authority",
-        "react"
-      ]
+      "dependencies": ["@radix-ui/react-label", "class-variance-authority", "react"]
     },
     "src/ui/web/components/pagination.tsx": {
       "path": "src/ui/web/components/pagination.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component"
-      ],
+      "patterns": ["tailwind-component"],
       "aiSummary": "",
-      "dependencies": [
-        "lucide-react",
-        "react"
-      ]
+      "dependencies": ["lucide-react", "react"]
     },
     "src/ui/web/components/progress.tsx": {
       "path": "src/ui/web/components/progress.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component"
-      ],
+      "patterns": ["tailwind-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/components/resizable-pane.tsx": {
       "path": "src/ui/web/components/resizable-pane.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/components/select.tsx": {
       "path": "src/ui/web/components/select.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "@radix-ui/react-select",
-        "lucide-react",
-        "react"
-      ]
+      "dependencies": ["@radix-ui/react-select", "lucide-react", "react"]
     },
     "src/ui/web/components/sheet.tsx": {
       "path": "src/ui/web/components/sheet.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "variant-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "variant-component", "client-component"],
       "aiSummary": "",
       "dependencies": [
         "@radix-ui/react-dialog",
@@ -8163,60 +5533,39 @@
       "path": "src/ui/web/components/split-pane-layout.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/components/textarea.tsx": {
       "path": "src/ui/web/components/textarea.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component"
-      ],
+      "patterns": ["tailwind-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/components/toaster.tsx": {
       "path": "src/ui/web/components/toaster.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "sonner"
-      ]
+      "dependencies": ["sonner"]
     },
     "src/ui/web/components/tooltip.tsx": {
       "path": "src/ui/web/components/tooltip.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "@radix-ui/react-tooltip"
-      ]
+      "dependencies": ["react", "@radix-ui/react-tooltip"]
     },
     "src/ui/web/courses/PDFViewer/PDFEmbed.tsx": {
       "path": "src/ui/web/courses/PDFViewer/PDFEmbed.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -8224,24 +5573,15 @@
       "path": "src/ui/web/exerciserenderer/ExerciseRenderer/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/web/exerciserenderer/answers/McqAnswerUI/index.tsx": {
       "path": "src/ui/web/exerciserenderer/answers/McqAnswerUI/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component"
-      ],
+      "patterns": ["tailwind-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -8249,9 +5589,7 @@
       "path": "src/ui/web/exerciserenderer/answers/TrueFalseAnswerUI/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component"
-      ],
+      "patterns": ["tailwind-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -8259,504 +5597,311 @@
       "path": "src/ui/web/exerciserenderer/blocks/AxisRenderer/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "next/dynamic"
-      ]
+      "dependencies": ["react", "next/dynamic"]
     },
     "src/ui/web/exerciserenderer/blocks/GeometryRenderer/index.tsx": {
       "path": "src/ui/web/exerciserenderer/blocks/GeometryRenderer/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "next/dynamic"
-      ]
+      "dependencies": ["react", "next/dynamic"]
     },
     "src/ui/web/exerciserenderer/blocks/GraphWithPrompt/index.tsx": {
       "path": "src/ui/web/exerciserenderer/blocks/GraphWithPrompt/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component"
-      ],
+      "patterns": ["tailwind-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/exerciserenderer/blocks/HtmlBlockRenderer/index.tsx": {
       "path": "src/ui/web/exerciserenderer/blocks/HtmlBlockRenderer/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "dompurify",
-        "react"
-      ]
+      "dependencies": ["dompurify", "react"]
     },
     "src/ui/web/exerciserenderer/blocks/MultiAxisRenderer/index.tsx": {
       "path": "src/ui/web/exerciserenderer/blocks/MultiAxisRenderer/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/exerciserenderer/blocks/SvgRenderer/index.tsx": {
       "path": "src/ui/web/exerciserenderer/blocks/SvgRenderer/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/exerciserenderer/components/FeedbackDisplay/index.tsx": {
       "path": "src/ui/web/exerciserenderer/components/FeedbackDisplay/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/web/exerciserenderer/components/HelpSystem/HelpSystemButtons.tsx": {
       "path": "src/ui/web/exerciserenderer/components/HelpSystem/HelpSystemButtons.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/web/exerciserenderer/components/HelpSystem/HelpSystemContent.tsx": {
       "path": "src/ui/web/exerciserenderer/components/HelpSystem/HelpSystemContent.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/web/exerciserenderer/components/HelpSystem/index.tsx": {
       "path": "src/ui/web/exerciserenderer/components/HelpSystem/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/exerciserenderer/components/MediaAttachments/index.tsx": {
       "path": "src/ui/web/exerciserenderer/components/MediaAttachments/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/exerciserenderer/components/QuestionCard/index.tsx": {
       "path": "src/ui/web/exerciserenderer/components/QuestionCard/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/web/exerciserenderer/components/VideoPlayer/index.tsx": {
       "path": "src/ui/web/exerciserenderer/components/VideoPlayer/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/exerciserenderer/context/MediaMapContext.tsx": {
       "path": "src/ui/web/exerciserenderer/context/MediaMapContext.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/exerciserenderer/graphics/JSXGraphBoard.tsx": {
       "path": "src/ui/web/exerciserenderer/graphics/JSXGraphBoard.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/exerciserenderer/hooks/useHelpSystem.ts": {
       "path": "src/ui/web/exerciserenderer/hooks/useHelpSystem.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/exerciserenderer/questions/FreeResponseQuestion/index.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/FreeResponseQuestion/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingColumn.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingColumn.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingItem.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingItem.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingLines.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingLines.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/exerciserenderer/questions/MatchingQuestion/index.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/MatchingQuestion/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/web/exerciserenderer/questions/McqQuestion/index.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/McqQuestion/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/web/exerciserenderer/questions/TableQuestion/ExerciseTable.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/TableQuestion/ExerciseTable.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/exerciserenderer/questions/TableQuestion/index.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/TableQuestion/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/web/exerciserenderer/questions/TrueFalseQuestion/index.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/TrueFalseQuestion/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/web/footer/RowLabel.tsx": {
       "path": "src/ui/web/footer/RowLabel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "@payloadcms/ui"
-      ]
+      "dependencies": ["@payloadcms/ui"]
     },
     "src/ui/web/footer/config.ts": {
       "path": "src/ui/web/footer/config.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "payload-hooks"
-      ],
+      "patterns": ["payload-hooks"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/ui/web/guards/RequireCourseSelection.tsx": {
       "path": "src/ui/web/guards/RequireCourseSelection.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "next/navigation",
-        "react"
-      ]
+      "dependencies": ["next/navigation", "react"]
     },
     "src/ui/web/header/Component.client.tsx": {
       "path": "src/ui/web/header/Component.client.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "next/navigation",
-        "react"
-      ]
+      "dependencies": ["next/navigation", "react"]
     },
     "src/ui/web/header/MobileMenu/MobileMenuAuthSection.tsx": {
       "path": "src/ui/web/header/MobileMenu/MobileMenuAuthSection.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "next/navigation",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "next/navigation", "lucide-react"]
     },
     "src/ui/web/header/MobileMenu/index.tsx": {
       "path": "src/ui/web/header/MobileMenu/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/web/header/Nav/index.tsx": {
       "path": "src/ui/web/header/Nav/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/web/header/RowLabel.tsx": {
       "path": "src/ui/web/header/RowLabel.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "@payloadcms/ui"
-      ]
+      "dependencies": ["@payloadcms/ui"]
     },
     "src/ui/web/header/config.ts": {
       "path": "src/ui/web/header/config.ts",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "payload-hooks"
-      ],
+      "patterns": ["payload-hooks"],
       "aiSummary": "",
-      "dependencies": [
-        "payload"
-      ]
+      "dependencies": ["payload"]
     },
     "src/ui/web/heros/HighImpact/index.tsx": {
       "path": "src/ui/web/heros/HighImpact/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/heros/PostHero/index.tsx": {
       "path": "src/ui/web/heros/PostHero/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/homepage/GreetingFlow/index.tsx": {
       "path": "src/ui/web/homepage/GreetingFlow/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/homepage/NavigationBar/index.tsx": {
       "path": "src/ui/web/homepage/NavigationBar/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "next/navigation"
-      ]
+      "dependencies": ["next/navigation"]
     },
     "src/ui/web/homepage/TopicCard/index.tsx": {
       "path": "src/ui/web/homepage/TopicCard/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -8764,435 +5909,262 @@
       "path": "src/ui/web/media/AudioMedia/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/media/DocumentMedia/index.tsx": {
       "path": "src/ui/web/media/DocumentMedia/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/media/ExternalMedia/index.tsx": {
       "path": "src/ui/web/media/ExternalMedia/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/media/ImageMedia/index.tsx": {
       "path": "src/ui/web/media/ImageMedia/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "next/image",
-        "react"
-      ]
+      "dependencies": ["next/image", "react"]
     },
     "src/ui/web/media/OtherMedia/index.tsx": {
       "path": "src/ui/web/media/OtherMedia/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/media/PDFMedia/index.tsx": {
       "path": "src/ui/web/media/PDFMedia/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/media/SVGMedia/index.tsx": {
       "path": "src/ui/web/media/SVGMedia/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "next/image"
-      ]
+      "dependencies": ["react", "next/image"]
     },
     "src/ui/web/media/VideoMedia/index.tsx": {
       "path": "src/ui/web/media/VideoMedia/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/providers/HeaderTheme/index.tsx": {
       "path": "src/ui/web/providers/HeaderTheme/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/providers/I18n/index.tsx": {
       "path": "src/ui/web/providers/I18n/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "i18n-component",
-        "client-component"
-      ],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/providers/PasswordLoginProvider.tsx": {
       "path": "src/ui/web/providers/PasswordLoginProvider.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/providers/Theme/ThemeSelector/index.tsx": {
       "path": "src/ui/web/providers/Theme/ThemeSelector/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/providers/Theme/index.tsx": {
       "path": "src/ui/web/providers/Theme/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/search/Component.tsx": {
       "path": "src/ui/web/search/Component.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "next/navigation"
-      ]
+      "dependencies": ["react", "next/navigation"]
     },
     "src/ui/web/shared/EmptyState/EmptyState.tsx": {
       "path": "src/ui/web/shared/EmptyState/EmptyState.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component"
-      ],
+      "patterns": ["tailwind-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/web/shared/EmptyState/ErrorState.tsx": {
       "path": "src/ui/web/shared/EmptyState/ErrorState.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component"
-      ],
+      "patterns": ["tailwind-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/ui/web/shared/Icon/Icon.tsx": {
       "path": "src/ui/web/shared/Icon/Icon.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "variant-component"
-      ],
+      "patterns": ["tailwind-component", "variant-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "class-variance-authority",
-        "lucide-react"
-      ]
+      "dependencies": ["react", "class-variance-authority", "lucide-react"]
     },
     "src/ui/web/shared/Layout/Grid.tsx": {
       "path": "src/ui/web/shared/Layout/Grid.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "variant-component"
-      ],
+      "patterns": ["tailwind-component", "variant-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "class-variance-authority"
-      ]
+      "dependencies": ["react", "class-variance-authority"]
     },
     "src/ui/web/shared/Layout/Section.tsx": {
       "path": "src/ui/web/shared/Layout/Section.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "variant-component"
-      ],
+      "patterns": ["tailwind-component", "variant-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "class-variance-authority"
-      ]
+      "dependencies": ["react", "class-variance-authority"]
     },
     "src/ui/web/shared/Layout/Stack.tsx": {
       "path": "src/ui/web/shared/Layout/Stack.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "variant-component"
-      ],
+      "patterns": ["tailwind-component", "variant-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "class-variance-authority"
-      ]
+      "dependencies": ["react", "class-variance-authority"]
     },
     "src/ui/web/shared/Loading/Skeleton.tsx": {
       "path": "src/ui/web/shared/Loading/Skeleton.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "variant-component"
-      ],
+      "patterns": ["tailwind-component", "variant-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "class-variance-authority"
-      ]
+      "dependencies": ["react", "class-variance-authority"]
     },
     "src/ui/web/shared/Loading/Spinner.tsx": {
       "path": "src/ui/web/shared/Loading/Spinner.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "variant-component"
-      ],
+      "patterns": ["tailwind-component", "variant-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "class-variance-authority"
-      ]
+      "dependencies": ["react", "class-variance-authority"]
     },
     "src/ui/web/shared/MathInput/FormulaComposer.tsx": {
       "path": "src/ui/web/shared/MathInput/FormulaComposer.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "lucide-react",
-        "mathlive"
-      ]
+      "dependencies": ["react", "lucide-react", "mathlive"]
     },
     "src/ui/web/shared/MathInput/MathField.tsx": {
       "path": "src/ui/web/shared/MathInput/MathField.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "mathlive"
-      ]
+      "dependencies": ["react", "mathlive"]
     },
     "src/ui/web/shared/MathInput/MathFieldToolbar.tsx": {
       "path": "src/ui/web/shared/MathInput/MathFieldToolbar.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "mathlive"
-      ]
+      "dependencies": ["react", "mathlive"]
     },
     "src/ui/web/shared/MathMarkdown/index.tsx": {
       "path": "src/ui/web/shared/MathMarkdown/index.tsx",
       "type": "component",
       "domain": "ui",
-      "patterns": [
-        "shared-markdown",
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["shared-markdown", "tailwind-component", "client-component"],
       "aiSummary": "Shared markdown renderer with KaTeX math support and RTL isolation",
-      "dependencies": [
-        "react-markdown",
-        "rehype-katex",
-        "remark-gfm",
-        "remark-math"
-      ]
+      "dependencies": ["react-markdown", "rehype-katex", "remark-gfm", "remark-math"]
     },
     "src/ui/web/shared/MathMarkdown/rehype-math-wrapper.ts": {
       "path": "src/ui/web/shared/MathMarkdown/rehype-math-wrapper.ts",
       "type": "utility",
       "domain": "ui",
-      "patterns": [
-        "rtl-isolation"
-      ],
+      "patterns": ["rtl-isolation"],
       "aiSummary": "Rehype plugin that wraps KaTeX math output with dir=\"ltr\" for RTL language support",
-      "dependencies": [
-        "hast",
-        "unist-util-visit"
-      ]
+      "dependencies": ["hast", "unist-util-visit"]
     },
     "src/ui/web/shared/MathMarkdown/remark-color-syntax.ts": {
       "path": "src/ui/web/shared/MathMarkdown/remark-color-syntax.ts",
       "type": "utility",
       "domain": "ui",
-      "patterns": [
-        "remark-plugin"
-      ],
+      "patterns": ["remark-plugin"],
       "aiSummary": "Simplified remark plugin to transform ::text-highlight-N{text} syntax (single-node only)",
-      "dependencies": [
-        "unist-util-visit"
-      ]
+      "dependencies": ["unist-util-visit"]
     },
     "src/ui/web/shared/ProgressCircle/index.tsx": {
       "path": "src/ui/web/shared/ProgressCircle/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "client-component"
-      ],
+      "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/shared/TypingAnimation/index.tsx": {
       "path": "src/ui/web/shared/TypingAnimation/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "client-component"
-      ],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react"
-      ]
+      "dependencies": ["react"]
     },
     "src/ui/web/shared/Typography/Heading.tsx": {
       "path": "src/ui/web/shared/Typography/Heading.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "variant-component"
-      ],
+      "patterns": ["tailwind-component", "variant-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "class-variance-authority"
-      ]
+      "dependencies": ["react", "class-variance-authority"]
     },
     "src/ui/web/shared/Typography/Text.tsx": {
       "path": "src/ui/web/shared/Typography/Text.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": [
-        "tailwind-component",
-        "variant-component"
-      ],
+      "patterns": ["tailwind-component", "variant-component"],
       "aiSummary": "",
-      "dependencies": [
-        "react",
-        "class-variance-authority"
-      ]
+      "dependencies": ["react", "class-variance-authority"]
     }
   },
   "metadata": {
-    "generatedAt": "2026-03-15T21:46:49.251Z",
-    "totalFiles": 543,
-    "totalPatterns": 188
+    "generatedAt": "2026-03-15T21:59:46.281Z",
+    "totalFiles": 544,
+    "totalPatterns": 189
   }
 }

--- a/scripts/inspector/index.ts
+++ b/scripts/inspector/index.ts
@@ -20,6 +20,7 @@ import { failureMinerPlugin } from './plugins/cody/failure-miner/index'
 import { knowledgeGardenerPlugin } from './plugins/cody/knowledge-gardener/index'
 import { securityScannerPlugin } from './plugins/project/security-scanner/index'
 import { apiSurfaceAuditorPlugin } from './plugins/project/api-surface/index'
+import { queueManagerPlugin } from './plugins/cody/queue-manager/index'
 import type { InspectorConfig } from './core/types'
 
 const logger = pino({ level: 'info' })
@@ -64,6 +65,7 @@ async function main(): Promise<void> {
 
   // Register plugins
   registry.register(healthCheckPlugin)
+  registry.register(queueManagerPlugin)
   registry.register(failureAnalysisPlugin)
   registry.register(auditPlugin)
   registry.register(deferredStagesPlugin)

--- a/scripts/inspector/plugins/cody/queue-manager/gate-reviewer.ts
+++ b/scripts/inspector/plugins/cody/queue-manager/gate-reviewer.ts
@@ -1,0 +1,136 @@
+/**
+ * @fileType utility
+ * @domain inspector
+ * @pattern gate-review
+ * @ai-summary LLM-powered gate review using MiniMax M2.5 — reviews specs/plans before auto-approving
+ */
+
+import type { GateReviewInput, GateReviewResult } from './types'
+
+const SYSTEM_PROMPT = `You are a technical reviewer for an AI coding agent pipeline called "Cody".
+
+Your task is to review a pipeline stage output (spec or plan) and decide if it adequately addresses the original requirement.
+
+## Review criteria:
+1. Does the spec/plan correctly understand the requirement?
+2. Are there critical gaps or misunderstandings?
+3. Are there security concerns?
+4. Does the plan reference realistic files and patterns?
+
+## Output format (JSON):
+{
+  "approved": true/false,
+  "feedback": "Your review feedback — always provide suggestions, even on approval",
+  "confidence": 0.0-1.0
+}
+
+## Guidelines:
+- APPROVE if the core requirement is addressed and there are no critical gaps
+- REJECT if: requirement is misunderstood, scope is fundamentally wrong, critical security issues, or plan references nonexistent patterns
+- Be lenient on minor issues — the pipeline has verification stages that catch code-level problems
+- Always provide actionable feedback, even on approval (refinement suggestions help the next stage)
+- Keep feedback concise (2-3 sentences max)`
+
+/**
+ * Review a gate output using MiniMax M2.5 LLM.
+ * Fails open: if LLM is unavailable, auto-approves.
+ */
+export async function reviewGate(input: GateReviewInput): Promise<GateReviewResult> {
+  const apiKey = process.env.MINIMAX_API_KEY
+
+  if (!apiKey) {
+    return {
+      approved: true,
+      feedback: 'Auto-approved (no LLM available — MINIMAX_API_KEY not set)',
+      confidence: 0,
+    }
+  }
+
+  const userPrompt = buildUserPrompt(input)
+
+  try {
+    const response = await fetch('https://api.minimax.chat/v1/text/chatcompletion_v2', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'MiniMax-M2.5',
+        messages: [
+          { role: 'system', content: SYSTEM_PROMPT },
+          { role: 'user', content: userPrompt },
+        ],
+        temperature: 0.3,
+      }),
+    })
+
+    if (!response.ok) {
+      return {
+        approved: true,
+        feedback: `Auto-approved (LLM API returned ${response.status})`,
+        confidence: 0,
+      }
+    }
+
+    const data = (await response.json()) as { choices?: { message?: { content?: string } }[] }
+    const content = data.choices?.[0]?.message?.content
+
+    if (!content) {
+      return {
+        approved: true,
+        feedback: 'Auto-approved (empty LLM response)',
+        confidence: 0,
+      }
+    }
+
+    return parseGateResponse(content)
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error)
+    return {
+      approved: true,
+      feedback: `Auto-approved (LLM error: ${msg})`,
+      confidence: 0,
+    }
+  }
+}
+
+function buildUserPrompt(input: GateReviewInput): string {
+  const parts = [
+    `## Original Requirement`,
+    input.requirement,
+    ``,
+    `## Gate Stage: ${input.gateName}`,
+    `## Task ID: ${input.taskId}`,
+    ``,
+    `## Gate Output`,
+    input.gateOutput.slice(0, 8000), // Truncate to avoid token limits
+  ]
+  return parts.join('\n')
+}
+
+function parseGateResponse(content: string): GateReviewResult {
+  try {
+    // Try to extract JSON from markdown code blocks or raw JSON
+    const jsonMatch = content.match(/```json\n?([\s\S]*?)\n?```/) || content.match(/\{[\s\S]*\}/)
+    const jsonStr = jsonMatch ? jsonMatch[1] || jsonMatch[0] : content
+    const parsed = JSON.parse(jsonStr)
+
+    return {
+      approved: typeof parsed.approved === 'boolean' ? parsed.approved : true,
+      feedback:
+        typeof parsed.feedback === 'string' && parsed.feedback.length > 0
+          ? parsed.feedback
+          : 'No specific feedback provided.',
+      confidence:
+        typeof parsed.confidence === 'number' ? Math.max(0, Math.min(1, parsed.confidence)) : 0.5,
+    }
+  } catch {
+    // If JSON parsing fails, treat the raw text as feedback and auto-approve
+    return {
+      approved: true,
+      feedback: content.slice(0, 500) || 'Auto-approved (could not parse LLM response)',
+      confidence: 0.3,
+    }
+  }
+}

--- a/scripts/inspector/plugins/cody/queue-manager/index.ts
+++ b/scripts/inspector/plugins/cody/queue-manager/index.ts
@@ -1,0 +1,527 @@
+/**
+ * @fileType plugin
+ * @domain inspector
+ * @pattern queue-manager-plugin
+ * @ai-summary Autonomous sequential task queue processor with AI gate approval and failure recovery
+ *
+ * Picks queued tasks one-by-one, runs them through the Cody pipeline, auto-approves gates
+ * using AI review, monitors for failures, and retries up to 2 times — all without human intervention.
+ */
+
+import type {
+  InspectorPlugin,
+  ActionRequest,
+  InspectorContext,
+  EvaluatedTask,
+} from '../../../core/types'
+import { readTaskFile } from '../../../clients/github'
+import { classifyRetryability } from '../failure-analysis/classifier'
+import { analyzeFailure } from '../failure-analysis/analyzer'
+import { resolveFromStage } from '../failure-analysis/stage-router'
+import { reviewGate } from './gate-reviewer'
+import {
+  getQueueState,
+  saveQueueState,
+  getQueuedTasks,
+  getActiveTask,
+  activateTask,
+  completeTask,
+  failTask,
+  getRetryCount,
+  incrementRetry,
+  cleanTaskState,
+} from './queue-state'
+import type { QueuedTask, QueueState } from './types'
+import { MAX_RETRIES, STARTUP_GRACE_PERIOD_MS } from './types'
+
+/**
+ * Create an action to activate a queued task and trigger its workflow.
+ */
+function createActivateAction(
+  task: QueuedTask,
+  queueLength: number,
+  _ctx: InspectorContext,
+): ActionRequest {
+  return {
+    plugin: 'cody-queue-manager',
+    type: 'activate-task',
+    target: task.taskId,
+    urgency: 'info',
+    title: `Queue: Activate ${task.taskId}`,
+    detail: `Starting task (position 1 of ${queueLength})`,
+    dedupKey: `queue-activate:${task.taskId}`,
+    dedupWindowMinutes: 15,
+    execute: async (execCtx: InspectorContext) => {
+      activateTask(execCtx, task)
+
+      // Update queue state
+      let state = getQueueState(execCtx)
+      state = {
+        ...state,
+        activeTaskId: task.taskId,
+        activeIssueNumber: task.issueNumber,
+        activeStartedAt: new Date().toISOString(),
+      }
+      saveQueueState(execCtx, state)
+
+      // Trigger the pipeline
+      execCtx.github.triggerWorkflow('cody.yml', {
+        task_id: task.taskId,
+        mode: 'full',
+      })
+
+      execCtx.github.postComment(
+        task.issueNumber,
+        `🚀 **Queue Manager**: Starting task (position 1 of ${queueLength})\n\nThis task was picked from the queue and will be processed automatically.`,
+      )
+
+      return { success: true, message: `Activated ${task.taskId}` }
+    },
+  }
+}
+
+/**
+ * Create an action to review a gated task.
+ */
+function createGateReviewAction(
+  task: QueuedTask,
+  evaluated: EvaluatedTask,
+  _ctx: InspectorContext,
+): ActionRequest {
+  return {
+    plugin: 'cody-queue-manager',
+    type: 'gate-review',
+    target: task.taskId,
+    urgency: 'warning',
+    title: `Queue: Review gate for ${task.taskId}`,
+    detail: `Task is gated at ${evaluated.failedStage || 'unknown stage'}`,
+    dedupKey: `queue-gate:${task.taskId}`,
+    dedupWindowMinutes: 15,
+    execute: async (execCtx: InspectorContext) => {
+      const issueData = execCtx.github.getIssue(task.issueNumber)
+      const requirement = issueData.body || 'No requirement found'
+
+      // Try to read gate-relevant files
+      const taskJson = readTaskFile(task.taskId, 'task.json')
+      const planMd = readTaskFile(task.taskId, 'plan.md')
+      const specMd = readTaskFile(task.taskId, 'spec.md')
+      const gateOutput = taskJson || planMd || specMd || 'No gate output available'
+
+      // Determine gate name from the evaluated task's failed stage or pipeline info
+      const gateName = evaluated.failedStage || 'unknown'
+
+      const result = await reviewGate({
+        requirement,
+        gateOutput,
+        gateName,
+        taskId: task.taskId,
+      })
+
+      let state = getQueueState(execCtx)
+
+      if (result.approved) {
+        // Post approval comment with /cody approve command
+        execCtx.github.postComment(
+          task.issueNumber,
+          `/cody approve\n\n**[queue-manager]** AI Review: ✅ Approved (confidence: ${(result.confidence * 100).toFixed(0)}%)\n\n${result.feedback}`,
+        )
+
+        // Track gate approval
+        const prevApprovals = state.gateApprovals[task.taskId] || []
+        state = {
+          ...state,
+          gateApprovals: {
+            ...state.gateApprovals,
+            [task.taskId]: [...prevApprovals, gateName],
+          },
+        }
+        saveQueueState(execCtx, state)
+
+        return { success: true, message: `Gate approved for ${task.taskId}` }
+      } else {
+        // Post rejection feedback and trigger rerun
+        execCtx.github.postComment(
+          task.issueNumber,
+          `**[queue-manager]** AI Review: ❌ Changes requested (confidence: ${(result.confidence * 100).toFixed(0)}%)\n\n${result.feedback}`,
+        )
+
+        // Trigger rerun with the feedback
+        const fromStage = resolveFromStage(gateName)
+        execCtx.github.triggerWorkflow('cody.yml', {
+          task_id: task.taskId,
+          mode: 'rerun',
+          from_stage: fromStage,
+          feedback: result.feedback,
+        })
+
+        return { success: true, message: `Gate rejected for ${task.taskId}, rerun triggered` }
+      }
+    },
+  }
+}
+
+/**
+ * Create an action to handle a failed task — retry or fail permanently.
+ */
+function createFailureAction(
+  task: QueuedTask,
+  evaluated: EvaluatedTask,
+  _ctx: InspectorContext,
+): ActionRequest {
+  return {
+    plugin: 'cody-queue-manager',
+    type: 'handle-failure',
+    target: task.taskId,
+    urgency: 'critical',
+    title: `Queue: Handle failure for ${task.taskId}`,
+    detail: `Task failed at ${evaluated.failedStage || 'unknown'}: ${evaluated.failedError || 'unknown error'}`,
+    dedupKey: `queue-retry:${task.taskId}`,
+    dedupWindowMinutes: 15,
+    execute: async (execCtx: InspectorContext) => {
+      let state = getQueueState(execCtx)
+      const retryCount = getRetryCount(state, task.taskId)
+
+      // Check if retries exhausted
+      if (retryCount >= MAX_RETRIES) {
+        failTask(execCtx, task)
+        state = cleanTaskState(state, task.taskId)
+        saveQueueState(execCtx, state)
+
+        execCtx.github.postComment(
+          task.issueNumber,
+          `⛔ **Queue Manager**: Max retries exhausted (${retryCount}/${MAX_RETRIES})\n\nManual intervention required. Review the failure history and either:\n- Fix the issue manually and close\n- Refine the issue description and re-add to queue`,
+        )
+
+        // Try to advance to next task
+        advanceQueue(execCtx, state)
+
+        return { success: true, message: `Max retries exhausted for ${task.taskId}` }
+      }
+
+      // Pre-classify retryability
+      const classification = classifyRetryability(
+        evaluated.failedStage || 'unknown',
+        evaluated.failedError || '',
+      )
+
+      if (!classification.canRetry) {
+        failTask(execCtx, task)
+        state = cleanTaskState(state, task.taskId)
+        saveQueueState(execCtx, state)
+
+        execCtx.github.postComment(
+          task.issueNumber,
+          `⛔ **Queue Manager**: Non-retryable failure\n\n**Category:** ${classification.category}\n**Reason:** ${classification.reason}\n\nManual intervention required.`,
+        )
+
+        advanceQueue(execCtx, state)
+
+        return { success: true, message: `Non-retryable failure for ${task.taskId}` }
+      }
+
+      // Increment retry count
+      state = incrementRetry(state, task.taskId)
+      const currentAttempt = getRetryCount(state, task.taskId)
+      saveQueueState(execCtx, state)
+
+      // For format-only failures, skip LLM analysis
+      if (classification.category === 'format-only') {
+        const fromStage = resolveFromStage(evaluated.failedStage || 'build')
+        execCtx.github.postComment(
+          task.issueNumber,
+          `🔄 **[queue-manager-retry: ${currentAttempt}/${MAX_RETRIES}]** Format-only failure. Auto-retrying from \`${fromStage}\`.`,
+        )
+        execCtx.github.triggerWorkflow('cody.yml', {
+          task_id: task.taskId,
+          mode: 'rerun',
+          from_stage: fromStage,
+          feedback: 'Format-only failure — run lint:fix and format:fix before verify.',
+        })
+        return { success: true, message: `Format-only retry triggered for ${task.taskId}` }
+      }
+
+      // Full LLM analysis
+      const requirement =
+        execCtx.github.getIssue(task.issueNumber).body || 'No issue body available'
+      const stageOutput = readTaskFile(task.taskId, `${evaluated.failedStage}.md`)
+      const verifyOutput = readTaskFile(task.taskId, 'verify.md')
+      const previousFeedback = readTaskFile(task.taskId, 'rerun-feedback.md')
+
+      const analysis = await analyzeFailure({
+        requirement,
+        errorMessage: evaluated.failedError || 'Unknown error',
+        failedStage: evaluated.failedStage || 'unknown',
+        stageOutput,
+        verifyOutput: verifyOutput || undefined,
+        previousFeedback: previousFeedback || undefined,
+        retryNumber: currentAttempt,
+      })
+
+      const fromStage = resolveFromStage(evaluated.failedStage || 'build')
+
+      execCtx.github.postComment(
+        task.issueNumber,
+        `🔄 **[queue-manager-retry: ${currentAttempt}/${MAX_RETRIES}]** Failure Analysis\n\n**Failed stage:** \`${evaluated.failedStage}\`\n**Root cause:** ${analysis.rootCause}\n\n${analysis.canRetry ? `Retrying from \`${fromStage}\`...` : 'No retry possible — manual intervention required.'}`,
+      )
+
+      if (analysis.canRetry && analysis.refinedFeedback) {
+        execCtx.github.triggerWorkflow('cody.yml', {
+          task_id: task.taskId,
+          mode: 'rerun',
+          from_stage: fromStage,
+          feedback: analysis.refinedFeedback,
+        })
+        return { success: true, message: `Retry triggered from ${fromStage}` }
+      }
+
+      // Analysis says no retry possible
+      failTask(execCtx, task)
+      state = cleanTaskState(state, task.taskId)
+      saveQueueState(execCtx, state)
+      advanceQueue(execCtx, state)
+
+      return { success: true, message: 'Analysis posted, no retry possible' }
+    },
+  }
+}
+
+/**
+ * Create an action to complete a task and advance the queue.
+ */
+function createCompleteAction(task: QueuedTask, _ctx: InspectorContext): ActionRequest {
+  return {
+    plugin: 'cody-queue-manager',
+    type: 'complete-task',
+    target: task.taskId,
+    urgency: 'info',
+    title: `Queue: Complete ${task.taskId}`,
+    detail: `Task completed successfully`,
+    dedupKey: `queue-complete:${task.taskId}`,
+    dedupWindowMinutes: 30,
+    execute: async (execCtx: InspectorContext) => {
+      completeTask(execCtx, task)
+
+      let state = getQueueState(execCtx)
+      state = cleanTaskState(state, task.taskId)
+      saveQueueState(execCtx, state)
+
+      // Check for next task
+      const queued = getQueuedTasks(execCtx)
+      const nextTask = queued.length > 0 ? queued[0] : null
+
+      if (nextTask) {
+        activateTask(execCtx, nextTask)
+        const newState: typeof state = {
+          ...state,
+          activeTaskId: nextTask.taskId,
+          activeIssueNumber: nextTask.issueNumber,
+          activeStartedAt: new Date().toISOString(),
+        }
+        saveQueueState(execCtx, newState)
+
+        execCtx.github.triggerWorkflow('cody.yml', {
+          task_id: nextTask.taskId,
+          mode: 'full',
+        })
+
+        execCtx.github.postComment(
+          task.issueNumber,
+          `✅ **Queue Manager**: Task completed! Starting next task: #${nextTask.issueNumber} (${nextTask.title})`,
+        )
+        execCtx.github.postComment(
+          nextTask.issueNumber,
+          `🚀 **Queue Manager**: Starting task (advanced from completed #${task.issueNumber})`,
+        )
+      } else {
+        execCtx.github.postComment(
+          task.issueNumber,
+          `✅ **Queue Manager**: Task completed! Queue is now empty.`,
+        )
+      }
+
+      return {
+        success: true,
+        message: `Completed ${task.taskId}${nextTask ? `, advancing to ${nextTask.taskId}` : ''}`,
+      }
+    },
+  }
+}
+
+/**
+ * Try to advance the queue to the next task after a failure/completion.
+ */
+function advanceQueue(ctx: InspectorContext, state: QueueState): void {
+  const queued = getQueuedTasks(ctx)
+  if (queued.length === 0) return
+
+  const nextTask = queued[0]
+  activateTask(ctx, nextTask)
+
+  const newState: QueueState = {
+    ...state,
+    activeTaskId: nextTask.taskId,
+    activeIssueNumber: nextTask.issueNumber,
+    activeStartedAt: new Date().toISOString(),
+  }
+  saveQueueState(ctx, newState)
+
+  ctx.github.triggerWorkflow('cody.yml', {
+    task_id: nextTask.taskId,
+    mode: 'full',
+  })
+
+  ctx.github.postComment(
+    nextTask.issueNumber,
+    `🚀 **Queue Manager**: Starting task (advanced from queue)`,
+  )
+}
+
+/**
+ * Queue Manager Plugin.
+ *
+ * Runs every cycle (5 min). Depends on health-check plugin's evaluatedTasks in state.
+ */
+export const queueManagerPlugin: InspectorPlugin = {
+  name: 'cody-queue-manager',
+  description:
+    'Autonomous sequential task queue processor with AI gate approval and failure recovery',
+  domain: 'cody',
+
+  async run(ctx) {
+    ctx.log.debug('Running queue-manager plugin')
+
+    const state = getQueueState(ctx)
+    const evaluatedTasks = ctx.state.get<EvaluatedTask[]>('cody:evaluatedTasks') || []
+
+    // Check for active task
+    const activeTask = getActiveTask(ctx)
+
+    if (!activeTask) {
+      // No active task — pick next from queue
+      const queued = getQueuedTasks(ctx)
+
+      if (queued.length === 0) {
+        ctx.log.debug('Queue empty, no active task')
+        return []
+      }
+
+      ctx.log.info({ queueLength: queued.length }, 'No active task, activating next from queue')
+      return [createActivateAction(queued[0], queued.length, ctx)]
+    }
+
+    // Active task found — check its health
+    ctx.log.debug({ taskId: activeTask.taskId }, 'Active task found, checking health')
+
+    const evaluated = evaluatedTasks.find((t) => t.issueNumber === activeTask.issueNumber)
+
+    if (!evaluated) {
+      // Task not found in evaluatedTasks — check if recently activated
+      const startedAt = state.activeStartedAt ? new Date(state.activeStartedAt).getTime() : 0
+      const elapsed = Date.now() - startedAt
+
+      if (elapsed < STARTUP_GRACE_PERIOD_MS) {
+        ctx.log.debug(
+          { taskId: activeTask.taskId, elapsedMs: elapsed },
+          'Active task not in evaluatedTasks yet — within grace period',
+        )
+        return []
+      }
+
+      // Grace period expired — treat as failed
+      ctx.log.warn(
+        { taskId: activeTask.taskId },
+        'Active task not in evaluatedTasks after grace period — treating as failed',
+      )
+      const syntheticEvaluated: EvaluatedTask = {
+        taskId: activeTask.taskId,
+        issueNumber: activeTask.issueNumber,
+        issueTitle: activeTask.title,
+        labels: activeTask.labels,
+        status: null,
+        issueUpdatedAt: activeTask.updatedAt,
+        statusUpdatedAt: null,
+        health: 'failed',
+        healthDetail: 'Task not found in evaluatedTasks after grace period',
+        failedStage: 'unknown',
+        failedError: 'Task disappeared from health check after 10 minutes',
+      }
+      return [createFailureAction(activeTask, syntheticEvaluated, ctx)]
+    }
+
+    // Route based on health
+    const actions: ActionRequest[] = []
+
+    switch (evaluated.health) {
+      case 'healthy':
+        // Task is running — wait
+        ctx.log.debug({ taskId: activeTask.taskId }, 'Active task healthy, waiting')
+        break
+
+      case 'gated':
+        ctx.log.info({ taskId: activeTask.taskId }, 'Active task gated, creating review action')
+        actions.push(createGateReviewAction(activeTask, evaluated, ctx))
+        break
+
+      case 'failed':
+        ctx.log.info({ taskId: activeTask.taskId }, 'Active task failed, creating failure action')
+        actions.push(createFailureAction(activeTask, evaluated, ctx))
+        break
+
+      case 'completed':
+        ctx.log.info({ taskId: activeTask.taskId }, 'Active task completed')
+        actions.push(createCompleteAction(activeTask, ctx))
+        break
+
+      case 'orphaned':
+      case 'stalled': {
+        ctx.log.warn(
+          { taskId: activeTask.taskId, health: evaluated.health },
+          'Active task orphaned/stalled — treating as failed',
+        )
+        const failedEval: EvaluatedTask = {
+          ...evaluated,
+          health: 'failed',
+          failedStage: evaluated.failedStage || 'unknown',
+          failedError:
+            evaluated.failedError || `Task is ${evaluated.health}: ${evaluated.healthDetail}`,
+        }
+        actions.push(createFailureAction(activeTask, failedEval, ctx))
+        break
+      }
+
+      case 'unknown': {
+        // Check if recently activated
+        const startedAt = state.activeStartedAt ? new Date(state.activeStartedAt).getTime() : 0
+        const elapsed = Date.now() - startedAt
+
+        if (elapsed < STARTUP_GRACE_PERIOD_MS) {
+          ctx.log.debug(
+            { taskId: activeTask.taskId, elapsedMs: elapsed },
+            'Active task health unknown — within grace period',
+          )
+        } else {
+          ctx.log.warn(
+            { taskId: activeTask.taskId },
+            'Active task health unknown after grace period — treating as failed',
+          )
+          const failedEval: EvaluatedTask = {
+            ...evaluated,
+            health: 'failed',
+            failedStage: 'unknown',
+            failedError: 'Task health unknown after grace period',
+          }
+          actions.push(createFailureAction(activeTask, failedEval, ctx))
+        }
+        break
+      }
+
+      default:
+        ctx.log.warn(
+          { taskId: activeTask.taskId, health: evaluated.health },
+          'Unexpected health status',
+        )
+    }
+
+    return actions
+  },
+}

--- a/scripts/inspector/plugins/cody/queue-manager/queue-state.ts
+++ b/scripts/inspector/plugins/cody/queue-manager/queue-state.ts
@@ -1,0 +1,118 @@
+/**
+ * @fileType utility
+ * @domain inspector
+ * @pattern queue-state
+ * @ai-summary Queue state management helpers — read/write state, label operations, retry tracking
+ */
+
+import type { InspectorContext } from '../../../core/types'
+import type { QueueState, QueuedTask } from './types'
+import { QUEUE_LABELS, DEFAULT_QUEUE_STATE } from './types'
+
+const STATE_KEY = 'queue:state'
+
+/**
+ * Get the persisted queue state from the inspector state store.
+ * Returns defaults if no state exists yet.
+ */
+export function getQueueState(ctx: InspectorContext): QueueState {
+  return ctx.state.get<QueueState>(STATE_KEY) ?? { ...DEFAULT_QUEUE_STATE }
+}
+
+/**
+ * Save queue state to the inspector state store.
+ */
+export function saveQueueState(ctx: InspectorContext, state: QueueState): void {
+  ctx.state.set(STATE_KEY, state)
+}
+
+/**
+ * Get all queued tasks (label: cody:queued), sorted by updatedAt ascending (FIFO).
+ */
+export function getQueuedTasks(ctx: InspectorContext): QueuedTask[] {
+  const issues = ctx.github.getOpenIssues([QUEUE_LABELS.QUEUED])
+  return issues
+    .map((issue) => ({
+      issueNumber: issue.number,
+      title: issue.title,
+      labels: issue.labels,
+      updatedAt: issue.updatedAt,
+      taskId: `issue-${issue.number}`,
+    }))
+    .sort((a, b) => new Date(a.updatedAt).getTime() - new Date(b.updatedAt).getTime())
+}
+
+/**
+ * Get the currently active queue task (label: cody:queue-active), or null.
+ */
+export function getActiveTask(ctx: InspectorContext): QueuedTask | null {
+  const issues = ctx.github.getOpenIssues([QUEUE_LABELS.ACTIVE])
+  if (issues.length === 0) return null
+  const issue = issues[0]
+  return {
+    issueNumber: issue.number,
+    title: issue.title,
+    labels: issue.labels,
+    updatedAt: issue.updatedAt,
+    taskId: `issue-${issue.number}`,
+  }
+}
+
+/**
+ * Activate a task: remove cody:queued, add cody:queue-active.
+ */
+export function activateTask(ctx: InspectorContext, task: QueuedTask): void {
+  ctx.github.removeLabel(task.issueNumber, QUEUE_LABELS.QUEUED)
+  ctx.github.addLabel(task.issueNumber, QUEUE_LABELS.ACTIVE)
+}
+
+/**
+ * Complete a task: remove cody:queue-active label.
+ */
+export function completeTask(ctx: InspectorContext, task: QueuedTask): void {
+  ctx.github.removeLabel(task.issueNumber, QUEUE_LABELS.ACTIVE)
+}
+
+/**
+ * Fail a task: remove cody:queue-active, add cody:queue-failed.
+ */
+export function failTask(ctx: InspectorContext, task: QueuedTask): void {
+  ctx.github.removeLabel(task.issueNumber, QUEUE_LABELS.ACTIVE)
+  ctx.github.addLabel(task.issueNumber, QUEUE_LABELS.FAILED)
+}
+
+/**
+ * Get the retry count for a task.
+ */
+export function getRetryCount(state: QueueState, taskId: string): number {
+  return state.retries[taskId] ?? 0
+}
+
+/**
+ * Return a new state with an incremented retry count for the given task.
+ */
+export function incrementRetry(state: QueueState, taskId: string): QueueState {
+  return {
+    ...state,
+    retries: {
+      ...state.retries,
+      [taskId]: (state.retries[taskId] ?? 0) + 1,
+    },
+  }
+}
+
+/**
+ * Clean up retry and gate approval state for a completed/failed task.
+ */
+export function cleanTaskState(state: QueueState, taskId: string): QueueState {
+  const { [taskId]: _retries, ...remainingRetries } = state.retries
+  const { [taskId]: _gates, ...remainingGates } = state.gateApprovals
+  return {
+    ...state,
+    activeTaskId: null,
+    activeIssueNumber: null,
+    activeStartedAt: null,
+    retries: remainingRetries,
+    gateApprovals: remainingGates,
+  }
+}

--- a/scripts/inspector/plugins/cody/queue-manager/types.ts
+++ b/scripts/inspector/plugins/cody/queue-manager/types.ts
@@ -1,0 +1,85 @@
+/**
+ * @fileType types
+ * @domain inspector
+ * @pattern queue-manager-types
+ * @ai-summary Types for the queue manager plugin — queue state, gate review I/O
+ */
+
+// ============================================================================
+// Queue Labels
+// ============================================================================
+
+export const QUEUE_LABELS = {
+  QUEUED: 'cody:queued',
+  ACTIVE: 'cody:queue-active',
+  FAILED: 'cody:queue-failed',
+} as const
+
+// ============================================================================
+// Queue State (persisted across inspector cycles)
+// ============================================================================
+
+export interface QueueState {
+  /** Task ID of the currently active queue task, or null */
+  activeTaskId: string | null
+  /** Issue number of the currently active queue task, or null */
+  activeIssueNumber: number | null
+  /** ISO timestamp when the active task was started */
+  activeStartedAt: string | null
+  /** Map of taskId → retry count (0-2) */
+  retries: Record<string, number>
+  /** Map of taskId → list of auto-approved gate stage names */
+  gateApprovals: Record<string, string[]>
+}
+
+// ============================================================================
+// Queued Task
+// ============================================================================
+
+export interface QueuedTask {
+  issueNumber: number
+  title: string
+  labels: string[]
+  updatedAt: string
+  /** Derived task ID (e.g. 'issue-42') */
+  taskId: string
+}
+
+// ============================================================================
+// Gate Review
+// ============================================================================
+
+export interface GateReviewInput {
+  /** Original requirement (issue body) */
+  requirement: string
+  /** Gate output content (task.json or plan.md) */
+  gateOutput: string
+  /** Name of the gate stage (e.g. 'taskify', 'architect') */
+  gateName: string
+  /** Task ID for tracking */
+  taskId: string
+}
+
+export interface GateReviewResult {
+  /** Whether the gate is approved */
+  approved: boolean
+  /** Feedback message (always non-empty) */
+  feedback: string
+  /** Confidence score 0-1 */
+  confidence: number
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+export const MAX_RETRIES = 2
+export const STARTUP_GRACE_PERIOD_MS = 10 * 60 * 1000 // 10 minutes
+
+export const DEFAULT_QUEUE_STATE: QueueState = {
+  activeTaskId: null,
+  activeIssueNumber: null,
+  activeStartedAt: null,
+  retries: {},
+  gateApprovals: {},
+}

--- a/src/ui/cody/api.ts
+++ b/src/ui/cody/api.ts
@@ -341,6 +341,32 @@ export const tasksApi = {
     })
     return handleResponse(res)
   },
+
+  addToQueue: async (issueNumber: number, actorLogin?: string): Promise<ActionResponse> => {
+    const res = await fetch(`${API_BASE}/tasks/issue-${issueNumber}/actions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        action: 'add-label',
+        label: 'cody:queued',
+        ...(actorLogin && { actorLogin }),
+      }),
+    })
+    return handleResponse(res)
+  },
+
+  removeFromQueue: async (issueNumber: number, actorLogin?: string): Promise<ActionResponse> => {
+    const res = await fetch(`${API_BASE}/tasks/issue-${issueNumber}/actions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        action: 'remove-label',
+        label: 'cody:queued',
+        ...(actorLogin && { actorLogin }),
+      }),
+    })
+    return handleResponse(res)
+  },
 }
 
 // ============ PRs API ============

--- a/src/ui/cody/components/CodyDashboard.tsx
+++ b/src/ui/cody/components/CodyDashboard.tsx
@@ -398,6 +398,16 @@ export function CodyDashboard({ initialIssueNumber, initialModal }: CodyDashboar
 
   // Keyboard shortcuts (after sortedTasks is defined)
   useKeyboardShortcuts({
+    isModalOpen:
+      showCreateDialog ||
+      !!editingTask ||
+      showBugDialog ||
+      showBranchCleanup ||
+      showPreview ||
+      showShortcutsHelp ||
+      showMobileMenu ||
+      showMobileDetail ||
+      showMobileChat,
     onNavigateDown: () => setFocusedIndex((i) => Math.min(i + 1, sortedTasks.length - 1)),
     onNavigateUp: () => setFocusedIndex((i) => Math.max(i - 1, 0)),
     onOpenSelected: () => {

--- a/src/ui/cody/components/CodyDashboard.tsx
+++ b/src/ui/cody/components/CodyDashboard.tsx
@@ -10,6 +10,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import type { CodyTask, SortField } from '../types'
 import { filterTasksByView, getViewModeCounts, sortTasks } from '../utils'
 import { TaskList } from './TaskList'
+import { QueueView } from './QueueView'
 
 import { CreateTaskDialog } from './CreateTaskDialog'
 import { EditTaskDialog } from './EditTaskDialog'
@@ -95,7 +96,7 @@ export function CodyDashboard({ initialIssueNumber, initialModal }: CodyDashboar
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
     if (typeof window === 'undefined') return 'running'
     const v = new URLSearchParams(window.location.search).get('view')
-    return (v === 'backlog' ? 'backlog' : 'running') as ViewMode
+    return (['backlog', 'queue'].includes(v ?? '') ? v : 'running') as ViewMode
   })
   const [showMobileMenu, setShowMobileMenu] = useState(false)
   const [showMobileDetail, setShowMobileDetail] = useState(false)
@@ -145,7 +146,7 @@ export function CodyDashboard({ initialIssueNumber, initialModal }: CodyDashboar
     error,
     refetch,
     dataUpdatedAt,
-  } = useCodyTasks({ days, viewMode })
+  } = useCodyTasks({ days, viewMode: viewMode === 'queue' ? 'running' : viewMode })
 
   const queryClient = useQueryClient()
 
@@ -376,7 +377,7 @@ export function CodyDashboard({ initialIssueNumber, initialModal }: CodyDashboar
   const totalCount = tasks.length
 
   // View mode counts — backlog = open column, running = everything else
-  const { runningCount, backlogCount } = getViewModeCounts(tasks)
+  const { runningCount, backlogCount, queueCount } = getViewModeCounts(tasks)
 
   // Filter tasks by view mode, then by status and label (combined with AND logic)
   const baseFilteredTasks = filterTasksByView(tasks, { viewMode, statusFilter, labelFilter })
@@ -869,6 +870,7 @@ export function CodyDashboard({ initialIssueNumber, initialModal }: CodyDashboar
                   filteredCount={filteredTasks.length}
                   runningCount={runningCount}
                   backlogCount={backlogCount}
+                  queueCount={queueCount}
                   searchQuery={searchQuery}
                   onSearchChange={handleSearchChange}
                   sortField={sortField as SortField}
@@ -917,6 +919,19 @@ export function CodyDashboard({ initialIssueNumber, initialModal }: CodyDashboar
                   <div className="flex items-center justify-center h-full">
                     <div className="text-muted-foreground">Loading...</div>
                   </div>
+                ) : viewMode === 'queue' ? (
+                  <QueueView
+                    tasks={filteredTasks}
+                    onTaskSelect={handleTaskSelect}
+                    onRemoveFromQueue={(issueNumber) => {
+                      tasksApi.removeFromQueue(issueNumber, githubUser?.login).then(() => {
+                        toast.success('Removed from queue')
+                        refetch()
+                      })
+                    }}
+                    onRetry={(taskId) => handleExecuteTask(taskId)}
+                    selectedTask={selectedTask}
+                  />
                 ) : (
                   <TaskList
                     tasks={filteredTasks}

--- a/src/ui/cody/components/CodyDashboard.tsx
+++ b/src/ui/cody/components/CodyDashboard.tsx
@@ -411,7 +411,7 @@ export function CodyDashboard({ initialIssueNumber, initialModal }: CodyDashboar
     onRefresh: () => refetch(),
     onNewTask: () => setShowCreateDialog(true),
     onEdit: () => {
-      if (selectedTask) setEditingTask(selectedTask)
+      if (selectedTask && selectedTask.column === 'open') setEditingTask(selectedTask)
     },
     onOpenPreview: () => {
       if (selectedTask?.associatedPR) setShowPreview(true)

--- a/src/ui/cody/components/FilterBar.tsx
+++ b/src/ui/cody/components/FilterBar.tsx
@@ -18,7 +18,7 @@ import { cn } from '../utils'
 import { Search, ArrowUp, ArrowDown } from 'lucide-react'
 import type { SortField, SortDirection } from '../types'
 
-export type ViewMode = 'running' | 'backlog'
+export type ViewMode = 'running' | 'backlog' | 'queue'
 
 const SORT_OPTIONS = [
   { label: 'Updated', value: 'updatedAt' },
@@ -66,6 +66,7 @@ export interface FilterBarProps {
   filteredCount: number
   runningCount: number
   backlogCount: number
+  queueCount?: number
   searchQuery?: string
   onSearchChange?: (value: string) => void
   sortField?: SortField
@@ -80,17 +81,19 @@ export interface FilterBarHandle {
 
 export { DATE_FILTERS, STATUS_FILTERS }
 
-/** Pill-style toggle between Running and Backlog views */
+/** Pill-style toggle between Running, Backlog, and Queue views */
 export function ViewToggle({
   viewMode,
   onViewModeChange,
   runningCount,
   backlogCount,
+  queueCount,
 }: {
   viewMode: ViewMode
   onViewModeChange: (mode: ViewMode) => void
   runningCount: number
   backlogCount: number
+  queueCount?: number
 }) {
   return (
     <div className="inline-flex items-center rounded-md bg-white/[0.04] p-0.5 gap-0.5">
@@ -118,6 +121,20 @@ export function ViewToggle({
       >
         Backlog ({backlogCount})
       </button>
+      {queueCount !== undefined && (
+        <button
+          type="button"
+          onClick={() => onViewModeChange('queue')}
+          className={cn(
+            'px-3 py-1 rounded text-xs font-medium transition-colors',
+            viewMode === 'queue'
+              ? 'bg-purple-600 text-white shadow-sm'
+              : 'text-muted-foreground hover:text-foreground hover:bg-white/[0.06]',
+          )}
+        >
+          Queue ({queueCount})
+        </button>
+      )}
     </div>
   )
 }
@@ -139,6 +156,7 @@ export const FilterBar = forwardRef<FilterBarHandle, FilterBarProps>(function Fi
     filteredCount,
     runningCount,
     backlogCount,
+    queueCount,
     searchQuery = '',
     onSearchChange,
     sortField = 'updatedAt',
@@ -164,6 +182,7 @@ export const FilterBar = forwardRef<FilterBarHandle, FilterBarProps>(function Fi
         onViewModeChange={onViewModeChange}
         runningCount={runningCount}
         backlogCount={backlogCount}
+        queueCount={queueCount}
       />
 
       {/* Search input */}

--- a/src/ui/cody/components/QueueView.tsx
+++ b/src/ui/cody/components/QueueView.tsx
@@ -1,0 +1,223 @@
+/**
+ * @fileType component
+ * @domain cody
+ * @pattern queue-view
+ * @ai-summary Queue-specific task list showing queued, active, and failed queue tasks
+ */
+'use client'
+
+import { cn } from '../utils'
+import { MiniPipelineProgress } from './MiniPipelineProgress'
+import type { CodyTask } from '../types'
+import { Button } from '@/ui/web/components/button'
+import { Loader2, ListMinus, RotateCcw, Inbox, CheckCircle2, XCircle, Clock } from 'lucide-react'
+
+interface QueueViewProps {
+  tasks: CodyTask[]
+  onTaskSelect?: (task: CodyTask) => void
+  onRemoveFromQueue?: (issueNumber: number) => void
+  onRetry?: (taskId: string) => void
+  selectedTask?: CodyTask | null
+}
+
+type QueueStatus = 'active' | 'waiting' | 'failed'
+
+function getQueueStatus(task: CodyTask): QueueStatus {
+  if (task.labels.includes('cody:queue-active')) return 'active'
+  if (task.labels.includes('cody:queue-failed')) return 'failed'
+  return 'waiting'
+}
+
+const statusConfig: Record<
+  QueueStatus,
+  { label: string; bg: string; text: string; icon: React.ElementType }
+> = {
+  active: {
+    label: 'Active',
+    bg: 'bg-green-500/15',
+    text: 'text-green-400',
+    icon: Loader2,
+  },
+  waiting: {
+    label: 'Waiting',
+    bg: 'bg-blue-500/15',
+    text: 'text-blue-400',
+    icon: Clock,
+  },
+  failed: {
+    label: 'Failed',
+    bg: 'bg-red-500/15',
+    text: 'text-red-400',
+    icon: XCircle,
+  },
+}
+
+export function QueueView({
+  tasks,
+  onTaskSelect,
+  onRemoveFromQueue,
+  onRetry,
+  selectedTask,
+}: QueueViewProps) {
+  // Sort: active first, then waiting (FIFO), then failed
+  const sortedTasks = [...tasks].sort((a, b) => {
+    const statusOrder: Record<QueueStatus, number> = { active: 0, waiting: 1, failed: 2 }
+    const aStatus = getQueueStatus(a)
+    const bStatus = getQueueStatus(b)
+    if (statusOrder[aStatus] !== statusOrder[bStatus]) {
+      return statusOrder[aStatus] - statusOrder[bStatus]
+    }
+    return new Date(a.updatedAt).getTime() - new Date(b.updatedAt).getTime()
+  })
+
+  // Summary counts
+  const activeCount = tasks.filter((t) => t.labels.includes('cody:queue-active')).length
+  const waitingCount = tasks.filter((t) => t.labels.includes('cody:queued')).length
+  const failedCount = tasks.filter((t) => t.labels.includes('cody:queue-failed')).length
+
+  if (tasks.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground px-4 py-16">
+        <div className="w-14 h-14 mx-auto mb-3 rounded-2xl bg-white/[0.03] ring-1 ring-white/[0.06] flex items-center justify-center">
+          <Inbox className="w-6 h-6 text-muted-foreground/30" />
+        </div>
+        <p className="text-sm text-muted-foreground/50 text-center">
+          No tasks in queue.
+          <br />
+          Add tasks from the backlog using the &quot;Add to Queue&quot; action.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Summary bar */}
+      <div className="flex items-center gap-3 px-4 py-2.5 border-b border-white/[0.06] text-xs">
+        <span className="text-muted-foreground">
+          <span className="font-semibold text-foreground">{waitingCount}</span> queued
+        </span>
+        <span className="text-white/20">·</span>
+        <span className="text-muted-foreground">
+          <span className="font-semibold text-green-400">{activeCount}</span> active
+        </span>
+        <span className="text-white/20">·</span>
+        <span className="text-muted-foreground">
+          <span className="font-semibold text-red-400">{failedCount}</span> failed
+        </span>
+      </div>
+
+      {/* Queue list */}
+      <div className="flex-1 overflow-y-auto">
+        {sortedTasks.map((task, index) => {
+          const status = getQueueStatus(task)
+          const config = statusConfig[status]
+          const StatusIcon = config.icon
+          const isSelected = selectedTask?.id === task.id
+
+          // Position number for waiting tasks
+          const position =
+            status === 'waiting'
+              ? sortedTasks.filter((t, i) => i < index && getQueueStatus(t) === 'waiting').length +
+                1
+              : null
+
+          return (
+            <div
+              key={task.id}
+              onClick={() => onTaskSelect?.(task)}
+              className={cn(
+                'flex items-center gap-3 px-4 py-3 border-b border-white/[0.04] cursor-pointer transition-colors',
+                'hover:bg-white/[0.03]',
+                isSelected && 'bg-blue-500/[0.08] border-l-2 border-l-blue-500',
+              )}
+            >
+              {/* Position / Status indicator */}
+              <div
+                className={cn(
+                  'w-8 h-8 rounded-lg flex items-center justify-center shrink-0 text-xs font-bold',
+                  config.bg,
+                  config.text,
+                )}
+              >
+                {status === 'active' ? (
+                  <StatusIcon className="w-4 h-4 animate-spin" />
+                ) : position ? (
+                  position
+                ) : (
+                  <StatusIcon className="w-4 h-4" />
+                )}
+              </div>
+
+              {/* Task info */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-foreground truncate">{task.title}</span>
+                  <span className="text-xs text-muted-foreground/50 shrink-0">
+                    #{task.issueNumber}
+                  </span>
+                </div>
+
+                {/* Status badge + pipeline progress for active */}
+                <div className="flex items-center gap-2 mt-1">
+                  <span
+                    className={cn(
+                      'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider',
+                      config.bg,
+                      config.text,
+                    )}
+                  >
+                    {config.label}
+                  </span>
+
+                  {status === 'active' && task.pipeline && (
+                    <div className="flex-1 min-w-0">
+                      <MiniPipelineProgress task={task} variant="inline" />
+                    </div>
+                  )}
+
+                  {status === 'failed' && (
+                    <span className="text-[10px] text-red-400/70">Needs manual review</span>
+                  )}
+                </div>
+              </div>
+
+              {/* Actions */}
+              <div className="flex items-center gap-1 shrink-0">
+                {status === 'waiting' && onRemoveFromQueue && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 w-7 p-0 text-muted-foreground/50 hover:text-red-400"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onRemoveFromQueue(task.issueNumber)
+                    }}
+                    title="Remove from queue"
+                  >
+                    <ListMinus className="w-3.5 h-3.5" />
+                  </Button>
+                )}
+                {status === 'failed' && onRetry && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 w-7 p-0 text-muted-foreground/50 hover:text-orange-400"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onRetry(task.id)
+                    }}
+                    title="Retry task"
+                  >
+                    <RotateCcw className="w-3.5 h-3.5" />
+                  </Button>
+                )}
+                {status === 'active' && <CheckCircle2 className="w-4 h-4 text-green-500/50" />}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/ui/cody/components/TaskDetail.tsx
+++ b/src/ui/cody/components/TaskDetail.tsx
@@ -54,6 +54,8 @@ import {
   Eye,
   Pencil,
   Copy,
+  ListPlus,
+  ListMinus,
 } from 'lucide-react'
 
 interface TaskDetailProps {
@@ -322,6 +324,31 @@ function getOverflowActions(
       },
       pendingKey: 'reject',
       destructive: true,
+    })
+  }
+
+  // Queue: Add to Queue (only if task has no queue-related labels)
+  const queueLabels = ['cody:queued', 'cody:queue-active', 'cody:queue-failed']
+  const hasQueueLabel = task.labels.some((l) => queueLabels.includes(l))
+
+  if (!hasQueueLabel && task.state === 'open') {
+    actions.push({
+      icon: ListPlus,
+      label: 'Add to Queue',
+      pendingLabel: 'Adding…',
+      onClick: () => taskActions.addToQueue(),
+      pendingKey: 'add-to-queue',
+    })
+  }
+
+  // Queue: Remove from Queue (only if task is queued but not active)
+  if (task.labels.includes('cody:queued')) {
+    actions.push({
+      icon: ListMinus,
+      label: 'Remove from Queue',
+      pendingLabel: 'Removing…',
+      onClick: () => taskActions.removeFromQueue(),
+      pendingKey: 'remove-from-queue',
     })
   }
 

--- a/src/ui/cody/components/TaskDetail.tsx
+++ b/src/ui/cody/components/TaskDetail.tsx
@@ -1163,8 +1163,8 @@ export function TaskDetail({
 
             <span className="w-px h-5 bg-white/[0.06] mx-0.5" />
 
-            {/* Edit button */}
-            {onEditTask && task && (
+            {/* Edit button — only for backlog items */}
+            {onEditTask && task && task.column === 'open' && (
               <SimpleTooltip content="Edit task" side="bottom">
                 <Button
                   variant="ghost"

--- a/src/ui/cody/components/TaskList.tsx
+++ b/src/ui/cody/components/TaskList.tsx
@@ -508,8 +508,8 @@ export function TaskList({
                   </div>
                 )}
 
-                {/* Edit button */}
-                {onEditTask && (
+                {/* Edit button — only for backlog items */}
+                {onEditTask && task.column === 'open' && (
                   <SimpleTooltip content="Edit task" side="bottom">
                     <Button
                       variant="ghost"

--- a/src/ui/cody/hooks/index.ts
+++ b/src/ui/cody/hooks/index.ts
@@ -379,6 +379,18 @@ export function useTaskActions({
     onError: handleError('unassign user'),
   })
 
+  const addToQueue = useMutation({
+    mutationFn: () => codyApi.tasks.addToQueue(issueNumber, actorLogin),
+    onSuccess: handleSuccess('Added to queue'),
+    onError: handleError('add to queue'),
+  })
+
+  const removeFromQueue = useMutation({
+    mutationFn: () => codyApi.tasks.removeFromQueue(issueNumber, actorLogin),
+    onSuccess: handleSuccess('Removed from queue'),
+    onError: handleError('remove from queue'),
+  })
+
   const isPending =
     execute.isPending ||
     close.isPending ||
@@ -391,7 +403,9 @@ export function useTaskActions({
     approveUI.isPending ||
     approvePR.isPending ||
     assign.isPending ||
-    unassign.isPending
+    unassign.isPending ||
+    addToQueue.isPending ||
+    removeFromQueue.isPending
 
   return {
     execute: execute.mutate,
@@ -406,6 +420,8 @@ export function useTaskActions({
     approvePR: approvePR.mutate,
     assign: assign.mutate,
     unassign: unassign.mutate,
+    addToQueue: addToQueue.mutate,
+    removeFromQueue: removeFromQueue.mutate,
     isPending,
     pendingAction: execute.isPending
       ? 'execute'
@@ -427,6 +443,10 @@ export function useTaskActions({
                       ? 'reset'
                       : reopen.isPending
                         ? 'reopen'
-                        : null,
+                        : addToQueue.isPending
+                          ? 'add-to-queue'
+                          : removeFromQueue.isPending
+                            ? 'remove-from-queue'
+                            : null,
   }
 }

--- a/src/ui/cody/hooks/useKeyboardShortcuts.ts
+++ b/src/ui/cody/hooks/useKeyboardShortcuts.ts
@@ -19,9 +19,13 @@ interface KeyboardShortcutHandlers {
   onOpenPreview?: () => void
   onFocusSearch?: () => void
   onShowHelp?: () => void
+  /** If true, skip shortcuts that open modals/dialogs */
+  isModalOpen?: boolean
 }
 
 export function useKeyboardShortcuts(handlers: KeyboardShortcutHandlers) {
+  const { isModalOpen = false, ...restHandlers } = handlers
+
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
       // Skip if user is typing in an input/textarea
@@ -40,43 +44,51 @@ export function useKeyboardShortcuts(handlers: KeyboardShortcutHandlers) {
         return
       }
 
+      // Skip shortcuts that open modals when a modal is already open
+      if (isModalOpen) {
+        // Allow Escape to close modals
+        if (event.key !== 'Escape') {
+          return
+        }
+      }
+
       switch (event.key) {
         case 'j':
-          handlers.onNavigateDown?.()
+          restHandlers.onNavigateDown?.()
           break
         case 'k':
-          handlers.onNavigateUp?.()
+          restHandlers.onNavigateUp?.()
           break
         case 'Enter':
           event.preventDefault()
-          handlers.onOpenSelected?.()
+          restHandlers.onOpenSelected?.()
           break
         case 'Escape':
-          handlers.onCloseDetail?.()
+          restHandlers.onCloseDetail?.()
           break
         case 'r':
           // Only trigger refresh if not in an input
-          handlers.onRefresh?.()
+          restHandlers.onRefresh?.()
           break
         case 'n':
-          handlers.onNewTask?.()
+          restHandlers.onNewTask?.()
           break
         case 'e':
-          handlers.onEdit?.()
+          restHandlers.onEdit?.()
           break
         case 'p':
-          handlers.onOpenPreview?.()
+          restHandlers.onOpenPreview?.()
           break
         case '/':
           event.preventDefault()
-          handlers.onFocusSearch?.()
+          restHandlers.onFocusSearch?.()
           break
         case '?':
-          handlers.onShowHelp?.()
+          restHandlers.onShowHelp?.()
           break
       }
     },
-    [handlers],
+    [isModalOpen, restHandlers],
   )
 
   useEffect(() => {

--- a/src/ui/cody/utils.ts
+++ b/src/ui/cody/utils.ts
@@ -61,10 +61,17 @@ export interface ViewModeFilterOptions {
  * - 'backlog' view: only tasks in 'open' column
  * Status and label filters apply within the selected view.
  */
+
+// Queue labels
+export const QUEUE_LABELS = ['cody:queued', 'cody:queue-active', 'cody:queue-failed'] as const
+
 export function filterTasksByView(tasks: CodyTask[], options: ViewModeFilterOptions): CodyTask[] {
   const { viewMode, statusFilter, labelFilter } = options
   return tasks.filter((task) => {
     // View mode filter — primary split
+    if (viewMode === 'queue') {
+      return task.labels.some((l) => QUEUE_LABELS.includes(l as (typeof QUEUE_LABELS)[number]))
+    }
     if (viewMode === 'backlog' && task.column !== 'open') return false
     if (viewMode === 'running' && task.column === 'open') return false
     // Status filter
@@ -82,11 +89,16 @@ export function filterTasksByView(tasks: CodyTask[], options: ViewModeFilterOpti
 export function getViewModeCounts(tasks: CodyTask[]): {
   runningCount: number
   backlogCount: number
+  queueCount: number
 } {
   const backlogCount = tasks.filter((t) => t.column === 'open').length
+  const queueCount = tasks.filter((t) =>
+    t.labels.some((l) => QUEUE_LABELS.includes(l as (typeof QUEUE_LABELS)[number])),
+  ).length
   return {
     backlogCount,
     runningCount: tasks.length - backlogCount,
+    queueCount,
   }
 }
 

--- a/tests/unit/scripts/inspector/queue-manager.test.ts
+++ b/tests/unit/scripts/inspector/queue-manager.test.ts
@@ -1,0 +1,614 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type {
+  InspectorContext,
+  EvaluatedTask,
+  GitHubClient,
+  StateStore,
+  IssueInfo,
+} from '../../../../scripts/inspector/core/types'
+import {
+  getQueueState,
+  saveQueueState,
+  getQueuedTasks,
+  getActiveTask,
+  activateTask,
+  completeTask,
+  failTask,
+  getRetryCount,
+  incrementRetry,
+  cleanTaskState,
+} from '../../../../scripts/inspector/plugins/cody/queue-manager/queue-state'
+import {
+  DEFAULT_QUEUE_STATE,
+  QUEUE_LABELS,
+} from '../../../../scripts/inspector/plugins/cody/queue-manager/types'
+import type {
+  QueueState,
+  QueuedTask,
+} from '../../../../scripts/inspector/plugins/cody/queue-manager/types'
+import { queueManagerPlugin } from '../../../../scripts/inspector/plugins/cody/queue-manager/index'
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createMockContext(overrides?: Partial<InspectorContext>): InspectorContext {
+  const stateStore: Record<string, unknown> = {}
+
+  return {
+    repo: 'owner/repo',
+    dryRun: false,
+    state: {
+      get: vi.fn((key: string) => stateStore[key]),
+      set: vi.fn((key: string, value: unknown) => {
+        stateStore[key] = value
+      }),
+      save: vi.fn(),
+    } as unknown as StateStore,
+    github: {
+      postComment: vi.fn(),
+      getIssue: vi.fn().mockReturnValue({ body: 'Test requirement body', title: 'Test issue' }),
+      getOpenIssues: vi.fn().mockReturnValue([]),
+      triggerWorkflow: vi.fn(),
+      addLabel: vi.fn(),
+      removeLabel: vi.fn(),
+      setLifecycleLabel: vi.fn(),
+      closeIssue: vi.fn(),
+      getIssueComments: vi.fn().mockReturnValue([]),
+      listWorkflowRuns: vi.fn().mockReturnValue([]),
+      createIssue: vi.fn().mockReturnValue(null),
+      searchIssues: vi.fn().mockReturnValue([]),
+    } as unknown as GitHubClient,
+    log: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as InspectorContext['log'],
+    runTimestamp: new Date().toISOString(),
+    cycleNumber: 1,
+    ...overrides,
+  }
+}
+
+function createEvaluatedTask(overrides?: Partial<EvaluatedTask>): EvaluatedTask {
+  return {
+    taskId: 'issue-42',
+    issueNumber: 42,
+    issueTitle: 'Test task',
+    labels: ['cody:queue-active'],
+    status: null,
+    issueUpdatedAt: new Date().toISOString(),
+    statusUpdatedAt: null,
+    health: 'healthy',
+    healthDetail: 'Pipeline running normally',
+    ...overrides,
+  }
+}
+
+function createQueuedTask(overrides?: Partial<QueuedTask>): QueuedTask {
+  return {
+    issueNumber: 42,
+    title: 'Test task',
+    labels: ['cody:queued'],
+    updatedAt: new Date().toISOString(),
+    taskId: 'issue-42',
+    ...overrides,
+  }
+}
+
+function createIssueInfo(overrides?: Partial<IssueInfo>): IssueInfo {
+  return {
+    number: 42,
+    title: 'Test task',
+    labels: ['cody:queued'],
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+// ============================================================================
+// Queue State Helpers
+// ============================================================================
+
+describe('queue-state helpers', () => {
+  let ctx: InspectorContext
+
+  beforeEach(() => {
+    ctx = createMockContext()
+  })
+
+  it('getQueueState returns defaults when state is empty', () => {
+    const state = getQueueState(ctx)
+    expect(state).toEqual(DEFAULT_QUEUE_STATE)
+  })
+
+  it('getQueueState returns stored state', () => {
+    const stored: QueueState = {
+      activeTaskId: 'issue-10',
+      activeIssueNumber: 10,
+      activeStartedAt: '2026-01-01T00:00:00Z',
+      retries: { 'issue-10': 1 },
+      gateApprovals: {},
+    }
+    ;(ctx.state.get as ReturnType<typeof vi.fn>).mockReturnValue(stored)
+
+    const state = getQueueState(ctx)
+    expect(state).toEqual(stored)
+  })
+
+  it('saveQueueState writes to state store', () => {
+    const state: QueueState = {
+      ...DEFAULT_QUEUE_STATE,
+      activeTaskId: 'issue-5',
+    }
+    saveQueueState(ctx, state)
+    expect(ctx.state.set).toHaveBeenCalledWith('queue:state', state)
+  })
+
+  it('getQueuedTasks returns tasks sorted by updatedAt ascending (FIFO)', () => {
+    const issues: IssueInfo[] = [
+      createIssueInfo({ number: 3, updatedAt: '2026-03-15T10:00:00Z' }),
+      createIssueInfo({ number: 1, updatedAt: '2026-03-15T08:00:00Z' }),
+      createIssueInfo({ number: 2, updatedAt: '2026-03-15T09:00:00Z' }),
+    ]
+    ;(ctx.github.getOpenIssues as ReturnType<typeof vi.fn>).mockReturnValue(issues)
+
+    const tasks = getQueuedTasks(ctx)
+
+    expect(tasks.map((t) => t.issueNumber)).toEqual([1, 2, 3])
+    expect(ctx.github.getOpenIssues).toHaveBeenCalledWith([QUEUE_LABELS.QUEUED])
+  })
+
+  it('getActiveTask returns first active task', () => {
+    const issues: IssueInfo[] = [createIssueInfo({ number: 42, labels: ['cody:queue-active'] })]
+    ;(ctx.github.getOpenIssues as ReturnType<typeof vi.fn>).mockReturnValue(issues)
+
+    const task = getActiveTask(ctx)
+
+    expect(task).not.toBeNull()
+    expect(task?.issueNumber).toBe(42)
+    expect(ctx.github.getOpenIssues).toHaveBeenCalledWith([QUEUE_LABELS.ACTIVE])
+  })
+
+  it('getActiveTask returns null when no active task', () => {
+    ;(ctx.github.getOpenIssues as ReturnType<typeof vi.fn>).mockReturnValue([])
+
+    const task = getActiveTask(ctx)
+
+    expect(task).toBeNull()
+  })
+
+  it('activateTask swaps labels correctly', () => {
+    const task = createQueuedTask({ issueNumber: 42 })
+
+    activateTask(ctx, task)
+
+    expect(ctx.github.removeLabel).toHaveBeenCalledWith(42, QUEUE_LABELS.QUEUED)
+    expect(ctx.github.addLabel).toHaveBeenCalledWith(42, QUEUE_LABELS.ACTIVE)
+  })
+
+  it('completeTask removes active label', () => {
+    const task = createQueuedTask({ issueNumber: 42 })
+
+    completeTask(ctx, task)
+
+    expect(ctx.github.removeLabel).toHaveBeenCalledWith(42, QUEUE_LABELS.ACTIVE)
+  })
+
+  it('failTask swaps to failed label', () => {
+    const task = createQueuedTask({ issueNumber: 42 })
+
+    failTask(ctx, task)
+
+    expect(ctx.github.removeLabel).toHaveBeenCalledWith(42, QUEUE_LABELS.ACTIVE)
+    expect(ctx.github.addLabel).toHaveBeenCalledWith(42, QUEUE_LABELS.FAILED)
+  })
+
+  it('getRetryCount returns 0 for unknown task', () => {
+    expect(getRetryCount(DEFAULT_QUEUE_STATE, 'issue-99')).toBe(0)
+  })
+
+  it('incrementRetry correctly tracks retry count', () => {
+    let state = { ...DEFAULT_QUEUE_STATE }
+
+    state = incrementRetry(state, 'issue-42')
+    expect(getRetryCount(state, 'issue-42')).toBe(1)
+
+    state = incrementRetry(state, 'issue-42')
+    expect(getRetryCount(state, 'issue-42')).toBe(2)
+  })
+
+  it('cleanTaskState removes task-specific data', () => {
+    const state: QueueState = {
+      activeTaskId: 'issue-42',
+      activeIssueNumber: 42,
+      activeStartedAt: '2026-01-01T00:00:00Z',
+      retries: { 'issue-42': 2, 'issue-43': 1 },
+      gateApprovals: { 'issue-42': ['taskify'], 'issue-43': ['architect'] },
+    }
+
+    const cleaned = cleanTaskState(state, 'issue-42')
+
+    expect(cleaned.activeTaskId).toBeNull()
+    expect(cleaned.activeIssueNumber).toBeNull()
+    expect(cleaned.retries).toEqual({ 'issue-43': 1 })
+    expect(cleaned.gateApprovals).toEqual({ 'issue-43': ['architect'] })
+  })
+})
+
+// ============================================================================
+// Main Plugin
+// ============================================================================
+
+describe('cody-queue-manager plugin', () => {
+  let ctx: InspectorContext
+
+  beforeEach(() => {
+    ctx = createMockContext()
+  })
+
+  it('returns no actions when queue is empty and no active task', async () => {
+    ;(ctx.github.getOpenIssues as ReturnType<typeof vi.fn>).mockReturnValue([])
+
+    const actions = await queueManagerPlugin.run(ctx)
+
+    expect(actions).toEqual([])
+  })
+
+  it('activates first task when queue has tasks and no active task', async () => {
+    // First call for active (empty), second call for queued (has tasks)
+    const getOpenIssuesFn = ctx.github.getOpenIssues as ReturnType<typeof vi.fn>
+    getOpenIssuesFn
+      .mockReturnValueOnce([]) // getActiveTask — no active
+      .mockReturnValueOnce([
+        createIssueInfo({ number: 10, updatedAt: '2026-03-15T08:00:00Z' }),
+        createIssueInfo({ number: 20, updatedAt: '2026-03-15T09:00:00Z' }),
+      ]) // getQueuedTasks
+
+    const actions = await queueManagerPlugin.run(ctx)
+
+    expect(actions).toHaveLength(1)
+    expect(actions[0].type).toBe('activate-task')
+    expect(actions[0].target).toBe('issue-10') // First in FIFO order
+  })
+
+  it('returns no actions when active task is healthy', async () => {
+    // Active task exists
+    ;(ctx.github.getOpenIssues as ReturnType<typeof vi.fn>).mockReturnValue([
+      createIssueInfo({ number: 42, labels: ['cody:queue-active'] }),
+    ])
+
+    // Health check says healthy
+    ;(ctx.state.get as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+      if (key === 'cody:evaluatedTasks') {
+        return [createEvaluatedTask({ health: 'healthy' })]
+      }
+      if (key === 'queue:state') {
+        return {
+          ...DEFAULT_QUEUE_STATE,
+          activeTaskId: 'issue-42',
+          activeIssueNumber: 42,
+          activeStartedAt: new Date().toISOString(),
+        }
+      }
+      return undefined
+    })
+
+    const actions = await queueManagerPlugin.run(ctx)
+
+    expect(actions).toEqual([])
+  })
+
+  it('creates gate review action when active task is gated', async () => {
+    ;(ctx.github.getOpenIssues as ReturnType<typeof vi.fn>).mockReturnValue([
+      createIssueInfo({ number: 42, labels: ['cody:queue-active'] }),
+    ])
+    ;(ctx.state.get as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+      if (key === 'cody:evaluatedTasks') {
+        return [
+          createEvaluatedTask({
+            health: 'gated',
+            healthDetail: 'Waiting for gate approval',
+            failedStage: 'taskify',
+          }),
+        ]
+      }
+      if (key === 'queue:state') {
+        return {
+          ...DEFAULT_QUEUE_STATE,
+          activeTaskId: 'issue-42',
+          activeIssueNumber: 42,
+          activeStartedAt: new Date().toISOString(),
+        }
+      }
+      return undefined
+    })
+
+    const actions = await queueManagerPlugin.run(ctx)
+
+    expect(actions).toHaveLength(1)
+    expect(actions[0].type).toBe('gate-review')
+    expect(actions[0].target).toBe('issue-42')
+  })
+
+  it('creates failure action when active task failed with retries remaining', async () => {
+    ;(ctx.github.getOpenIssues as ReturnType<typeof vi.fn>).mockReturnValue([
+      createIssueInfo({ number: 42, labels: ['cody:queue-active'] }),
+    ])
+    ;(ctx.state.get as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+      if (key === 'cody:evaluatedTasks') {
+        return [
+          createEvaluatedTask({
+            health: 'failed',
+            failedStage: 'build',
+            failedError: 'TypeScript error',
+          }),
+        ]
+      }
+      if (key === 'queue:state') {
+        return {
+          ...DEFAULT_QUEUE_STATE,
+          activeTaskId: 'issue-42',
+          activeIssueNumber: 42,
+          activeStartedAt: new Date().toISOString(),
+          retries: {},
+        }
+      }
+      return undefined
+    })
+
+    const actions = await queueManagerPlugin.run(ctx)
+
+    expect(actions).toHaveLength(1)
+    expect(actions[0].type).toBe('handle-failure')
+    expect(actions[0].urgency).toBe('critical')
+  })
+
+  it('creates complete action and advances when active task completed', async () => {
+    ;(ctx.github.getOpenIssues as ReturnType<typeof vi.fn>).mockReturnValue([
+      createIssueInfo({ number: 42, labels: ['cody:queue-active'] }),
+    ])
+    ;(ctx.state.get as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+      if (key === 'cody:evaluatedTasks') {
+        return [createEvaluatedTask({ health: 'completed' })]
+      }
+      if (key === 'queue:state') {
+        return {
+          ...DEFAULT_QUEUE_STATE,
+          activeTaskId: 'issue-42',
+          activeIssueNumber: 42,
+          activeStartedAt: new Date().toISOString(),
+        }
+      }
+      return undefined
+    })
+
+    const actions = await queueManagerPlugin.run(ctx)
+
+    expect(actions).toHaveLength(1)
+    expect(actions[0].type).toBe('complete-task')
+  })
+
+  it('treats orphaned tasks as failed', async () => {
+    ;(ctx.github.getOpenIssues as ReturnType<typeof vi.fn>).mockReturnValue([
+      createIssueInfo({ number: 42, labels: ['cody:queue-active'] }),
+    ])
+    ;(ctx.state.get as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+      if (key === 'cody:evaluatedTasks') {
+        return [
+          createEvaluatedTask({
+            health: 'orphaned',
+            healthDetail: 'No workflow run found',
+          }),
+        ]
+      }
+      if (key === 'queue:state') {
+        return {
+          ...DEFAULT_QUEUE_STATE,
+          activeTaskId: 'issue-42',
+          activeIssueNumber: 42,
+          activeStartedAt: new Date().toISOString(),
+        }
+      }
+      return undefined
+    })
+
+    const actions = await queueManagerPlugin.run(ctx)
+
+    expect(actions).toHaveLength(1)
+    expect(actions[0].type).toBe('handle-failure')
+  })
+
+  it('waits during startup grace period for unknown health', async () => {
+    ;(ctx.github.getOpenIssues as ReturnType<typeof vi.fn>).mockReturnValue([
+      createIssueInfo({ number: 42, labels: ['cody:queue-active'] }),
+    ])
+
+    const recentStart = new Date().toISOString() // Just started
+
+    ;(ctx.state.get as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+      if (key === 'cody:evaluatedTasks') {
+        return [createEvaluatedTask({ health: 'unknown' })]
+      }
+      if (key === 'queue:state') {
+        return {
+          ...DEFAULT_QUEUE_STATE,
+          activeTaskId: 'issue-42',
+          activeIssueNumber: 42,
+          activeStartedAt: recentStart,
+        }
+      }
+      return undefined
+    })
+
+    const actions = await queueManagerPlugin.run(ctx)
+
+    expect(actions).toEqual([])
+  })
+
+  it('treats unknown health as failed after grace period', async () => {
+    ;(ctx.github.getOpenIssues as ReturnType<typeof vi.fn>).mockReturnValue([
+      createIssueInfo({ number: 42, labels: ['cody:queue-active'] }),
+    ])
+
+    const staleStart = new Date(Date.now() - 15 * 60 * 1000).toISOString() // 15 min ago
+
+    ;(ctx.state.get as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+      if (key === 'cody:evaluatedTasks') {
+        return [createEvaluatedTask({ health: 'unknown' })]
+      }
+      if (key === 'queue:state') {
+        return {
+          ...DEFAULT_QUEUE_STATE,
+          activeTaskId: 'issue-42',
+          activeIssueNumber: 42,
+          activeStartedAt: staleStart,
+        }
+      }
+      return undefined
+    })
+
+    const actions = await queueManagerPlugin.run(ctx)
+
+    expect(actions).toHaveLength(1)
+    expect(actions[0].type).toBe('handle-failure')
+  })
+
+  it('waits during grace period when task not in evaluatedTasks', async () => {
+    ;(ctx.github.getOpenIssues as ReturnType<typeof vi.fn>).mockReturnValue([
+      createIssueInfo({ number: 42, labels: ['cody:queue-active'] }),
+    ])
+
+    const recentStart = new Date().toISOString()
+
+    ;(ctx.state.get as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+      if (key === 'cody:evaluatedTasks') {
+        return [] // Not yet in evaluated tasks
+      }
+      if (key === 'queue:state') {
+        return {
+          ...DEFAULT_QUEUE_STATE,
+          activeTaskId: 'issue-42',
+          activeIssueNumber: 42,
+          activeStartedAt: recentStart,
+        }
+      }
+      return undefined
+    })
+
+    const actions = await queueManagerPlugin.run(ctx)
+
+    expect(actions).toEqual([])
+  })
+
+  it('has correct plugin metadata', () => {
+    expect(queueManagerPlugin.name).toBe('cody-queue-manager')
+    expect(queueManagerPlugin.domain).toBe('cody')
+    expect(typeof queueManagerPlugin.run).toBe('function')
+  })
+})
+
+// ============================================================================
+// Action Execution (execute callbacks)
+// ============================================================================
+
+describe('action execution', () => {
+  let ctx: InspectorContext
+
+  beforeEach(() => {
+    ctx = createMockContext()
+  })
+
+  it('activate action triggers workflow and posts comment', async () => {
+    const getOpenIssuesFn = ctx.github.getOpenIssues as ReturnType<typeof vi.fn>
+    getOpenIssuesFn
+      .mockReturnValueOnce([]) // getActiveTask — no active
+      .mockReturnValueOnce([createIssueInfo({ number: 10, updatedAt: '2026-03-15T08:00:00Z' })])
+
+    const actions = await queueManagerPlugin.run(ctx)
+    expect(actions).toHaveLength(1)
+
+    // Execute the action
+    const result = await actions[0].execute(ctx)
+
+    expect(result.success).toBe(true)
+    expect(ctx.github.removeLabel).toHaveBeenCalledWith(10, QUEUE_LABELS.QUEUED)
+    expect(ctx.github.addLabel).toHaveBeenCalledWith(10, QUEUE_LABELS.ACTIVE)
+    expect(ctx.github.triggerWorkflow).toHaveBeenCalledWith('cody.yml', {
+      task_id: 'issue-10',
+      mode: 'full',
+    })
+    expect(ctx.github.postComment).toHaveBeenCalled()
+  })
+
+  it('complete action removes active label and advances queue', async () => {
+    // Setup: active task completed
+    ;(ctx.github.getOpenIssues as ReturnType<typeof vi.fn>).mockReturnValueOnce([
+      createIssueInfo({ number: 42, labels: ['cody:queue-active'] }),
+    ])
+    ;(ctx.state.get as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+      if (key === 'cody:evaluatedTasks') {
+        return [createEvaluatedTask({ health: 'completed' })]
+      }
+      if (key === 'queue:state') {
+        return {
+          ...DEFAULT_QUEUE_STATE,
+          activeTaskId: 'issue-42',
+          activeIssueNumber: 42,
+          activeStartedAt: new Date().toISOString(),
+        }
+      }
+      return undefined
+    })
+
+    const actions = await queueManagerPlugin.run(ctx)
+    expect(actions).toHaveLength(1)
+
+    // For the execute callback: setup getQueuedTasks to return a next task
+    ;(ctx.github.getOpenIssues as ReturnType<typeof vi.fn>).mockReturnValue([
+      createIssueInfo({ number: 50, labels: ['cody:queued'], updatedAt: '2026-03-15T08:00:00Z' }),
+    ])
+
+    const result = await actions[0].execute(ctx)
+
+    expect(result.success).toBe(true)
+    expect(ctx.github.removeLabel).toHaveBeenCalledWith(42, QUEUE_LABELS.ACTIVE)
+    // Should trigger next task
+    expect(ctx.github.triggerWorkflow).toHaveBeenCalledWith('cody.yml', {
+      task_id: 'issue-50',
+      mode: 'full',
+    })
+  })
+
+  it('complete action handles empty queue gracefully', async () => {
+    ;(ctx.github.getOpenIssues as ReturnType<typeof vi.fn>).mockReturnValueOnce([
+      createIssueInfo({ number: 42, labels: ['cody:queue-active'] }),
+    ])
+    ;(ctx.state.get as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+      if (key === 'cody:evaluatedTasks') {
+        return [createEvaluatedTask({ health: 'completed' })]
+      }
+      if (key === 'queue:state') {
+        return {
+          ...DEFAULT_QUEUE_STATE,
+          activeTaskId: 'issue-42',
+          activeIssueNumber: 42,
+          activeStartedAt: new Date().toISOString(),
+        }
+      }
+      return undefined
+    })
+
+    const actions = await queueManagerPlugin.run(ctx)
+
+    // For execute: empty queue
+    ;(ctx.github.getOpenIssues as ReturnType<typeof vi.fn>).mockReturnValue([])
+
+    const result = await actions[0].execute(ctx)
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('Completed issue-42')
+    expect(ctx.github.triggerWorkflow).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What / Why

Add a new inspector plugin (cody-queue-manager) that implements autonomous sequential task processing. Users add issues to a queue via dashboard UI (adds cody:queued label), and the plugin picks them up one-by-one, runs through the Cody pipeline, auto-approves gates using AI review, monitors for failures, and retries up to 2 times — all without human intervention.

## Key Components
- Queue state management with label-based lifecycle
- AI-powered gate review (MiniMax M2.5, fail-open design)
- Failure analysis reusing existing classifier/analyzer
- Dashboard Queue view with status indicators
- Add/Remove from Queue actions in task detail menu
- 26 unit tests

## Files Changed (13 files)
- 4 new files in scripts/inspector/plugins/cody/queue-manager/
- 1 new QueueView.tsx component
- 1 new test file (26 tests)
- 7 modified files (api, hooks, dashboard, filter bar, task detail, utils, inspector index)

## Quality Gates
- tsc --noEmit: PASSED
- lint: PASSED
- format: PASSED
- All 226 inspector tests PASSED (26 new)
- All view-mode tests PASSED (no regressions)

🤖 Generated with Claude Code