### PR TITLE
fix: Use logical CSS properties for RTL/LTR text alignment in lesson …

### DIFF
--- a/src/app/(frontend)/courses/[courseSlug]/_components/CourseLessonCard/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/_components/CourseLessonCard/index.tsx
@@ -4,8 +4,8 @@ import { SystemLink } from '@/infra/loading/components/SystemLink'
 import { cn } from '@/infra/utils/ui'
 import type { Lesson } from '@/payload-types'
 import { useTranslations } from '@/ui/web/providers/I18n'
-import { ProgressCircle } from '@/ui/web/shared/ProgressCircle'
 import { ContentStatusBadge } from '@/ui/web/shared/ContentStatusBadge'
+import { ProgressCircle } from '@/ui/web/shared/ProgressCircle'
 import { Clock } from 'lucide-react'
 import { toast } from 'sonner'
 
@@ -50,7 +50,7 @@ export function CourseLessonCard({
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden border border-border/40 shadow-sm transition-all',
+        'rounded-2xl overflow-hidden border border-border/40 shadow-elevation-1 transition-all',
         !isSoon && 'active:scale-[0.98]',
         isSoon && 'opacity-60',
       )}
@@ -61,25 +61,25 @@ export function CourseLessonCard({
         onClick={handleLessonClick}
         className={cn(
           'bg-card p-5',
-          'flex flex-row-reverse items-center justify-between',
+          'flex items-center justify-between',
           isSoon ? 'cursor-not-allowed' : 'cursor-pointer',
         )}
       >
-        <div className="flex flex-col text-end">
+        <div className="flex flex-col text-start">
           <span
             className="text-[10px] font-bold mb-1 uppercase tracking-wide"
             style={{ color: accentColor }}
           >
             {tc('lesson')} {index}
           </span>
-          <div className="flex items-center gap-2">
-            <h3 className="text-lg font-bold text-card-foreground">{lesson.title}</h3>
+          <div className="flex items-center gap-content-gap-xs">
+            <h3 className="text-body-lg font-bold text-card-foreground">{lesson.title}</h3>
             <ContentStatusBadge
               contentStatus={lesson.contentStatus}
               contentStatusExpiresAt={lesson.contentStatusExpiresAt ?? undefined}
             />
           </div>
-          <p className="text-xs text-muted-foreground mt-1 flex items-center justify-end gap-1">
+          <p className="text-body-xs text-muted-foreground mt-1 flex items-center justify-start gap-1">
             {progress === 0 && <Clock className="w-3 h-3" />}
             {progressText}
           </p>
@@ -97,7 +97,7 @@ export function CourseLessonCard({
               y="50%"
               textAnchor="middle"
               dy=".3em"
-              className="text-sm font-bold fill-foreground"
+              className="text-body-sm font-bold fill-foreground"
             >
               {Math.round(progress)}%
             </text>

--- a/src/app/(frontend)/courses/_components/CourseCard/index.tsx
+++ b/src/app/(frontend)/courses/_components/CourseCard/index.tsx
@@ -1,18 +1,18 @@
 'use client'
 
-import { BookOpen, CheckCircle, Loader2 } from 'lucide-react'
-import { useEffect, useState } from 'react'
-import { cn } from '@/infra/utils/ui'
-import { useRouterWithLoading } from '@/infra/loading/hooks/useRouterWithLoading'
+import { getUserProfile, setUserProfile } from '@/client/state/localStorage/userProfile'
 import { useLoadingState } from '@/infra/loading/hooks/useLoadingState'
+import { useRouterWithLoading } from '@/infra/loading/hooks/useRouterWithLoading'
 import { LOADING_KEYS } from '@/infra/loading/keys'
-import { setUserProfile, getUserProfile } from '@/client/state/localStorage/userProfile'
+import { cn } from '@/infra/utils/ui'
 import type { Course } from '@/payload-types'
-import { useTranslations } from '@/ui/web/providers/I18n'
 import { Button } from '@/ui/web/components/button'
+import { useTranslations } from '@/ui/web/providers/I18n'
 import { SafeHtml } from '@/ui/web/SafeHtml'
 import { ContentStatusBadge } from '@/ui/web/shared/ContentStatusBadge'
 import { ProgressCircle } from '@/ui/web/shared/ProgressCircle'
+import { BookOpen, CheckCircle, Loader2 } from 'lucide-react'
+import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
 interface CourseCardProps {
@@ -83,7 +83,7 @@ export function CourseCard({ course, isOwned = false }: CourseCardProps) {
   return (
     <div
       className={cn(
-        'relative bg-card p-6 rounded-[2rem] flex flex-col',
+        'relative bg-card p-card-padding rounded-[2rem] flex flex-col',
         borderClass,
         'shadow-[0_1px_2px_0_rgba(60,64,67,.3),0_1px_3px_1px_rgba(60,64,67,.15)]',
         'transition-all hover:-translate-y-0.5',
@@ -92,7 +92,7 @@ export function CourseCard({ course, isOwned = false }: CourseCardProps) {
     >
       {isOwned && (
         <span
-          className="absolute -top-3 left-6 bg-[hsl(var(--success))] text-white px-4 py-1 rounded-full shadow-md uppercase tracking-wider"
+          className="absolute -top-3 start-6 bg-[hsl(var(--success))] text-white px-4 py-1 rounded-full shadow-elevation-3 uppercase tracking-wider"
           style={{ fontSize: '9px', fontWeight: 900 }}
         >
           הקורס שלך
@@ -103,10 +103,10 @@ export function CourseCard({ course, isOwned = false }: CourseCardProps) {
       <ContentStatusBadge
         contentStatus={course.contentStatus}
         contentStatusExpiresAt={course.contentStatusExpiresAt ?? undefined}
-        className="absolute -top-3 right-6"
+        className="absolute -top-3 end-6"
       />
 
-      <div className="mb-6 flex justify-between items-start gap-4">
+      <div className="mb-6 flex justify-between items-start gap-content-gap">
         <div className="flex-1">
           {course.courseLabel && (
             <span
@@ -117,7 +117,7 @@ export function CourseCard({ course, isOwned = false }: CourseCardProps) {
             </span>
           )}
           <h4
-            className="text-card-foreground text-right"
+            className="text-card-foreground text-start"
             style={{ fontSize: '20px', fontWeight: 900 }}
           >
             {course.title}
@@ -125,7 +125,7 @@ export function CourseCard({ course, isOwned = false }: CourseCardProps) {
           {course.description && (
             <SafeHtml
               html={course.description}
-              className="text-muted-foreground mt-1 line-clamp-2 text-right [&_p]:m-0"
+              className="text-muted-foreground mt-1 line-clamp-2 text-start [&_p]:m-0"
               style={{ fontSize: '12px' }}
             />
           )}
@@ -183,7 +183,7 @@ export function CourseCard({ course, isOwned = false }: CourseCardProps) {
         >
           {isLoading ? (
             <>
-              <Loader2 className="w-4 h-4 animate-spin mr-2" />
+              <Loader2 className="w-4 h-4 animate-spin me-2" />
               {t('openCourse')}
             </>
           ) : (


### PR DESCRIPTION
…cards

Replace hardcoded physical alignment classes (text-right, left-6, right-6, flex-row-reverse, mr-2) with logical Tailwind equivalents (text-start, start-6, end-6, me-2) so card text and badges align correctly in both Hebrew (RTL) and English (LTR) based on the document dir attribute.