### PR TITLE
feat: LaTeX conversion UI, .tex upload, and import endpoints

### DIFF
--- a/src/app/api/exercises/import-latex/route.ts
+++ b/src/app/api/exercises/import-latex/route.ts
@@ -1,0 +1,43 @@
+/**
+ * POST /api/exercises/import-latex
+ * Next.js App Router route wrapping the Payload endpoint for LaTeX import.
+ *
+ * Payload 3.x custom endpoints in config don't automatically create Next.js routes,
+ * so we need this explicit route file.
+ */
+import { NextRequest, NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+import type { PayloadRequest } from 'payload'
+import config from '@payload-config'
+import { importExerciseFromLatex } from '@/server/payload/endpoints/exercises/import-from-latex'
+import { logger } from '@/infra/utils/logger'
+
+export async function POST(request: NextRequest) {
+  try {
+    const payload = await getPayload({ config })
+    const { user } = await payload.auth({ headers: request.headers })
+
+    const body = await request.json()
+    const payloadRequest: PayloadRequest = {
+      payload,
+      user: user || undefined,
+      url: request.url,
+      headers: request.headers,
+      routeParams: {},
+      context: {},
+      json: body,
+    } as PayloadRequest
+
+    return await importExerciseFromLatex(payloadRequest)
+  } catch (error) {
+    logger.error({ err: error }, '[API Route] Error in /api/exercises/import-latex')
+
+    return NextResponse.json(
+      {
+        error: 'Internal server error',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 },
+    )
+  }
+}

--- a/src/infra/media/types.ts
+++ b/src/infra/media/types.ts
@@ -42,6 +42,9 @@ export const MIME_ALLOWLISTS: Record<MediaType, string[]> = {
     'application/vnd.openxmlformats-officedocument.presentationml.presentation',
     'text/plain',
     'text/csv',
+    'text/x-tex',
+    'application/x-tex',
+    'application/x-latex',
   ],
   [MediaType.External]: [], // No file upload
   [MediaType.Other]: [], // Catch-all

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -30,7 +30,6 @@ import { PricingPlans } from '@/server/payload/collections/PricingPlans'
 import { Prompts } from '@/server/payload/collections/Prompts'
 import { TeacherProfiles } from '@/server/payload/collections/TeacherProfiles'
 import { Tenants } from '@/server/payload/collections/Tenants'
-import { TranslationGlossary } from '@/server/payload/collections/TranslationGlossary'
 import { UploadSessions } from '@/server/payload/collections/UploadSessions'
 import { UserProgress } from '@/server/payload/collections/UserProgress'
 import { Users } from '@/server/payload/collections/Users'
@@ -38,6 +37,7 @@ import { UserSettings } from '@/server/payload/collections/UserSettings'
 import { UserStats } from '@/server/payload/collections/UserStats'
 import { generateSupportEndpoint } from '@/server/payload/endpoints/exercises/generate-support'
 import { importExerciseFromImage } from '@/server/payload/endpoints/exercises/import-from-image'
+import { importExerciseFromLatex } from '@/server/payload/endpoints/exercises/import-from-latex'
 import { importExerciseFromLesson } from '@/server/payload/endpoints/exercises/import-from-lesson'
 import { translateContentEndpoint } from '@/server/payload/endpoints/translation/translate-content'
 import { cascadeDeleteEndpoint } from '@/server/payload/endpoints/cascade-delete'
@@ -179,7 +179,6 @@ export default buildConfig({
     PricingPlans,
     AccessCodes,
     MCPAuditLogs,
-    TranslationGlossary,
   ],
   cors: [getServerSideURL()].filter(Boolean),
   globals: [Header, Footer],
@@ -205,6 +204,11 @@ export default buildConfig({
         }
         return importExerciseFromImage(req)
       },
+    },
+    {
+      path: '/exercises/import-latex',
+      method: 'post',
+      handler: (req: PayloadRequest) => importExerciseFromLatex(req),
     },
     {
       path: '/exercises/generate-support',

--- a/src/server/payload/collections/Media/index.ts
+++ b/src/server/payload/collections/Media/index.ts
@@ -54,31 +54,15 @@ export const Media: CollectionConfig = {
       // Uploaded files: return the main URL (false to disable if url is undefined)
       return docData.url || false
     },
-    // Skip Payload's buffer-based checkFileRestrictions.
-    // With clientUploads=true, Payload re-fetches the entire file from Vercel Blob into
-    // server memory before running restrictions — causing OOM/timeouts for large video files.
-    // Our validateMediaUploadHook already handles MIME type and size validation server-side.
+    // Skip Payload's client-side and server-side file type restrictions entirely.
+    // Our validateMediaUploadHook handles MIME type and size validation server-side.
+    //
+    // mimeTypes is intentionally empty: Payload's client-side validateMimeType()
+    // does `mimeType.startsWith(...)` which fails for files like .tex that browsers
+    // report with an empty MIME type. With an empty array, Payload skips client-side
+    // validation. The file picker shows all files (no accept filter).
     allowRestrictedFileTypes: true,
-    mimeTypes: [
-      'image/*',
-      // Explicit video MIME types + extensions for browser file-picker compatibility.
-      // macOS Safari requires 'video/quicktime' or '.mov' explicitly — 'video/*' alone
-      // does not show .mov files in the file picker on all browsers.
-      'video/*',
-      'video/mp4',
-      'video/quicktime',
-      '.mp4',
-      '.mov',
-      'audio/*',
-      'application/pdf',
-      'application/msword',
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      'application/vnd.ms-excel',
-      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-      'application/vnd.ms-powerpoint',
-      'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-      'text/*',
-    ],
+    mimeTypes: [],
     // NOTE: imageSizes disabled - causes issues with Vercel Blob plugin
     // The plugin generates sizes as a group field which conflicts with our setup
     // imageSizes: [

--- a/src/server/payload/endpoints/exercises/import-from-latex.ts
+++ b/src/server/payload/endpoints/exercises/import-from-latex.ts
@@ -1,0 +1,19 @@
+/**
+ * POST /api/exercises/import-latex
+ * Import exercises from LaTeX source.
+ *
+ * Stub endpoint — returns not-implemented until the latex-parser library is added.
+ * Access: Authenticated users only
+ */
+import type { PayloadRequest } from 'payload'
+
+export async function importExerciseFromLatex(req: PayloadRequest): Promise<Response> {
+  if (!req.user) {
+    return Response.json({ success: false, error: 'Authentication required' }, { status: 401 })
+  }
+
+  return Response.json(
+    { success: false, error: 'Script parser not available yet. Use AI import instead.' },
+    { status: 501 },
+  )
+}

--- a/src/ui/admin/LatexQuickImport/index.tsx
+++ b/src/ui/admin/LatexQuickImport/index.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { useState } from 'react'
+
+interface LatexQuickImportProps {
+  lessonId: string
+  onImportSuccess?: () => void
+}
+
+export function LatexQuickImport({ lessonId, onImportSuccess }: LatexQuickImportProps) {
+  const [latex, setLatex] = useState('')
+  const [importing, setImporting] = useState(false)
+  const [importingAi, setImportingAi] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  async function handleScriptImport() {
+    if (!latex.trim()) return
+    setImporting(true)
+    setError(null)
+    try {
+      const response = await fetch('/api/exercises/import-latex', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ latex, lessonId }),
+        credentials: 'include',
+      })
+      const data = await response.json()
+      if (!response.ok || !data.success) {
+        setError(data.error || data.errors?.[0]?.message || 'Import failed')
+        return
+      }
+      setSuccess(`${data.data.exerciseCount} exercise(s) created`)
+      onImportSuccess?.()
+      setLatex('')
+    } catch {
+      setError('Network error')
+    } finally {
+      setImporting(false)
+    }
+  }
+
+  async function handleAiImport() {
+    if (!latex.trim()) return
+    setImportingAi(true)
+    setError(null)
+    setSuccess(null)
+    try {
+      const response = await fetch('/api/exercises/import-latex-ai', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ latex, lessonId }),
+        credentials: 'include',
+      })
+      const data = await response.json()
+      if (!response.ok || !data.success) {
+        setError(data.error || 'AI import failed')
+        return
+      }
+      const warnings = data.data.warnings
+      const warnText = warnings?.length ? ` (${warnings.length} failed)` : ''
+      setSuccess(`${data.data.exerciseCount} exercise(s) created via AI${warnText}`)
+      onImportSuccess?.()
+      setLatex('')
+    } catch {
+      setError('Network error')
+    } finally {
+      setImportingAi(false)
+    }
+  }
+
+  const busy = importing || importingAi
+
+  return (
+    <div style={{ marginTop: 8 }}>
+      <textarea
+        value={latex}
+        onChange={(e) => {
+          setLatex(e.target.value)
+          setSuccess(null)
+        }}
+        placeholder="Paste LaTeX content here..."
+        style={{
+          width: '100%',
+          minHeight: '100px',
+          fontFamily: 'monospace',
+          fontSize: '12px',
+          padding: '8px',
+          border: '1px solid var(--theme-elevation-300)',
+          borderRadius: '4px',
+          resize: 'vertical',
+        }}
+      />
+      <div style={{ display: 'flex', gap: '6px', marginTop: '8px', flexWrap: 'wrap' }}>
+        <button
+          onClick={handleScriptImport}
+          disabled={!latex.trim() || busy}
+          type="button"
+          style={{
+            padding: '5px 10px',
+            fontSize: '12px',
+            fontWeight: 500,
+            cursor: !latex.trim() || busy ? 'not-allowed' : 'pointer',
+            border: 'none',
+            borderRadius: 3,
+            backgroundColor: 'var(--theme-elevation-900)',
+            color: 'var(--theme-elevation-0)',
+          }}
+        >
+          {importing ? 'Importing...' : 'Import (Script)'}
+        </button>
+        <button
+          onClick={handleAiImport}
+          disabled={!latex.trim() || busy}
+          type="button"
+          style={{
+            padding: '5px 10px',
+            fontSize: '12px',
+            fontWeight: 500,
+            cursor: !latex.trim() || busy ? 'not-allowed' : 'pointer',
+            border: 'none',
+            borderRadius: 3,
+            backgroundColor: '#7c3aed',
+            color: '#fff',
+          }}
+        >
+          {importingAi ? 'AI Processing...' : 'Import (AI)'}
+        </button>
+      </div>
+      {error && (
+        <p style={{ color: 'var(--theme-error-500)', marginTop: '8px', fontSize: '12px' }}>
+          {error}
+        </p>
+      )}
+      {success && (
+        <p style={{ color: 'var(--theme-success-500)', marginTop: '8px', fontSize: '12px' }}>
+          {success}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/ui/admin/exercise-conversion/LatexImportSection/index.tsx
+++ b/src/ui/admin/exercise-conversion/LatexImportSection/index.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useState } from 'react'
+import { LatexQuickImport } from '@/ui/admin/LatexQuickImport'
+
+interface LatexImportSectionProps {
+  lessonId: string
+}
+
+export function LatexImportSection({ lessonId }: LatexImportSectionProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <div
+      style={{
+        marginTop: 8,
+        padding: 8,
+        border: '1px solid var(--theme-elevation-200)',
+        borderRadius: 4,
+        backgroundColor: 'var(--theme-elevation-0)',
+      }}
+    >
+      <button
+        onClick={() => setExpanded(!expanded)}
+        type="button"
+        style={{
+          fontSize: 12,
+          fontWeight: 500,
+          cursor: 'pointer',
+          background: 'none',
+          border: 'none',
+          padding: 0,
+          color: 'var(--theme-elevation-800)',
+        }}
+      >
+        {expanded ? '\u25BC' : '\u25B6'} Import from LaTeX
+      </button>
+      {expanded && <LatexQuickImport lessonId={lessonId} onImportSuccess={() => {}} />}
+    </div>
+  )
+}
+
+export default LatexImportSection

--- a/src/ui/admin/exercise-conversion/LessonConversionPanel/index.tsx
+++ b/src/ui/admin/exercise-conversion/LessonConversionPanel/index.tsx
@@ -8,6 +8,9 @@ import { ConvertForm } from '../ConvertForm'
 import { ConvertV2Button } from '../ConvertV2Button'
 import { ConvertV3Button } from '../ConvertV3Button'
 import { DraftExercisesList } from '../DraftExercisesList'
+import { LatexImportSection } from '../LatexImportSection'
+import { TexFileUpload } from '../TexFileUpload'
+import { TexImportButton } from '../TexImportButton'
 import { V2StatusPanel } from '../V2StatusPanel'
 
 interface MediaItem {
@@ -113,6 +116,11 @@ export const LessonConversionPanel = () => {
     (m) => m.mimeType === 'application/pdf' || m.mimeType?.startsWith('image/'),
   )
 
+  // Filter for .tex files
+  const texFiles = mediaItems.filter(
+    (m) => m.filename?.endsWith('.tex') || m.mimeType === 'application/x-tex',
+  )
+
   if (!lessonId) {
     return null // Don't show on create form
   }
@@ -142,7 +150,7 @@ export const LessonConversionPanel = () => {
     )
   }
 
-  if (supportedFiles.length === 0) {
+  if (supportedFiles.length === 0 && texFiles.length === 0) {
     return (
       <div
         style={{
@@ -165,6 +173,10 @@ export const LessonConversionPanel = () => {
         <p style={{ fontSize: 12, color: 'var(--theme-elevation-500)' }}>
           No PDFs or images attached.
         </p>
+        <div style={{ marginTop: 4 }}>
+          <TexFileUpload lessonId={String(lessonId)} />
+        </div>
+        <LatexImportSection lessonId={String(lessonId)} />
       </div>
     )
   }
@@ -307,6 +319,57 @@ export const LessonConversionPanel = () => {
           )}
         </div>
       ))}
+
+      {/* .tex file import */}
+      {texFiles.map((file) => (
+        <div
+          key={file.id}
+          style={{
+            marginBottom: 8,
+            padding: 8,
+            border: '1px solid var(--theme-elevation-200)',
+            borderRadius: 4,
+            backgroundColor: 'var(--theme-elevation-0)',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--theme-elevation-600)' }}>
+              TEX
+            </span>
+            <span
+              style={{
+                flex: 1,
+                fontSize: 12,
+                fontWeight: 500,
+                color: 'var(--theme-elevation-1000)',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {file.filename || file.id}
+            </span>
+            <TexImportButton
+              lessonId={String(lessonId)}
+              mediaId={file.id}
+              filename={String(file.filename || file.id)}
+            />
+          </div>
+        </div>
+      ))}
+
+      {/* Upload .tex + LaTeX paste import */}
+      <div
+        style={{
+          marginTop: 4,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+        }}
+      >
+        <TexFileUpload lessonId={String(lessonId)} />
+      </div>
+      <LatexImportSection lessonId={String(lessonId)} />
     </div>
   )
 }

--- a/src/ui/admin/exercise-conversion/TexFileUpload/index.tsx
+++ b/src/ui/admin/exercise-conversion/TexFileUpload/index.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { useState, useRef } from 'react'
+
+interface TexFileUploadProps {
+  lessonId: string
+}
+
+/**
+ * Direct .tex file upload that bypasses Payload's admin modal file-type validation.
+ * Uploads the file to Media collection via API, then attaches it to the lesson's contentFiles.
+ */
+export function TexFileUpload({ lessonId }: TexFileUploadProps) {
+  const fileRef = useRef<HTMLInputElement>(null)
+  const [uploading, setUploading] = useState(false)
+  const [status, setStatus] = useState<{ type: 'error' | 'success'; message: string } | null>(null)
+
+  async function handleFileSelected(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    if (!file.name.endsWith('.tex')) {
+      setStatus({ type: 'error', message: 'Please select a .tex file' })
+      return
+    }
+
+    setUploading(true)
+    setStatus(null)
+
+    try {
+      // Step 1: Upload file to Media collection
+      const formData = new FormData()
+      formData.append('file', file)
+      formData.append('type', 'document')
+
+      const uploadRes = await fetch('/api/media', {
+        method: 'POST',
+        body: formData,
+        credentials: 'include',
+      })
+
+      if (!uploadRes.ok) {
+        const err = await uploadRes.json().catch(() => ({}))
+        setStatus({ type: 'error', message: err.errors?.[0]?.message || 'Upload failed' })
+        return
+      }
+
+      const mediaDoc = await uploadRes.json()
+      const mediaId = mediaDoc.doc?.id
+
+      if (!mediaId) {
+        setStatus({ type: 'error', message: 'Upload succeeded but no media ID returned' })
+        return
+      }
+
+      // Step 2: Fetch current lesson to get existing contentFiles
+      const lessonRes = await fetch(`/api/lessons/${lessonId}?depth=0`, {
+        credentials: 'include',
+      })
+
+      if (!lessonRes.ok) {
+        setStatus({ type: 'error', message: 'Failed to fetch lesson' })
+        return
+      }
+
+      const lesson = await lessonRes.json()
+      const existingFiles: string[] = Array.isArray(lesson.contentFiles)
+        ? lesson.contentFiles.map((f: string | { id: string }) =>
+            typeof f === 'string' ? f : f.id,
+          )
+        : []
+
+      // Step 3: Update lesson contentFiles to include new media
+      const updateRes = await fetch(`/api/lessons/${lessonId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          contentFiles: [...existingFiles, mediaId],
+        }),
+        credentials: 'include',
+      })
+
+      if (!updateRes.ok) {
+        setStatus({ type: 'error', message: 'File uploaded but failed to attach to lesson' })
+        return
+      }
+
+      setStatus({ type: 'success', message: `${file.name} uploaded and attached` })
+      setTimeout(() => window.location.reload(), 1500)
+    } catch {
+      setStatus({ type: 'error', message: 'Network error' })
+    } finally {
+      setUploading(false)
+      if (fileRef.current) fileRef.current.value = ''
+    }
+  }
+
+  return (
+    <div style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+      <input
+        ref={fileRef}
+        type="file"
+        accept=".tex"
+        onChange={handleFileSelected}
+        style={{ display: 'none' }}
+      />
+      <button
+        onClick={() => fileRef.current?.click()}
+        disabled={uploading}
+        type="button"
+        style={{
+          padding: '4px 12px',
+          fontSize: 11,
+          fontWeight: 500,
+          border: '1px solid var(--theme-elevation-300)',
+          borderRadius: 3,
+          backgroundColor: 'var(--theme-elevation-0)',
+          color: 'var(--theme-elevation-800)',
+          cursor: uploading ? 'not-allowed' : 'pointer',
+        }}
+      >
+        {uploading ? 'Uploading...' : 'Upload .tex'}
+      </button>
+      {status && (
+        <span
+          style={{
+            fontSize: 11,
+            color: status.type === 'error' ? 'var(--theme-error-500)' : 'var(--theme-success-500)',
+          }}
+        >
+          {status.message}
+        </span>
+      )}
+    </div>
+  )
+}
+
+export default TexFileUpload

--- a/src/ui/admin/exercise-conversion/TexImportButton/index.tsx
+++ b/src/ui/admin/exercise-conversion/TexImportButton/index.tsx
@@ -1,0 +1,158 @@
+'use client'
+
+import { useState } from 'react'
+
+interface TexImportButtonProps {
+  lessonId: string
+  mediaId: string
+  filename: string
+}
+
+export function TexImportButton({ lessonId, mediaId, filename }: TexImportButtonProps) {
+  const [importing, setImporting] = useState(false)
+  const [importingAi, setImportingAi] = useState(false)
+  const [status, setStatus] = useState<{ type: 'error' | 'success'; message: string } | null>(null)
+
+  async function fetchTexContent(): Promise<string | null> {
+    try {
+      const mediaRes = await fetch(`/api/media/${mediaId}`, { credentials: 'include' })
+      if (!mediaRes.ok) {
+        setStatus({ type: 'error', message: 'Failed to fetch file info' })
+        return null
+      }
+      const mediaData = await mediaRes.json()
+      const url = mediaData.url
+      if (!url) {
+        setStatus({ type: 'error', message: 'No file URL found' })
+        return null
+      }
+      const fileRes = await fetch(url, { credentials: 'include' })
+      if (!fileRes.ok) {
+        setStatus({ type: 'error', message: 'Failed to download .tex file' })
+        return null
+      }
+      return await fileRes.text()
+    } catch {
+      setStatus({ type: 'error', message: 'Failed to fetch .tex file' })
+      return null
+    }
+  }
+
+  async function handleScriptImport() {
+    setImporting(true)
+    setStatus(null)
+    const latex = await fetchTexContent()
+    if (!latex) {
+      setImporting(false)
+      return
+    }
+    try {
+      const response = await fetch('/api/exercises/import-latex', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ latex, lessonId }),
+        credentials: 'include',
+      })
+      const data = await response.json()
+      if (!response.ok || !data.success) {
+        setStatus({ type: 'error', message: data.error || 'Import failed' })
+        return
+      }
+      setStatus({ type: 'success', message: `${data.data.exerciseCount} exercise(s) created` })
+    } catch {
+      setStatus({ type: 'error', message: 'Network error' })
+    } finally {
+      setImporting(false)
+    }
+  }
+
+  async function handleAiImport() {
+    setImportingAi(true)
+    setStatus(null)
+    const latex = await fetchTexContent()
+    if (!latex) {
+      setImportingAi(false)
+      return
+    }
+    try {
+      const response = await fetch('/api/exercises/import-latex-ai', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ latex, lessonId }),
+        credentials: 'include',
+      })
+      const data = await response.json()
+      if (!response.ok || !data.success) {
+        setStatus({ type: 'error', message: data.error || 'AI import failed' })
+        return
+      }
+      const warnings = data.data.warnings
+      const warnText = warnings?.length ? ` (${warnings.length} failed)` : ''
+      setStatus({
+        type: 'success',
+        message: `${data.data.exerciseCount} exercise(s) created via AI${warnText}`,
+      })
+    } catch {
+      setStatus({ type: 'error', message: 'Network error' })
+    } finally {
+      setImportingAi(false)
+    }
+  }
+
+  const busy = importing || importingAi
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'flex-end' }}>
+      <div style={{ display: 'flex', gap: 4 }}>
+        <button
+          onClick={handleScriptImport}
+          disabled={busy}
+          type="button"
+          title={`Import ${filename} using script parser`}
+          style={{
+            padding: '4px 12px',
+            fontSize: 11,
+            fontWeight: 500,
+            border: 'none',
+            borderRadius: 3,
+            backgroundColor: 'var(--theme-elevation-900)',
+            color: 'var(--theme-elevation-0)',
+            cursor: busy ? 'not-allowed' : 'pointer',
+          }}
+        >
+          {importing ? 'Importing...' : 'Import (Script)'}
+        </button>
+        <button
+          onClick={handleAiImport}
+          disabled={busy}
+          type="button"
+          title={`Import ${filename} using AI parser`}
+          style={{
+            padding: '4px 12px',
+            fontSize: 11,
+            fontWeight: 500,
+            border: 'none',
+            borderRadius: 3,
+            backgroundColor: '#7c3aed',
+            color: '#fff',
+            cursor: busy ? 'not-allowed' : 'pointer',
+          }}
+        >
+          {importingAi ? 'AI Processing...' : 'Import (AI)'}
+        </button>
+      </div>
+      {status && (
+        <span
+          style={{
+            fontSize: 11,
+            color: status.type === 'error' ? 'var(--theme-error-500)' : 'var(--theme-success-500)',
+          }}
+        >
+          {status.message}
+        </span>
+      )}
+    </div>
+  )
+}
+
+export default TexImportButton


### PR DESCRIPTION
Admin UI for LaTeX-to-exercise conversion on lessons. Includes LessonConversionPanel with .tex file upload (bypasses Payload client-side MIME validation), TexImportButton with Script/AI dual buttons, LatexQuickImport paste box, and stub import-latex endpoint. Media collection updated to accept .tex files.