### PR TITLE
feat(chat): Fix math rendering — preserve inline math and add LaTeX f…

### DIFF
--- a/src/infra/llm/prompt-composer.server.ts
+++ b/src/infra/llm/prompt-composer.server.ts
@@ -10,6 +10,18 @@ import { buildLessonContextPrompt } from './lesson-context'
 export const SYSTEM_PROMPT_SEPARATOR = '\n\n---\n\n'
 
 /**
+ * Mandatory math formatting instructions injected into every chat prompt.
+ * Ensures the LLM always uses LaTeX delimiters so the frontend can render math properly.
+ */
+const MATH_FORMATTING_INSTRUCTIONS = `## Math Formatting
+
+Always use LaTeX delimiters for mathematical expressions:
+- Inline math (within sentences): \\(...\\)
+- Block/display math (standalone equations): \\[...\\]
+
+Never write math as plain text. Use proper LaTeX notation for fractions (\\frac{}{}), multiplication (\\cdot), square roots (\\sqrt{}), trigonometric functions (\\sin, \\cos, \\tan), Greek letters (\\alpha, \\pi), etc.`
+
+/**
  * Composes final system instructions for AI chat.
  *
  * Order (deterministic):
@@ -44,6 +56,9 @@ export function composeSystemInstructions(
   // Step 3: Append lesson prompt
   const withLessonPrompt = withTeacherProfile + lessonPromptTemplate
 
-  // Step 4: Inject lesson context (reuse existing function)
-  return buildLessonContextPrompt(withLessonPrompt, lessonContextText)
+  // Step 4: Append mandatory math formatting instructions
+  const withMathFormatting = withLessonPrompt + '\n\n' + MATH_FORMATTING_INSTRUCTIONS
+
+  // Step 5: Inject lesson context (reuse existing function)
+  return buildLessonContextPrompt(withMathFormatting, lessonContextText)
 }

--- a/src/infra/llm/prompt-composer.server.ts
+++ b/src/infra/llm/prompt-composer.server.ts
@@ -13,13 +13,17 @@ export const SYSTEM_PROMPT_SEPARATOR = '\n\n---\n\n'
  * Mandatory math formatting instructions injected into every chat prompt.
  * Ensures the LLM always uses LaTeX delimiters so the frontend can render math properly.
  */
-const MATH_FORMATTING_INSTRUCTIONS = `## Math Formatting
+const MATH_FORMATTING_INSTRUCTIONS = `## Math Formatting (CRITICAL)
 
 Always use LaTeX delimiters for mathematical expressions:
 - Inline math (within sentences): \\(...\\)
 - Block/display math (standalone equations): \\[...\\]
 
