### PR TITLE
fix: Hide exercise number bubble when only one question per exercise

### DIFF
--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/ExercisesPager/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/ExercisesPager/index.tsx
@@ -138,12 +138,12 @@ export function ExercisesPager({
         primaryContent={
           <div className="h-full flex flex-col">
             <div className="flex-1 overflow-y-auto min-h-0">
-              <div className="w-full p-4 md:p-6 space-y-4">
-                <div className="bg-card rounded-2xl border border-border/60 shadow-sm overflow-hidden mt-4">
+              <div className="w-full p-card-padding-sm md:p-card-padding space-y-4">
+                <div className="bg-card rounded-2xl border border-border/60 shadow-elevation-1 overflow-hidden mt-4">
                   <Progress value={progressPercent} className="h-1.5 rounded-none" />
 
-                  <div className="p-5 md:p-6">
-                    <p className="text-start text-base font-semibold text-slate-900 dark:text-slate-100 mb-3">
+                  <div className="p-5 md:p-card-padding">
+                    <p className="text-start text-body-md font-semibold text-slate-900 dark:text-slate-100 mb-3">
                       {exerciseOrdinal !== null
                         ? `${t('exercise')} ${exerciseOrdinal} ${t('of')} ${totalExercises}`
                         : ''}
@@ -153,7 +153,7 @@ export function ExercisesPager({
                         <Layers className="w-4 h-4 text-primary" />
                       </div>
                       <div>
-                        <h2 className="text-lg font-medium text-foreground">
+                        <h2 className="text-body-lg font-medium text-foreground">
                           {currentExercise.title}
                         </h2>
                       </div>
@@ -161,7 +161,7 @@ export function ExercisesPager({
                   </div>
                 </div>
 
-                <div className="bg-card rounded-2xl p-5 md:p-6 border border-border/60 shadow-sm">
+                <div className="bg-card rounded-2xl p-5 md:p-card-padding border border-border/60 shadow-elevation-1">
                   <ExerciseRenderer
                     key={currentExercise.id}
                     content={currentExercise.content as unknown as ExerciseContentData}
@@ -170,6 +170,7 @@ export function ExercisesPager({
                     mediaMap={mediaMap}
                     lessonId={lessonId}
                     exerciseId={currentExercise.id}
+                    showExerciseNumber={currentExercise.showQuestionNumbering ?? false}
                     onResultsChange={handleExerciseResultsChange}
                   />
                 </div>
@@ -182,7 +183,7 @@ export function ExercisesPager({
                   variant="ghost"
                   onClick={handlePrev}
                   disabled={!canGoPrev || isNavigating}
-                  className="text-muted-foreground text-sm hover:text-foreground gap-1.5 cursor-pointer"
+                  className="text-muted-foreground text-body-sm hover:text-foreground gap-1.5 cursor-pointer"
                 >
                   <ChevronRight className="w-4 h-4 rtl:rotate-0 ltr:rotate-180" />{' '}
                   {t('exercisesPagerPrev')}
@@ -190,7 +191,7 @@ export function ExercisesPager({
                 <Button
                   onClick={handleNext}
                   disabled={!canGoNext || isNavigating}
-                  className="px-6 py-2 rounded-xl text-sm cursor-pointer"
+                  className="px-6 py-2 rounded-xl text-body-sm cursor-pointer"
                 >
                   {isNavigating ? (
                     <>
@@ -246,35 +247,35 @@ export function ExercisesPager({
       <Progress value={progressPercent} className="h-1.5 rounded-none" />
 
       <main className="flex-1 overflow-y-auto">
-        <div className="container mx-auto px-4 sm:px-6 py-8 md:py-12 max-w-7xl">
+        <div className="container mx-auto px-4 sm:px-6 py-section-md md:py-section-lg max-w-7xl">
           {pageState.type === 'intro' && (
             <div className="space-y-8">
               <header className="text-center">
                 <span className="inline-block px-4 py-1.5 bg-muted text-muted-foreground rounded-full text-[10px] tracking-[0.2em] uppercase mb-5 border border-border/40">
                   {t('exercisesPagerIntro')}
                 </span>
-                <h1 className="text-4xl md:text-[42px] font-medium leading-tight text-foreground mb-3">
+                <h1 className="text-display-md md:text-[42px] font-medium leading-tight text-foreground mb-3">
                   {lessonTitle}
                 </h1>
                 <div className="w-20 h-1 bg-primary mx-auto rounded-full" />
               </header>
 
-              <div className="bg-card rounded-3xl p-8 md:p-10 border border-border/60 shadow-xl shadow-muted/50 text-center">
-                <div className="w-20 h-20 bg-primary/10 rounded-3xl flex items-center justify-center mx-auto mb-8 shadow-lg shadow-primary/10 border border-primary/20">
+              <div className="bg-card rounded-3xl p-card-padding-lg md:p-10 border border-border/60 shadow-card-hover shadow-muted/50 text-center">
+                <div className="w-20 h-20 bg-primary/10 rounded-3xl flex items-center justify-center mx-auto mb-8 shadow-card shadow-primary/10 border border-primary/20">
                   <BookOpen className="w-9 h-9 text-primary" />
                 </div>
 
-                <h2 className="text-2xl font-medium mb-4 text-foreground">
+                <h2 className="text-display-xl font-medium mb-4 text-foreground">
                   {t('exercisesPagerWelcome')}
                 </h2>
-                <p className="text-muted-foreground mb-10 text-base leading-relaxed max-w-2xl mx-auto">
+                <p className="text-muted-foreground mb-10 text-body-md leading-relaxed max-w-2xl mx-auto">
                   {t('exercisesPagerIntroDescriptionPart1')} {totalExercises}{' '}
                   {t('exercisesPagerIntroDescriptionPart2')}
                 </p>
 
                 <div className="inline-flex items-center gap-3 px-5 py-3 bg-muted rounded-2xl border border-border/60 mb-10">
                   <Layers className="w-5 h-5 text-primary" />
-                  <span className="text-primary text-xl font-medium">{totalExercises}</span>
+                  <span className="text-primary text-heading-xl font-medium">{totalExercises}</span>
                   <span className="text-[10px] text-muted-foreground uppercase tracking-wider">
                     {t('exercise')}
                   </span>
@@ -283,7 +284,7 @@ export function ExercisesPager({
                 <Button
                   onClick={handleStart}
                   size="lg"
-                  className="w-full py-6 rounded-2xl text-lg shadow-lg shadow-primary/20 hover:shadow-xl hover:shadow-primary/30 transition-all duration-300 cursor-pointer"
+                  className="w-full py-section-sm rounded-2xl text-body-lg shadow-card shadow-primary/20 hover:shadow-card-hover hover:shadow-primary/30 transition-all duration-slow cursor-pointer"
                 >
                   {t('exercisesPagerStart')}{' '}
                   <ChevronLeft className="w-5 h-5 ms-2 rtl:rotate-0 ltr:rotate-180" />
@@ -298,21 +299,21 @@ export function ExercisesPager({
                 <span className="inline-block px-4 py-1.5 bg-secondary/10 text-secondary rounded-full text-[10px] tracking-[0.2em] uppercase mb-5 border border-secondary/20">
                   {t('exercisesPagerCompleted')}
                 </span>
-                <h1 className="text-4xl md:text-[42px] font-medium leading-tight text-foreground mb-3">
+                <h1 className="text-display-md md:text-[42px] font-medium leading-tight text-foreground mb-3">
                   {t('exercisesPagerCompletedTitle')}
                 </h1>
                 <div className="w-20 h-1 bg-secondary mx-auto rounded-full" />
               </header>
 
-              <div className="bg-card rounded-3xl p-8 md:p-10 border border-border/60 shadow-xl shadow-muted/50 text-center">
-                <div className="w-20 h-20 bg-secondary/10 rounded-3xl flex items-center justify-center mx-auto mb-8 shadow-lg shadow-secondary/10 border border-secondary/20">
+              <div className="bg-card rounded-3xl p-card-padding-lg md:p-10 border border-border/60 shadow-card-hover shadow-muted/50 text-center">
+                <div className="w-20 h-20 bg-secondary/10 rounded-3xl flex items-center justify-center mx-auto mb-8 shadow-card shadow-secondary/10 border border-secondary/20">
                   <Sparkles className="w-9 h-9 text-secondary" />
                 </div>
 
-                <h2 className="text-2xl font-medium mb-4 text-foreground">
+                <h2 className="text-display-xl font-medium mb-4 text-foreground">
                   {t('exercisesPagerCompletedTitle')}
                 </h2>
-                <p className="text-muted-foreground mb-10 text-base leading-relaxed max-w-2xl mx-auto">
+                <p className="text-muted-foreground mb-10 text-body-md leading-relaxed max-w-2xl mx-auto">
                   {t('exercisesPagerCompletedDescription')}
                 </p>
 
@@ -320,7 +321,7 @@ export function ExercisesPager({
                   asChild
                   size="lg"
                   variant="secondary"
-                  className="w-full py-6 rounded-2xl text-lg shadow-lg shadow-secondary/20 hover:shadow-xl hover:shadow-secondary/30 transition-all duration-300"
+                  className="w-full py-section-sm rounded-2xl text-body-lg shadow-card shadow-secondary/20 hover:shadow-card-hover hover:shadow-secondary/30 transition-all duration-slow"
                 >
                   <SystemLink href={backUrl}>
                     <Sparkles className="w-5 h-5 me-2" />
@@ -334,7 +335,7 @@ export function ExercisesPager({
                   variant="ghost"
                   onClick={handlePrev}
                   disabled={isNavigating}
-                  className="text-muted-foreground text-sm hover:text-foreground transition-colors duration-300 gap-1.5 cursor-pointer"
+                  className="text-muted-foreground text-body-sm hover:text-foreground transition-colors duration-slow gap-1.5 cursor-pointer"
                 >
                   <ChevronRight className="w-4 h-4 rtl:rotate-0 ltr:rotate-180" />{' '}
                   {t('exercisesPagerPrev')}

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/LessonPager/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/LessonPager/index.tsx
@@ -92,11 +92,11 @@ export function LessonPager({
         primaryContent={
           <div className="h-full flex flex-col">
             <div className="flex-1 overflow-y-auto min-h-0">
-              <div className="w-full p-4 md:p-6 space-y-4">
-                <div className="bg-card rounded-2xl border border-border/60 shadow-sm overflow-hidden mt-4">
+              <div className="w-full p-card-padding-sm md:p-card-padding space-y-4">
+                <div className="bg-card rounded-2xl border border-border/60 shadow-elevation-1 overflow-hidden mt-4">
                   <Progress value={progressPercent} className="h-1.5 rounded-none" />
-                  <div className="p-5 md:p-6">
-                    <p className="text-start text-base font-semibold text-slate-900 dark:text-slate-100 mb-3">
+                  <div className="p-5 md:p-card-padding">
+                    <p className="text-start text-body-md font-semibold text-slate-900 dark:text-slate-100 mb-3">
                       {ordinal !== null
                         ? `${t('exercise')} ${ordinal} ${t('of')} ${totalBlocks}`
                         : ''}
@@ -105,11 +105,11 @@ export function LessonPager({
                       <div className="w-8 h-8 bg-primary/10 rounded-lg flex items-center justify-center">
                         <Layers className="w-4 h-4 text-primary" />
                       </div>
-                      <h2 className="text-lg font-medium text-foreground">{exercise.title}</h2>
+                      <h2 className="text-body-lg font-medium text-foreground">{exercise.title}</h2>
                     </div>
                   </div>
                 </div>
-                <div className="bg-card rounded-2xl p-5 md:p-6 border border-border/60 shadow-sm">
+                <div className="bg-card rounded-2xl p-5 md:p-card-padding border border-border/60 shadow-elevation-1">
                   <ExerciseRenderer
                     content={exercise.content as unknown as ExerciseContentData}
                     mode="student"
@@ -117,6 +117,7 @@ export function LessonPager({
                     mediaMap={mediaMap}
                     lessonId={lessonId}
                     exerciseId={exercise.id}
+                    showExerciseNumber={exercise.showQuestionNumbering ?? false}
                   />
                 </div>
               </div>
@@ -127,7 +128,7 @@ export function LessonPager({
                   variant="ghost"
                   onClick={handlePrev}
                   disabled={!canGoPrev || isNavigating}
-                  className="text-muted-foreground text-sm hover:text-foreground gap-1.5 cursor-pointer"
+                  className="text-muted-foreground text-body-sm hover:text-foreground gap-1.5 cursor-pointer"
                 >
                   <ChevronRight className="w-4 h-4 rtl:rotate-0 ltr:rotate-180" />{' '}
                   {t('exercisesPagerPrev')}
@@ -135,7 +136,7 @@ export function LessonPager({
                 <Button
                   onClick={handleNext}
                   disabled={!canGoNext || isNavigating}
-                  className="px-6 py-2 rounded-xl text-sm cursor-pointer"
+                  className="px-6 py-2 rounded-xl text-body-sm cursor-pointer"
                 >
                   {isNavigating ? (
                     <>
@@ -193,20 +194,20 @@ export function LessonPager({
       <div className="min-h-screen bg-background flex flex-col">
         <Progress value={progressPercent} className="h-1.5 rounded-none" />
         <main className="flex-1 overflow-y-auto">
-          <div className="container mx-auto px-4 sm:px-6 py-8 md:py-12 max-w-7xl">
+          <div className="container mx-auto px-4 sm:px-6 py-section-md md:py-section-lg max-w-7xl">
             <div className="space-y-8">
               <header className="text-center">
                 <span className="inline-block px-4 py-1.5 bg-muted text-muted-foreground rounded-full text-[10px] tracking-[0.2em] uppercase mb-5 border border-border/40">
                   <FileText className="w-3 h-3 inline-block me-1" />
                   {getCurrentBlockOrdinal()} / {totalBlocks}
                 </span>
-                <h1 className="text-4xl md:text-[42px] font-medium leading-tight text-foreground mb-3">
+                <h1 className="text-display-md md:text-[42px] font-medium leading-tight text-foreground mb-3">
                   {contentPage.title}
                 </h1>
                 <div className="w-20 h-1 bg-primary mx-auto rounded-full" />
               </header>
 
-              <div className="bg-card rounded-3xl p-8 md:p-10 border border-border/60 shadow-xl shadow-muted/50">
+              <div className="bg-card rounded-3xl p-card-padding-lg md:p-10 border border-border/60 shadow-card-hover shadow-muted/50">
                 {bodyRendered ? (
                   <div className="prose prose-lg max-w-none dark:prose-invert">{bodyRendered}</div>
                 ) : (
@@ -219,7 +220,7 @@ export function LessonPager({
                   variant="ghost"
                   onClick={handlePrev}
                   disabled={!canGoPrev || isNavigating}
-                  className="text-muted-foreground text-sm hover:text-foreground gap-1.5 cursor-pointer"
+                  className="text-muted-foreground text-body-sm hover:text-foreground gap-1.5 cursor-pointer"
                 >
                   <ChevronRight className="w-4 h-4 rtl:rotate-0 ltr:rotate-180" />{' '}
                   {t('exercisesPagerPrev')}
@@ -227,7 +228,7 @@ export function LessonPager({
                 <Button
                   onClick={handleNext}
                   disabled={!canGoNext || isNavigating}
-                  className="px-6 py-2 rounded-xl text-sm cursor-pointer"
+                  className="px-6 py-2 rounded-xl text-body-sm cursor-pointer"
                 >
                   {isNavigating ? <Loader2 className="w-4 h-4 me-2 animate-spin" /> : null}
                   {t('exercisesPagerNext')}
@@ -255,7 +256,7 @@ export function LessonPager({
                     {index > 0 && (
                       <div className="h-0.5 my-8 flex-shrink-0 bg-gradient-to-r from-transparent via-border to-transparent" />
                     )}
-                    <div className="border rounded-lg overflow-hidden bg-card shadow-lg h-full">
+                    <div className="border rounded-lg overflow-hidden bg-card shadow-card h-full">
                       <MediaComponent
                         resource={file}
                         className="w-full h-full"
@@ -272,7 +273,7 @@ export function LessonPager({
                   variant="ghost"
                   onClick={handlePrev}
                   disabled={!canGoPrev || isNavigating}
-                  className="text-muted-foreground text-sm hover:text-foreground gap-1.5 cursor-pointer"
+                  className="text-muted-foreground text-body-sm hover:text-foreground gap-1.5 cursor-pointer"
                 >
                   <ChevronRight className="w-4 h-4 rtl:rotate-0 ltr:rotate-180" />{' '}
                   {t('exercisesPagerPrev')}
@@ -280,7 +281,7 @@ export function LessonPager({
                 <Button
                   onClick={handleNext}
                   disabled={!canGoNext || isNavigating}
-                  className="px-6 py-2 rounded-xl text-sm cursor-pointer"
+                  className="px-6 py-2 rounded-xl text-body-sm cursor-pointer"
                 >
                   {isNavigating ? (
                     <>
@@ -311,35 +312,35 @@ export function LessonPager({
     <div className="min-h-screen bg-background flex flex-col">
       <Progress value={progressPercent} className="h-1.5 rounded-none" />
       <main className="flex-1 overflow-y-auto">
-        <div className="container mx-auto px-4 sm:px-6 py-8 md:py-12 max-w-7xl">
+        <div className="container mx-auto px-4 sm:px-6 py-section-md md:py-section-lg max-w-7xl">
           {pageState.type === 'intro' && (
             <div className="space-y-8">
               <header className="text-center">
                 <span className="inline-block px-4 py-1.5 bg-muted text-muted-foreground rounded-full text-[10px] tracking-[0.2em] uppercase mb-5 border border-border/40">
                   {t('exercisesPagerIntro')}
                 </span>
-                <h1 className="text-4xl md:text-[42px] font-medium leading-tight text-foreground mb-3">
+                <h1 className="text-display-md md:text-[42px] font-medium leading-tight text-foreground mb-3">
                   {lessonTitle}
                 </h1>
                 <div className="w-20 h-1 bg-primary mx-auto rounded-full" />
               </header>
 
-              <div className="bg-card rounded-3xl p-8 md:p-10 border border-border/60 shadow-xl shadow-muted/50 text-center">
-                <div className="w-20 h-20 bg-primary/10 rounded-3xl flex items-center justify-center mx-auto mb-8 shadow-lg shadow-primary/10 border border-primary/20">
+              <div className="bg-card rounded-3xl p-card-padding-lg md:p-10 border border-border/60 shadow-card-hover shadow-muted/50 text-center">
+                <div className="w-20 h-20 bg-primary/10 rounded-3xl flex items-center justify-center mx-auto mb-8 shadow-card shadow-primary/10 border border-primary/20">
                   <BookOpen className="w-9 h-9 text-primary" />
                 </div>
 
-                <h2 className="text-2xl font-medium mb-4 text-foreground">
+                <h2 className="text-display-xl font-medium mb-4 text-foreground">
                   {t('exercisesPagerWelcome')}
                 </h2>
-                <p className="text-muted-foreground mb-10 text-base leading-relaxed max-w-2xl mx-auto">
+                <p className="text-muted-foreground mb-10 text-body-md leading-relaxed max-w-2xl mx-auto">
                   {t('exercisesPagerIntroDescriptionPart1')} {totalBlocks}{' '}
                   {t('exercisesPagerIntroDescriptionPart2')}
                 </p>
 
                 <div className="inline-flex items-center gap-3 px-5 py-3 bg-muted rounded-2xl border border-border/60 mb-10">
                   <Layers className="w-5 h-5 text-primary" />
-                  <span className="text-primary text-xl font-medium">{exerciseCount}</span>
+                  <span className="text-primary text-heading-xl font-medium">{exerciseCount}</span>
                   <span className="text-[10px] text-muted-foreground uppercase tracking-wider">
                     {t('exercise')}
                   </span>
@@ -348,7 +349,7 @@ export function LessonPager({
                 <Button
                   onClick={handleStart}
                   size="lg"
-                  className="w-full py-6 rounded-2xl text-lg shadow-lg shadow-primary/20 hover:shadow-xl hover:shadow-primary/30 transition-all duration-300 cursor-pointer"
+                  className="w-full py-section-sm rounded-2xl text-body-lg shadow-card shadow-primary/20 hover:shadow-card-hover hover:shadow-primary/30 transition-all duration-slow cursor-pointer"
                 >
                   {t('exercisesPagerStart')}{' '}
                   <ChevronLeft className="w-5 h-5 ms-2 rtl:rotate-0 ltr:rotate-180" />
@@ -363,21 +364,21 @@ export function LessonPager({
                 <span className="inline-block px-4 py-1.5 bg-secondary/10 text-secondary rounded-full text-[10px] tracking-[0.2em] uppercase mb-5 border border-secondary/20">
                   {t('exercisesPagerCompleted')}
                 </span>
-                <h1 className="text-4xl md:text-[42px] font-medium leading-tight text-foreground mb-3">
+                <h1 className="text-display-md md:text-[42px] font-medium leading-tight text-foreground mb-3">
                   {t('exercisesPagerCompletedTitle')}
                 </h1>
                 <div className="w-20 h-1 bg-secondary mx-auto rounded-full" />
               </header>
 
-              <div className="bg-card rounded-3xl p-8 md:p-10 border border-border/60 shadow-xl shadow-muted/50 text-center">
-                <div className="w-20 h-20 bg-secondary/10 rounded-3xl flex items-center justify-center mx-auto mb-8 shadow-lg shadow-secondary/10 border border-secondary/20">
+              <div className="bg-card rounded-3xl p-card-padding-lg md:p-10 border border-border/60 shadow-card-hover shadow-muted/50 text-center">
+                <div className="w-20 h-20 bg-secondary/10 rounded-3xl flex items-center justify-center mx-auto mb-8 shadow-card shadow-secondary/10 border border-secondary/20">
                   <Sparkles className="w-9 h-9 text-secondary" />
                 </div>
 
-                <h2 className="text-2xl font-medium mb-4 text-foreground">
+                <h2 className="text-display-xl font-medium mb-4 text-foreground">
                   {t('exercisesPagerCompletedTitle')}
                 </h2>
-                <p className="text-muted-foreground mb-10 text-base leading-relaxed max-w-2xl mx-auto">
+                <p className="text-muted-foreground mb-10 text-body-md leading-relaxed max-w-2xl mx-auto">
                   {t('exercisesPagerCompletedDescription')}
                 </p>
 
@@ -385,7 +386,7 @@ export function LessonPager({
                   asChild
                   size="lg"
                   variant="secondary"
-                  className="w-full py-6 rounded-2xl text-lg shadow-lg shadow-secondary/20 hover:shadow-xl hover:shadow-secondary/30 transition-all duration-300"
+                  className="w-full py-section-sm rounded-2xl text-body-lg shadow-card shadow-secondary/20 hover:shadow-card-hover hover:shadow-secondary/30 transition-all duration-slow"
                 >
                   <SystemLink href={backUrl}>
                     <Sparkles className="w-5 h-5 me-2" />
@@ -399,7 +400,7 @@ export function LessonPager({
                   variant="ghost"
                   onClick={handlePrev}
                   disabled={isNavigating}
-                  className="text-muted-foreground text-sm hover:text-foreground transition-colors duration-300 gap-1.5 cursor-pointer"
+                  className="text-muted-foreground text-body-sm hover:text-foreground transition-colors duration-slow gap-1.5 cursor-pointer"
                 >
                   <ChevronRight className="w-4 h-4 rtl:rotate-0 ltr:rotate-180" />{' '}
                   {t('exercisesPagerPrev')}

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/ExercisePageContent/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/ExercisePageContent/index.tsx
@@ -5,15 +5,20 @@ import type { ExerciseContentData } from '@/ui/web/exerciserenderer/types'
 
 interface ExercisePageContentProps {
   contentJson: unknown
+  showQuestionNumbering?: boolean
 }
 
-export function ExercisePageContent({ contentJson }: ExercisePageContentProps) {
+export function ExercisePageContent({
+  contentJson,
+  showQuestionNumbering = false,
+}: ExercisePageContentProps) {
   return (
-    <div className="mt-8 p-8 md:p-6 sm:p-4 bg-card rounded-lg shadow-sm">
+    <div className="mt-8 p-card-padding-lg md:p-card-padding sm:p-card-padding-sm bg-card rounded-lg shadow-elevation-1">
       <ExerciseRenderer
         content={contentJson as ExerciseContentData}
         mode="student"
         showCheckAnswer={true}
+        showExerciseNumber={showQuestionNumbering}
       />
     </div>
   )

--- a/src/app/(frontend)/exercises/[id]/page.tsx
+++ b/src/app/(frontend)/exercises/[id]/page.tsx
@@ -41,18 +41,25 @@ export default async function ExercisePage({ params: paramsPromise }: Args) {
       <div className="container py-10 max-w-4xl mx-auto">
         <Card className="mb-8 border-none shadow-none bg-transparent">
           <CardHeader className="px-0">
-            <CardTitle className="text-3xl font-bold text-slate-900">{exercise.title}</CardTitle>
+            <CardTitle className="text-display-sm font-bold text-slate-900">
+              {exercise.title}
+            </CardTitle>
           </CardHeader>
         </Card>
 
-        <Card className="shadow-sm border-slate-200">
-          <CardContent className="p-8">
-            <ExerciseRenderer content={content} mode="student" showCheckAnswer />
+        <Card className="shadow-elevation-1 border-slate-200">
+          <CardContent className="p-card-padding-lg">
+            <ExerciseRenderer
+              content={content}
+              mode="student"
+              showCheckAnswer
+              showExerciseNumber={exercise.showQuestionNumbering ?? false}
+            />
           </CardContent>
         </Card>
 
-        <div className="mt-8 flex items-center gap-2">
-          <span className="text-xs text-slate-400 font-medium uppercase tracking-wider">
+        <div className="mt-8 flex items-center gap-content-gap-xs">
+          <span className="text-body-xs text-slate-400 font-medium uppercase tracking-wider">
             Exercise ID:
           </span>
           <Badge variant="outline" className="font-mono text-[10px] text-slate-500">

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -717,7 +717,7 @@ export interface Prompt {
   /**
    * Purpose of this prompt: chat conversation, PDF extraction, PDF verification, or context extraction for AI tutor
    */
-  usage?: ('chat' | 'extractor' | 'verifier' | 'context_extractor') | null;
+  usage?: ('chat' | 'extractor' | 'verifier' | 'context_extractor' | 'translator') | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -1396,6 +1396,10 @@ export interface Exercise {
    * URL-friendly identifier (auto-generated from title, unique within lesson)
    */
   slug?: string | null;
+  /**
+   * Show exercise question numbering (the circled number above questions). Enable when multiple exercises share a page.
+   */
+  showQuestionNumbering?: boolean | null;
   /**
    * Ordered blocks stream. Use question_* blocks to add questions, and rich_text blocks for instructions/notes between questions.
    */
@@ -3199,6 +3203,7 @@ export interface ExercisesSelect<T extends boolean = true> {
   order?: T;
   lesson?: T;
   slug?: T;
+  showQuestionNumbering?: T;
   content?: T;
   createdBy?: T;
   origin?: T;

--- a/src/server/payload/collections/Exercises/index.ts
+++ b/src/server/payload/collections/Exercises/index.ts
@@ -115,6 +115,15 @@ export const Exercises: CollectionConfig = {
             beforeValidate: [generateSlug, validateSlugUniqueness],
           },
         },
+        {
+          name: 'showQuestionNumbering',
+          type: 'checkbox',
+          defaultValue: false,
+          admin: {
+            description:
+              'Show exercise question numbering (the circled number above questions). Enable when multiple exercises share a page.',
+          },
+        },
       ],
     },
 

--- a/src/ui/web/exerciserenderer/ExerciseRenderer/index.tsx
+++ b/src/ui/web/exerciserenderer/ExerciseRenderer/index.tsx
@@ -351,19 +351,21 @@ export function ExerciseRenderer({
   return (
     <MediaMapProvider value={mediaMap}>
       <div className={cn('w-full max-w-3xl mx-auto', className)}>
-        {/* Exercise Number Bubble - shown once at the top */}
+        {/* Exercise Number Bubble - only shown when there are multiple questions */}
         {/* NOTE: We intentionally avoid flex-row-reverse here because it inverts the bubble
              position depending on DOM order. Instead we pin the bubble via auto margins. */}
-        <div className="w-full flex items-center justify-between mb-6">
-          <div
-            className={cn(
-              'w-7 h-7 rounded-full flex items-center justify-center bg-slate-50 border border-slate-200 shadow-elevation-1',
-              isHebrew ? 'ml-auto' : 'mr-auto',
-            )}
-          >
-            <span className="font-bold text-body-sm">{String(exerciseNumber)}</span>
+        {questionBlocks.length > 1 && (
+          <div className="w-full flex items-center justify-between mb-6">
+            <div
+              className={cn(
+                'w-7 h-7 rounded-full flex items-center justify-center bg-slate-50 border border-slate-200 shadow-elevation-1',
+                isHebrew ? 'ml-auto' : 'mr-auto',
+              )}
+            >
+              <span className="font-bold text-body-sm">{String(exerciseNumber)}</span>
+            </div>
           </div>
-        </div>
+        )}
 
         <div className="flex flex-col gap-content-gap-lg">
           {(() => {

--- a/src/ui/web/exerciserenderer/ExerciseRenderer/index.tsx
+++ b/src/ui/web/exerciserenderer/ExerciseRenderer/index.tsx
@@ -125,6 +125,7 @@ export function ExerciseRenderer({
   className = '',
   mediaMap = EMPTY_MEDIA_MAP,
   exerciseNumber = 1,
+  showExerciseNumber = false,
   lessonId = '',
   exerciseId = '',
   onResultsChange,
@@ -351,10 +352,10 @@ export function ExerciseRenderer({
   return (
     <MediaMapProvider value={mediaMap}>
       <div className={cn('w-full max-w-3xl mx-auto', className)}>
-        {/* Exercise Number Bubble - only shown when there are multiple questions */}
+        {/* Exercise Number Bubble - only shown when explicitly enabled (e.g. multiple exercises on one page) */}
         {/* NOTE: We intentionally avoid flex-row-reverse here because it inverts the bubble
              position depending on DOM order. Instead we pin the bubble via auto margins. */}
-        {questionBlocks.length > 1 && (
+        {showExerciseNumber && (
           <div className="w-full flex items-center justify-between mb-6">
             <div
               className={cn(

--- a/src/ui/web/exerciserenderer/types.ts
+++ b/src/ui/web/exerciserenderer/types.ts
@@ -201,6 +201,8 @@ export interface ExerciseRendererProps {
   mediaMap?: Record<string, import('@/payload-types').Media>
   /** Exercise number to display in the bubble (defaults to 1) */
   exerciseNumber?: number
+  /** Whether to show the exercise number bubble (defaults to false — enable when multiple exercises share a page) */
+  showExerciseNumber?: boolean
   /** Lesson ID for analytics and help system */
   lessonId?: string
   /** Exercise ID for analytics and help system */


### PR DESCRIPTION
The circled exercise number (e.g., "1") is redundant when an exercise has a single question. Now only shown when there are multiple sub-questions. Sub-question labels (א, ב, etc.) remain unchanged.