### PR TITLE
fix: image upload to chat everywhere

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -89,7 +89,7 @@ const nextConfig = {
           {
             key: 'Content-Security-Policy',
             value:
-              "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://vercel.live https://www.googletagmanager.com https://cdn.mxpnl.com; style-src 'self' 'unsafe-inline'; img-src 'self' *.blob.vercel-storage.com img.youtube.com avatars.githubusercontent.com github.com *.githubusercontent.com data: blob:; font-src 'self' data: https://r2cdn.perplexity.ai; connect-src 'self' https://*.vercel.app https://vercel.live wss://*.vercel.app https://*.blob.vercel-storage.com https://api-js.mixpanel.com https://*.mxpnl.com https://www.google-analytics.com; frame-src 'self' www.youtube.com vercel.live; object-src 'none'; base-uri 'self'; form-action 'self'",
+              "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://vercel.live https://www.googletagmanager.com https://cdn.mxpnl.com; style-src 'self' 'unsafe-inline'; img-src 'self' *.blob.vercel-storage.com img.youtube.com avatars.githubusercontent.com github.com *.githubusercontent.com data: blob:; font-src 'self' data: https://r2cdn.perplexity.ai; connect-src 'self' https://*.vercel.app https://vercel.live wss://*.vercel.app https://blob.vercel-storage.com https://*.blob.vercel-storage.com https://api-js.mixpanel.com https://*.mxpnl.com https://www.google-analytics.com; frame-src 'self' www.youtube.com vercel.live; object-src 'none'; base-uri 'self'; form-action 'self'",
           },
           { key: 'X-Frame-Options', value: 'DENY' },
           { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' },
@@ -106,7 +106,7 @@ const nextConfig = {
           {
             key: 'Content-Security-Policy',
             value:
-              "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.googletagmanager.com https://cdn.mxpnl.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' *.blob.vercel-storage.com img.youtube.com avatars.githubusercontent.com github.com *.githubusercontent.com data: blob:; font-src 'self' data:; connect-src 'self' *.sentry.io https://*.blob.vercel-storage.com https://api-js.mixpanel.com https://*.mxpnl.com; frame-src 'self' www.youtube.com vercel.live; object-src 'none'; base-uri 'self'; form-action 'self'",
+              "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.googletagmanager.com https://cdn.mxpnl.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' *.blob.vercel-storage.com img.youtube.com avatars.githubusercontent.com github.com *.githubusercontent.com data: blob:; font-src 'self' data:; connect-src 'self' *.sentry.io https://blob.vercel-storage.com https://*.blob.vercel-storage.com https://api-js.mixpanel.com https://*.mxpnl.com; frame-src 'self' www.youtube.com vercel.live; object-src 'none'; base-uri 'self'; form-action 'self'",
           },
           { key: 'X-Frame-Options', value: 'DENY' },
           { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' },

--- a/next.config.js
+++ b/next.config.js
@@ -89,7 +89,7 @@ const nextConfig = {
           {
             key: 'Content-Security-Policy',
             value:
-              "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://vercel.live https://www.googletagmanager.com https://cdn.mxpnl.com; style-src 'self' 'unsafe-inline'; img-src 'self' *.blob.vercel-storage.com img.youtube.com avatars.githubusercontent.com github.com *.githubusercontent.com data: blob:; font-src 'self' data: https://r2cdn.perplexity.ai; connect-src 'self' https://*.vercel.app https://vercel.live wss://*.vercel.app https://api-js.mixpanel.com https://*.mxpnl.com https://www.google-analytics.com; frame-src 'self' www.youtube.com vercel.live; object-src 'none'; base-uri 'self'; form-action 'self'",
+              "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://vercel.live https://www.googletagmanager.com https://cdn.mxpnl.com; style-src 'self' 'unsafe-inline'; img-src 'self' *.blob.vercel-storage.com img.youtube.com avatars.githubusercontent.com github.com *.githubusercontent.com data: blob:; font-src 'self' data: https://r2cdn.perplexity.ai; connect-src 'self' https://*.vercel.app https://vercel.live wss://*.vercel.app https://*.blob.vercel-storage.com https://api-js.mixpanel.com https://*.mxpnl.com https://www.google-analytics.com; frame-src 'self' www.youtube.com vercel.live; object-src 'none'; base-uri 'self'; form-action 'self'",
           },
           { key: 'X-Frame-Options', value: 'DENY' },
           { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' },
@@ -106,7 +106,7 @@ const nextConfig = {
           {
             key: 'Content-Security-Policy',
             value:
-              "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.googletagmanager.com https://cdn.mxpnl.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' *.blob.vercel-storage.com img.youtube.com avatars.githubusercontent.com github.com *.githubusercontent.com data: blob:; font-src 'self' data:; connect-src 'self' *.sentry.io https://api-js.mixpanel.com https://*.mxpnl.com; frame-src 'self' www.youtube.com vercel.live; object-src 'none'; base-uri 'self'; form-action 'self'",
+              "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.googletagmanager.com https://cdn.mxpnl.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' *.blob.vercel-storage.com img.youtube.com avatars.githubusercontent.com github.com *.githubusercontent.com data: blob:; font-src 'self' data:; connect-src 'self' *.sentry.io https://*.blob.vercel-storage.com https://api-js.mixpanel.com https://*.mxpnl.com; frame-src 'self' www.youtube.com vercel.live; object-src 'none'; base-uri 'self'; form-action 'self'",
           },
           { key: 'X-Frame-Options', value: 'DENY' },
           { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' },

--- a/src/infra/analytics/contracts/destinations.ts
+++ b/src/infra/analytics/contracts/destinations.ts
@@ -38,6 +38,7 @@ export const eventDestinations: Record<ProductEvent, AnalyticsDestination[]> = {
   // Content Events (Mixpanel only - product analytics)
   [PRODUCT_EVENTS.PDF_VIEWED]: ['mixpanel'],
   [PRODUCT_EVENTS.CHAT_MESSAGE_SENT]: ['mixpanel'],
+  [PRODUCT_EVENTS.PHOTO_SENT_TO_CHAT]: ['mixpanel'],
 
   // Auth Gate Events
   [PRODUCT_EVENTS.LOGIN_MODAL_SHOWN]: ['mixpanel'], // Product funnel - modal shown to anon user

--- a/src/infra/analytics/contracts/events.ts
+++ b/src/infra/analytics/contracts/events.ts
@@ -32,6 +32,7 @@ export const PRODUCT_EVENTS = {
   // Content Events (Mixpanel only)
   PDF_VIEWED: 'pdf_viewed',
   CHAT_MESSAGE_SENT: 'chat_message_sent',
+  PHOTO_SENT_TO_CHAT: 'photo_sent_to_chat',
 
   // Auth Gate Events
   LOGIN_MODAL_SHOWN: 'login_modal_shown', // Mixpanel only - auth gate modal appeared

--- a/src/infra/analytics/contracts/schemas.ts
+++ b/src/infra/analytics/contracts/schemas.ts
@@ -152,6 +152,19 @@ export const ChatMessageSentSchema = z.object({
 })
 
 /**
+ * photo_sent_to_chat - Track photo/file upload to chat
+ * Destination: Mixpanel
+ * Priority: P1
+ *
+ * NO file content - only metadata
+ */
+export const PhotoSentToChatSchema = z.object({
+  conversation_id: z.string().describe('Chat conversation ID'),
+  file_count: z.number().int().positive().describe('Number of files uploaded'),
+  file_types: z.array(z.string()).describe('MIME types of uploaded files'),
+})
+
+/**
  * login_modal_shown - Auth gate modal appeared for anonymous user
  * Destination: Mixpanel
  * Priority: P0
@@ -433,6 +446,7 @@ export const eventSchemas = {
   [PRODUCT_EVENTS.LESSON_COMPLETED]: LessonCompletedSchema,
   [PRODUCT_EVENTS.PDF_VIEWED]: PdfViewedSchema,
   [PRODUCT_EVENTS.CHAT_MESSAGE_SENT]: ChatMessageSentSchema,
+  [PRODUCT_EVENTS.PHOTO_SENT_TO_CHAT]: PhotoSentToChatSchema,
   [PRODUCT_EVENTS.LOGIN_MODAL_SHOWN]: LoginModalShownSchema,
   [PRODUCT_EVENTS.REGISTRATION_PROMPT_SHOWN]: RegistrationPromptShownSchema,
   [PRODUCT_EVENTS.REGISTRATION_COMPLETED]: RegistrationCompletedSchema,
@@ -478,6 +492,7 @@ export type LessonStartedProperties = z.infer<typeof LessonStartedSchema>
 export type LessonCompletedProperties = z.infer<typeof LessonCompletedSchema>
 export type PdfViewedProperties = z.infer<typeof PdfViewedSchema>
 export type ChatMessageSentProperties = z.infer<typeof ChatMessageSentSchema>
+export type PhotoSentToChatProperties = z.infer<typeof PhotoSentToChatSchema>
 export type LoginModalShownProperties = z.infer<typeof LoginModalShownSchema>
 export type RegistrationPromptShownProperties = z.infer<typeof RegistrationPromptShownSchema>
 export type RegistrationCompletedProperties = z.infer<typeof RegistrationCompletedSchema>
@@ -523,6 +538,7 @@ export type EventProperties =
   | LessonCompletedProperties
   | PdfViewedProperties
   | ChatMessageSentProperties
+  | PhotoSentToChatProperties
   | LoginModalShownProperties
   | RegistrationPromptShownProperties
   | RegistrationCompletedProperties

--- a/src/infra/analytics/system-events-subscriber.ts
+++ b/src/infra/analytics/system-events-subscriber.ts
@@ -167,6 +167,19 @@ export function initAnalyticsSubscriber(): () => void {
       })
     }),
 
+    safeSubscribe(SYSTEM_EVENTS.PHOTO_SENT_TO_CHAT, (envelope) => {
+      const payload = envelope.payload as {
+        conversation_id?: string
+        file_count?: number
+        file_types?: string[]
+      }
+      analytics.track(PRODUCT_EVENTS.PHOTO_SENT_TO_CHAT, {
+        conversation_id: payload.conversation_id,
+        file_count: payload.file_count,
+        file_types: payload.file_types,
+      })
+    }),
+
     // Auth Gate
     safeSubscribe(SYSTEM_EVENTS.LOGIN_MODAL_SHOWN, (envelope) => {
       const payload = envelope.payload as {

--- a/src/infra/system-events/events.ts
+++ b/src/infra/system-events/events.ts
@@ -47,6 +47,8 @@ export const SYSTEM_EVENTS = {
   STUDENT_ANSWER_SUBMITTED: 'system.student_answer_submitted',
   /** Student selected an answer option (MCQ/TF) */
   ANSWER_SELECTED: 'system.answer_selected',
+  /** User sent a photo/file to chat */
+  PHOTO_SENT_TO_CHAT: 'system.photo_sent_to_chat',
   /** Chat was auto-triggered (e.g. on incorrect answer) */
   CHAT_AUTO_TRIGGERED: 'system.chat_auto_triggered',
   /** User viewed an exercise */

--- a/src/infra/system-events/schemas.ts
+++ b/src/infra/system-events/schemas.ts
@@ -166,6 +166,21 @@ export const ChatMessageSubmittedSchema = z
 export type ChatMessageSubmittedPayload = z.infer<typeof ChatMessageSubmittedSchema>
 
 // ============================================================================
+// Photo Sent to Chat Event
+// ============================================================================
+
+export const PhotoSentToChatSchema = z
+  .object({
+    conversation_id: z.string().min(1, 'conversation_id is required'),
+    file_count: z.number().int().positive(),
+    file_types: z.array(z.string()),
+    locale: z.string().optional(),
+  })
+  .strict()
+
+export type PhotoSentToChatPayload = z.infer<typeof PhotoSentToChatSchema>
+
+// ============================================================================
 // Login Modal Shown Event
 // ============================================================================
 
@@ -360,6 +375,7 @@ export const eventSchemas = {
   [SYSTEM_EVENTS.LESSON_ENDED]: LessonEndedSchema,
   [SYSTEM_EVENTS.PDF_VIEWED]: PdfViewedSchema,
   [SYSTEM_EVENTS.CHAT_MESSAGE_SUBMITTED]: ChatMessageSubmittedSchema,
+  [SYSTEM_EVENTS.PHOTO_SENT_TO_CHAT]: PhotoSentToChatSchema,
   [SYSTEM_EVENTS.LOGIN_MODAL_SHOWN]: LoginModalShownSchema,
   [SYSTEM_EVENTS.REGISTRATION_PROMPT_SHOWN]: RegistrationPromptShownSchema,
   [SYSTEM_EVENTS.REGISTRATION_COMPLETED]: RegistrationCompletedSchema,

--- a/src/infra/system-events/types.ts
+++ b/src/infra/system-events/types.ts
@@ -23,6 +23,7 @@ import type {
   AnswerIncorrectPayload,
   ChapterCompletedPayload,
   ChatMessageSubmittedPayload,
+  PhotoSentToChatPayload,
   CouponCodeEnteredPayload,
   CourseEnteredPayload,
   ExerciseSkippedPayload,
@@ -80,6 +81,7 @@ export type SystemEventPayloads = {
   'system.lesson_ended': LessonEndedPayload
   'system.pdf_viewed': PdfViewedPayload
   'system.chat_message_submitted': ChatMessageSubmittedPayload
+  'system.photo_sent_to_chat': PhotoSentToChatPayload
   'system.login_modal_shown': LoginModalShownPayload
   'system.registration_prompt_shown': RegistrationPromptShownPayload
   'system.registration_completed': RegistrationCompletedPayload

--- a/src/ui/web/chat/hooks/useNotebookChat.ts
+++ b/src/ui/web/chat/hooks/useNotebookChat.ts
@@ -390,6 +390,18 @@ export function useNotebookChat({
       message_length: message.length,
     })
 
+    // Track photo uploads to chat
+    if (completedChatAssetIds.length > 0) {
+      const fileTypes = directUploads
+        .filter((f) => f.status === 'complete' && f.chatAssetId)
+        .map((f) => f.file.type)
+      systemEventBus.emit(SYSTEM_EVENTS.PHOTO_SENT_TO_CHAT, {
+        conversation_id: contextKey || 'unknown',
+        file_count: completedChatAssetIds.length,
+        file_types: fileTypes,
+      })
+    }
+
     const context = {
       exerciseId,
       lessonId,

--- a/tests/unit/system-events/contracts.test.ts
+++ b/tests/unit/system-events/contracts.test.ts
@@ -16,6 +16,7 @@ import {
   LoginModalShownSchema,
   PageViewedSchema,
   PdfViewedSchema,
+  PhotoSentToChatSchema,
   PII_FIELDS,
   RegistrationCompletedSchema,
   RegistrationPromptShownSchema,
@@ -278,7 +279,7 @@ describe('Schema Validation', () => {
 describe('Schema Registry', () => {
   it('contains all system events', () => {
     const eventNames = Object.keys(eventSchemas)
-    expect(eventNames.length).toBe(33)
+    expect(eventNames.length).toBe(34)
   })
 
   it('maps each event name to its schema', () => {
@@ -291,6 +292,7 @@ describe('Schema Registry', () => {
     expect(eventSchemas[SYSTEM_EVENTS.LESSON_ENDED]).toBe(LessonEndedSchema)
     expect(eventSchemas[SYSTEM_EVENTS.PDF_VIEWED]).toBe(PdfViewedSchema)
     expect(eventSchemas[SYSTEM_EVENTS.CHAT_MESSAGE_SUBMITTED]).toBe(ChatMessageSubmittedSchema)
+    expect(eventSchemas[SYSTEM_EVENTS.PHOTO_SENT_TO_CHAT]).toBe(PhotoSentToChatSchema)
     expect(eventSchemas[SYSTEM_EVENTS.LOGIN_MODAL_SHOWN]).toBe(LoginModalShownSchema)
     expect(eventSchemas[SYSTEM_EVENTS.REGISTRATION_PROMPT_SHOWN]).toBe(
       RegistrationPromptShownSchema,


### PR DESCRIPTION
…ploads in Mixpanel

The CSP connect-src directive was missing blob.vercel-storage.com, causing Fetch API calls to Vercel Blob storage to be blocked. This manifested as console CSP errors on desktop and "client token" errors on iPhone/iPad. Also adds photo_sent_to_chat Mixpanel event through the full analytics pipeline (system event -> product event -> Mixpanel).