### PR TITLE
feat(cody): Defer test writing to inspector plugin

### DIFF
--- a/.opencode/plans/20260316-deferred-tests-plugin.md
+++ b/.opencode/plans/20260316-deferred-tests-plugin.md
@@ -1,0 +1,237 @@
+# Plan: Defer Test Writing to Inspector Plugin
+
+**Created**: 2026-03-16
+**Status**: Draft
+**Priority**: High
+
+---
+
+## Problem Statement
+
+The Cody pipeline's `test` stage runs in **parallel** with the `build` stage (TDD Red Phase). Tests are written against the *plan*, not the actual implementation. After build completes, the pipeline spends significant time in fix loops trying to reconcile tests with the actual code:
+
+1. **Build post-action** (`run-quality-with-autofix`): Runs `pnpm -s test:unit` → tests fail because they don't match impl → re-invokes build agent (45m timeout) → re-runs gates. Up to **2 feedback loops**.
+2. **Verify stage**: Runs `pnpm -s test:unit` again → if fails, triggers `fix` stage (30m timeout) → verify again. Up to **2 fix attempts**.
+
+**Worst case: ~200 minutes** of fix loops caused by test-impl mismatches. This is the #1 source of pipeline failures and the biggest bottleneck in feature delivery.
+
+## Solution
+
+Remove test writing and test execution from the live pipeline entirely. Create a `deferred-tests` inspector plugin that writes tests against the **actual merged implementation** on `dev`, then opens a follow-up PR.
+
+**Key insight**: Writing tests *after* implementation exists is fundamentally more reliable — the test agent reads actual code, not guesses from a plan.
+
+## Prerequisites: Fix Deferred Infrastructure
+
+> **IMPORTANT**: The existing `deferred-stages` plugin (docs) has not been working reliably. Before building the tests plugin, we must diagnose and fix the shared deferred infrastructure.
+
+### Diagnostic Steps (Phase 0)
+
+1. **Inspector cron firing?** — Check GitHub Actions run history for `inspector.yml` (should run every 5 min)
+2. **Plugin finding eligible tasks?** — Check/add logging for tasks scanned vs matched in deferred-stages plugin
+3. **Workflow dispatch succeeding?** — Verify `github.triggerWorkflow('cody.yml', ...)` actually triggers runs. Check `GH_PAT` permissions.
+4. **Rerun mode working?** — When `cody.yml` runs with `mode=rerun from_stage=docs`, does the state machine correctly pick up from that stage?
+5. **State persistence working?** — Does `STATE_KEY` survive across inspector runs via GitHub Actions variables? Or does it lose track and re-process/miss tasks?
+
+Fix any issues found in the shared infrastructure before proceeding. Both plugins (docs and tests) will benefit.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Pipeline Changes (remove tests from live pipeline)
+
+#### 1.1 Remove `test` from pipeline order
+
+**File:** `scripts/cody/stages/registry.ts`
+
+- **Line 262** (`IMPL_ORDER_STANDARD`): Change `{ parallel: ['test', 'build'] }` → `'build'`
+- **Line 275** (`IMPL_ORDER_LIGHTWEIGHT`): Same change
+
+The `test` stage definition stays in the registry (like `docs` does) so it can be triggered via `mode=rerun from_stage=test`.
+
+#### 1.2 Remove unit test gate from build post-actions
+
+**File:** `scripts/cody/pipeline/definitions.ts`
+
+- **Lines 252-258**: Remove the `Unit Tests` gate from `run-quality-with-autofix`. Keep only TypeScript:
+
+```typescript
+{
+  type: 'run-quality-with-autofix',
+  gates: [
+    { name: 'TypeScript', command: 'pnpm -s tsc --noEmit', source: 'tsc' as const },
+    // Unit Tests gate removed — tests are deferred to inspector
+  ],
+  maxFeedbackLoops: 2,
+},
+```
+
+This eliminates the 2 feedback loops (up to ~100 min) caused by test-impl mismatches.
+
+#### 1.3 Remove unit test gate from verify stage
+
+**File:** `scripts/cody/scripted-stages.ts`
+
+- **Line 70**: Remove `{ name: 'Unit Tests', program: 'pnpm', args: ['-s', 'test:unit'] }` from `gateDefinitions`
+- Keep: TypeScript, Lint, Format gates
+
+#### 1.4 Update test stage prompt for deferred mode
+
+**File:** `scripts/cody/stage-prompts.ts`
+
+- **Lines 63-65**: Change from TDD Red Phase to post-implementation mode:
+
+```typescript
+test: () => `Write comprehensive tests for the implemented code.
+Read the actual source files in src/ to understand what was built.
+Write tests that validate the implementation against spec.md.
+Run tests to verify they pass. Fix any failures before completing.`,
+```
+
+#### 1.5 Update review stage prompt
+
+**File:** `scripts/cody/stage-prompts.ts`
+
+- **Lines 82-90**: Remove "verify there is matching code AND a test" — change to just verify there is matching code. Tests won't exist at review time.
+
+```
+Before: "for every requirement in spec.md, verify there is matching code AND a test"
+After:  "for every requirement in spec.md, verify there is matching code"
+```
+
+---
+
+### Phase 2: Create Deferred Tests Inspector Plugin
+
+#### 2.1 Create plugin
+
+**New file:** `scripts/inspector/plugins/cody/deferred-tests/index.ts`
+
+Modeled on `scripts/inspector/plugins/cody/deferred-stages/index.ts`:
+
+| Property | Value |
+|----------|-------|
+| Name | `cody-deferred-tests` |
+| Domain | `cody` |
+| Schedule | Every 6 cycles (~30 min) |
+| Complexity threshold | **0** (every task gets tests) |
+| Dedup window | 6 hours |
+| Trigger condition | Task has `pr` stage completed + no `test.md` in task dir + `test` stage not completed |
+| Action | `cody.yml` workflow dispatch: `task_id=X, mode=rerun, from_stage=test` |
+| Target branch | `dev` (tests written against merged code) |
+| Staleness guard | Skip tasks older than 7 days (prevent testing stale/drifted code) |
+
+The plugin will:
+1. Scan `.tasks/` for completed tasks (PR stage = completed)
+2. Skip tasks that already have `test.md` or `test` stage = completed
+3. Skip already-processed tasks (tracked in state key `cody:deferredTestsProcessed`)
+4. Skip stale tasks (> 7 days old)
+5. Create workflow dispatch action to trigger test writing
+
+#### 2.2 Register the plugin
+
+**File:** `scripts/inspector/index.ts`
+
+- Add import for `deferredTestsPlugin`
+- Add `registry.register(deferredTestsPlugin)` after line 76 (after `deferredStagesPlugin`)
+
+#### 2.3 Update error classifier fix instructions
+
+**File:** `scripts/cody/pipeline/error-classifier.ts`
+
+- The `test_failure` fix instructions currently say "update the source code (not the tests) to make them pass"
+- Change to: "Fix failing test(s). The tests may not match the implementation. Update the tests to correctly reflect what the code actually does."
+- In deferred mode, test failures mean the *tests* are wrong (since the source is already merged), not the source.
+
+---
+
+## Files Changed Summary
+
+| File | Action | Description |
+|------|--------|-------------|
+| `scripts/cody/stages/registry.ts` | Modify | Remove `test` from `IMPL_ORDER_STANDARD` and `IMPL_ORDER_LIGHTWEIGHT` |
+| `scripts/cody/pipeline/definitions.ts` | Modify | Remove Unit Tests gate from build post-actions |
+| `scripts/cody/scripted-stages.ts` | Modify | Remove Unit Tests gate from verify stage |
+| `scripts/cody/stage-prompts.ts` | Modify | Update test + review stage prompts |
+| `scripts/cody/pipeline/error-classifier.ts` | Modify | Update test_failure fix instructions |
+| `scripts/inspector/plugins/cody/deferred-tests/index.ts` | **Create** | New inspector plugin |
+| `scripts/inspector/index.ts` | Modify | Register new plugin |
+
+**Total: 6 files modified, 1 file created**
+
+---
+
+## What Changes at Runtime
+
+### Pipeline (before → after)
+
+```
+BEFORE:
+taskify → gap → clarify → architect → plan-gap → [test || build] → commit → review → fix → verify → pr
+                                                                     ↑ unit tests gate    ↑ unit tests gate
+
+AFTER:
+taskify → gap → clarify → architect → plan-gap → build → commit → review → fix → verify → pr
+                                                                                  ↑ no unit tests
+
+~30 min later (inspector):
+deferred-tests plugin → cody.yml rerun from_stage=test → test agent writes tests → follow-up PR to dev
+```
+
+### Gate changes
+
+| Gate | Build Post-Actions | Verify Stage |
+|------|--------------------|-------------|
+| TypeScript (`tsc --noEmit`) | Kept | Kept |
+| Lint | N/A | Kept |
+| Format | N/A | Kept |
+| **Unit Tests** | **Removed** | **Removed** |
+
+---
+
+## Expected Impact
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Worst-case fix loop time | ~200 min | ~30 min (only tsc/lint/format failures) |
+| Typical pipeline time | Variable, often 60-90+ min | ~30-50 min |
+| Test-impl mismatch failures | Frequent (#1 failure class) | Eliminated |
+| Test quality | Plan-based (often inaccurate) | Implementation-based (accurate) |
+| Test coverage gap | None | ~30 min window on `dev` |
+
+## Trade-offs
+
+### Accepted
+- Features land on `dev` without tests for ~30 min until inspector picks them up
+- Test PRs are separate from feature PRs (slightly harder to review together)
+
+### Mitigated
+- Staleness guard (7 day cutoff) prevents testing drifted code
+- Dedup window (6 hours) prevents re-triggering
+- Tests written against actual code are higher quality
+
+### Not Changed
+- `test` stage definition stays in `definitions.ts` (needed for `mode=rerun from_stage=test`)
+- `test` stage config stays in stage registry (timeout, context files, etc.)
+- Test-writer agent definitions stay (`.opencode/agents/test.md`, `.opencode/agents/test-writer.md`)
+- Turbo pipeline unchanged (already doesn't have a test stage)
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Inspector infra doesn't work reliably | **High** (known issue) | High — no tests written at all | Phase 0 diagnostic + fix first |
+| Review agent hallucinates missing-test findings | Medium | Low — causes unnecessary fix loop | Strong prompt update |
+| Stale code drift before tests arrive | Low | Medium — tests may not cover latest state | 7-day staleness guard |
+| Dependent Cody tasks build on untested code | Low | Medium — cascading quality issues | Tasks are usually independent |
+
+---
+
+## Open Items
+
+- [ ] Phase 0: Diagnose and fix deferred-stages infrastructure
+- [ ] Determine if test PRs should auto-merge or require review
+- [ ] Consider adding a dashboard indicator for "tests pending" on tasks

--- a/scripts/cody/pipeline/definitions.ts
+++ b/scripts/cody/pipeline/definitions.ts
@@ -194,6 +194,30 @@ No critical gaps identified. Plan was refined in-place.
     maxRetries: 1,
     minComplexity: getStageComplexityThreshold('test'),
     shouldSkip: (ctx) => skipIfInputQuality(ctx, 'test'),
+    preExecute: async (ctx) => {
+      // Ensure feature branch for deferred test runs (triggered by inspector plugin).
+      // Without this, the test stage would try to commit/push to dev (branch-protected).
+      if (!ctx.input.dryRun) {
+        try {
+          const td = readTask(ctx.taskDir)
+          if (td) {
+            ensureFeatureBranch(ctx.taskId, td.task_type, undefined, ctx.taskDir)
+          }
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error)
+          throw new Error(`Test stage preExecute failed: ${msg}`)
+        }
+      }
+    },
+    postActions: [
+      // Commit test files after test stage completes (for deferred test runs)
+      {
+        type: 'commit-task-files',
+        stagingStrategy: 'tracked+task',
+        push: true,
+        ensureBranch: true,
+      },
+    ],
     validator: createTestValidator(),
   })
   // build stage - has preExecute for ensureFeatureBranch (G20)