-Never write math as plain text. Use proper LaTeX notation for fractions (\\frac{}{}), multiplication (\\cdot), square roots (\\sqrt{}), trigonometric functions (\\sin, \\cos, \\tan), Greek letters (\\alpha, \\pi), etc.`
+IMPORTANT: Never use dollar signs ($) for math delimiters. Always use \\(...\\) for inline math and \\[...\\] for block math.
+
+Never write math as plain text. Use proper LaTeX notation for fractions (\\frac{}{}), multiplication (\\cdot), square roots (\\sqrt{}), trigonometric functions (\\sin, \\cos, \\tan), Greek letters (\\alpha, \\pi), etc.
+
+When referencing exercise content, always wrap mathematical expressions in \\(...\\) or \\[...\\] delimiters, even for simple variables like \\(x\\), coordinates like \\((2,0)\\), or function names like \\(f(x)\\).`
 
 /**
  * Composes final system instructions for AI chat.

--- a/src/infra/llm/prompt-resolver.server.ts
+++ b/src/infra/llm/prompt-resolver.server.ts
@@ -16,7 +16,15 @@ export const BUILTIN_FALLBACK_PROMPT = `You are a helpful math and science tutor
 
 Guide students through problem-solving without giving direct answers.
 Ask clarifying questions to help them think critically.
-Be supportive and patient.`
+Be supportive and patient.
+
+## Math Formatting
+
+Always use LaTeX delimiters for mathematical expressions:
+- Inline math (within sentences): \\(...\\)
+- Block/display math (standalone equations): \\[...\\]
+
+Never write math as plain text. Use proper LaTeX notation for fractions (\\frac{}{}), multiplication (\\cdot), square roots (\\sqrt{}), trigonometric functions (\\sin, \\cos, \\tan), Greek letters (\\alpha, \\pi), etc.`
 
 export type PromptResolutionResult = {
   template: string

--- a/src/infra/llm/prompts/exercise-chat-agent-prompt.md
+++ b/src/infra/llm/prompts/exercise-chat-agent-prompt.md
@@ -10,6 +10,15 @@ You are a helpful math and science tutor for students working on exercises.
 - Encourage step-by-step thinking
 - Be supportive and patient
 
+## Math Formatting
+
+Always use LaTeX delimiters for mathematical expressions:
+
+- Inline math (within sentences): `\(...\)` — e.g., "השטח הוא \(S = \frac{1}{2} \cdot a \cdot h\)"
+- Block/display math (standalone equations): `\[...\]` — e.g., \[S = \frac{1}{2} \cdot AB \cdot AC \cdot \sin(\alpha)\]
+
+Never write math as plain text. Use proper LaTeX notation for fractions (`\frac{}{}`), multiplication (`\cdot`), square roots (`\sqrt{}`), trigonometric functions (`\sin`, `\cos`, `\tan`), Greek letters (`\alpha`, `\pi`), etc.
+
 ## Response Style
 
 Keep responses concise and conversational. Focus on helping the student learn, not just get the answer.

--- a/src/ui/web/chat/ChatMessageContent/normalize-latex.ts
+++ b/src/ui/web/chat/ChatMessageContent/normalize-latex.ts
@@ -4,9 +4,6 @@
  * remark-math only recognizes $...$ and $$...$$ delimiters.
  * LLMs often output \[...\] and \(...\) with various escape levels.
  *
- * All math expressions are converted to block/display math ($$...$$) to ensure
- * they appear on their own line, separate from text.
- *
  * Handles:
  * - Single/double/triple backslash delimiters: \[, \\[, \\\[ → $$
  * - Bare brackets with LaTeX: [ \frac{a}{b} ] → $$...$$ (detected by LaTeX command presence)
@@ -15,7 +12,7 @@
  *
  * Conversions:
  * - \[...\], \\[...\\], \\\[...\\\] → $$...$$ (block/display math)
- * - \(...\), \\(...\\), \\\(...\\\) → $$...$$ (converted to block math)
+ * - \(...\), \\(...\\), \\\(...\\\) → $...$ (inline math, preserves sentence flow)
  * - \\frac, \\sigma, etc. → \frac, \sigma (normalize commands)
  */
 export function normalizeLatexDelimiters(content: string): string {
@@ -33,9 +30,9 @@ export function normalizeLatexDelimiters(content: string): string {
       // Convert block math delimiters: \\\[, \\[, \[ → $$ (with newline for remark-math)
       .replace(/\\{1,3}\[/g, () => '\n$$\n')
       .replace(/\\{1,3}\]/g, () => '\n$$\n')
-      // Convert inline math delimiters to block math: \\\(, \\(, \( → $$ (all math on own line)
-      .replace(/\\{1,3}\(/g, () => '\n$$\n')
-      .replace(/\\{1,3}\)/g, () => '\n$$\n')
+      // Convert inline math delimiters: \\\(, \\(, \( → $ (preserves inline flow)
+      .replace(/\\{1,3}\(/g, () => '$')
+      .replace(/\\{1,3}\)/g, () => '$')
       // Normalize over-escaped LaTeX commands: \\frac → \frac, \\sigma → \sigma
       .replace(/\\\\([a-zA-Z])/g, '\\$1')
       // Remove escaped equals: \= → =

--- a/src/ui/web/chat/ChatMessageContent/normalize-latex.ts
+++ b/src/ui/web/chat/ChatMessageContent/normalize-latex.ts
@@ -7,6 +7,7 @@
  * Handles:
  * - Single/double/triple backslash delimiters: \[, \\[, \\\[ → $$
  * - Bare brackets with LaTeX: [ \frac{a}{b} ] → $$...$$ (detected by LaTeX command presence)
+ * - Undelimited LaTeX: \frac{a}{b} outside of $ → wrapped in $...$
  * - Over-escaped LaTeX commands: \\frac → \frac
  * - Escaped equals: \= → =
  *
@@ -14,28 +15,76 @@
  * - \[...\], \\[...\\], \\\[...\\\] → $$...$$ (block/display math)
  * - \(...\), \\(...\\), \\\(...\\\) → $...$ (inline math, preserves sentence flow)
  * - \\frac, \\sigma, etc. → \frac, \sigma (normalize commands)
+ * - Bare LaTeX commands → wrapped in $...$ (safety net for LLM output)
  */
 export function normalizeLatexDelimiters(content: string): string {
   if (!content) return content
 
   // Use a function replacer to avoid $$ special replacement pattern issues
-  return (
-    content
-      // Pre-process: detect bare brackets containing LaTeX commands
-      // Closed: [ \frac{a}{b} ] → \[ \frac{a}{b} \] (but not markdown links [text](url))
-      // Use negative lookbehind (?<!\\) to avoid matching already-escaped \[ or \\[
-      .replace(/(?<!\\)\[([^\]]*\\[a-zA-Z]+[^\]]*)\](?!\()/g, '\\[$1\\]')
-      // Unclosed (no closing ]): [ \frac{a}{b} (end of line) → \[ \frac{a}{b} \]
-      .replace(/(?<!\\)\[([^\]\n]*\\[a-zA-Z]+[^\]\n]*)$/gm, '\\[$1\\]')
-      // Convert block math delimiters: \\\[, \\[, \[ → $$ (with newline for remark-math)
-      .replace(/\\{1,3}\[/g, () => '\n$$\n')
-      .replace(/\\{1,3}\]/g, () => '\n$$\n')
-      // Convert inline math delimiters: \\\(, \\(, \( → $ (preserves inline flow)
-      .replace(/\\{1,3}\(/g, () => '$')
-      .replace(/\\{1,3}\)/g, () => '$')
-      // Normalize over-escaped LaTeX commands: \\frac → \frac, \\sigma → \sigma
-      .replace(/\\\\([a-zA-Z])/g, '\\$1')
-      // Remove escaped equals: \= → =
-      .replace(/\\=/g, '=')
+  let result = content
+    // Pre-process: detect bare brackets containing LaTeX commands
+    // Closed: [ \frac{a}{b} ] → \[ \frac{a}{b} \] (but not markdown links [text](url))
+    // Use negative lookbehind (?<!\\) to avoid matching already-escaped \[ or \\[
+    .replace(/(?<!\\)\[([^\]]*\\[a-zA-Z]+[^\]]*)\](?!\()/g, '\\[$1\\]')
+    // Unclosed (no closing ]): [ \frac{a}{b} (end of line) → \[ \frac{a}{b} \]
+    .replace(/(?<!\\)\[([^\]\n]*\\[a-zA-Z]+[^\]\n]*)$/gm, '\\[$1\\]')
+    // Convert block math delimiters: \\\[, \\[, \[ → $$ (with newline for remark-math)
+    .replace(/\\{1,3}\[/g, () => '\n$$\n')
+    .replace(/\\{1,3}\]/g, () => '\n$$\n')
+    // Convert inline math delimiters: \\\(, \\(, \( → $ (preserves inline flow)
+    .replace(/\\{1,3}\(/g, () => '$')
+    .replace(/\\{1,3}\)/g, () => '$')
+    // Normalize over-escaped LaTeX commands: \\frac → \frac, \\sigma → \sigma
+    .replace(/\\\\([a-zA-Z])/g, '\\$1')
+    // Remove escaped equals: \= → =
+    .replace(/\\=/g, '=')
+
+  // Safety net: wrap undelimited LaTeX commands in $...$
+  // Matches sequences starting with a known LaTeX command that aren't already inside $ delimiters.
+  // Works by splitting on existing $/$$ regions and only processing non-math segments.
+  result = wrapUndelimitedLatex(result)
+
+  return result
+}
+
+/**
+ * Finds LaTeX commands outside of existing $...$ or $$...$$ regions and wraps them in $...$.
+ *
+ * Strategy: split content into math and non-math segments, then only process non-math segments
+ * to find and wrap bare LaTeX expressions.
+ */
+function wrapUndelimitedLatex(content: string): string {
+  // Split content into segments: math regions (inside $/$$ delimiters) and text regions
+  // Match $$...$$, $...$ (non-greedy), preserving them as-is
+  const segments = content.split(/(\$\$[\s\S]*?\$\$|\$[^$\n]+?\$)/g)
+
+  return segments
+    .map((segment, i) => {
+      // Odd indices are the captured math regions — leave them untouched
+      if (i % 2 === 1) return segment
+
+      // Even indices are non-math text — look for bare LaTeX commands
+      return wrapBareLatexInSegment(segment)
+    })
+    .join('')
+}
+
+/**
+ * Wraps bare LaTeX command sequences found in a non-math text segment.
+ *
+ * Matches a LaTeX command followed by its arguments (braces, subscripts, superscripts)
+ * and wraps the entire expression in $...$.
+ */
+function wrapBareLatexInSegment(segment: string): string {
+  // Match a LaTeX command followed by optional arguments: braces {}, subscript _, superscript ^
+  // The pattern captures the full math expression including nested braces
+  // Negative lookbehind for $ ensures we don't match already-delimited content
+  //
+  // Structure: \command + (brace args | subscript/superscript)*
+  // - \{[^}]*\} matches brace arguments like {a}, {CD}, {\\triangle ABC}
+  // - [_^](?:\{[^}]*\}|[^\s{},]) matches subscript/superscript with optional brace group
+  return segment.replace(
+    /(?<!\$)(?<![a-zA-Z])(\\(?:frac|sqrt|sum|prod|int|lim|sin|cos|tan|log|ln|exp|alpha|beta|gamma|delta|epsilon|theta|lambda|mu|pi|sigma|omega|phi|psi|triangle|angle|cdot|times|div|pm|mp|leq|geq|neq|approx|infty|partial|nabla|forall|exists|in|subset|supset|cup|cap|vec|hat|bar|dot|tilde|overline|underline|text|mathrm|mathbf|mathit|binom|dbinom|tbinom)(?:\{[^}]*\}|[_^](?:\{[^}]*\}|[^\s{},]))*)/g,
+    (match) => `$${match}$`,
   )
 }

