### PR TITLE
feat: Add multi-axis editor and positive direction arrows on axes

### DIFF
--- a/src/server/payload/collections/Exercises/defaults.ts
+++ b/src/server/payload/collections/Exercises/defaults.ts
@@ -12,6 +12,7 @@ import type {
   LatexBlock,
   MediaBlock,
   QuestionAxisBlock,
+  QuestionMultiAxisBlock,
   QuestionFreeResponseBlock,
   QuestionGeometryBlock,
   QuestionMatchingBlock,
@@ -347,5 +348,33 @@ export const ExerciseBlockDefaults: Record<string, () => ContentBlock> = {
     hint: DEFAULT_HINT_SOLUTION(),
     solution: DEFAULT_HINT_SOLUTION(),
     fullSolution: DEFAULT_HINT_SOLUTION(),
+  }),
+
+  question_multi_axis: (): QuestionMultiAxisBlock => ({
+    id: generateId(),
+    type: 'question_multi_axis',
+    prompt: DEFAULT_HINT_SOLUTION(),
+    textPosition: 'above',
+    graphs: [
+      {
+        id: generateId(),
+        label: 'Graph 1',
+        axis: {
+          kind: 'cartesian',
+          units: 1,
+          grid: { enabled: true, color: '#e0e0e0' },
+          axes: {
+            showNumbers: true,
+            showLabels: true,
+            ticks: 1,
+            labels: { x: 'x', y: 'y' },
+            origin: { x: 0, y: 0 },
+          },
+          viewport: { xMin: -10, xMax: 10, yMin: -10, yMax: 10 },
+          elements: { points: [], graphs: [] },
+        },
+        order: 0,
+      },
+    ],
   }),
 }

