### PR TITLE
fix: Add status badges and Soon lock to /study LessonGridCard

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -106,7 +106,7 @@ const nextConfig = {
           {
             key: 'Content-Security-Policy',
             value:
-              "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.googletagmanager.com https://cdn.mxpnl.com; style-src 'self' 'unsafe-inline'; img-src 'self' *.blob.vercel-storage.com img.youtube.com avatars.githubusercontent.com github.com *.githubusercontent.com data: blob:; font-src 'self' data:; connect-src 'self' *.sentry.io; frame-src 'self' www.youtube.com vercel.live; object-src 'none'; base-uri 'self'; form-action 'self'",
+              "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.googletagmanager.com https://cdn.mxpnl.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' *.blob.vercel-storage.com img.youtube.com avatars.githubusercontent.com github.com *.githubusercontent.com data: blob:; font-src 'self' data:; connect-src 'self' *.sentry.io; frame-src 'self' www.youtube.com vercel.live; object-src 'none'; base-uri 'self'; form-action 'self'",
           },
           { key: 'X-Frame-Options', value: 'DENY' },
           { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' },

--- a/src/app/(frontend)/courses/[courseSlug]/_components/CourseLessonCard/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/_components/CourseLessonCard/index.tsx
@@ -50,7 +50,7 @@ export function CourseLessonCard({
   return (
     <div
       className={cn(
-        'relative rounded-2xl overflow-hidden border border-border/40 shadow-elevation-1 transition-all',
+        'relative rounded-2xl overflow-visible border border-border/40 shadow-elevation-1 transition-all',
         !isSoon && 'active:scale-[0.98]',
         isSoon && 'opacity-60',
       )}

--- a/src/app/(frontend)/courses/[courseSlug]/_components/CourseLessonCard/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/_components/CourseLessonCard/index.tsx
@@ -50,12 +50,18 @@ export function CourseLessonCard({
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden border border-border/40 shadow-elevation-1 transition-all',
+        'relative rounded-2xl overflow-hidden border border-border/40 shadow-elevation-1 transition-all',
         !isSoon && 'active:scale-[0.98]',
         isSoon && 'opacity-60',
       )}
       style={{ borderTopWidth: 3, borderTopColor: accentColor }}
     >
+      <ContentStatusBadge
+        contentStatus={lesson.contentStatus}
+        contentStatusExpiresAt={lesson.contentStatusExpiresAt ?? undefined}
+        contentStatusLabel={lesson.contentStatusLabel ?? undefined}
+        className="absolute -top-3 right-4 z-10"
+      />
       <SystemLink
         href={isSoon ? '#' : href}
         onClick={handleLessonClick}
@@ -72,14 +78,7 @@ export function CourseLessonCard({
           >
             {tc('lesson')} {index}
           </span>
-          <div className="flex items-center gap-content-gap-xs">
-            <h3 className="text-body-lg font-bold text-card-foreground">{lesson.title}</h3>
-            <ContentStatusBadge
-              contentStatus={lesson.contentStatus}
-              contentStatusExpiresAt={lesson.contentStatusExpiresAt ?? undefined}
-              contentStatusLabel={lesson.contentStatusLabel ?? undefined}
-            />
-          </div>
+          <h3 className="text-body-lg font-bold text-card-foreground">{lesson.title}</h3>
           <p className="text-body-xs text-muted-foreground mt-1 flex items-center justify-end gap-1">
             {progress === 0 && <Clock className="w-3 h-3" />}
             {progressText}

--- a/src/app/(frontend)/courses/[courseSlug]/_components/CourseLessonCard/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/_components/CourseLessonCard/index.tsx
@@ -50,7 +50,7 @@ export function CourseLessonCard({
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden border border-border/40 shadow-sm transition-all',
+        'rounded-2xl overflow-hidden border border-border/40 shadow-elevation-1 transition-all',
         !isSoon && 'active:scale-[0.98]',
         isSoon && 'opacity-60',
       )}
@@ -72,14 +72,15 @@ export function CourseLessonCard({
           >
             {tc('lesson')} {index}
           </span>
-          <div className="flex items-center gap-2">
-            <h3 className="text-lg font-bold text-card-foreground">{lesson.title}</h3>
+          <div className="flex items-center gap-content-gap-xs">
+            <h3 className="text-body-lg font-bold text-card-foreground">{lesson.title}</h3>
             <ContentStatusBadge
               contentStatus={lesson.contentStatus}
               contentStatusExpiresAt={lesson.contentStatusExpiresAt ?? undefined}
+              contentStatusLabel={lesson.contentStatusLabel ?? undefined}
             />
           </div>
-          <p className="text-xs text-muted-foreground mt-1 flex items-center justify-end gap-1">
+          <p className="text-body-xs text-muted-foreground mt-1 flex items-center justify-end gap-1">
             {progress === 0 && <Clock className="w-3 h-3" />}
             {progressText}
           </p>
@@ -97,7 +98,7 @@ export function CourseLessonCard({
               y="50%"
               textAnchor="middle"
               dy=".3em"
-              className="text-sm font-bold fill-foreground"
+              className="text-body-sm font-bold fill-foreground"
             >
               {Math.round(progress)}%
             </text>

--- a/src/app/(frontend)/courses/_components/CourseCard/index.tsx
+++ b/src/app/(frontend)/courses/_components/CourseCard/index.tsx
@@ -83,7 +83,7 @@ export function CourseCard({ course, isOwned = false }: CourseCardProps) {
   return (
     <div
       className={cn(
-        'relative bg-card p-6 rounded-[2rem] flex flex-col',
+        'relative bg-card p-card-padding rounded-[2rem] flex flex-col',
         borderClass,
         'shadow-[0_1px_2px_0_rgba(60,64,67,.3),0_1px_3px_1px_rgba(60,64,67,.15)]',
         'transition-all hover:-translate-y-0.5',
@@ -92,7 +92,7 @@ export function CourseCard({ course, isOwned = false }: CourseCardProps) {
     >
       {isOwned && (
         <span
-          className="absolute -top-3 left-6 bg-[hsl(var(--success))] text-white px-4 py-1 rounded-full shadow-md uppercase tracking-wider"
+          className="absolute -top-3 left-6 bg-[hsl(var(--success))] text-white px-4 py-1 rounded-full shadow-elevation-3 uppercase tracking-wider"
           style={{ fontSize: '9px', fontWeight: 900 }}
         >
           הקורס שלך
@@ -103,10 +103,11 @@ export function CourseCard({ course, isOwned = false }: CourseCardProps) {
       <ContentStatusBadge
         contentStatus={course.contentStatus}
         contentStatusExpiresAt={course.contentStatusExpiresAt ?? undefined}
+        contentStatusLabel={course.contentStatusLabel ?? undefined}
         className="absolute -top-3 right-6"
       />
 
-      <div className="mb-6 flex justify-between items-start gap-4">
+      <div className="mb-6 flex justify-between items-start gap-content-gap">
         <div className="flex-1">
           {course.courseLabel && (
             <span

--- a/src/app/(frontend)/courses/_components/LessonCard/index.tsx
+++ b/src/app/(frontend)/courses/_components/LessonCard/index.tsx
@@ -46,21 +46,22 @@ export function LessonCard({ lesson, courseSlug, chapterSlug }: LessonCardProps)
   }
 
   return (
-    <Card className={cn('hover:shadow-elevation-3 transition-shadow', isSoon && 'opacity-60')}>
+    <Card
+      className={cn('relative hover:shadow-elevation-3 transition-shadow', isSoon && 'opacity-60')}
+    >
+      <ContentStatusBadge
+        contentStatus={lesson.contentStatus}
+        contentStatusExpiresAt={lesson.contentStatusExpiresAt ?? undefined}
+        contentStatusLabel={lesson.contentStatusLabel ?? undefined}
+        className="absolute -top-3 right-4 z-10"
+      />
       <CardHeader>
         <div className="flex items-center gap-3 mb-2">
           <span className="text-body-md font-semibold text-muted-foreground">
             {t('lesson')} {lesson.order}
           </span>
         </div>
-        <div className="flex items-center gap-content-gap-xs">
-          <CardTitle className="text-heading-xl">{lesson.title}</CardTitle>
-          <ContentStatusBadge
-            contentStatus={lesson.contentStatus}
-            contentStatusExpiresAt={lesson.contentStatusExpiresAt ?? undefined}
-            contentStatusLabel={lesson.contentStatusLabel ?? undefined}
-          />
-        </div>
+        <CardTitle className="text-heading-xl">{lesson.title}</CardTitle>
         {lesson.description && (
           <SafeHtml
             html={lesson.description}

--- a/src/app/(frontend)/courses/_components/LessonCard/index.tsx
+++ b/src/app/(frontend)/courses/_components/LessonCard/index.tsx
@@ -46,22 +46,26 @@ export function LessonCard({ lesson, courseSlug, chapterSlug }: LessonCardProps)
   }
 
   return (
-    <Card className={cn('hover:shadow-md transition-shadow', isSoon && 'opacity-60')}>
+    <Card className={cn('hover:shadow-elevation-3 transition-shadow', isSoon && 'opacity-60')}>
       <CardHeader>
         <div className="flex items-center gap-3 mb-2">
-          <span className="text-base font-semibold text-muted-foreground">
+          <span className="text-body-md font-semibold text-muted-foreground">
             {t('lesson')} {lesson.order}
           </span>
         </div>
-        <div className="flex items-center gap-2">
-          <CardTitle className="text-xl">{lesson.title}</CardTitle>
+        <div className="flex items-center gap-content-gap-xs">
+          <CardTitle className="text-heading-xl">{lesson.title}</CardTitle>
           <ContentStatusBadge
             contentStatus={lesson.contentStatus}
             contentStatusExpiresAt={lesson.contentStatusExpiresAt ?? undefined}
+            contentStatusLabel={lesson.contentStatusLabel ?? undefined}
           />
         </div>
         {lesson.description && (
-          <SafeHtml html={lesson.description} className="text-sm text-muted-foreground [&_p]:m-0" />
+          <SafeHtml
+            html={lesson.description}
+            className="text-body-sm text-muted-foreground [&_p]:m-0"
+          />
         )}
       </CardHeader>
       <CardFooter>

--- a/src/app/(frontend)/study/_components/StudyContent/index.tsx
+++ b/src/app/(frontend)/study/_components/StudyContent/index.tsx
@@ -276,7 +276,7 @@ function LessonGridCard({
   return (
     <div
       className={cn(
-        'relative rounded-2xl overflow-hidden border border-border/40 shadow-elevation-1 transition-all',
+        'relative rounded-2xl overflow-visible border border-border/40 shadow-elevation-1 transition-all',
         !isSoon && 'active:scale-[0.98]',
         isSoon && 'opacity-60',
       )}

--- a/src/app/(frontend)/study/_components/StudyContent/index.tsx
+++ b/src/app/(frontend)/study/_components/StudyContent/index.tsx
@@ -276,12 +276,18 @@ function LessonGridCard({
   return (
     <div
       className={cn(
-        'rounded-2xl overflow-hidden border border-border/40 shadow-elevation-1 transition-all',
+        'relative rounded-2xl overflow-hidden border border-border/40 shadow-elevation-1 transition-all',
         !isSoon && 'active:scale-[0.98]',
         isSoon && 'opacity-60',
       )}
       style={{ borderTopWidth: 3, borderTopColor: accentColor }}
     >
+      <ContentStatusBadge
+        contentStatus={lesson.contentStatus}
+        contentStatusExpiresAt={lesson.contentStatusExpiresAt ?? undefined}
+        contentStatusLabel={lesson.contentStatusLabel ?? undefined}
+        className="absolute -top-3 right-4 z-10"
+      />
       <SystemLink
         href={isSoon ? '#' : href}
         onClick={handleLessonClick}
@@ -298,14 +304,7 @@ function LessonGridCard({
           >
             {tc('lesson')} {index}
           </span>
-          <div className="flex items-center gap-content-gap-xs">
-            <h3 className="text-body-lg font-bold text-card-foreground">{lesson.title}</h3>
-            <ContentStatusBadge
-              contentStatus={lesson.contentStatus}
-              contentStatusExpiresAt={lesson.contentStatusExpiresAt ?? undefined}
-              contentStatusLabel={lesson.contentStatusLabel ?? undefined}
-            />
-          </div>
+          <h3 className="text-body-lg font-bold text-card-foreground">{lesson.title}</h3>
           <p className="text-body-xs text-muted-foreground mt-1 flex items-center justify-end gap-1">
             {progress === 0 && <Clock className="w-3 h-3" />}
             {progressText}

--- a/src/app/(frontend)/study/_components/StudyContent/index.tsx
+++ b/src/app/(frontend)/study/_components/StudyContent/index.tsx
@@ -17,8 +17,10 @@ import {
 } from '@/server/constants/lesson-types'
 import { AccessGateProvider } from '@/ui/web/auth/AccessGateProvider'
 import { useLocale, useTranslations } from '@/ui/web/providers/I18n'
+import { ContentStatusBadge } from '@/ui/web/shared/ContentStatusBadge'
 import { ProgressCircle } from '@/ui/web/shared/ProgressCircle'
 import { BarChart3, Clock, GraduationCap, Sparkles } from 'lucide-react'
+import { toast } from 'sonner'
 import { useEffect, useMemo, useState } from 'react'
 import { useProgressMap } from '@/client/hooks/useProgressMap'
 
@@ -127,7 +129,7 @@ export function StudyContent({ lessonType = DEFAULT_LESSON_TYPE }: StudyContentP
 
   if (isLoading) {
     return (
-      <div className="container mx-auto px-4 py-8">
+      <div className="container mx-auto px-4 py-section-md">
         <div className="text-center text-muted-foreground">{ts('loading')}</div>
       </div>
     )
@@ -149,19 +151,19 @@ export function StudyContent({ lessonType = DEFAULT_LESSON_TYPE }: StudyContentP
       isAuthenticated={isAuthenticated}
     >
       {/* Centered title area - clean background */}
-      <div className="w-full py-6 px-6">
+      <div className="w-full py-section-sm px-6">
         <div className="max-w-5xl mx-auto text-center">
           <ExamReminderBubble courseId={courseInfo?.courseId ?? ''} />
-          <h1 className="text-3xl md:text-4xl font-black text-foreground mt-4 text-center">
+          <h1 className="text-display-sm md:text-display-md font-black text-foreground mt-4 text-center">
             {sectionTitle}
           </h1>
         </div>
       </div>
 
       {/* Main Content */}
-      <main className="container mx-auto px-6 py-6 max-w-5xl">
+      <main className="container mx-auto px-6 py-section-sm max-w-5xl">
         {filteredLessons.length > 0 ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-content-gap-lg">
             {filteredLessons.map((lesson, idx) => (
               <LessonGridCard
                 key={lesson.id}
@@ -176,28 +178,28 @@ export function StudyContent({ lessonType = DEFAULT_LESSON_TYPE }: StudyContentP
           </div>
         ) : (
           <div className="text-center py-20 text-muted-foreground italic">
-            <p className="text-lg">{ts('noTopicsAvailable')}</p>
+            <p className="text-body-lg">{ts('noTopicsAvailable')}</p>
           </div>
         )}
 
         {/* Footer actions with divider */}
         <div className="mt-16 pt-8 border-t border-border">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-content-gap">
             <SystemLink
               href="/stats"
-              className="flex items-center justify-center gap-2 text-sm font-bold text-foreground bg-card border border-border px-6 py-3 rounded-full hover:bg-muted/50 transition-all"
+              className="flex items-center justify-center gap-content-gap-xs text-body-sm font-bold text-foreground bg-card border border-border px-6 py-3 rounded-full hover:bg-muted/50 transition-all"
             >
               <BarChart3 className="w-4 h-4" />
               {t('statsAndPerformance')}
             </SystemLink>
             <SystemLink
               href="/study-plan"
-              className="flex items-center justify-center gap-2 text-sm font-bold text-primary-foreground bg-primary px-6 py-3 rounded-full shadow-lg hover:opacity-90 transition-all"
+              className="flex items-center justify-center gap-content-gap-xs text-body-sm font-bold text-primary-foreground bg-primary px-6 py-3 rounded-full shadow-card hover:opacity-90 transition-all"
             >
               <GraduationCap className="w-4 h-4" />
               {t('upcomingExam')}
             </SystemLink>
-            <button className="flex items-center justify-center gap-2 text-sm font-bold text-foreground bg-card border border-border px-6 py-3 rounded-full hover:bg-muted/50 transition-all">
+            <button className="flex items-center justify-center gap-content-gap-xs text-body-sm font-bold text-foreground bg-card border border-border px-6 py-3 rounded-full hover:bg-muted/50 transition-all">
               <Sparkles className="w-4 h-4" />
               {t('bagrutTransition')}
             </button>
@@ -225,7 +227,7 @@ function ExamReminderBubble({ courseId }: { courseId: string }) {
 
   return (
     <div className="flex justify-center mt-4 animate-in fade-in">
-      <span className="bg-primary text-white text-sm font-bold px-6 py-2 rounded-full">
+      <span className="bg-primary text-white text-body-sm font-bold px-6 py-2 rounded-full">
         {message}
       </span>
     </div>
@@ -257,27 +259,36 @@ function LessonGridCard({
   if (!lesson.slug) return null
 
   const href = `/courses/${courseSlug}/chapters/${chapterSlug}/lessons/${lesson.slug}`
+  const isSoon = lesson.contentStatus === 'soon'
   const progress = progressProp ?? 0
   const progressText =
-    progress >= 100
-      ? t('lessonCompleted')
-      : progress > 0
-        ? t('lessonsRemaining').replace('{count}', String(3))
-        : t('notStarted')
+    progress >= 100 ? t('lessonCompleted') : progress > 0 ? t('statusInProgress') : t('notStarted')
 
   const accentColor = tabColor?.stroke ?? 'hsl(var(--primary))'
 
+  const handleLessonClick = (e: React.MouseEvent) => {
+    if (isSoon) {
+      e.preventDefault()
+      toast.info(tc('contentLocked'))
+    }
+  }
+
   return (
     <div
-      className="rounded-2xl overflow-hidden border border-border/40 shadow-sm transition-all active:scale-[0.98]"
+      className={cn(
+        'rounded-2xl overflow-hidden border border-border/40 shadow-elevation-1 transition-all',
+        !isSoon && 'active:scale-[0.98]',
+        isSoon && 'opacity-60',
+      )}
       style={{ borderTopWidth: 3, borderTopColor: accentColor }}
     >
       <SystemLink
-        href={href}
+        href={isSoon ? '#' : href}
+        onClick={handleLessonClick}
         className={cn(
           'bg-card p-5',
           'flex flex-row-reverse items-center justify-between',
-          'cursor-pointer',
+          isSoon ? 'cursor-not-allowed' : 'cursor-pointer',
         )}
       >
         <div className="flex flex-col text-end">
@@ -287,8 +298,14 @@ function LessonGridCard({
           >
             {tc('lesson')} {index}
           </span>
-          <h3 className="text-lg font-bold text-card-foreground">{lesson.title}</h3>
-          <p className="text-xs text-muted-foreground mt-1 flex items-center justify-end gap-1">
+          <div className="flex items-center gap-content-gap-xs">
+            <h3 className="text-body-lg font-bold text-card-foreground">{lesson.title}</h3>
+            <ContentStatusBadge
+              contentStatus={lesson.contentStatus}
+              contentStatusExpiresAt={lesson.contentStatusExpiresAt ?? undefined}
+            />
+          </div>
+          <p className="text-body-xs text-muted-foreground mt-1 flex items-center justify-end gap-1">
             {progress === 0 && <Clock className="w-3 h-3" />}
             {progressText}
           </p>
@@ -306,7 +323,7 @@ function LessonGridCard({
               y="50%"
               textAnchor="middle"
               dy=".3em"
-              className="text-sm font-bold fill-foreground"
+              className="text-body-sm font-bold fill-foreground"
             >
               {Math.round(progress)}%
             </text>

--- a/src/app/(frontend)/study/_components/StudyContent/index.tsx
+++ b/src/app/(frontend)/study/_components/StudyContent/index.tsx
@@ -303,6 +303,7 @@ function LessonGridCard({
             <ContentStatusBadge
               contentStatus={lesson.contentStatus}
               contentStatusExpiresAt={lesson.contentStatusExpiresAt ?? undefined}
+              contentStatusLabel={lesson.contentStatusLabel ?? undefined}
             />
           </div>
           <p className="text-body-xs text-muted-foreground mt-1 flex items-center justify-end gap-1">

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -561,7 +561,7 @@ export interface Course {
   /**
    * Content status badge displayed to students
    */
-  contentStatus: 'none' | 'soon' | 'justAdded';
+  contentStatus: 'none' | 'soon' | 'justAdded' | 'custom';
   /**
    * When unchecked, "Soon" content is completely hidden from student listings
    */
@@ -570,6 +570,10 @@ export interface Course {
    * Badge auto-expires after this date (leave empty for permanent badge)
    */
   contentStatusExpiresAt?: string | null;
+  /**
+   * Custom badge text (e.g. "מותאם לבגרות")
+   */
+  contentStatusLabel?: string | null;
   /**
    * User who created this document
    */
@@ -717,7 +721,7 @@ export interface Prompt {
   /**
    * Purpose of this prompt: chat conversation, PDF extraction, PDF verification, or context extraction for AI tutor
    */
-  usage?: ('chat' | 'extractor' | 'verifier' | 'context_extractor') | null;
+  usage?: ('chat' | 'extractor' | 'verifier' | 'context_extractor' | 'translator') | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -1346,7 +1350,7 @@ export interface Lesson {
   /**
    * Content status badge displayed to students
    */
-  contentStatus: 'none' | 'soon' | 'justAdded';
+  contentStatus: 'none' | 'soon' | 'justAdded' | 'custom';
   /**
    * When unchecked, "Soon" content is completely hidden from student listings
    */
@@ -1355,6 +1359,10 @@ export interface Lesson {
    * Badge auto-expires after this date (leave empty for permanent badge)
    */
   contentStatusExpiresAt?: string | null;
+  /**
+   * Custom badge text (e.g. "מותאם לבגרות")
+   */
+  contentStatusLabel?: string | null;
   /**
    * User who created this document
    */
@@ -3068,6 +3076,7 @@ export interface CoursesSelect<T extends boolean = true> {
   contentStatus?: T;
   contentStatusVisible?: T;
   contentStatusExpiresAt?: T;
+  contentStatusLabel?: T;
   createdBy?: T;
   updatedAt?: T;
   createdAt?: T;
@@ -3118,6 +3127,7 @@ export interface LessonsSelect<T extends boolean = true> {
   contentStatus?: T;
   contentStatusVisible?: T;
   contentStatusExpiresAt?: T;
+  contentStatusLabel?: T;
   createdBy?: T;
   updatedAt?: T;
   createdAt?: T;

--- a/src/server/payload/fields/contentStatus.ts
+++ b/src/server/payload/fields/contentStatus.ts
@@ -7,7 +7,7 @@ import type { Field } from 'payload'
  * - "Soon": Upcoming content, locked from student access
  * - "Just Added": New content, fully accessible with visual highlight
  */
-export const CONTENT_STATUS_OPTIONS = ['none', 'soon', 'justAdded'] as const
+export const CONTENT_STATUS_OPTIONS = ['none', 'soon', 'justAdded', 'custom'] as const
 export type ContentStatus = (typeof CONTENT_STATUS_OPTIONS)[number]
 export const DEFAULT_CONTENT_STATUS: ContentStatus = 'none'
 
@@ -27,7 +27,14 @@ export const contentStatusFields: Field[] = [
     index: true,
     defaultValue: DEFAULT_CONTENT_STATUS,
     options: CONTENT_STATUS_OPTIONS.map((status) => ({
-      label: status === 'none' ? 'None' : status === 'soon' ? 'Soon' : 'Just Added',
+      label:
+        status === 'none'
+          ? 'None'
+          : status === 'soon'
+            ? 'Soon'
+            : status === 'justAdded'
+              ? 'Just Added'
+              : 'Custom',
       value: status,
     })),
     admin: {
@@ -52,6 +59,15 @@ export const contentStatusFields: Field[] = [
       position: 'sidebar',
       description: 'Badge auto-expires after this date (leave empty for permanent badge)',
       condition: (data) => data?.contentStatus === 'justAdded',
+    },
+  },
+  {
+    name: 'contentStatusLabel',
+    type: 'text',
+    admin: {
+      position: 'sidebar',
+      description: 'Custom badge text (e.g. "מותאם לבגרות")',
+      condition: (data) => data?.contentStatus === 'custom',
     },
   },
 ]

--- a/src/ui/web/shared/ContentStatusBadge/index.tsx
+++ b/src/ui/web/shared/ContentStatusBadge/index.tsx
@@ -4,8 +4,9 @@ import { useTranslations } from '@/ui/web/providers/I18n'
 import { cn } from '@/infra/utils/ui'
 
 interface ContentStatusBadgeProps {
-  contentStatus?: 'none' | 'soon' | 'justAdded' | null
+  contentStatus?: 'none' | 'soon' | 'justAdded' | 'custom' | null
   contentStatusExpiresAt?: string | null
+  contentStatusLabel?: string | null
   className?: string
 }
 
@@ -15,12 +16,14 @@ interface ContentStatusBadgeProps {
  * Displays a pill-shaped badge indicating content status:
  * - "Soon": Neutral gray styling, locked content
  * - "Just Added": Green styling with pulse animation, accessible content
+ * - "Custom": Accent styling with admin-defined label text
  *
  * Returns null for 'none', null/undefined status, or expired 'justAdded' badges
  */
 export function ContentStatusBadge({
   contentStatus,
   contentStatusExpiresAt,
+  contentStatusLabel,
   className,
 }: ContentStatusBadgeProps) {
   const t = useTranslations('courses')
@@ -65,6 +68,21 @@ export function ContentStatusBadge({
         )}
       >
         {t('justAddedBadge')}
+      </span>
+    )
+  }
+
+  // "Custom" badge - accent styling with admin-defined label
+  if (contentStatus === 'custom' && contentStatusLabel) {
+    return (
+      <span
+        className={cn(
+          'inline-flex items-center rounded-full px-2.5 py-0.5 text-body-xs font-bold',
+          'bg-secondary text-secondary-foreground',
+          className,
+        )}
+      >
+        {contentStatusLabel}
       </span>
     )
   }

--- a/tests/unit/fields/contentStatus.test.ts
+++ b/tests/unit/fields/contentStatus.test.ts
@@ -24,15 +24,16 @@ describe('contentStatusFields', () => {
     it('exports an array of 3 Field objects', () => {
       expect(contentStatusFields).toBeDefined()
       expect(Array.isArray(contentStatusFields)).toBe(true)
-      expect(contentStatusFields).toHaveLength(3)
+      expect(contentStatusFields).toHaveLength(4)
     })
 
-    it('contains contentStatus, contentStatusVisible, and contentStatusExpiresAt fields', () => {
+    it('contains contentStatus, contentStatusVisible, contentStatusExpiresAt, and contentStatusLabel fields', () => {
       const fields = contentStatusFields as BasicField[]
       const fieldNames = fields.map((f) => f.name)
       expect(fieldNames).toContain('contentStatus')
       expect(fieldNames).toContain('contentStatusVisible')
       expect(fieldNames).toContain('contentStatusExpiresAt')
+      expect(fieldNames).toContain('contentStatusLabel')
     })
   })
 
@@ -48,8 +49,8 @@ describe('contentStatusFields', () => {
       const field = fields.find((f) => f.name === 'contentStatus')
       expect(field?.options).toBeDefined()
       const options = field?.options as Array<{ label: string; value: string }>
-      expect(options).toHaveLength(3)
-      expect(options.map((o) => o.value)).toEqual(['none', 'soon', 'justAdded'])
+      expect(options).toHaveLength(4)
+      expect(options.map((o) => o.value)).toEqual(['none', 'soon', 'justAdded', 'custom'])
     })
 
     it('defaults to "none"', () => {


### PR DESCRIPTION
…route

Badges (Soon/Just Added) were only visible on the deprecated /study page. The new /courses pages already had badge integration but users were being sent to /study after completing lessons. This changes all backUrl references from /study to /courses/{courseSlug}, updates HomePage and NavigationBar to point to /courses, removes the old /study route, and relocates StudyContent to a shared component for /test and /practice pages.