--- a/src/ui/web/chat/ChatMessageContent/normalize-latex.ts
+++ b/src/ui/web/chat/ChatMessageContent/normalize-latex.ts
@@ -51,6 +51,14 @@ export function normalizeLatexDelimiters(content: string): string {
   // and escapes the $ so they render as plain text instead of broken math.
   result = escapeMismatchedDollarSigns(result)
 
+  // Ensure spaces around inline $...$ when adjacent to non-ASCII characters (e.g. Hebrew).
+  // remarkMath requires certain boundary conditions around $ delimiters — Hebrew characters
+  // directly touching $ (like "ההיקף$s$של") prevent detection. Adding spaces fixes this.
+  // Only targets non-ASCII characters (Hebrew, Arabic, etc.) adjacent to $.
+  result = result
+    .replace(/([\u0590-\u05FF\uFB1D-\uFB4F\u0600-\u06FF])(\$[^$\n]+?\$)/g, '$1 $2')
+    .replace(/(\$[^$\n]+?\$)([\u0590-\u05FF\uFB1D-\uFB4F\u0600-\u06FF])/g, '$1 $2')
+
   // Safety net: wrap undelimited LaTeX commands in $...$
   // Matches sequences starting with a known LaTeX command that aren't already inside $ delimiters.
   // Works by splitting on existing $/$$ regions and only processing non-math segments.

--- a/src/ui/web/chat/ChatMessageContent/normalize-latex.ts
+++ b/src/ui/web/chat/ChatMessageContent/normalize-latex.ts
@@ -39,6 +39,11 @@ export function normalizeLatexDelimiters(content: string): string {
     // Remove escaped equals: \= → =
     .replace(/\\=/g, '=')
 
+  // Ensure $$ block math delimiters are on their own lines (required by remark-math).
+  // LLMs sometimes output $$...$$ inline with text, which breaks block math detection.
+  // Match complete $$...$$ pairs and ensure newlines around them.
+  result = result.replace(/\$\$([\s\S]*?)\$\$/g, (_, expr) => `\n$$\n${expr.trim()}\n$$\n`)
+
   // Safety net: wrap undelimited LaTeX commands in $...$
   // Matches sequences starting with a known LaTeX command that aren't already inside $ delimiters.
   // Works by splitting on existing $/$$ regions and only processing non-math segments.

--- a/src/ui/web/chat/ChatMessageContent/normalize-latex.ts
+++ b/src/ui/web/chat/ChatMessageContent/normalize-latex.ts
@@ -44,12 +44,47 @@ export function normalizeLatexDelimiters(content: string): string {
   // Match complete $$...$$ pairs and ensure newlines around them.
   result = result.replace(/\$\$([\s\S]*?)\$\$/g, (_, expr) => `\n$$\n${expr.trim()}\n$$\n`)
 
+  // Escape mismatched $ pairs that contain Hebrew text (RTL chars).
+  // When the LLM misuses $ delimiters, remarkMath may pair them incorrectly,
+  // creating expressions that contain Hebrew text. KaTeX can't parse Hebrew,
+  // so it shows red error text. This step finds $...$ pairs with Hebrew inside
+  // and escapes the $ so they render as plain text instead of broken math.
+  result = escapeMismatchedDollarSigns(result)
+
   // Safety net: wrap undelimited LaTeX commands in $...$
   // Matches sequences starting with a known LaTeX command that aren't already inside $ delimiters.
   // Works by splitting on existing $/$$ regions and only processing non-math segments.
   result = wrapUndelimitedLatex(result)
 
   return result
+}
+
+/**
+ * Hebrew character range for detecting mismatched $ delimiters.
+ * Matches any Hebrew letter (U+0590–U+05FF) or Hebrew presentation form (U+FB1D–U+FB4F).
+ */
+const HEBREW_REGEX = /[\u0590-\u05FF\uFB1D-\uFB4F]/
+
+/**
+ * Escapes $ signs that are part of mismatched pairs containing Hebrew text.
+ *
+ * When the LLM uses $ for math but mismatches them, remarkMath may pair
+ * a $ with the wrong closing $, creating a huge "expression" with Hebrew
+ * text inside. KaTeX can't parse Hebrew, producing red error text.
+ *
+ * This function finds $...$ pairs where the content contains Hebrew characters
+ * and escapes the $ so the text renders as plain text instead.
+ * Legitimate math like $\frac{a}{b}$ won't contain Hebrew, so this is safe.
+ */
+function escapeMismatchedDollarSigns(content: string): string {
+  // Match $...$ pairs (not $$) — non-greedy, single line only
+  return content.replace(/\$([^$\n]+?)\$/g, (match, inner) => {
+    // If the content between $ contains Hebrew characters, it's not valid math
+    if (HEBREW_REGEX.test(inner)) {
+      return `\\$${inner}\\$`
+    }
+    return match
+  })
 }
 
 /**

--- a/tests/unit/components/chat/ChatMessageContent.test.tsx
+++ b/tests/unit/components/chat/ChatMessageContent.test.tsx
@@ -117,13 +117,13 @@ describe('ChatMessageContent', () => {
       expect(blockMath?.querySelector('.katex-display')).not.toBeNull()
     })
 
-    it('renders \\(...\\) as block math (all math on own line)', () => {
+    it('renders \\(...\\) as inline math (preserves sentence flow)', () => {
       const { container } = render(<ChatMessageContent content={'The value is \\(x^2\\) here'} />)
 
-      // All math is now rendered as block math for better readability
-      const blockMath = container.querySelector('.isolate.block[dir="ltr"]')
-      expect(blockMath).not.toBeNull()
-      expect(blockMath?.querySelector('.katex-display')).not.toBeNull()
+      // Inline math should render with inline-block isolation, not block
+      const inlineMath = container.querySelector('.isolate.inline-block[dir="ltr"]')
+      expect(inlineMath).not.toBeNull()
+      expect(inlineMath?.querySelector('.katex')).not.toBeNull()
     })
 
     it('renders Gaussian formula with \\[...\\] delimiters', () => {
@@ -159,14 +159,14 @@ describe('ChatMessageContent', () => {
       expect(blockMath?.querySelector('.katex-display')).not.toBeNull()
     })
 
-    it('converts \\(...\\) to $$...$$ for block math (all math on own line)', () => {
-      // Test that LaTeX-style inline delimiters are converted to block math
+    it('converts \\(...\\) to $...$ for inline math (preserves sentence flow)', () => {
+      // Test that LaTeX-style inline delimiters are converted to inline math
       const { container } = render(<ChatMessageContent content={'The value is \\(x^2\\) here'} />)
 
-      // Should render as block math with katex-display
-      const blockMath = container.querySelector('.isolate.block[dir="ltr"]')
-      expect(blockMath).not.toBeNull()
-      expect(blockMath?.querySelector('.katex-display')).not.toBeNull()
+      // Should render as inline math with katex (not katex-display)
+      const inlineMath = container.querySelector('.isolate.inline-block[dir="ltr"]')
+      expect(inlineMath).not.toBeNull()
+      expect(inlineMath?.querySelector('.katex')).not.toBeNull()
     })
   })
 })

--- a/tests/unit/components/chat/normalize-latex.test.ts
+++ b/tests/unit/components/chat/normalize-latex.test.ts
@@ -26,26 +26,26 @@ describe('normalizeLatexDelimiters', () => {
     })
   })
 
-  describe('inline math \\(...\\) converted to block', () => {
-    it('converts \\( to $$ with newlines', () => {
-      expect(normalizeLatexDelimiters('\\(')).toBe('\n$$\n')
+  describe('inline math \\(...\\) preserved as inline', () => {
+    it('converts \\( to $', () => {
+      expect(normalizeLatexDelimiters('\\(')).toBe('$')
     })
 
-    it('converts \\) to $$ with newlines', () => {
-      expect(normalizeLatexDelimiters('\\)')).toBe('\n$$\n')
+    it('converts \\) to $', () => {
+      expect(normalizeLatexDelimiters('\\)')).toBe('$')
     })
 
-    it('converts full inline math expression to block math', () => {
+    it('converts full inline math expression to inline $...$', () => {
       const input = 'The value is \\(x^2\\) here'
-      const expected = 'The value is \n$$\nx^2\n$$\n here'
+      const expected = 'The value is $x^2$ here'
       expect(normalizeLatexDelimiters(input)).toBe(expected)
     })
   })
 
   describe('mixed content', () => {
-    it('converts both inline and block in same content (all as block math)', () => {
+    it('converts inline as $ and block as $$', () => {
       const input = 'Inline \\(a+b\\) and block:\n\\[ x^2 \\]'
-      const expected = 'Inline \n$$\na+b\n$$\n and block:\n\n$$\n x^2 \n$$\n'
+      const expected = 'Inline $a+b$ and block:\n\n$$\n x^2 \n$$\n'
       expect(normalizeLatexDelimiters(input)).toBe(expected)
     })
 
@@ -89,17 +89,17 @@ describe('normalizeLatexDelimiters', () => {
       expect(normalizeLatexDelimiters(input)).toBe(expected)
     })
 
-    it('converts JSON-escaped \\( to $$ with newlines', () => {
-      expect(normalizeLatexDelimiters('\\\\(')).toBe('\n$$\n')
+    it('converts JSON-escaped \\( to $', () => {
+      expect(normalizeLatexDelimiters('\\\\(')).toBe('$')
     })
 
-    it('converts JSON-escaped \\) to $$ with newlines', () => {
-      expect(normalizeLatexDelimiters('\\\\)')).toBe('\n$$\n')
+    it('converts JSON-escaped \\) to $', () => {
+      expect(normalizeLatexDelimiters('\\\\)')).toBe('$')
     })
 
-    it('converts full JSON-escaped inline math expression to block math', () => {
+    it('converts full JSON-escaped inline math expression to inline $', () => {
       const input = 'The value is \\\\(x^2\\\\) here'
-      const expected = 'The value is \n$$\nx^2\n$$\n here'
+      const expected = 'The value is $x^2$ here'
       expect(normalizeLatexDelimiters(input)).toBe(expected)
     })
   })
@@ -113,9 +113,9 @@ describe('normalizeLatexDelimiters', () => {
       expect(normalizeLatexDelimiters('\\\\\\]')).toBe('\n$$\n')
     })
 
-    it('converts triple-escaped inline delimiters to block math', () => {
-      expect(normalizeLatexDelimiters('\\\\\\(')).toBe('\n$$\n')
-      expect(normalizeLatexDelimiters('\\\\\\)')).toBe('\n$$\n')
+    it('converts triple-escaped inline delimiters to inline $', () => {
+      expect(normalizeLatexDelimiters('\\\\\\(')).toBe('$')
+      expect(normalizeLatexDelimiters('\\\\\\)')).toBe('$')
     })
 
     it('normalizes over-escaped LaTeX commands (\\\\frac → \\frac)', () => {

--- a/tests/unit/components/chat/normalize-latex.test.ts
+++ b/tests/unit/components/chat/normalize-latex.test.ts
@@ -118,9 +118,10 @@ describe('normalizeLatexDelimiters', () => {
       expect(normalizeLatexDelimiters('\\\\\\)')).toBe('$')
     })
 
-    it('normalizes over-escaped LaTeX commands (\\\\frac → \\frac)', () => {
+    it('normalizes over-escaped LaTeX commands (\\\\frac → \\frac) and wraps in $', () => {
       const input = '\\\\frac{a}{b}'
-      const expected = '\\frac{a}{b}'
+      // After normalization: \frac{a}{b}, then bare LaTeX wrapping adds $...$
+      const expected = '$\\frac{a}{b}$'
       expect(normalizeLatexDelimiters(input)).toBe(expected)
     })
 
@@ -225,6 +226,63 @@ describe('normalizeLatexDelimiters', () => {
       const result = normalizeLatexDelimiters(input)
       expect(result).toContain('$$')
       expect(result).toContain('חשבו את')
+    })
+  })
+
+  describe('undelimited LaTeX safety net', () => {
+    it('wraps bare \\frac in $...$', () => {
+      const input = 'the ratio is \\frac{CD}{AB}'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toContain('$\\frac{CD}{AB}$')
+    })
+
+    it('wraps bare \\triangle in $...$', () => {
+      const input = 'in \\triangle ABC'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toContain('$\\triangle$')
+    })
+
+    it('wraps bare \\angle in $...$', () => {
+      const input = 'where \\angle B = 90'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toContain('$\\angle$')
+    })
+
+    it('wraps bare \\sqrt in $...$', () => {
+      const input = 'equals \\sqrt{3}'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toContain('$\\sqrt{3}$')
+    })
+
+    it('does NOT double-wrap already delimited math', () => {
+      const input = 'already $\\frac{a}{b}$ here'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toBe(input)
+    })
+
+    it('does NOT double-wrap block math', () => {
+      const input = '$$\\frac{a}{b}$$'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toBe(input)
+    })
+
+    it('wraps complex expression with subscripts', () => {
+      const input = 'area \\frac{S_{\\triangle AEF}}{S_{\\triangle CDF}}'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toContain('$')
+      expect(result).not.toMatch(/^area \\frac/) // should be wrapped
+    })
+
+    it('wraps multiple bare commands in the same text', () => {
+      const input = 'given \\triangle ABC and \\angle B'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toContain('$\\triangle$')
+      expect(result).toContain('$\\angle$')
+    })
+
+    it('leaves plain text without LaTeX commands unchanged', () => {
+      const input = 'no math here, just text'
+      expect(normalizeLatexDelimiters(input)).toBe(input)
     })
   })
 })

--- a/tests/unit/components/chat/normalize-latex.test.ts
+++ b/tests/unit/components/chat/normalize-latex.test.ts
@@ -323,4 +323,44 @@ describe('normalizeLatexDelimiters', () => {
       expect(result).toContain('c + d')
     })
   })
+
+  describe('inline $ spacing for remarkMath detection', () => {
+    it('adds space before $ when preceded by Hebrew text', () => {
+      const input = 'ההיקף$s$של'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toContain(' $s$ ')
+    })
+
+    it('adds space after $ when followed by Hebrew text', () => {
+      const input = '$x$נתון'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toContain('$x$ ')
+    })
+
+    it('preserves existing spaces around $', () => {
+      const input = 'text $x$ more'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toBe('text $x$ more')
+    })
+
+    it('does not add space before $ after punctuation', () => {
+      const input = 'value,$x$ here'
+      const result = normalizeLatexDelimiters(input)
+      // comma is not a word char so no space needed before, but after $x$ before "here"
+      expect(result).toContain('$x$')
+    })
+
+    it('does not add space after $ before punctuation', () => {
+      const input = '$x$, and $y$.'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toBe('$x$, and $y$.')
+    })
+
+    it('handles multiple inline math with Hebrew between', () => {
+      const input = "מצאו$f(x)$וגם$f'(x)$חיובית"
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toContain(' $f(x)$ ')
+      expect(result).toContain(" $f'(x)$ ")
+    })
+  })
 })

--- a/tests/unit/components/chat/normalize-latex.test.ts
+++ b/tests/unit/components/chat/normalize-latex.test.ts
@@ -13,7 +13,7 @@ describe('normalizeLatexDelimiters', () => {
 
     it('converts full block math expression', () => {
       const input = '\\[ f(x) = \\frac{a}{b} \\]'
-      const expected = '\n$$\n f(x) = \\frac{a}{b} \n$$\n'
+      const expected = '\n\n$$\nf(x) = \\frac{a}{b}\n$$\n\n'
       expect(normalizeLatexDelimiters(input)).toBe(expected)
     })
 
@@ -21,7 +21,7 @@ describe('normalizeLatexDelimiters', () => {
       const input =
         '\\[ f(x) = \\frac{1}{\\sigma\\sqrt{2\\pi}} e^{-\\frac{1}{2}\\left(\\frac{x-\\mu}{\\sigma}\\right)^2} \\]'
       const expected =
-        '\n$$\n f(x) = \\frac{1}{\\sigma\\sqrt{2\\pi}} e^{-\\frac{1}{2}\\left(\\frac{x-\\mu}{\\sigma}\\right)^2} \n$$\n'
+        '\n\n$$\nf(x) = \\frac{1}{\\sigma\\sqrt{2\\pi}} e^{-\\frac{1}{2}\\left(\\frac{x-\\mu}{\\sigma}\\right)^2}\n$$\n\n'
       expect(normalizeLatexDelimiters(input)).toBe(expected)
     })
   })
@@ -45,13 +45,13 @@ describe('normalizeLatexDelimiters', () => {
   describe('mixed content', () => {
     it('converts inline as $ and block as $$', () => {
       const input = 'Inline \\(a+b\\) and block:\n\\[ x^2 \\]'
-      const expected = 'Inline $a+b$ and block:\n\n$$\n x^2 \n$$\n'
+      const expected = 'Inline $a+b$ and block:\n\n\n$$\nx^2\n$$\n\n'
       expect(normalizeLatexDelimiters(input)).toBe(expected)
     })
 
     it('preserves Hebrew text', () => {
       const input = 'הנוסחה היא \\[ f(x) = x^2 \\]'
-      const expected = 'הנוסחה היא \n$$\n f(x) = x^2 \n$$\n'
+      const expected = 'הנוסחה היא \n\n$$\nf(x) = x^2\n$$\n\n'
       expect(normalizeLatexDelimiters(input)).toBe(expected)
     })
   })
@@ -62,9 +62,11 @@ describe('normalizeLatexDelimiters', () => {
       expect(normalizeLatexDelimiters(input)).toBe(input)
     })
 
-    it('leaves $$...$$ unchanged', () => {
+    it('ensures $$...$$ has newlines for remark-math', () => {
       const input = '$$\\frac{a}{b}$$'
-      expect(normalizeLatexDelimiters(input)).toBe(input)
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toContain('$$')
+      expect(result).toContain('\\frac{a}{b}')
     })
 
     it('leaves plain text unchanged', () => {
@@ -85,7 +87,7 @@ describe('normalizeLatexDelimiters', () => {
 
     it('converts full JSON-escaped block math expression', () => {
       const input = '\\\\[ f(x) = x^2 \\\\]'
-      const expected = '\n$$\n f(x) = x^2 \n$$\n'
+      const expected = '\n\n$$\nf(x) = x^2\n$$\n\n'
       expect(normalizeLatexDelimiters(input)).toBe(expected)
     })
 
@@ -136,7 +138,7 @@ describe('normalizeLatexDelimiters', () => {
       const input =
         '\\\\\\[ f(x) \\= \\\\frac{1}{\\\\sigma\\\\sqrt{2\\\\pi}} e^{-\\\\frac{1}{2}\\\\left(\\\\frac{x-\\\\mu}{\\\\sigma}\\\\right)^2} \\\\\\]'
       const expected =
-        '\n$$\n f(x) = \\frac{1}{\\sigma\\sqrt{2\\pi}} e^{-\\frac{1}{2}\\left(\\frac{x-\\mu}{\\sigma}\\right)^2} \n$$\n'
+        '\n\n$$\nf(x) = \\frac{1}{\\sigma\\sqrt{2\\pi}} e^{-\\frac{1}{2}\\left(\\frac{x-\\mu}{\\sigma}\\right)^2}\n$$\n\n'
       expect(normalizeLatexDelimiters(input)).toBe(expected)
     })
   })
@@ -153,7 +155,7 @@ describe('normalizeLatexDelimiters', () => {
 
     it('handles multiple block expressions', () => {
       const input = '\\[ a \\] and \\[ b \\]'
-      const expected = '\n$$\n a \n$$\n and \n$$\n b \n$$\n'
+      const expected = '\n\n$$\na\n$$\n\n and \n\n$$\nb\n$$\n\n'
       expect(normalizeLatexDelimiters(input)).toBe(expected)
     })
   })
@@ -263,7 +265,9 @@ describe('normalizeLatexDelimiters', () => {
     it('does NOT double-wrap block math', () => {
       const input = '$$\\frac{a}{b}$$'
       const result = normalizeLatexDelimiters(input)
-      expect(result).toBe(input)
+      // Should contain the math content with $$ delimiters, not wrapped again in $
+      expect(result).toContain('\\frac{a}{b}')
+      expect(result).not.toMatch(/\$\$\$/) // no triple $
     })
 
     it('wraps complex expression with subscripts', () => {
@@ -283,6 +287,40 @@ describe('normalizeLatexDelimiters', () => {
     it('leaves plain text without LaTeX commands unchanged', () => {
       const input = 'no math here, just text'
       expect(normalizeLatexDelimiters(input)).toBe(input)
+    })
+  })
+
+  describe('inline $$ normalization (block math must be on own line)', () => {
+    it('adds newlines around inline $$ delimiters', () => {
+      const input = 'text $$\\frac{a}{b}$$ more'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toContain('text')
+      expect(result).toContain('\n$$\n')
+      expect(result).toContain('\\frac{a}{b}')
+      expect(result).toContain('more')
+    })
+
+    it('preserves $$ already on their own lines', () => {
+      const input = 'text\n$$\n\\frac{a}{b}\n$$\nmore'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toContain('\\frac{a}{b}')
+      expect(result).toContain('$$')
+    })
+
+    it('handles Hebrew text with inline $$ from PDF context', () => {
+      const input = 'הגרף שלה חותך את ציר $$\\frac{8-4x}{(x-1)^2}$$ בנקודה'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toContain('\n$$\n')
+      expect(result).toContain('הגרף שלה חותך את ציר')
+      expect(result).toContain('בנקודה')
+    })
+
+    it('handles multiple inline $$ in one line', () => {
+      const input = 'given $$a + b$$ and $$c + d$$ values'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toContain('\n$$\n')
+      expect(result).toContain('a + b')
+      expect(result).toContain('c + d')
     })
   })
 })

--- a/tests/unit/lib/ai/prompt-composer.test.ts
+++ b/tests/unit/lib/ai/prompt-composer.test.ts
@@ -36,7 +36,8 @@ describe('composeSystemInstructions', () => {
   it('works with empty system prompts array', () => {
     const result = composeSystemInstructions([], 'Lesson prompt', undefined)
 
-    expect(result).toBe('Lesson prompt')
+    expect(result).toContain('Lesson prompt')
+    expect(result).toContain('## Math Formatting')
     expect(result).not.toContain(SYSTEM_PROMPT_SEPARATOR)
   })
 
@@ -57,7 +58,8 @@ describe('composeSystemInstructions', () => {
   it('adds separator between system prompts and lesson prompt', () => {
     const result = composeSystemInstructions(['System'], 'Lesson')
 
-    expect(result).toBe(`System${SYSTEM_PROMPT_SEPARATOR}Lesson`)
+    expect(result).toContain(`System${SYSTEM_PROMPT_SEPARATOR}Lesson`)
+    expect(result).toContain('## Math Formatting')
   })
 
   it('includes lesson context with proper delimiters', () => {
@@ -71,7 +73,8 @@ describe('composeSystemInstructions', () => {
   it('handles single system prompt correctly', () => {
     const result = composeSystemInstructions(['Only system prompt'], 'Lesson prompt')
 
-    expect(result).toBe(`Only system prompt${SYSTEM_PROMPT_SEPARATOR}Lesson prompt`)
+    expect(result).toContain(`Only system prompt${SYSTEM_PROMPT_SEPARATOR}Lesson prompt`)
+    expect(result).toContain('## Math Formatting')
   })
 
   it('handles multiple system prompts with lesson context', () => {


### PR DESCRIPTION
…ormatting instructions

Inline math delimiters \(...\) now map to $...$ instead of $$...$$, so formulas flow naturally within Hebrew sentences. Math formatting instructions are injected at the prompt composition level so the LLM always uses LaTeX delimiters regardless of which DB prompt is active.