### PR TITLE
feat: Add block spacing 

### DIFF
--- a/src/app/(frontend)/[slug]/page.tsx
+++ b/src/app/(frontend)/[slug]/page.tsx
@@ -50,7 +50,7 @@ export default async function Page({ params: paramsPromise }: Args) {
     return <PayloadRedirects url={url} />
   }
 
-  const { hero, layout } = page
+  const { hero, layout, defaultBlockSpacing } = page
 
   return (
     <article className="pt-16 pb-24">
@@ -61,7 +61,7 @@ export default async function Page({ params: paramsPromise }: Args) {
       {draft && <LivePreviewListener />}
 
       <RenderHero {...hero} />
-      <RenderBlocks blocks={layout} />
+      <RenderBlocks blocks={layout} defaultSpacing={defaultBlockSpacing} />
     </article>
   )
 }

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/content/[pageSlug]/page.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/content/[pageSlug]/page.tsx
@@ -111,7 +111,9 @@ export default async function ContentPageRoute({ params }: ContentPageRouteProps
       Array.isArray(block.data.body) &&
       block.data.body.length > 0
     ) {
-      contentPageBodies[block.data.id] = <RenderBlocks blocks={block.data.body} />
+      contentPageBodies[block.data.id] = (
+        <RenderBlocks blocks={block.data.body} defaultSpacing={block.data.defaultBlockSpacing} />
+      )
     }
   }
 

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/page.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/page.tsx
@@ -149,7 +149,9 @@ export default async function LessonPage({ params }: LessonPageProps) {
         Array.isArray(block.data.body) &&
         block.data.body.length > 0
       ) {
-        contentPageBodies[block.data.id] = <RenderBlocks blocks={block.data.body} />
+        contentPageBodies[block.data.id] = (
+          <RenderBlocks blocks={block.data.body} defaultSpacing={block.data.defaultBlockSpacing} />
+        )
       }
     }
 

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -283,6 +283,10 @@ export interface Page {
   generateSlug?: boolean | null;
   slug: string;
   /**
+   * Default vertical spacing between layout blocks
+   */
+  defaultBlockSpacing?: ('none' | 'small' | 'medium' | 'large' | 'xlarge') | null;
+  /**
    * User who created this document
    */
   createdBy?: (string | null) | User;
@@ -329,6 +333,10 @@ export interface CallToActionBlock {
         id?: string | null;
       }[]
     | null;
+  /**
+   * Override the page default spacing after this block
+   */
+  spacingAfter?: ('inherit' | 'none' | 'small' | 'medium' | 'large' | 'xlarge') | null;
   id?: string | null;
   blockName?: string | null;
   blockType: 'cta';
@@ -374,6 +382,10 @@ export interface ContentBlock {
         id?: string | null;
       }[]
     | null;
+  /**
+   * Override the page default spacing after this block
+   */
+  spacingAfter?: ('inherit' | 'none' | 'small' | 'medium' | 'large' | 'xlarge') | null;
   id?: string | null;
   blockName?: string | null;
   blockType: 'content';
@@ -408,6 +420,10 @@ export interface ArchiveBlock {
         value: string | Course;
       }[]
     | null;
+  /**
+   * Override the page default spacing after this block
+   */
+  spacingAfter?: ('inherit' | 'none' | 'small' | 'medium' | 'large' | 'xlarge') | null;
   id?: string | null;
   blockName?: string | null;
   blockType: 'archive';
@@ -798,6 +814,10 @@ export interface HtmlBlock {
    * Enter HTML content. Links must be relative (/path or #anchor). Allowed attributes: class, id, data-* on all tags; href (required), title, class, id, data-* on <a> tags; colspan, rowspan, scope on table cells; plus safe SVG attributes (e.g., viewBox, fill, stroke, d). No style=, target=, or on*= attributes allowed. The <style> tag is allowed.
    */
   html: string;
+  /**
+   * Override the page default spacing after this block
+   */
+  spacingAfter?: ('inherit' | 'none' | 'small' | 'medium' | 'large' | 'xlarge') | null;
   id?: string | null;
   blockName?: string | null;
   blockType: 'html';
@@ -808,6 +828,10 @@ export interface HtmlBlock {
  */
 export interface MediaBlock {
   media: string | Media;
+  /**
+   * Override the page default spacing after this block
+   */
+  spacingAfter?: ('inherit' | 'none' | 'small' | 'medium' | 'large' | 'xlarge') | null;
   id?: string | null;
   blockName?: string | null;
   blockType: 'mediaBlock';
@@ -821,6 +845,10 @@ export interface TableBlock {
   rows: string;
   showBorders?: boolean | null;
   showHeader?: boolean | null;
+  /**
+   * Override the page default spacing after this block
+   */
+  spacingAfter?: ('inherit' | 'none' | 'small' | 'medium' | 'large' | 'xlarge') | null;
   id?: string | null;
   blockName?: string | null;
   blockType: 'tableBlock';
@@ -847,6 +875,10 @@ export interface FormBlock {
     };
     [k: string]: unknown;
   } | null;
+  /**
+   * Override the page default spacing after this block
+   */
+  spacingAfter?: ('inherit' | 'none' | 'small' | 'medium' | 'large' | 'xlarge') | null;
   id?: string | null;
   blockName?: string | null;
   blockType: 'formBlock';
@@ -1748,6 +1780,10 @@ export interface ContentPage {
  */
 export interface GeometryBlock {
   spec: string;
+  /**
+   * Override the page default spacing after this block
+   */
+  spacingAfter?: ('inherit' | 'none' | 'small' | 'medium' | 'large' | 'xlarge') | null;
   id?: string | null;
   blockName?: string | null;
   blockType: 'geometryBlock';
@@ -1759,6 +1795,10 @@ export interface GeometryBlock {
 export interface GraphBlock {
   spec: string;
   displaySize?: ('small' | 'medium' | 'large' | 'full') | null;
+  /**
+   * Override the page default spacing after this block
+   */
+  spacingAfter?: ('inherit' | 'none' | 'small' | 'medium' | 'large' | 'xlarge') | null;
   id?: string | null;
   blockName?: string | null;
   blockType: 'graphBlock';
@@ -2871,6 +2911,7 @@ export interface PagesSelect<T extends boolean = true> {
   publishedAt?: T;
   generateSlug?: T;
   slug?: T;
+  defaultBlockSpacing?: T;
   createdBy?: T;
   updatedAt?: T;
   createdAt?: T;
@@ -2897,6 +2938,7 @@ export interface CallToActionBlockSelect<T extends boolean = true> {
             };
         id?: T;
       };
+  spacingAfter?: T;
   id?: T;
   blockName?: T;
 }
@@ -2923,6 +2965,7 @@ export interface ContentBlockSelect<T extends boolean = true> {
             };
         id?: T;
       };
+  spacingAfter?: T;
   id?: T;
   blockName?: T;
 }
@@ -2937,6 +2980,7 @@ export interface ArchiveBlockSelect<T extends boolean = true> {
   categories?: T;
   limit?: T;
   selectedDocs?: T;
+  spacingAfter?: T;
   id?: T;
   blockName?: T;
 }
@@ -2948,6 +2992,7 @@ export interface FormBlockSelect<T extends boolean = true> {
   form?: T;
   enableIntro?: T;
   introContent?: T;
+  spacingAfter?: T;
   id?: T;
   blockName?: T;
 }
@@ -2957,6 +3002,7 @@ export interface FormBlockSelect<T extends boolean = true> {
  */
 export interface HtmlBlockSelect<T extends boolean = true> {
   html?: T;
+  spacingAfter?: T;
   id?: T;
   blockName?: T;
 }
@@ -3235,6 +3281,7 @@ export interface ContentPagesSelect<T extends boolean = true> {
  */
 export interface MediaBlockSelect<T extends boolean = true> {
   media?: T;
+  spacingAfter?: T;
   id?: T;
   blockName?: T;
 }
@@ -3247,6 +3294,7 @@ export interface TableBlockSelect<T extends boolean = true> {
   rows?: T;
   showBorders?: T;
   showHeader?: T;
+  spacingAfter?: T;
   id?: T;
   blockName?: T;
 }
@@ -3256,6 +3304,7 @@ export interface TableBlockSelect<T extends boolean = true> {
  */
 export interface GeometryBlockSelect<T extends boolean = true> {
   spec?: T;
+  spacingAfter?: T;
   id?: T;
   blockName?: T;
 }
@@ -3266,6 +3315,7 @@ export interface GeometryBlockSelect<T extends boolean = true> {
 export interface GraphBlockSelect<T extends boolean = true> {
   spec?: T;
   displaySize?: T;
+  spacingAfter?: T;
   id?: T;
   blockName?: T;
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1768,6 +1768,10 @@ export interface ContentPage {
    */
   isActive: boolean;
   /**
+   * Default vertical spacing between layout blocks
+   */
+  defaultBlockSpacing?: ('none' | 'small' | 'medium' | 'large' | 'xlarge') | null;
+  /**
    * User who created this document
    */
   createdBy?: (string | null) | User;
@@ -3271,6 +3275,7 @@ export interface ContentPagesSelect<T extends boolean = true> {
       };
   status?: T;
   isActive?: T;
+  defaultBlockSpacing?: T;
   createdBy?: T;
   updatedAt?: T;
   createdAt?: T;

--- a/src/server/payload/blocks/ArchiveBlock/config.ts
+++ b/src/server/payload/blocks/ArchiveBlock/config.ts
@@ -1,5 +1,6 @@
 import type { Block } from 'payload'
 
+import { blockSpacingField } from '../../fields/blockSpacing'
 import {
   FixedToolbarFeature,
   HeadingFeature,
@@ -86,6 +87,7 @@ export const Archive: Block = {
       label: 'Selection',
       relationTo: ['courses'],
     },
+    blockSpacingField,
   ],
   labels: {
     plural: 'Archives',

--- a/src/server/payload/blocks/CallToAction/config.ts
+++ b/src/server/payload/blocks/CallToAction/config.ts
@@ -8,6 +8,7 @@ import {
 } from '@payloadcms/richtext-lexical'
 
 import { linkGroup } from '../../fields/linkGroup'
+import { blockSpacingField } from '../../fields/blockSpacing'
 
 export const CallToAction: Block = {
   slug: 'cta',
@@ -34,6 +35,7 @@ export const CallToAction: Block = {
         maxRows: 2,
       },
     }),
+    blockSpacingField,
   ],
   labels: {
     plural: 'Calls to Action',

--- a/src/server/payload/blocks/Content/config.ts
+++ b/src/server/payload/blocks/Content/config.ts
@@ -8,6 +8,7 @@ import {
 } from '@payloadcms/richtext-lexical'
 
 import { link } from '@/server/payload/fields/link'
+import { blockSpacingField } from '@/server/payload/fields/blockSpacing'
 
 const columnFields: Field[] = [
   {
@@ -75,5 +76,6 @@ export const Content: Block = {
       },
       fields: columnFields,
     },
+    blockSpacingField,
   ],
 }

--- a/src/server/payload/blocks/Form/config.ts
+++ b/src/server/payload/blocks/Form/config.ts
@@ -1,5 +1,6 @@
 import type { Block } from 'payload'
 
+import { blockSpacingField } from '../../fields/blockSpacing'
 import {
   FixedToolbarFeature,
   HeadingFeature,
@@ -40,6 +41,7 @@ export const FormBlock: Block = {
       }),
       label: 'Intro Content',
     },
+    blockSpacingField,
   ],
   graphQL: {
     singularName: 'FormBlock',

--- a/src/server/payload/blocks/GeometryBlock/config.ts
+++ b/src/server/payload/blocks/GeometryBlock/config.ts
@@ -1,5 +1,7 @@
 import type { Block } from 'payload'
 
+import { blockSpacingField } from '../../fields/blockSpacing'
+
 export const GeometryBlock: Block = {
   slug: 'geometryBlock',
   interfaceName: 'GeometryBlock',
@@ -18,5 +20,6 @@ export const GeometryBlock: Block = {
         },
       },
     },
+    blockSpacingField,
   ],
 }

--- a/src/server/payload/blocks/GraphBlock/config.ts
+++ b/src/server/payload/blocks/GraphBlock/config.ts
@@ -1,5 +1,7 @@
 import type { Block } from 'payload'
 
+import { blockSpacingField } from '../../fields/blockSpacing'
+
 export const GraphBlock: Block = {
   slug: 'graphBlock',
   interfaceName: 'GraphBlock',
@@ -29,5 +31,6 @@ export const GraphBlock: Block = {
         { label: 'Full', value: 'full' },
       ],
     },
+    blockSpacingField,
   ],
 }

--- a/src/server/payload/blocks/HtmlBlock/config.ts
+++ b/src/server/payload/blocks/HtmlBlock/config.ts
@@ -1,5 +1,6 @@
 import type { Block } from 'payload'
 
+import { blockSpacingField } from '../../fields/blockSpacing'
 import { validateHtml } from './validate-html'
 
 export const HtmlBlock: Block = {
@@ -24,5 +25,6 @@ export const HtmlBlock: Block = {
       },
       validate: validateHtml,
     },
+    blockSpacingField,
   ],
 }

--- a/src/server/payload/blocks/MediaBlock/config.ts
+++ b/src/server/payload/blocks/MediaBlock/config.ts
@@ -1,5 +1,7 @@
 import type { Block } from 'payload'
 
+import { blockSpacingField } from '../../fields/blockSpacing'
+
 export const MediaBlock: Block = {
   slug: 'mediaBlock',
   interfaceName: 'MediaBlock',
@@ -10,5 +12,6 @@ export const MediaBlock: Block = {
       relationTo: 'media',
       required: true,
     },
+    blockSpacingField,
   ],
 }

--- a/src/server/payload/blocks/RenderBlocks.tsx
+++ b/src/server/payload/blocks/RenderBlocks.tsx
@@ -9,6 +9,7 @@ import { GraphBlock } from '@/server/payload/blocks/GraphBlock/Component'
 import { HtmlBlock } from '@/server/payload/blocks/HtmlBlock/Component'
 import { MediaBlock } from '@/server/payload/blocks/MediaBlock/Component'
 import { TableBlock } from '@/server/payload/blocks/TableBlock/Component'
+import { resolveSpacingClass } from '@/server/payload/fields/blockSpacing'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const blockComponents: Record<string, React.FC<any>> = {
@@ -24,9 +25,10 @@ const blockComponents: Record<string, React.FC<any>> = {
 }
 
 export const RenderBlocks: React.FC<{
-  blocks: { blockType: string }[]
+  blocks: { blockType: string; spacingAfter?: string | null }[]
+  defaultSpacing?: string | null
 }> = (props) => {
-  const { blocks } = props
+  const { blocks, defaultSpacing } = props
 
   const hasBlocks = blocks && Array.isArray(blocks) && blocks.length > 0
 
@@ -39,7 +41,7 @@ export const RenderBlocks: React.FC<{
 
           if (Block) {
             return (
-              <div className="my-16" key={index}>
+              <div className={resolveSpacingClass(block.spacingAfter, defaultSpacing)} key={index}>
                 <Block {...block} disableInnerContainer />
               </div>
             )

--- a/src/server/payload/blocks/TableBlock/config.ts
+++ b/src/server/payload/blocks/TableBlock/config.ts
@@ -1,5 +1,7 @@
 import type { Block } from 'payload'
 
+import { blockSpacingField } from '../../fields/blockSpacing'
+
 export const TableBlock: Block = {
   slug: 'tableBlock',
   interfaceName: 'TableBlock',
@@ -38,5 +40,6 @@ export const TableBlock: Block = {
       type: 'checkbox',
       defaultValue: true,
     },
+    blockSpacingField,
   ],
 }

--- a/src/server/payload/collections/ContentPages.ts
+++ b/src/server/payload/collections/ContentPages.ts
@@ -9,6 +9,7 @@ import { MediaBlock } from '../blocks/MediaBlock/config'
 import { TableBlock } from '../blocks/TableBlock/config'
 import { adminOnly } from '../access/adminOnly'
 import { publishedAndActive } from '../access/publishedAndActive'
+import { pageDefaultSpacingField } from '../fields/blockSpacing'
 import { createdByField } from '../fields/createdBy'
 import { formatSlug } from '../fields/formatSlug'
 
@@ -107,6 +108,7 @@ export const ContentPages: CollectionConfig = {
         description: 'Whether this content page is currently active',
       },
     },
+    pageDefaultSpacingField,
     createdByField,
   ],
 }

--- a/src/server/payload/collections/Pages/index.ts
+++ b/src/server/payload/collections/Pages/index.ts
@@ -21,6 +21,7 @@ import {
 } from '@payloadcms/plugin-seo/fields'
 import { createdByField } from '../../fields/createdBy'
 import { contentLocaleField } from '../../fields/contentLocale'
+import { pageDefaultSpacingField } from '../../fields/blockSpacing'
 import { enforceFieldLocaleUniqueness } from '../../hooks/validateLocaleUniqueness'
 
 export const Pages: CollectionConfig<'pages'> = {
@@ -118,6 +119,9 @@ export const Pages: CollectionConfig<'pages'> = {
       },
     },
     slugField(),
+
+    // Block spacing
+    pageDefaultSpacingField,
 
     // Created By
     createdByField,

--- a/src/server/payload/fields/blockSpacing.ts
+++ b/src/server/payload/fields/blockSpacing.ts
@@ -1,0 +1,59 @@
+import type { Field } from 'payload'
+
+export const SPACING_VALUES = ['none', 'small', 'medium', 'large', 'xlarge'] as const
+export type SpacingValue = (typeof SPACING_VALUES)[number]
+
+export const SPACING_OPTIONS: { label: string; value: SpacingValue }[] = [
+  { label: 'None', value: 'none' },
+  { label: 'Small', value: 'small' },
+  { label: 'Medium', value: 'medium' },
+  { label: 'Large (Default)', value: 'large' },
+  { label: 'Extra Large', value: 'xlarge' },
+]
+
+export const SPACING_CLASS_MAP: Record<SpacingValue, string> = {
+  none: 'my-0',
+  small: 'my-4',
+  medium: 'my-8',
+  large: 'my-16',
+  xlarge: 'my-24',
+}
+
+export function resolveSpacingClass(
+  blockSpacing: string | null | undefined,
+  pageDefault: string | null | undefined,
+): string {
+  const effective =
+    blockSpacing && blockSpacing !== 'inherit' ? blockSpacing : (pageDefault ?? 'large')
+  return SPACING_CLASS_MAP[effective as SpacingValue] ?? SPACING_CLASS_MAP.large
+}
+
+export const blockSpacingField: Field = {
+  type: 'collapsible',
+  label: 'Layout Settings',
+  admin: {
+    initCollapsed: true,
+  },
+  fields: [
+    {
+      name: 'spacingAfter',
+      type: 'select',
+      defaultValue: 'inherit',
+      options: [{ label: 'Inherit from Page', value: 'inherit' }, ...SPACING_OPTIONS],
+      admin: {
+        description: 'Override the page default spacing after this block',
+      },
+    },
+  ],
+}
+
+export const pageDefaultSpacingField: Field = {
+  name: 'defaultBlockSpacing',
+  type: 'select',
+  defaultValue: 'large',
+  options: SPACING_OPTIONS,
+  admin: {
+    position: 'sidebar',
+    description: 'Default vertical spacing between layout blocks',
+  },
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -26,6 +26,11 @@ const config = {
     'bg-success/30',
     'border-warning',
     'bg-warning/30',
+    'my-0',
+    'my-4',
+    'my-8',
+    'my-16',
+    'my-24',
   ],
   theme: {
     container: {


### PR DESCRIPTION
…block override

Blocks previously had hardcoded 64px vertical margin. Now pages have a sidebar "Default Block Spacing" setting, and each block has an optional "Spacing After" override in a collapsible Layout Settings section. Existing pages are unaffected (defaults to large/64px).