### PR TITLE
fix: Graph viewport clipping and geometry rendering fixes

### DIFF
--- a/src/infra/contracts/graphics/geometry.v1.ts
+++ b/src/infra/contracts/graphics/geometry.v1.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { ColorStringSchema, PositionEnumSchema } from '../primitives'
-import { EvaluationModeSchema, InteractionToolSchema } from './interaction.base'
+import { InteractionToolSchema, EvaluationModeSchema } from './interaction.base'
 
 /**
  * GeometrySpecV1 - Declarative JSON specification for Euclidean geometry
@@ -13,6 +13,9 @@ const CanvasSchema = z.object({
   height: z.number().positive(),
   background: ColorStringSchema.optional(),
   grid: z.boolean().optional(),
+  axis: z.boolean().optional(),
+  /** JSXGraph bounding box [xMin, yMax, xMax, yMin] — overrides width/height-based box when set */
+  boundingBox: z.tuple([z.number(), z.number(), z.number(), z.number()]).optional(),
 })
 
 /** Point element */

--- a/src/ui/web/exerciserenderer/blocks/AxisRenderer/index.tsx
+++ b/src/ui/web/exerciserenderer/blocks/AxisRenderer/index.tsx
@@ -103,6 +103,7 @@ export function AxisRenderer({ blockId, spec, displaySize = 'full' }: AxisRender
           ticks: spec.axes.ticks,
           labels: spec.axes.labels,
           tickPosition: spec.axes.tickPosition ?? { x: 'default', y: 'default' },
+          origin: spec.axes.origin,
         }}
         onBoardReady={handleBoardReady}
         className="border-border"