--- a/src/ui/admin/ExerciseContentEditor/BlockTypeSelector.tsx
+++ b/src/ui/admin/ExerciseContentEditor/BlockTypeSelector.tsx
@@ -7,6 +7,7 @@ import {
   Edit3,
   FileText,
   Image as ImageIcon,
+  LayoutGrid,
   LineChart,
   List,
   Table as TableIcon,
@@ -100,6 +101,12 @@ export const BlockTypeSelector: React.FC<BlockTypeSelectorProps> = ({
       label: 'Axis Graph',
       description: 'Coordinate graph with functions',
       icon: <LineChart size={20} />,
+    },
+    {
+      type: 'question_multi_axis',
+      label: 'Multi Axis Graph',
+      description: 'Up to 4 graphs side by side (1, 2, or 4 per row)',
+      icon: <LayoutGrid size={20} />,
     },
   ]
 

--- a/src/ui/admin/ExerciseContentEditor/components/shared/JSXGraphBoard.tsx
+++ b/src/ui/admin/ExerciseContentEditor/components/shared/JSXGraphBoard.tsx
@@ -80,6 +80,8 @@ export const JSXGraphBoard: React.FC<JSXGraphBoardProps> = ({
                 withLabel: axisConfig.showLabels ?? true,
                 // Standardized title position: far right, slightly below
                 label: { position: 'rt', offset: [0, 12] as [number, number] },
+                // Arrow at positive end to indicate direction
+                lastArrow: true,
               },
               y: {
                 ticks: {
@@ -97,6 +99,8 @@ export const JSXGraphBoard: React.FC<JSXGraphBoardProps> = ({
                 withLabel: axisConfig.showLabels ?? true,
                 // Standardized title position: near top, slightly to right
                 label: { position: 'rt', offset: [15, 0] as [number, number] },
+                // Arrow at positive end to indicate direction
+                lastArrow: true,
               },
             },
           }

--- a/src/ui/admin/ExerciseContentEditor/editors/MultiAxisEditor.tsx
+++ b/src/ui/admin/ExerciseContentEditor/editors/MultiAxisEditor.tsx
@@ -1,0 +1,228 @@
+'use client'
+
+import React, { useCallback } from 'react'
+import type {
+  QuestionMultiAxisBlock,
+  MultiAxisGraphItem,
+} from '@/server/payload/collections/Exercises/types'
+import type { AxisSpecV1 } from '@/infra/contracts/graphics/axis.v1'
+import { generateId } from '@/server/payload/collections/Exercises/defaults'
+import { CollapsibleSection } from '@/ui/admin/shared/CollapsibleSection'
+import { AxisCanvas } from '../components/axis/AxisCanvas'
+import { AxisConfigPanel } from '../components/axis/AxisConfigPanel'
+import { GraphsPanel } from '../components/axis/GraphsPanel'
+import { AxisPointsPanel } from '../components/axis/AxisPointsPanel'
+import { AsymptotesPanel } from '../components/axis/AsymptotesPanel'
+import { InlineRichTextEditor } from './InlineRichTextEditor'
+import { Plus, Trash2 } from 'lucide-react'
+
+interface MultiAxisEditorProps {
+  block: QuestionMultiAxisBlock
+  onChange: (block: QuestionMultiAxisBlock) => void
+}
+
+const DEFAULT_AXIS: AxisSpecV1 = {
+  kind: 'cartesian',
+  units: 1,
+  grid: { enabled: true, color: '#e0e0e0' },
+  axes: {
+    showNumbers: true,
+    showLabels: true,
+    ticks: 1,
+    labels: { x: 'x', y: 'y' },
+    origin: { x: 0, y: 0 },
+  },
+  viewport: { xMin: -10, xMax: 10, yMin: -10, yMax: 10 },
+  elements: { points: [], graphs: [] },
+}
+
+export const MultiAxisEditor: React.FC<MultiAxisEditorProps> = ({ block, onChange }) => {
+  const updateGraph = useCallback(
+    (graphId: string, updates: Partial<MultiAxisGraphItem>) => {
+      onChange({
+        ...block,
+        graphs: block.graphs.map((g) => (g.id === graphId ? { ...g, ...updates } : g)),
+      })
+    },
+    [block, onChange],
+  )
+
+  const updateGraphAxis = useCallback(
+    (graphId: string, axisUpdates: Partial<AxisSpecV1>) => {
+      onChange({
+        ...block,
+        graphs: block.graphs.map((g) =>
+          g.id === graphId ? { ...g, axis: { ...g.axis, ...axisUpdates } } : g,
+        ),
+      })
+    },
+    [block, onChange],
+  )
+
+  const updateGraphElements = useCallback(
+    (graphId: string, elementUpdates: Partial<AxisSpecV1['elements']>) => {
+      const graph = block.graphs.find((g) => g.id === graphId)
+      if (!graph) return
+      updateGraphAxis(graphId, { elements: { ...graph.axis.elements, ...elementUpdates } })
+    },
+    [block.graphs, updateGraphAxis],
+  )
+
+  const handleAddGraph = useCallback(() => {
+    if (block.graphs.length >= 4) return
+    const newGraph: MultiAxisGraphItem = {
+      id: generateId(),
+      label: `Graph ${block.graphs.length + 1}`,
+      axis: { ...DEFAULT_AXIS },
+      order: block.graphs.length,
+    }
+    onChange({ ...block, graphs: [...block.graphs, newGraph] })
+  }, [block, onChange])
+
+  const handleRemoveGraph = useCallback(
+    (graphId: string) => {
+      if (block.graphs.length <= 1) return
+      const remaining = block.graphs
+        .filter((g) => g.id !== graphId)
+        .map((g, i) => ({ ...g, order: i }))
+      onChange({ ...block, graphs: remaining })
+    },
+    [block, onChange],
+  )
+
+  const handlePointMoved = useCallback(
+    (graphId: string, index: number, x: number, y: number) => {
+      const graph = block.graphs.find((g) => g.id === graphId)
+      if (!graph) return
+      const newPoints = graph.axis.elements.points.map((p, i) => (i === index ? { ...p, x, y } : p))
+      updateGraphElements(graphId, { points: newPoints })
+    },
+    [block.graphs, updateGraphElements],
+  )
+
+  return (
+    <div className="multi-axis-editor">
+      <div className="question-editor-section">
+        <label className="question-editor-label">Prompt (optional)</label>
+        <InlineRichTextEditor
+          value={
+            block.prompt ?? { type: 'rich_text', format: 'md-math-v1', value: '', mediaIds: [] }
+          }
+          onChange={(prompt) => onChange({ ...block, prompt })}
+          placeholder="Enter an optional prompt for the multi-graph block..."
+        />
+      </div>
+
+      <div className="question-editor-section">
+        <label className="question-editor-label">Text Position</label>
+        <select
+          className="panel-field-select"
+          value={block.textPosition || 'above'}
+          onChange={(e) =>
+            onChange({ ...block, textPosition: e.target.value as 'above' | 'below' })
+          }
+        >
+          <option value="above">Above Graphs</option>
+          <option value="below">Below Graphs</option>
+        </select>
+      </div>
+
+      <div className="question-editor-section">
+        <label className="question-editor-label">Graphs ({block.graphs.length}/4)</label>
+
+        {block.graphs.map((graph, idx) => (
+          <CollapsibleSection
+            key={graph.id}
+            title={`${graph.label || `Graph ${idx + 1}`}`}
+            defaultExpanded={idx === 0}
+          >
+            <div className="panel-item-row" style={{ marginBottom: 8 }}>
+              <div className="panel-field">
+                <span className="panel-field-label">Label</span>
+                <input
+                  type="text"
+                  className="panel-field-input"
+                  value={graph.label}
+                  onChange={(e) => updateGraph(graph.id, { label: e.target.value })}
+                />
+              </div>
+              {block.graphs.length > 1 && (
+                <button
+                  type="button"
+                  className="panel-remove-btn"
+                  onClick={() => handleRemoveGraph(graph.id)}
+                  title="Remove graph"
+                >
+                  <Trash2 size={14} />
+                </button>
+              )}
+            </div>
+
+            <div className="graph-editor-layout">
+              <div className="graph-editor-form">
+                <CollapsibleSection title="Configuration" defaultExpanded={false}>
+                  <AxisConfigPanel
+                    spec={graph.axis}
+                    onChange={(s) => updateGraph(graph.id, { axis: s })}
+                  />
+                </CollapsibleSection>
+
+                <CollapsibleSection
+                  title={`Graphs (${graph.axis.elements.graphs.length})`}
+                  defaultExpanded
+                >
+                  <GraphsPanel
+                    graphs={graph.axis.elements.graphs}
+                    onChange={(graphs) => updateGraphElements(graph.id, { graphs })}
+                  />
+                </CollapsibleSection>
+
+                <CollapsibleSection
+                  title={`Points (${graph.axis.elements.points.length})`}
+                  defaultExpanded={false}
+                >
+                  <AxisPointsPanel
+                    points={graph.axis.elements.points}
+                    onChange={(points) => updateGraphElements(graph.id, { points })}
+                  />
+                </CollapsibleSection>
+
+                <CollapsibleSection title="Asymptotes" defaultExpanded={false}>
+                  <AsymptotesPanel
+                    vertical={graph.axis.elements.asymptotesVertical || []}
+                    horizontal={graph.axis.elements.asymptotesHorizontal || []}
+                    onVerticalChange={(v) =>
+                      updateGraphElements(graph.id, { asymptotesVertical: v })
+                    }
+                    onHorizontalChange={(h) =>
+                      updateGraphElements(graph.id, { asymptotesHorizontal: h })
+                    }
+                  />
+                </CollapsibleSection>
+              </div>
+
+              <div className="graph-editor-canvas">
+                <AxisCanvas
+                  id={`multi-axis-canvas-${graph.id}`}
+                  axis={graph.axis}
+                  onPointMoved={(index, x, y) => handlePointMoved(graph.id, index, x, y)}
+                />
+              </div>
+            </div>
+          </CollapsibleSection>
+        ))}
+
+        <button
+          type="button"
+          className="panel-add-btn"
+          onClick={handleAddGraph}
+          disabled={block.graphs.length >= 4}
+          style={{ marginTop: 8 }}
+        >
+          <Plus size={14} />
+          <span>Add Graph ({block.graphs.length}/4)</span>
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/ui/admin/ExerciseContentEditor/index.tsx
+++ b/src/ui/admin/ExerciseContentEditor/index.tsx
@@ -11,6 +11,7 @@ import { JSONInspector } from './JSONInspector'
 import { InlineRichTextEditor } from './editors/InlineRichTextEditor'
 import { FreeResponseEditor } from './editors/FreeResponseEditor'
 import { AxisEditor } from './editors/AxisEditor'
+import { MultiAxisEditor } from './editors/MultiAxisEditor'
 import { GeometryEditor } from './editors/GeometryEditor'
 import { HtmlBlockEditor } from './editors/HtmlBlockEditor'
 import { MediaBlockEditor } from './editors/MediaBlockEditor'
@@ -288,7 +289,7 @@ export const ExerciseContentEditor: React.FC<{ path: string }> = ({ path }) => {
   const selectedBlock = blocks.find((b) => b.id === selectedBlockId) || null
 
   if (!localValue) {
-    return <div className="p-4 text-muted-foreground">Loading editor...</div>
+    return <div className="p-card-padding-sm text-muted-foreground">Loading editor...</div>
   }
 
   return (
@@ -416,6 +417,7 @@ function getBlockTypeLabel(block: ContentBlock): string {
   if (block.type === 'media') return 'Media'
   if (block.type === 'question_geometry') return 'Geometry'
   if (block.type === 'question_axis') return 'Axis Graph'
+  if (block.type === 'question_multi_axis') return 'Multi Axis Graph'
   return block.type
 }
 
@@ -602,6 +604,29 @@ function renderQuestionEditor(
       >
         <AxisEditor
           block={block as import('@/server/payload/collections/Exercises/types').QuestionAxisBlock}
+          onChange={onChange}
+        />
+      </QuestionBlockWrapper>
+    )
+  }
+  if (block.type === ('question_multi_axis' as string)) {
+    return (
+      <QuestionBlockWrapper
+        blockType={getBlockTypeLabel(block)}
+        block={block}
+        onBlockChange={onChange}
+        onMoveUp={onMoveUp}
+        onMoveDown={onMoveDown}
+        onDuplicate={onDuplicate}
+        onDelete={onDelete}
+        canMoveUp={blockIndex > 0}
+        canMoveDown={blockIndex < blockCount - 1}
+        canDelete={blockCount > 1}
+      >
+        <MultiAxisEditor
+          block={
+            block as import('@/server/payload/collections/Exercises/types').QuestionMultiAxisBlock
+          }
           onChange={onChange}
         />
       </QuestionBlockWrapper>

--- a/src/ui/web/exerciserenderer/graphics/JSXGraphBoard.tsx
+++ b/src/ui/web/exerciserenderer/graphics/JSXGraphBoard.tsx
@@ -65,6 +65,8 @@ export function JSXGraphBoard({
                 withLabel: axisConfig?.showLabels ?? true,
                 // Standardized title position: far right, slightly below
                 label: { position: 'rt', offset: [0, 12] },
+                // Arrow at positive end to indicate direction
+                lastArrow: true,
               },
               y: {
                 ticks: {
@@ -79,6 +81,8 @@ export function JSXGraphBoard({
                 withLabel: axisConfig?.showLabels ?? true,
                 // Standardized title position: near top, slightly to right
                 label: { position: 'rt', offset: [15, 0] },
+                // Arrow at positive end to indicate direction
+                lastArrow: true,
               },
             },
           }


### PR DESCRIPTION
Add MultiAxisEditor admin component for creating exercises with up to 4 coordinate graphs side by side. Register question_multi_axis in block selector and wire it into the ExerciseContentEditor. Add default factory in defaults.ts.

Add lastArrow to both frontend and admin JSXGraphBoard axis config so the positive direction of x and y axes is visually indicated with arrows.