--- a/scripts/cody/pipeline/definitions.ts
+++ b/scripts/cody/pipeline/definitions.ts
@@ -252,7 +252,7 @@ No critical gaps identified. Plan was refined in-place.
         type: 'run-quality-with-autofix',
         gates: [
           { name: 'TypeScript', command: 'pnpm -s tsc --noEmit', source: 'tsc' as const },
-          { name: 'Unit Tests', command: 'pnpm -s test:unit', source: 'test' as const },
+          // Unit Tests gate removed — tests are deferred to inspector plugin (cody-deferred-tests)
         ],
         maxFeedbackLoops: 2,
       },

--- a/scripts/cody/pipeline/error-classifier.ts
+++ b/scripts/cody/pipeline/error-classifier.ts
@@ -39,7 +39,7 @@ const FIX_INSTRUCTIONS: Record<ErrorCategory, string> = {
   lint_error: 'Fix lint errors. Run `pnpm lint:fix` first, then manually fix any remaining issues.',
   format_error: 'Fix format errors. Run `pnpm format:fix` to auto-format all files.',
   test_failure:
-    'Fix failing test(s). Read the test expectations carefully and update the source code (not the tests) to make them pass.',
+    'Fix failing test(s). The tests may not match the implementation. Update the tests to correctly reflect what the code actually does.',
   unknown: 'Unknown error type. Read the full output below and fix the underlying issue.',
 }
 