--- a/src/ui/web/exerciserenderer/blocks/GeometryRenderer/index.tsx
+++ b/src/ui/web/exerciserenderer/blocks/GeometryRenderer/index.tsx
@@ -28,8 +28,8 @@ export function GeometryRenderer({ blockId, spec }: GeometryRendererProps) {
 
   const { canvas } = spec
   const boundingBox = useMemo<[number, number, number, number]>(
-    () => [0, canvas.height, canvas.width, 0],
-    [canvas.width, canvas.height],
+    () => canvas.boundingBox ?? [0, canvas.height, canvas.width, 0],
+    [canvas.boundingBox, canvas.width, canvas.height],
   )
 
   return (
@@ -40,7 +40,7 @@ export function GeometryRenderer({ blockId, spec }: GeometryRendererProps) {
         height={canvas.height}
         boundingBox={boundingBox}
         showGrid={canvas.grid ?? false}
-        showAxis={false}
+        showAxis={canvas.axis ?? false}
         onBoardReady={handleBoardReady}
         className="border-border"
       />

--- a/src/ui/web/exerciserenderer/graphics/JSXGraphBoard.tsx
+++ b/src/ui/web/exerciserenderer/graphics/JSXGraphBoard.tsx
@@ -16,6 +16,7 @@ interface JSXGraphBoardProps {
     ticks?: number
     labels?: { x: string; y: string }
     tickPosition?: { x: 'default' | 'inverted'; y: 'default' | 'inverted' }
+    origin?: { x: number; y: number }
   }
   onBoardReady: (board: JXG.Board) => void
   className?: string
@@ -48,41 +49,48 @@ export function JSXGraphBoard({
       jxgRef.current = JXGLib
       const containerId = `jsxgraph-${id}`
 
-      const axisOpts = showAxis
-        ? {
-            axis: true,
-            defaultAxes: {
-              x: {
-                ticks: {
-                  visible: axisConfig?.showNumbers ?? true,
-                  ticksDistance: axisConfig?.ticks ?? 1,
-                  label: {
-                    // Invert tick position: -10 (above) for default, 10 (below) for inverted
-                    offset: [0, axisConfig?.tickPosition?.x === 'inverted' ? 10 : -10],
+      // Check if origin is outside the viewport — if so, create axes manually
+      const ox = axisConfig?.origin?.x ?? 0
+      const oy = axisConfig?.origin?.y ?? 0
+      const [bbXMin, bbYMax, bbXMax, bbYMin] = boundingBox
+      const originOutside = showAxis && (ox < bbXMin || ox > bbXMax || oy < bbYMin || oy > bbYMax)
+
+      const tickDist = axisConfig?.ticks ?? 1
+      const showNumbers = axisConfig?.showNumbers ?? true
+      const showLabels = axisConfig?.showLabels ?? true
+
+      const axisOpts =
+        showAxis && !originOutside
+          ? {
+              axis: true,
+              defaultAxes: {
+                x: {
+                  ticks: {
+                    visible: showNumbers,
+                    ticksDistance: tickDist,
+                    label: {
+                      offset: [0, axisConfig?.tickPosition?.x === 'inverted' ? 10 : -10],
+                    },
                   },
+                  name: axisConfig?.labels?.x ?? 'x',
+                  withLabel: showLabels,
+                  label: { position: 'rt', offset: [0, 12] },
                 },
-                name: axisConfig?.labels?.x ?? 'x',
-                withLabel: axisConfig?.showLabels ?? true,
-                // Standardized title position: far right, slightly below
-                label: { position: 'rt', offset: [0, 12] },
-              },
-              y: {
-                ticks: {
-                  visible: axisConfig?.showNumbers ?? true,
-                  ticksDistance: axisConfig?.ticks ?? 1,
-                  label: {
-                    // Invert tick position: -10 (left) for default, 10 (right) for inverted
-                    offset: [axisConfig?.tickPosition?.y === 'inverted' ? 10 : -10, 0],
+                y: {
+                  ticks: {
+                    visible: showNumbers,
+                    ticksDistance: tickDist,
+                    label: {
+                      offset: [axisConfig?.tickPosition?.y === 'inverted' ? 10 : -10, 0],
+                    },
                   },
+                  name: axisConfig?.labels?.y ?? 'y',
+                  withLabel: showLabels,
+                  label: { position: 'rt', offset: [15, 0] },
                 },
-                name: axisConfig?.labels?.y ?? 'y',
-                withLabel: axisConfig?.showLabels ?? true,
-                // Standardized title position: near top, slightly to right
-                label: { position: 'rt', offset: [15, 0] },
               },
-            },
-          }
-        : { axis: false }
+            }
+          : { axis: false }
 
       const board = JXGLib.JSXGraph.initBoard(containerId, {
         boundingbox: boundingBox,
@@ -94,6 +102,42 @@ export function JSXGraphBoard({
         pan: { needShift: true },
         zoom: { factorX: 1, factorY: 1 },
       } as JXG.BoardAttributes)
+
+      // When origin is outside viewport, create axes manually at viewport edge
+      if (originOutside) {
+        const axOriginX = Math.max(bbXMin, Math.min(ox, bbXMax))
+        const axOriginY = Math.max(bbYMin, Math.min(oy, bbYMax))
+        const tickOpts = {
+          visible: showNumbers,
+          ticksDistance: tickDist,
+          label: { fontSize: 12 },
+          drawZero: true,
+        }
+        board.create(
+          'axis',
+          [
+            [axOriginX, axOriginY],
+            [axOriginX + 1, axOriginY],
+          ],
+          {
+            ticks: tickOpts,
+            name: axisConfig?.labels?.x ?? 'x',
+            withLabel: showLabels,
+          },
+        )
+        board.create(
+          'axis',
+          [
+            [axOriginX, axOriginY],
+            [axOriginX, axOriginY + 1],
+          ],
+          {
+            ticks: tickOpts,
+            name: axisConfig?.labels?.y ?? 'y',
+            withLabel: showLabels,
+          },
+        )
+      }
 
       boardRef.current = board
       onBoardReady(board)

--- a/src/ui/web/exerciserenderer/graphics/axisElements.ts
+++ b/src/ui/web/exerciserenderer/graphics/axisElements.ts
@@ -4,7 +4,11 @@ import { parseMathExpression } from '../utils/safeMathEval'
 type GraphSpec = AxisSpecV1['elements']['graphs'][number]
 type PointSpec = AxisSpecV1['elements']['points'][number]
 
-function renderGraphs(board: JXG.Board, graphs: GraphSpec[]): void {
+function renderGraphs(
+  board: JXG.Board,
+  graphs: GraphSpec[],
+  viewport: AxisSpecV1['viewport'],
+): void {
   for (const graph of graphs) {
     const parsed = parseMathExpression(graph.fn)
     if (!parsed.valid) continue
@@ -15,14 +19,11 @@ function renderGraphs(board: JXG.Board, graphs: GraphSpec[]): void {
     }
     if (graph.color) attrs.strokeColor = graph.color
 
-    const rangeFrom = graph.range?.fromX ?? undefined
-    const rangeTo = graph.range?.toX ?? undefined
+    // Always clip to domain or viewport — prevents polynomial explosion outside visible range
+    const rangeFrom = graph.range?.fromX ?? viewport?.xMin ?? -5
+    const rangeTo = graph.range?.toX ?? viewport?.xMax ?? 5
 
-    if (rangeFrom !== undefined && rangeTo !== undefined) {
-      board.create('functiongraph', [parsed.evaluate, rangeFrom, rangeTo], attrs)
-    } else {
-      board.create('functiongraph', [parsed.evaluate], attrs)
-    }
+    board.create('functiongraph', [parsed.evaluate, rangeFrom, rangeTo], attrs)
   }
 }
 
@@ -123,7 +124,7 @@ function renderLineBetweenPoints(
  * Render all axis elements from an AxisSpecV1 onto a JSXGraph board.
  */
 export function renderAxisSpec(board: JXG.Board, spec: AxisSpecV1): void {
-  renderGraphs(board, spec.elements.graphs)
+  renderGraphs(board, spec.elements.graphs, spec.viewport)
   renderAxisPoints(board, spec.elements.points)
 
   if (spec.elements.asymptotesVertical?.length) {


### PR DESCRIPTION
Fix polynomial Y explosion by clipping graphs to viewport bounds. Fix geometry Y-inversion (remove double flip), use raw TikZ coordinates with JSXGraph bounding box, fix circle radius scaling. Add boundingBox and axis support to geometry canvas schema.