--- a/scripts/cody/scripted-stages.ts
+++ b/scripts/cody/scripted-stages.ts
@@ -67,7 +67,7 @@ export function runVerifyStage(
     { name: 'TypeScript', program: 'pnpm', args: ['-s', 'tsc', '--noEmit'] },
     { name: 'Lint', program: 'pnpm', args: ['-s', 'lint'] },
     { name: 'Format', program: 'pnpm', args: ['-s', 'format:check'] },
-    { name: 'Unit Tests', program: 'pnpm', args: ['-s', 'test:unit'] },
+    // Unit Tests gate removed — tests are deferred to inspector plugin (cody-deferred-tests)
   ]
 
   const gates: GateResult[] = []

--- a/scripts/cody/stage-prompts.ts
+++ b/scripts/cody/stage-prompts.ts
@@ -60,9 +60,10 @@ export const stageInstructions: Record<string, (taskId: string) => string> = {
 
   'plan-gap': () => ``,
 
-  test: () => `TDD RED PHASE: Write failing tests from the plan.
-You run in PARALLEL with the build agent. Write tests to tests/ ONLY.
-Do NOT modify src/. Do NOT run tests (they will fail without implementation).`,
+  test: () => `DEFERRED TEST STAGE: Write comprehensive tests for the implemented code.
+Read the actual source files in src/ to understand what was built.
+Write tests to tests/ that validate the implementation against spec.md.
+Run tests with pnpm test:unit to verify they pass. Fix any failures before completing.`,
 
   build: () => `CRITICAL: IMPLEMENTATION STAGE - NOT DOCUMENTATION
 
@@ -83,10 +84,11 @@ DO NOT just write build.md - that will fail the pipeline! The pipeline validates
 
 You are reviewing already-generated code AND verifying spec satisfaction. DO NOT modify code files.
 
-Your #1 job is the GOAL-BACKWARD SPEC CHECK: for every requirement in spec.md, verify there is matching code AND a test.
+Your #1 job is the GOAL-BACKWARD SPEC CHECK: for every requirement in spec.md, verify there is matching code.
 Your #2 job is standard code review (security, correctness, quality).
+NOTE: Tests are written separately via the deferred-tests inspector plugin. Do NOT flag missing tests as issues.
 
-Produce review.md with a Spec Satisfaction matrix (requirement → code location → test → status) FIRST, then code quality findings.
+Produce review.md with a Spec Satisfaction matrix (requirement → code location → status) FIRST, then code quality findings.
 If ANY spec requirement has no corresponding code: mark as Critical issue.`,
 
   fix: () => `CRITICAL: TARGETED FIX STAGE

--- a/scripts/cody/stages/registry.ts
+++ b/scripts/cody/stages/registry.ts
@@ -259,7 +259,7 @@ export const SPEC_ORDER_LIGHTWEIGHT: StageName[] = ['taskify', 'clarify']
 export const IMPL_ORDER_STANDARD: TypedPipelineStep[] = [
   'architect',
   'plan-gap',
-  { parallel: ['test', 'build'] },
+  'build', // test stage deferred to inspector plugin (cody-deferred-tests)
   'commit',
   'review',
   'fix',
@@ -272,7 +272,7 @@ export const IMPL_ORDER_STANDARD: TypedPipelineStep[] = [
 
 export const IMPL_ORDER_LIGHTWEIGHT: TypedPipelineStep[] = [
   'architect',
-  { parallel: ['test', 'build'] },
+  'build', // test stage deferred to inspector plugin (cody-deferred-tests)
   'commit',
   'review',
   'fix',

--- a/scripts/inspector/core/state.ts
+++ b/scripts/inspector/core/state.ts
@@ -119,7 +119,7 @@ export class GhVariableStateStore implements StateStore {
         {
           encoding: 'utf-8',
           stdio: ['pipe', 'pipe', 'pipe'],
-          env: { ...process.env },
+          env: { ...process.env, GH_TOKEN: process.env.GH_PAT || process.env.GH_TOKEN || '' },
         },
       ).trim()
 
@@ -156,7 +156,7 @@ export class GhVariableStateStore implements StateStore {
         {
           encoding: 'utf-8',
           stdio: ['pipe', 'pipe', 'pipe'],
-          env: { ...process.env },
+          env: { ...process.env, GH_TOKEN: process.env.GH_PAT || process.env.GH_TOKEN || '' },
         },
       )
       this.dirty = false

--- a/scripts/inspector/index.ts
+++ b/scripts/inspector/index.ts
@@ -13,6 +13,7 @@ import { healthCheckPlugin } from './plugins/cody/health-check/index'
 import { auditPlugin } from './plugins/cody/audit/index'
 import { failureAnalysisPlugin } from './plugins/cody/failure-analysis/index'
 import { deferredStagesPlugin } from './plugins/cody/deferred-stages/index'
+import { deferredTestsPlugin } from './plugins/cody/deferred-tests/index'
 import { docsSyncPlugin } from './plugins/docs-sync/index'
 import { zombieReaperPlugin } from './plugins/cody/zombie-reaper/index'
 import { successTrackerPlugin } from './plugins/cody/success-tracker/index'
@@ -74,6 +75,7 @@ async function main(): Promise<void> {
   registry.register(failureAnalysisPlugin)
   registry.register(auditPlugin)
   registry.register(deferredStagesPlugin)
+  registry.register(deferredTestsPlugin)
   registry.register(docsSyncPlugin)
   registry.register(zombieReaperPlugin)
   registry.register(successTrackerPlugin)

--- a/scripts/inspector/plugins/cody/deferred-tests/index.ts
+++ b/scripts/inspector/plugins/cody/deferred-tests/index.ts
@@ -133,6 +133,8 @@ function createDeferredTestsAction(taskId: string, _ctx: InspectorContext): Acti
           task_id: taskId,
           mode: 'rerun',
           from_stage: 'test',
+          feedback:
+            'Deferred test run: write tests for the implemented code on dev. Create a new test branch.',
         })
         execCtx.log.info({ taskId }, 'Triggered cody.yml for deferred test stage')
         return { success: true, message: `Triggered deferred tests for ${taskId}` }

--- a/scripts/inspector/plugins/cody/deferred-tests/index.ts
+++ b/scripts/inspector/plugins/cody/deferred-tests/index.ts
@@ -1,0 +1,220 @@
+/**
+ * @fileType plugin
+ * @domain inspector
+ * @pattern deferred-tests-plugin
+ * @ai-summary Writes tests for tasks that completed PR but have no test coverage yet
+ *
+ * Test writing was removed from the live pipeline to eliminate the ~200 min worst-case
+ * fix loops caused by test-impl mismatches (tests written against plan, not actual code).
+ * This inspector plugin picks up completed tasks and triggers the test stage via
+ * `cody.yml` workflow dispatch with `mode=rerun from_stage=test`.
+ *
+ * Unlike the deferred-stages (docs) plugin, there is no complexity threshold — every
+ * task gets tests. A staleness guard skips tasks older than 7 days.
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+
+import type { InspectorPlugin, ActionRequest, InspectorContext } from '../../../core/types'
+
+const STATE_KEY = 'cody:deferredTestsProcessed'
+
+/** Maximum age (in days) for a task to be eligible for deferred tests */
+const MAX_TASK_AGE_DAYS = 7
+
+interface StageEntry {
+  state?: string
+}
+
+interface TaskStatus {
+  state?: string
+  version?: number
+  stages?: Record<string, StageEntry>
+  startedAt?: string
+}
+
+interface TaskJson {
+  complexity?: number
+  created_at?: string
+}
+
+/**
+ * Get the task creation date. Checks task.json first, then status.json startedAt.
+ * Returns null if no date can be determined.
+ */
+function getTaskCreationDate(taskDir: string, status: TaskStatus): Date | null {
+  // Try task.json created_at
+  const taskJsonPath = path.join(taskDir, 'task.json')
+  try {
+    if (fs.existsSync(taskJsonPath)) {
+      const data = JSON.parse(fs.readFileSync(taskJsonPath, 'utf-8')) as TaskJson
+      if (data.created_at) {
+        return new Date(data.created_at)
+      }
+    }
+  } catch {
+    // Ignore errors
+  }
+
+  // Fall back to status.json startedAt
+  if (status.startedAt) {
+    return new Date(status.startedAt)
+  }
+
+  return null
+}
+
+/**
+ * Check if a task is eligible for deferred tests.
+ *
+ * A task is eligible if:
+ *   1. The `pr` stage is completed (pipeline finished)
+ *   2. The `test` stage is not completed
+ *   3. test.md output file does not already exist
+ *   4. Task is not older than MAX_TASK_AGE_DAYS (staleness guard)
+ */
+function isEligibleForDeferredTests(taskDir: string, status: TaskStatus): boolean {
+  const stages = status.stages || {}
+
+  // Must have completed pr stage
+  const prStage = stages['pr']
+  if (!prStage || prStage.state !== 'completed') {
+    return false
+  }
+
+  // Check if test is already completed
+  const testStage = stages['test']
+  if (testStage?.state === 'completed') {
+    return false
+  }
+
+  // Check if test.md output file already exists (tests ran outside status tracking)
+  const testMdPath = path.join(taskDir, 'test.md')
+  if (fs.existsSync(testMdPath)) {
+    return false
+  }
+
+  // Staleness guard: skip tasks older than MAX_TASK_AGE_DAYS
+  const createdDate = getTaskCreationDate(taskDir, status)
+  if (createdDate) {
+    const ageMs = Date.now() - createdDate.getTime()
+    const ageDays = ageMs / (1000 * 60 * 60 * 24)
+    if (ageDays > MAX_TASK_AGE_DAYS) {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
+ * Create an action to trigger test writing for a task via cody.yml workflow dispatch.
+ */
+function createDeferredTestsAction(taskId: string, _ctx: InspectorContext): ActionRequest {
+  return {
+    plugin: 'cody-deferred-tests',
+    type: 'trigger-deferred-tests',
+    target: taskId,
+    urgency: 'info',
+    title: `Run deferred tests for ${taskId}`,
+    detail: `Task ${taskId} completed PR but has no test coverage. Triggering deferred test stage.`,
+    // Dedup: don't retrigger the same task within 6 hours
+    dedupKey: `deferred-tests:${taskId}`,
+    dedupWindowMinutes: 360,
+    async execute(execCtx: InspectorContext): Promise<{ success: boolean; message?: string }> {
+      if (execCtx.dryRun) {
+        execCtx.log.info({ taskId }, '[dry-run] Would trigger cody.yml for deferred test stage')
+        return { success: true, message: 'dry-run: skipped' }
+      }
+
+      try {
+        execCtx.github.triggerWorkflow('cody.yml', {
+          task_id: taskId,
+          mode: 'rerun',
+          from_stage: 'test',
+        })
+        execCtx.log.info({ taskId }, 'Triggered cody.yml for deferred test stage')
+        return { success: true, message: `Triggered deferred tests for ${taskId}` }
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error)
+        execCtx.log.error({ taskId, error: msg }, 'Failed to trigger deferred test stage')
+        return { success: false, message: msg }
+      }
+    },
+  }
+}
+
+/**
+ * Deferred Tests plugin — writes tests for tasks that completed the pipeline without test coverage.
+ *
+ * Runs every 6th cycle (~30 min) to batch up multiple completed tasks.
+ * No complexity threshold — every task gets tests.
+ * Staleness guard: skips tasks older than 7 days.
+ */
+export const deferredTestsPlugin: InspectorPlugin = {
+  name: 'cody-deferred-tests',
+  description: 'Trigger test writing for tasks that completed PR but have no test coverage',
+  domain: 'cody',
+  schedule: { every: 6 }, // Every 6th cycle = every ~30 min
+
+  async run(ctx) {
+    ctx.log.debug('Running deferred-tests plugin')
+
+    const processedTasks = ctx.state.get<string[]>(STATE_KEY) || []
+    ctx.log.debug({ processedCount: processedTasks.length }, 'Previously processed tasks')
+
+    const tasksDir = path.join(process.cwd(), '.tasks')
+    if (!fs.existsSync(tasksDir)) {
+      return []
+    }
+
+    const entries = fs.readdirSync(tasksDir, { withFileTypes: true })
+    const actions: ActionRequest[] = []
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+
+      const taskId = entry.name
+
+      // Skip already processed
+      if (processedTasks.includes(taskId)) {
+        ctx.log.debug({ taskId }, 'Skipping already-processed task')
+        continue
+      }
+
+      const taskDir = path.join(tasksDir, taskId)
+      const statusPath = path.join(taskDir, 'status.json')
+
+      if (!fs.existsSync(statusPath)) continue
+
+      let status: TaskStatus
+      try {
+        status = JSON.parse(fs.readFileSync(statusPath, 'utf-8')) as TaskStatus
+      } catch {
+        continue
+      }
+
+      if (!isEligibleForDeferredTests(taskDir, status)) {
+        // If PR is completed, mark as processed so we don't keep checking
+        const stages = status.stages || {}
+        const prStage = stages['pr']
+        if (prStage?.state === 'completed') {
+          processedTasks.push(taskId)
+        }
+        continue
+      }
+
+      ctx.log.info({ taskId }, 'Task eligible for deferred tests')
+      actions.push(createDeferredTestsAction(taskId, ctx))
+
+      // Mark as processed so we only trigger once per task
+      processedTasks.push(taskId)
+    }
+
+    ctx.state.set(STATE_KEY, processedTasks)
+
+    ctx.log.debug({ actionCount: actions.length }, 'Generated deferred-tests actions')
+    return actions
+  },
+}

--- a/tests/unit/cody-pipeline-fixes.spec.ts
+++ b/tests/unit/cody-pipeline-fixes.spec.ts
@@ -287,16 +287,18 @@ This is valid promoted content from a previous successful run.
   // ========================================================================
 
   describe('parallel stage error handling (Fix #3)', () => {
-    it('should have parallel test+build group in the implementation pipeline', async () => {
+    it('should have build as a direct string entry in the implementation pipeline (test deferred to inspector)', async () => {
       const { IMPL_ORDER_STANDARD } = await import('../../scripts/cody/pipeline/definitions')
 
-      // Verify parallel group exists for test+build
+      // test stage deferred to inspector plugin (cody-deferred-tests)
+      // build is now a direct string entry, not part of a parallel group
+      expect(IMPL_ORDER_STANDARD).toContain('build')
+
+      // No parallel groups in standard impl pipeline
       const parallelStep = IMPL_ORDER_STANDARD.find(
         (step) => typeof step === 'object' && 'parallel' in step,
       )
-
-      expect(parallelStep).toBeDefined()
-      expect((parallelStep as { parallel: string[] }).parallel).toEqual(['test', 'build'])
+      expect(parallelStep).toBeUndefined()
     })
   })
 

--- a/tests/unit/scripts/cody/lightweight-pipeline.integration.test.ts
+++ b/tests/unit/scripts/cody/lightweight-pipeline.integration.test.ts
@@ -127,8 +127,9 @@ describe('lightweight pipeline integration', () => {
     it('returns 7 steps (no duplicate commit in registry)', async () => {
       const pipeline = getImplPipeline('lightweight')
 
-      // architect, test+build (parallel), commit, review, fix, verify, pr
+      // architect, build, commit, review, fix, verify, pr
       // No duplicate commit — fix stage commits via post-action
+      // test stage deferred to inspector plugin (cody-deferred-tests)
       expect(pipeline).toHaveLength(7)
     })
 
@@ -138,16 +139,8 @@ describe('lightweight pipeline integration', () => {
       const pipeline = getImplPipeline('lightweight')
       const flatNames = flattenPipeline(pipeline)
 
-      expect(flatNames).toEqual([
-        'architect',
-        'test',
-        'build',
-        'commit',
-        'review',
-        'fix',
-        'verify',
-        'pr',
-      ])
+      // test stage deferred to inspector plugin (cody-deferred-tests)
+      expect(flatNames).toEqual(['architect', 'build', 'commit', 'review', 'fix', 'verify', 'pr'])
     })
 
     it('does not include plan-gap', async () => {
@@ -170,30 +163,29 @@ describe('lightweight pipeline integration', () => {
   })
 
   describe('LIGHTWEIGHT_IMPL_PIPELINE constant', () => {
-    it('flattens to 8 stage names', async () => {
+    it('flattens to 7 stage names', async () => {
       // Using module-level shims from registry
 
       const flatNames = flattenPipeline(LIGHTWEIGHT_IMPL_PIPELINE)
 
-      // No duplicate commit in registry version
-      expect(flatNames).toHaveLength(8)
+      // No duplicate commit in registry version; test deferred to inspector
+      expect(flatNames).toHaveLength(7)
     })
 
-    it('contains architect, build, commit, review, fix, commit, verify, pr', async () => {
+    it('contains architect, build, commit, review, fix, verify, pr', async () => {
       // Using module-level shims from registry
 
       const flatNames = flattenPipeline(LIGHTWEIGHT_IMPL_PIPELINE)
 
       expect(flatNames).toContain('architect')
-      expect(flatNames).toContain('test')
       expect(flatNames).toContain('build')
       expect(flatNames).toContain('commit')
       expect(flatNames).toContain('review')
       expect(flatNames).toContain('fix')
-      expect(flatNames).toContain('commit')
       expect(flatNames).toContain('verify')
       expect(flatNames).toContain('pr')
-      // docs is deferred to inspector (not in live pipeline); reflect removed
+      // test deferred to inspector; docs deferred to inspector; reflect removed
+      expect(flatNames).not.toContain('test')
       expect(flatNames).not.toContain('docs')
       expect(flatNames).not.toContain('reflect')
     })
@@ -287,13 +279,13 @@ describe('standard pipeline integration', () => {
   })
 
   describe('IMPL_PIPELINE constant', () => {
-    it('flattens to 9 stage names', async () => {
+    it('flattens to 8 stage names', async () => {
       // Using module-level shims from registry
 
       const flatNames = flattenPipeline(IMPL_PIPELINE)
 
-      // 9 stages (no duplicate commit in registry)
-      expect(flatNames).toHaveLength(9)
+      // 8 stages (no duplicate commit in registry; test deferred to inspector)
+      expect(flatNames).toHaveLength(8)
     })
 
     it('contains all heavyweight stages', async () => {
@@ -325,17 +317,8 @@ describe('end-to-end pipeline selection', () => {
     const implPipeline = getImplPipeline(profile)
     const implStages = flattenPipeline(implPipeline)
 
-    // No duplicate commit in registry version
-    expect(implStages).toEqual([
-      'architect',
-      'test',
-      'build',
-      'commit',
-      'review',
-      'fix',
-      'verify',
-      'pr',
-    ])
+    // No duplicate commit in registry version; test deferred to inspector
+    expect(implStages).toEqual(['architect', 'build', 'commit', 'review', 'fix', 'verify', 'pr'])
 
     // Only plan-gap is skipped in lightweight
     expect(implStages).not.toContain('plan-gap')

--- a/tests/unit/scripts/cody/pipeline-utils.test.ts
+++ b/tests/unit/scripts/cody/pipeline-utils.test.ts
@@ -517,15 +517,14 @@ describe('pipeline stage definitions', () => {
     expect(ALL_IMPL_STAGE_NAMES).toContain('commit')
   })
 
-  it('should have exactly 9 unique impl stages (10 with duplicate commit)', async () => {
-    // docs is deferred to inspector (deferred-stages plugin); reflect removed
+  it('should have exactly 8 unique impl stages', async () => {
+    // docs deferred to inspector; test deferred to inspector; reflect removed
     const { flattenTypedPipeline, IMPL_ORDER_STANDARD } =
       await import('../../../../scripts/cody/stages/registry')
     const ALL_IMPL_STAGE_NAMES = flattenTypedPipeline(IMPL_ORDER_STANDARD)
-    // Registry version doesn't duplicate commit — unlike the old IMPL_PIPELINE
-    // The old IMPL_PIPELINE had 10 entries (with duplicate 'commit')
-    // The new IMPL_ORDER_STANDARD has 9 entries (no duplicate commit — fix stage commits via post-action)
-    expect(ALL_IMPL_STAGE_NAMES.length).toBeGreaterThanOrEqual(9)
+    // Registry version: architect, plan-gap, build, commit, review, fix, verify, pr = 8
+    // No duplicate commit (fix stage commits via post-action); test deferred to inspector
+    expect(ALL_IMPL_STAGE_NAMES.length).toBeGreaterThanOrEqual(8)
   })
 
   it('should have correct stage order', async () => {

--- a/tests/unit/scripts/cody/scripted-stages.test.ts
+++ b/tests/unit/scripts/cody/scripted-stages.test.ts
@@ -39,7 +39,7 @@ vi.spyOn(console, 'error').mockImplementation(() => {})
 // Helpers
 // =============================================================================
 
-const mockExecSync = vi.mocked(childProcess.execSync)
+const _mockExecSync = vi.mocked(childProcess.execSync)
 const mockExecFileSync = vi.mocked(childProcess.execFileSync)
 const mockWriteFileSync = vi.mocked(fs.writeFileSync)
 const mockExistsSync = vi.mocked(fs.existsSync)
@@ -47,7 +47,7 @@ const mockReadFileSync = vi.mocked(fs.readFileSync)
 const mockGetDefaultBranch = vi.mocked(getDefaultBranch)
 
 /**
- * Configure execFileSync to succeed for all 4 verify gates.
+ * Configure execFileSync to succeed for all 3 verify gates.
  */
 function mockAllGatesPass() {
   mockExecFileSync.mockReturnValue('OK')
@@ -62,7 +62,7 @@ function mockGateFails(
   errorOutput: { stdout?: string; stderr?: string; message?: string },
 ) {
   mockExecFileSync.mockImplementation(
-    (program: string, args?: readonly string[], _options?: any) => {
+    (program: string, args?: readonly string[], _options?: unknown) => {
       const argsArr = args || []
       const fullCommand = `${program} ${argsArr.join(' ')}`
       if (fullCommand.includes(failingCommand)) {
@@ -80,11 +80,11 @@ function mockGateFails(
 }
 
 /**
- * Configure execFileSync to fail for all verify gates.
+ * Configure execFileSync to fail for all 3 verify gates.
  */
 function mockAllGatesFail() {
   mockExecFileSync.mockImplementation(
-    (program: string, args?: readonly string[], _options?: any) => {
+    (program: string, args?: readonly string[], _options?: unknown) => {
       const argsArr = args || []
       const fullCommand = `${program} ${argsArr.join(' ')}`
       if (
@@ -140,7 +140,7 @@ describe('runVerifyStage', () => {
       expect(result.report).toContain('## TypeScript: PASS ✅')
       expect(result.report).toContain('## Lint: PASS ✅')
       expect(result.report).toContain('## Format: PASS ✅')
-      expect(result.report).toContain('## Unit Tests: PASS ✅')
+      // Unit Tests gate removed — tests deferred to inspector plugin
     })
 
     it('should NOT include error code blocks when all pass', () => {
@@ -158,7 +158,7 @@ describe('runVerifyStage', () => {
       expect(mockWriteFileSync).toHaveBeenCalledWith('/tmp/verify.md', result.report)
     })
 
-    it('should run all 4 gates with correct commands and cwd', () => {
+    it('should run all 3 gates with correct commands and cwd', () => {
       mockAllGatesPass()
 
       runVerifyStage('/tmp/verify.md', '/my/project')
@@ -178,11 +178,7 @@ describe('runVerifyStage', () => {
         ['-s', 'format:check'],
         expect.objectContaining({ cwd: '/my/project' }),
       )
-      expect(mockExecFileSync).toHaveBeenCalledWith(
-        'pnpm',
-        ['-s', 'test:unit'],
-        expect.objectContaining({ cwd: '/my/project' }),
-      )
+      // Unit Tests gate removed — tests deferred to inspector plugin
     })
   })
 
@@ -211,12 +207,7 @@ describe('runVerifyStage', () => {
       expect(result.passed).toBe(false)
     })
 
-    it('should return { passed: false } when Unit Tests fails', () => {
-      mockGateFails('test:unit', { stdout: '3 tests failed' })
-
-      const result = runVerifyStage('/tmp/verify.md', '/fake/cwd')
-      expect(result.passed).toBe(false)
-    })
+    // Unit Tests gate removed — tests deferred to inspector plugin (cody-deferred-tests)
 
     it('should include FAIL icon for the failing gate', () => {
       mockGateFails('lint', { stderr: 'ESLint: 3 errors found' })
@@ -239,7 +230,7 @@ describe('runVerifyStage', () => {
       const result = runVerifyStage('/tmp/verify.md', '/fake/cwd')
       expect(result.report).toContain('## TypeScript: PASS ✅')
       expect(result.report).toContain('## Format: PASS ✅')
-      expect(result.report).toContain('## Unit Tests: PASS ✅')
+      // Unit Tests gate removed — tests deferred to inspector plugin
     })
 
     it('should include FAIL in the result line', () => {
@@ -268,7 +259,7 @@ describe('runVerifyStage', () => {
       expect(result.report).toContain('## TypeScript: FAIL ❌')
       expect(result.report).toContain('## Lint: FAIL ❌')
       expect(result.report).toContain('## Format: FAIL ❌')
-      expect(result.report).toContain('## Unit Tests: FAIL ❌')
+      // Unit Tests gate removed — tests deferred to inspector plugin
     })
 
     it('should include error output for all failed gates', () => {
@@ -278,7 +269,7 @@ describe('runVerifyStage', () => {
       expect(result.report).toContain('Error output for: pnpm -s tsc --noEmit')
       expect(result.report).toContain('Error output for: pnpm -s lint')
       expect(result.report).toContain('Error output for: pnpm -s format:check')
-      expect(result.report).toContain('Error output for: pnpm -s test:unit')
+      // Unit Tests gate removed — tests deferred to inspector plugin
     })
 
     it('should include FAIL in the result line', () => {
@@ -307,9 +298,8 @@ describe('runVerifyStage', () => {
     it('should truncate error output to 5000 chars', () => {
       const longError = 'E'.repeat(10000)
       mockExecFileSync.mockImplementation(
-        (program: string, args?: readonly string[], _options?: any) => {
+        (program: string, args?: readonly string[], _options?: unknown) => {
           const argsArr = args || []
-          const fullCommand = argsArr.join(' ')
           // Check for 'tsc' as a separate argument (not just substring)
           if (argsArr.includes('tsc')) {
             const error = new Error('failed') as Error & { stdout?: string; stderr?: string }
@@ -333,7 +323,7 @@ describe('runVerifyStage', () => {
 
     it('should use error.message as fallback when stdout and stderr are empty', () => {
       mockExecFileSync.mockImplementation(
-        (program: string, args?: readonly string[], _options?: any) => {
+        (program: string, args?: readonly string[], _options?: unknown) => {
           const argsArr = args || []
           if (argsArr.join(' ').includes('tsc')) {
             const error = new Error('Command tsc not found')
@@ -349,7 +339,7 @@ describe('runVerifyStage', () => {
 
     it('should use "Unknown error" when error has no stdout, stderr, or message', () => {
       mockExecFileSync.mockImplementation(
-        (program: string, args?: readonly string[], _options?: any) => {
+        (program: string, args?: readonly string[], _options?: unknown) => {
           const argsArr = args || []
           if (argsArr.join(' ').includes('tsc')) {
             throw {} // plain object, no message
@@ -428,7 +418,7 @@ describe('runVerifyStage', () => {
       expect(result.report).toContain('## Lint: SKIPPED ❌')
       expect(result.report).toContain('aggregate timeout exceeded')
       expect(result.report).toContain('## Format: SKIPPED ❌')
-      expect(result.report).toContain('## Unit Tests: SKIPPED ❌')
+      // Unit Tests gate removed — tests deferred to inspector plugin
 
       // Final result should be FAIL since not all gates passed
       expect(result.report).toContain('## Result: FAIL')
@@ -459,11 +449,10 @@ describe('runVerifyStage', () => {
       // Check that gates after the first are marked as SKIPPED
       const lintMatch = result.report.match(/## Lint: (PASS|FAIL|SKIPPED)/)
       const formatMatch = result.report.match(/## Format: (PASS|FAIL|SKIPPED)/)
-      const unitTestsMatch = result.report.match(/## Unit Tests: (PASS|FAIL|SKIPPED)/)
 
       expect(lintMatch?.[1]).toBe('SKIPPED')
       expect(formatMatch?.[1]).toBe('SKIPPED')
-      expect(unitTestsMatch?.[1]).toBe('SKIPPED')
+      // Unit Tests gate removed — tests deferred to inspector plugin
     })
 
     it('should include aggregate timeout message in skipped gate output', () => {
@@ -510,9 +499,9 @@ describe('runVerifyStage', () => {
       expect(result.report).toContain('## TypeScript: PASS ✅')
       expect(result.report).toContain('## Lint: PASS ✅')
 
-      // Remaining gates should be skipped
+      // Remaining gate should be skipped
       expect(result.report).toContain('## Format: SKIPPED')
-      expect(result.report).toContain('## Unit Tests: SKIPPED')
+      // Unit Tests gate removed — tests deferred to inspector plugin
     })
   })
 })

--- a/tests/unit/scripts/cody/stage-prompts.test.ts
+++ b/tests/unit/scripts/cody/stage-prompts.test.ts
@@ -168,11 +168,10 @@ describe('stage-prompts', () => {
 
   describe('getImplStages', () => {
     it('should return full implementation stage list (default standard profile)', () => {
-      // docs is deferred to inspector; fix stage commits via post-action (no duplicate commit)
+      // docs deferred to inspector; test deferred to inspector; no duplicate commit
       expect(getImplStages()).toEqual([
         'architect',
         'plan-gap',
-        'test',
         'build',
         'commit',
         'review',
@@ -183,10 +182,9 @@ describe('stage-prompts', () => {
     })
 
     it('should return reduced stage list for lightweight profile (no plan-gap)', () => {
-      // docs is deferred to inspector; fix stage commits via post-action (no duplicate commit)
+      // docs deferred to inspector; test deferred to inspector; no duplicate commit
       expect(getImplStages('lightweight')).toEqual([
         'architect',
-        'test',
         'build',
         'commit',
         'review',
@@ -197,11 +195,10 @@ describe('stage-prompts', () => {
     })
 
     it('should return full stage list for standard profile', () => {
-      // docs is deferred to inspector; fix stage commits via post-action (no duplicate commit)
+      // docs deferred to inspector; test deferred to inspector; no duplicate commit
       expect(getImplStages('standard')).toEqual([
         'architect',
         'plan-gap',
-        'test',
         'build',
         'commit',
         'review',
@@ -228,7 +225,7 @@ describe('stage-prompts', () => {
       }
     })
 
-    it('should return empty strings for non-spec stages (except build, review, fix, docs)', () => {
+    it('should return empty strings for non-spec stages (except build, review, fix, docs, test)', () => {
       const nonSpecStages = ALL_STAGES.filter(
         (s) => !SPEC_STAGES.includes(s as (typeof SPEC_STAGES)[number]),
       )
@@ -244,7 +241,7 @@ describe('stage-prompts', () => {
         } else if (stage === 'docs') {
           expect(instruction).toContain('DOCUMENTATION STAGE')
         } else if (stage === 'test') {
-          expect(instruction).toContain('TDD RED PHASE')
+          expect(instruction).toContain('DEFERRED TEST STAGE')
         } else {
           expect(instruction).toBe('')
         }


### PR DESCRIPTION
## Summary

- Remove test stage and unit test gates from the Cody pipeline to eliminate ~200 min worst-case fix loops
- Create `cody-deferred-tests` inspector plugin that writes tests against actual merged code on `dev`
- Update 5 test files to match new pipeline configuration

## Problem

The `test` stage runs in parallel with `build`, writing tests against the *plan* — not the actual implementation. After build, the pipeline spends up to ~200 minutes in fix loops trying to reconcile tests with code.

## Solution

**Pipeline:** Remove test from pipeline order, remove Unit Tests gates from build post-actions and verify stage, update prompts.

**Inspector plugin:** New `cody-deferred-tests` plugin triggers test writing ~30 min after PR merges. No complexity threshold, 7-day staleness guard.

## Expected Impact

| Metric | Before | After |
|--------|--------|-------|
| Worst-case fix loop time | ~200 min | ~30 min |
| Test-impl mismatch failures | Frequent | Eliminated |
| Test quality | Plan-based | Implementation-based |

## Quality Gates

- tsc: PASSED
- lint: PASSED (0 warnings)  
- format: PASSED
- test:unit: 237 passed, 3 failed (all pre-existing)