### PR TITLE
fix: Auto-generate lesson slugs 

### DIFF
--- a/src/server/payload/collections/Lessons.ts
+++ b/src/server/payload/collections/Lessons.ts
@@ -26,25 +26,21 @@ export const Lessons: CollectionConfig = {
 
         const title = data.title || originalDoc?.title
 
-        // Determine if slug needs regeneration:
-        // 1. No slug at all → generate from title
-        // 2. Slug contains -copy suffix (duplication) → regenerate from title
-        // 3. Existing slug → keep it (just trim)
-        let needsGeneration = !data.slug
+        // Strip -copy suffixes from Payload duplication
         if (data.slug) {
-          const cleaned = stripCopySuffix(data.slug.trim())
-          if (cleaned !== data.slug.trim()) {
-            // Had -copy suffix → regenerate from title instead
-            needsGeneration = true
-          } else {
-            data.slug = data.slug.trim()
-          }
+          data.slug = stripCopySuffix(data.slug.trim())
         }
 
-        if (needsGeneration && title) {
-          const baseSlug = formatSlug(title)
+        // Generate slug from title when missing
+        if (!data.slug && title) {
+          data.slug = formatSlug(title)
+        }
 
-          // Check uniqueness and add numeric suffix if needed
+        // On create, always ensure uniqueness (handles duplication & conflicts)
+        // On update, ensure uniqueness only if slug changed
+        const slugChanged = operation === 'update' && data.slug !== originalDoc?.slug
+        if (data.slug && (operation === 'create' || slugChanged)) {
+          const baseSlug = data.slug
           let slug = baseSlug
           let counter = 1
           const MAX_ATTEMPTS = 100
@@ -58,10 +54,7 @@ export const Lessons: CollectionConfig = {
               req,
             })
 
-            const isOwnDoc =
-              operation === 'update' && originalDoc?.id && existing.docs[0]?.id === originalDoc.id
-
-            if (existing.docs.length === 0 || isOwnDoc) {
+            if (existing.docs.length === 0) {
               data.slug = slug
               return data
             }

--- a/src/server/payload/collections/Lessons.ts
+++ b/src/server/payload/collections/Lessons.ts
@@ -7,7 +7,7 @@ import { adminOnly } from '../access/adminOnly'
 import { publishedAndActive } from '../access/publishedAndActive'
 import { contentStatusFields } from '../fields/contentStatus'
 import { createdByField } from '../fields/createdBy'
-import { formatSlug, stripCopySuffix } from '../fields/formatSlug'
+import { formatSlugAsync } from '../fields/formatSlug'
 import { translatedFromField } from '../fields/translatedFrom'
 
 export const Lessons: CollectionConfig = {
@@ -24,16 +24,16 @@ export const Lessons: CollectionConfig = {
       async ({ data, operation, originalDoc, req }) => {
         if (!data) return data
 
-        const title = data.title || originalDoc?.title
+        const title = data.title
+        const titleChanged = operation === 'update' && title && title !== originalDoc?.title
 
-        // Strip -copy suffixes from Payload duplication
-        if (data.slug) {
-          data.slug = stripCopySuffix(data.slug.trim())
-        }
-
-        // Generate slug from title when missing
-        if (!data.slug && title) {
-          data.slug = formatSlug(title)
+        // When title changes → always regenerate slug from the new title
+        // When no slug → generate from title
+        // Otherwise → keep slug as-is (including " - Copy" from duplication)
+        if (titleChanged || (!data.slug && title)) {
+          data.slug = await formatSlugAsync(title)
+        } else if (data.slug) {
+          data.slug = data.slug.trim()
         }
 
         // On create, always ensure uniqueness (handles duplication & conflicts)

--- a/src/server/payload/collections/Lessons.ts
+++ b/src/server/payload/collections/Lessons.ts
@@ -7,7 +7,7 @@ import { adminOnly } from '../access/adminOnly'
 import { publishedAndActive } from '../access/publishedAndActive'
 import { contentStatusFields } from '../fields/contentStatus'
 import { createdByField } from '../fields/createdBy'
-import { formatSlug } from '../fields/formatSlug'
+import { formatSlug, stripCopySuffix } from '../fields/formatSlug'
 import { translatedFromField } from '../fields/translatedFrom'
 
 export const Lessons: CollectionConfig = {
@@ -21,19 +21,59 @@ export const Lessons: CollectionConfig = {
   },
   hooks: {
     beforeChange: [
-      ({ data }) => {
-        if (data?.slug) {
-          data.slug = data.slug.trim()
+      async ({ data, operation, originalDoc, req }) => {
+        if (!data) return data
+
+        const title = data.title || originalDoc?.title
+
+        // Determine if slug needs regeneration:
+        // 1. No slug at all → generate from title
+        // 2. Slug contains -copy suffix (duplication) → regenerate from title
+        // 3. Existing slug → keep it (just trim)
+        let needsGeneration = !data.slug
+        if (data.slug) {
+          const cleaned = stripCopySuffix(data.slug.trim())
+          if (cleaned !== data.slug.trim()) {
+            // Had -copy suffix → regenerate from title instead
+            needsGeneration = true
+          } else {
+            data.slug = data.slug.trim()
+          }
         }
-        if (data?.title && !data?.slug) {
-          // Generate unique slug from title
-          // Include timestamp for uniqueness, falling back to random if timestamp not available
-          const timestamp =
-            typeof data.createdAt === 'string'
-              ? data.createdAt.replace(/[^0-9]/g, '').slice(-6)
-              : Date.now().toString().slice(-6)
-          data.slug = `${formatSlug(data.title)}-${timestamp}`
+
+        if (needsGeneration && title) {
+          const baseSlug = formatSlug(title)
+
+          // Check uniqueness and add numeric suffix if needed
+          let slug = baseSlug
+          let counter = 1
+          const MAX_ATTEMPTS = 100
+
+          for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+            const existing = await req.payload.find({
+              collection: 'lessons',
+              where: { slug: { equals: slug } },
+              limit: 1,
+              depth: 0,
+              req,
+            })
+
+            const isOwnDoc =
+              operation === 'update' && originalDoc?.id && existing.docs[0]?.id === originalDoc.id
+
+            if (existing.docs.length === 0 || isOwnDoc) {
+              data.slug = slug
+              return data
+            }
+
+            slug = `${baseSlug}-${counter}`
+            counter++
+          }
+
+          // Fallback: append timestamp if all numeric suffixes taken
+          data.slug = `${baseSlug}-${Date.now().toString(36)}`
         }
+
         return data
       },
     ],

--- a/src/server/payload/fields/formatSlug.ts
+++ b/src/server/payload/fields/formatSlug.ts
@@ -1,8 +1,10 @@
 import slugify from 'slugify'
 
+import { containsHebrew, translateHebrewForSlug } from './translateForSlug'
+
 /**
  * Hebrew-to-Latin transliteration map.
- * Covers standard Hebrew consonants and final forms (sofit).
+ * Used as fallback when translation API is unavailable.
  */
 const HEBREW_MAP: Record<string, string> = {
   א: '',
@@ -40,7 +42,6 @@ const HEBREW_MAP: Record<string, string> = {
  * Hebrew niqqud (diacritics, U+0591–U+05C7) are stripped.
  */
 function transliterateHebrew(input: string): string {
-  // Strip Hebrew diacritics (niqqud)
   const stripped = input.replace(/[\u0591-\u05C7]/g, '')
 
   let result = ''
@@ -54,21 +55,8 @@ function transliterateHebrew(input: string): string {
   return result
 }
 
-/**
- * Hebrew-safe slug formatting utility.
- *
- * Transliterates Hebrew characters to Latin equivalents, then uses slugify
- * for final URL-safe formatting. Falls back to a timestamp-based slug
- * for empty/invalid input.
- *
- * @param input - The string to convert to a slug
- * @param fallback - Optional fallback string if the result is empty
- * @returns A URL-safe, lowercase slug string
- */
-export function formatSlug(input: string, fallback?: string): string {
-  const transliterated = transliterateHebrew(input.trim())
-
-  const slug = slugify(transliterated, {
+function toSlug(input: string, fallback?: string): string {
+  const slug = slugify(input, {
     lower: true,
     strict: true,
     remove: /[*#@]/g,
@@ -86,8 +74,39 @@ export function formatSlug(input: string, fallback?: string): string {
 }
 
 /**
- * Strip Payload CMS duplication suffixes (-copy, -copy-2, etc.) from a slug.
+ * Synchronous slug formatting with transliteration fallback.
+ * Use formatSlugAsync when possible for better Hebrew support via translation.
+ */
+export function formatSlug(input: string, fallback?: string): string {
+  const transliterated = transliterateHebrew(input.trim())
+  return toSlug(transliterated, fallback)
+}
+
+/**
+ * Async slug formatting that translates Hebrew titles to English via OpenAI.
+ * Falls back to transliteration if translation fails or API is unavailable.
+ */
+export async function formatSlugAsync(input: string, fallback?: string): Promise<string> {
+  const trimmed = input.trim()
+
+  if (containsHebrew(trimmed)) {
+    const translated = await translateHebrewForSlug(trimmed)
+    if (translated) {
+      return toSlug(translated, fallback)
+    }
+  }
+
+  // Fallback: transliteration for Hebrew, direct slugify for Latin
+  const transliterated = transliterateHebrew(trimmed)
+  return toSlug(transliterated, fallback)
+}
+
+/**
+ * Strip Payload CMS duplication suffixes from a slug.
+ * Handles both formats:
+ *   - " - Copy", " - Copy (2)" (Payload's actual format with spaces + capital C)
+ *   - "-copy", "-copy-2" (URL-encoded variant)
  */
 export function stripCopySuffix(slug: string): string {
-  return slug.replace(/(-copy(-\d+)?)+$/g, '')
+  return slug.replace(/(\s*-\s*Copy(\s*\(\d+\))?)+$/g, '').replace(/(-copy(-\d+)?)+$/g, '')
 }

--- a/src/server/payload/fields/formatSlug.ts
+++ b/src/server/payload/fields/formatSlug.ts
@@ -1,20 +1,76 @@
 import slugify from 'slugify'
 
 /**
+ * Hebrew-to-Latin transliteration map.
+ * Covers standard Hebrew consonants and final forms (sofit).
+ */
+const HEBREW_MAP: Record<string, string> = {
+  א: '',
+  ב: 'b',
+  ג: 'g',
+  ד: 'd',
+  ה: 'h',
+  ו: 'v',
+  ז: 'z',
+  ח: 'ch',
+  ט: 't',
+  י: 'y',
+  כ: 'k',
+  ך: 'k',
+  ל: 'l',
+  מ: 'm',
+  ם: 'm',
+  נ: 'n',
+  ן: 'n',
+  ס: 's',
+  ע: 'a',
+  פ: 'p',
+  ף: 'f',
+  צ: 'ts',
+  ץ: 'ts',
+  ק: 'k',
+  ר: 'r',
+  ש: 'sh',
+  ת: 't',
+}
+
+/**
+ * Transliterate Hebrew characters to Latin equivalents.
+ * Non-Hebrew characters (including spaces, numbers, Latin letters) are kept as-is.
+ * Hebrew niqqud (diacritics, U+0591–U+05C7) are stripped.
+ */
+function transliterateHebrew(input: string): string {
+  // Strip Hebrew diacritics (niqqud)
+  const stripped = input.replace(/[\u0591-\u05C7]/g, '')
+
+  let result = ''
+  for (const char of stripped) {
+    if (char in HEBREW_MAP) {
+      result += HEBREW_MAP[char]
+    } else {
+      result += char
+    }
+  }
+  return result
+}
+
+/**
  * Hebrew-safe slug formatting utility.
  *
- * Uses slugify with Hebrew locale to ensure Hebrew characters are preserved
- * in generated slugs. Falls back to a timestamp-based slug for empty/invalid input.
+ * Transliterates Hebrew characters to Latin equivalents, then uses slugify
+ * for final URL-safe formatting. Falls back to a timestamp-based slug
+ * for empty/invalid input.
  *
  * @param input - The string to convert to a slug
  * @param fallback - Optional fallback string if the result is empty
  * @returns A URL-safe, lowercase slug string
  */
 export function formatSlug(input: string, fallback?: string): string {
-  const slug = slugify(input.trim(), {
+  const transliterated = transliterateHebrew(input.trim())
+
+  const slug = slugify(transliterated, {
     lower: true,
     strict: true,
-    locale: 'he',
     remove: /[*#@]/g,
   })
 
@@ -27,4 +83,11 @@ export function formatSlug(input: string, fallback?: string): string {
   }
 
   return slug
+}
+
+/**
+ * Strip Payload CMS duplication suffixes (-copy, -copy-2, etc.) from a slug.
+ */
+export function stripCopySuffix(slug: string): string {
+  return slug.replace(/(-copy(-\d+)?)+$/g, '')
 }

--- a/src/server/payload/fields/translateForSlug.ts
+++ b/src/server/payload/fields/translateForSlug.ts
@@ -32,7 +32,7 @@ export async function translateHebrewForSlug(title: string): Promise<string | nu
   try {
     const client = getGeminiClient()
     const model = client.getGenerativeModel({
-      model: 'gemini-2.0-flash-lite',
+      model: 'gemini-2.5-flash-lite',
       generationConfig: {
         temperature: 0,
         maxOutputTokens: 100,

--- a/src/server/payload/fields/translateForSlug.ts
+++ b/src/server/payload/fields/translateForSlug.ts
@@ -1,0 +1,61 @@
+import { OpenAI } from 'openai'
+
+import { logger } from '@/infra/utils/logger'
+
+let openai: OpenAI | null = null
+
+function getOpenAIClient(): OpenAI {
+  if (!openai) {
+    if (!process.env.OPENAI_API_KEY) {
+      throw new Error('OPENAI_API_KEY environment variable is not set')
+    }
+    openai = new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+    })
+  }
+  return openai
+}
+
+const HEBREW_REGEX = /[\u0590-\u05FF]/
+
+/**
+ * Returns true if the input contains any Hebrew characters.
+ */
+export function containsHebrew(input: string): boolean {
+  return HEBREW_REGEX.test(input)
+}
+
+/**
+ * Translate a Hebrew title to English for use as a URL slug.
+ * Uses gpt-4o-mini for cost efficiency (~0.01¢ per call).
+ * Returns null on failure so callers can fall back to transliteration.
+ */
+export async function translateHebrewForSlug(title: string): Promise<string | null> {
+  try {
+    const client = getOpenAIClient()
+    const response = await client.chat.completions.create({
+      model: 'gpt-4o-mini',
+      temperature: 0,
+      max_tokens: 100,
+      messages: [
+        {
+          role: 'system',
+          content:
+            'Translate the following Hebrew text to English. Return ONLY the English translation, nothing else. Keep it concise — this will be used as a URL slug.',
+        },
+        { role: 'user', content: title },
+      ],
+    })
+
+    const translation = response.choices[0]?.message?.content?.trim()
+    if (!translation) return null
+
+    return translation
+  } catch (error) {
+    logger.warn(
+      { title, err: error instanceof Error ? error : String(error) },
+      'Failed to translate Hebrew title for slug, falling back to transliteration',
+    )
+    return null
+  }
+}

--- a/src/server/payload/fields/translateForSlug.ts
+++ b/src/server/payload/fields/translateForSlug.ts
@@ -1,19 +1,17 @@
-import { OpenAI } from 'openai'
+import { GoogleGenerativeAI } from '@google/generative-ai'
 
 import { logger } from '@/infra/utils/logger'
 
-let openai: OpenAI | null = null
+let gemini: GoogleGenerativeAI | null = null
 
-function getOpenAIClient(): OpenAI {
-  if (!openai) {
-    if (!process.env.OPENAI_API_KEY) {
-      throw new Error('OPENAI_API_KEY environment variable is not set')
+function getGeminiClient(): GoogleGenerativeAI {
+  if (!gemini) {
+    if (!process.env.GEMINI_API_KEY) {
+      throw new Error('GEMINI_API_KEY environment variable is not set')
     }
-    openai = new OpenAI({
-      apiKey: process.env.OPENAI_API_KEY,
-    })
+    gemini = new GoogleGenerativeAI(process.env.GEMINI_API_KEY)
   }
-  return openai
+  return gemini
 }
 
 const HEBREW_REGEX = /[\u0590-\u05FF]/
@@ -27,27 +25,26 @@ export function containsHebrew(input: string): boolean {
 
 /**
  * Translate a Hebrew title to English for use as a URL slug.
- * Uses gpt-4o-mini for cost efficiency (~0.01¢ per call).
+ * Uses Gemini Flash Lite for cost efficiency.
  * Returns null on failure so callers can fall back to transliteration.
  */
 export async function translateHebrewForSlug(title: string): Promise<string | null> {
   try {
-    const client = getOpenAIClient()
-    const response = await client.chat.completions.create({
-      model: 'gpt-4o-mini',
-      temperature: 0,
-      max_tokens: 100,
-      messages: [
-        {
-          role: 'system',
-          content:
-            'Translate the following Hebrew text to English. Return ONLY the English translation, nothing else. Keep it concise — this will be used as a URL slug.',
-        },
-        { role: 'user', content: title },
-      ],
+    const client = getGeminiClient()
+    const model = client.getGenerativeModel({
+      model: 'gemini-2.0-flash-lite',
+      generationConfig: {
+        temperature: 0,
+        maxOutputTokens: 100,
+      },
     })
 
-    const translation = response.choices[0]?.message?.content?.trim()
+    const result = await model.generateContent(
+      'Translate the following Hebrew text to English. Return ONLY the English translation, nothing else. Keep it concise — this will be used as a URL slug.\n\n' +
+        title,
+    )
+
+    const translation = result.response.text()?.trim()
     if (!translation) return null
 
     return translation

--- a/tests/unit/collections/formatSlug-integration.test.ts
+++ b/tests/unit/collections/formatSlug-integration.test.ts
@@ -5,6 +5,12 @@ import { Courses } from '@/server/payload/collections/Courses'
 import { Chapters } from '@/server/payload/collections/Chapters'
 import { Lessons } from '@/server/payload/collections/Lessons'
 
+// Mock the translation module so tests don't call OpenAI
+vi.mock('@/server/payload/fields/translateForSlug', () => ({
+  containsHebrew: (input: string) => /[\u0590-\u05FF]/.test(input),
+  translateHebrewForSlug: vi.fn().mockResolvedValue('first lesson'),
+}))
+
 describe('formatSlug integration with collections', () => {
   describe('Courses beforeChange hook', () => {
     const beforeChangeHook = Courses.hooks?.beforeChange?.[0]
@@ -56,7 +62,6 @@ describe('formatSlug integration with collections', () => {
 
       expect(result.slug).toBeDefined()
       expect(result.slug.length).toBeGreaterThan(0)
-      // Should be transliterated, not a fallback
       expect(result.slug).not.toMatch(/^item-/)
     })
 
@@ -89,7 +94,7 @@ describe('formatSlug integration with collections', () => {
       mockPayloadFind.mockReset()
     })
 
-    it('should generate transliterated slug for Hebrew title', async () => {
+    it('should translate Hebrew title to English for slug on create', async () => {
       expect(beforeChangeHook).toBeDefined()
       mockPayloadFind.mockResolvedValue({ docs: [] })
 
@@ -101,10 +106,11 @@ describe('formatSlug integration with collections', () => {
         req: mockReq,
       })
 
-      expect(result.slug).toBe('shyavr-rshvn')
+      // Mock returns 'first lesson' → slugified to 'first-lesson'
+      expect(result.slug).toBe('first-lesson')
     })
 
-    it('should generate slug from English title', async () => {
+    it('should generate slug from English title on create', async () => {
       mockPayloadFind.mockResolvedValue({ docs: [] })
 
       const mockData = { title: 'First Lesson' }
@@ -118,25 +124,39 @@ describe('formatSlug integration with collections', () => {
       expect(result.slug).toBe('first-lesson')
     })
 
-    it('should keep existing slug on update when unchanged', async () => {
-      const mockData = { title: 'New Title', slug: 'existing-lesson-slug' }
+    it('should regenerate slug when title changes on update', async () => {
+      mockPayloadFind.mockResolvedValue({ docs: [] })
+
+      const mockData = { title: 'New Lesson Title', slug: 'old-slug' }
       // @ts-expect-error - Hook has complex signature
       const result = await beforeChangeHook({
         data: mockData,
         operation: 'update',
-        originalDoc: { id: 'my-id', slug: 'existing-lesson-slug' },
+        originalDoc: { id: 'my-id', title: 'Old Title', slug: 'old-slug' },
         req: mockReq,
       })
 
-      expect(result.slug).toBe('existing-lesson-slug')
-      // No DB query needed since slug didn't change
+      expect(result.slug).toBe('new-lesson-title')
+    })
+
+    it('should keep slug when title is unchanged on update', async () => {
+      const mockData = { title: 'Same Title', slug: 'existing-slug' }
+      // @ts-expect-error - Hook has complex signature
+      const result = await beforeChangeHook({
+        data: mockData,
+        operation: 'update',
+        originalDoc: { id: 'my-id', title: 'Same Title', slug: 'existing-slug' },
+        req: mockReq,
+      })
+
+      expect(result.slug).toBe('existing-slug')
       expect(mockPayloadFind).not.toHaveBeenCalled()
     })
 
-    it('should strip -copy suffix and regenerate slug', async () => {
+    it('should keep " - Copy" slug from duplication as-is', async () => {
       mockPayloadFind.mockResolvedValue({ docs: [] })
 
-      const mockData = { title: 'First Lesson', slug: 'first-lesson-copy' }
+      const mockData = { title: 'First Lesson', slug: 'first-lesson - Copy' }
       // @ts-expect-error - Hook has complex signature
       const result = await beforeChangeHook({
         data: mockData,
@@ -144,30 +164,15 @@ describe('formatSlug integration with collections', () => {
         req: mockReq,
       })
 
-      expect(result.slug).toBe('first-lesson')
-    })
-
-    it('should strip repeated -copy-copy suffixes and regenerate', async () => {
-      mockPayloadFind.mockResolvedValue({ docs: [] })
-
-      const mockData = {
-        title: 'First Lesson',
-        slug: 'first-lesson-copy-copy-copy',
-      }
-      // @ts-expect-error - Hook has complex signature
-      const result = await beforeChangeHook({
-        data: mockData,
-        operation: 'create',
-        req: mockReq,
-      })
-
-      expect(result.slug).toBe('first-lesson')
+      // Title matches (duplication copies title too), so no regeneration
+      // Slug kept as-is, uniqueness checked
+      expect(result.slug).toBe('first-lesson - Copy')
     })
 
     it('should add numeric suffix when slug already exists', async () => {
       mockPayloadFind
-        .mockResolvedValueOnce({ docs: [{ id: 'other-id' }] }) // first-lesson taken
-        .mockResolvedValueOnce({ docs: [] }) // first-lesson-1 available
+        .mockResolvedValueOnce({ docs: [{ id: 'other-id' }] })
+        .mockResolvedValueOnce({ docs: [] })
 
       const mockData = { title: 'First Lesson' }
       // @ts-expect-error - Hook has complex signature
@@ -180,37 +185,21 @@ describe('formatSlug integration with collections', () => {
       expect(result.slug).toBe('first-lesson-1')
     })
 
-    it('should check uniqueness when slug changes on update', async () => {
+    it('should ensure uniqueness when title changes to existing slug', async () => {
       mockPayloadFind
-        .mockResolvedValueOnce({ docs: [{ id: 'other-id' }] }) // new-slug taken
-        .mockResolvedValueOnce({ docs: [] }) // new-slug-1 available
+        .mockResolvedValueOnce({ docs: [{ id: 'other-id' }] })
+        .mockResolvedValueOnce({ docs: [] })
 
-      const mockData = { title: 'First Lesson', slug: 'new-slug' }
+      const mockData = { title: 'Taken Title', slug: 'old-slug' }
       // @ts-expect-error - Hook has complex signature
       const result = await beforeChangeHook({
         data: mockData,
         operation: 'update',
-        originalDoc: { id: 'my-id', slug: 'old-slug' },
+        originalDoc: { id: 'my-id', title: 'Old Title', slug: 'old-slug' },
         req: mockReq,
       })
 
-      expect(result.slug).toBe('new-slug-1')
-    })
-
-    it('should deduplicate slug on create even without -copy suffix', async () => {
-      mockPayloadFind
-        .mockResolvedValueOnce({ docs: [{ id: 'existing-id' }] }) // first-lesson taken
-        .mockResolvedValueOnce({ docs: [] }) // first-lesson-1 available
-
-      const mockData = { title: 'Other Title', slug: 'first-lesson' }
-      // @ts-expect-error - Hook has complex signature
-      const result = await beforeChangeHook({
-        data: mockData,
-        operation: 'create',
-        req: mockReq,
-      })
-
-      expect(result.slug).toBe('first-lesson-1')
+      expect(result.slug).toBe('taken-title-1')
     })
   })
 })

--- a/tests/unit/collections/formatSlug-integration.test.ts
+++ b/tests/unit/collections/formatSlug-integration.test.ts
@@ -118,16 +118,19 @@ describe('formatSlug integration with collections', () => {
       expect(result.slug).toBe('first-lesson')
     })
 
-    it('should NOT overwrite existing slug on update', async () => {
+    it('should keep existing slug on update when unchanged', async () => {
       const mockData = { title: 'New Title', slug: 'existing-lesson-slug' }
       // @ts-expect-error - Hook has complex signature
       const result = await beforeChangeHook({
         data: mockData,
         operation: 'update',
+        originalDoc: { id: 'my-id', slug: 'existing-lesson-slug' },
         req: mockReq,
       })
 
       expect(result.slug).toBe('existing-lesson-slug')
+      // No DB query needed since slug didn't change
+      expect(mockPayloadFind).not.toHaveBeenCalled()
     })
 
     it('should strip -copy suffix and regenerate slug', async () => {
@@ -177,19 +180,37 @@ describe('formatSlug integration with collections', () => {
       expect(result.slug).toBe('first-lesson-1')
     })
 
-    it('should allow own slug on update', async () => {
-      mockPayloadFind.mockResolvedValue({ docs: [{ id: 'my-id' }] })
+    it('should check uniqueness when slug changes on update', async () => {
+      mockPayloadFind
+        .mockResolvedValueOnce({ docs: [{ id: 'other-id' }] }) // new-slug taken
+        .mockResolvedValueOnce({ docs: [] }) // new-slug-1 available
 
-      const mockData = { title: 'First Lesson' }
+      const mockData = { title: 'First Lesson', slug: 'new-slug' }
       // @ts-expect-error - Hook has complex signature
       const result = await beforeChangeHook({
         data: mockData,
         operation: 'update',
-        originalDoc: { id: 'my-id' },
+        originalDoc: { id: 'my-id', slug: 'old-slug' },
         req: mockReq,
       })
 
-      expect(result.slug).toBe('first-lesson')
+      expect(result.slug).toBe('new-slug-1')
+    })
+
+    it('should deduplicate slug on create even without -copy suffix', async () => {
+      mockPayloadFind
+        .mockResolvedValueOnce({ docs: [{ id: 'existing-id' }] }) // first-lesson taken
+        .mockResolvedValueOnce({ docs: [] }) // first-lesson-1 available
+
+      const mockData = { title: 'Other Title', slug: 'first-lesson' }
+      // @ts-expect-error - Hook has complex signature
+      const result = await beforeChangeHook({
+        data: mockData,
+        operation: 'create',
+        req: mockReq,
+      })
+
+      expect(result.slug).toBe('first-lesson-1')
     })
   })
 })

--- a/tests/unit/collections/formatSlug-integration.test.ts
+++ b/tests/unit/collections/formatSlug-integration.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest'
+import type { PayloadRequest } from 'payload'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { Courses } from '@/server/payload/collections/Courses'
 import { Chapters } from '@/server/payload/collections/Chapters'
@@ -8,18 +9,14 @@ describe('formatSlug integration with collections', () => {
   describe('Courses beforeChange hook', () => {
     const beforeChangeHook = Courses.hooks?.beforeChange?.[0]
 
-    it('should generate non-empty slug for Hebrew title (via fallback)', () => {
+    it('should generate transliterated slug for Hebrew title', () => {
       expect(beforeChangeHook).toBeDefined()
 
-      // Simulate the hook call
       const mockData = { title: 'שלום עולם' }
       // @ts-expect-error - Hook has complex signature, we're testing simple case
       const result = beforeChangeHook({ data: mockData })
 
-      expect(result.slug).toBeDefined()
-      expect(result.slug.length).toBeGreaterThan(0)
-      // slugify with strict:true strips Hebrew → empty → fallback used
-      expect(result.slug).toMatch(/^item-[a-z0-9]+$/)
+      expect(result.slug).toBe('shlvm-avlm')
     })
 
     it('should generate slug from English title', () => {
@@ -50,7 +47,7 @@ describe('formatSlug integration with collections', () => {
   describe('Chapters beforeChange hook', () => {
     const beforeChangeHook = Chapters.hooks?.beforeChange?.[0]
 
-    it('should generate non-empty slug for Hebrew title (via fallback)', () => {
+    it('should generate transliterated slug for Hebrew title', () => {
       expect(beforeChangeHook).toBeDefined()
 
       const mockData = { title: 'פרק ראשון' }
@@ -59,8 +56,8 @@ describe('formatSlug integration with collections', () => {
 
       expect(result.slug).toBeDefined()
       expect(result.slug.length).toBeGreaterThan(0)
-      // slugify with strict:true strips Hebrew → empty → fallback used
-      expect(result.slug).toMatch(/^item-[a-z0-9]+$/)
+      // Should be transliterated, not a fallback
+      expect(result.slug).not.toMatch(/^item-/)
     })
 
     it('should generate slug from English title', () => {
@@ -83,36 +80,116 @@ describe('formatSlug integration with collections', () => {
   describe('Lessons beforeChange hook', () => {
     const beforeChangeHook = Lessons.hooks?.beforeChange?.[0]
 
-    it('should generate non-empty slug with timestamp suffix for Hebrew title', () => {
+    const mockPayloadFind = vi.fn()
+    const mockReq = {
+      payload: { find: mockPayloadFind },
+    } as unknown as PayloadRequest
+
+    beforeEach(() => {
+      mockPayloadFind.mockReset()
+    })
+
+    it('should generate transliterated slug for Hebrew title', async () => {
       expect(beforeChangeHook).toBeDefined()
+      mockPayloadFind.mockResolvedValue({ docs: [] })
 
-      const mockData = { title: 'שיעור ראשון', createdAt: '2024-01-01T12:00:00.000Z' }
+      const mockData = { title: 'שיעור ראשון' }
       // @ts-expect-error - Hook has complex signature
-      const result = beforeChangeHook({ data: mockData })
+      const result = await beforeChangeHook({
+        data: mockData,
+        operation: 'create',
+        req: mockReq,
+      })
 
-      expect(result.slug).toBeDefined()
-      expect(result.slug.length).toBeGreaterThan(0)
-      // slugify strips Hebrew → fallback with timestamp suffix
-      expect(result.slug).toMatch(/^item-[a-z0-9]+-[0-9]{6}$/)
+      expect(result.slug).toBe('shyavr-rshvn')
     })
 
-    it('should generate slug from English title with timestamp suffix', () => {
-      // When createdAt is not a string or doesn't match the expected format,
-      // the hook uses Date.now() for the timestamp
-      const mockData = { title: 'First Lesson', createdAt: undefined }
-      // @ts-expect-error - Hook has complex signature
-      const result = beforeChangeHook({ data: mockData })
+    it('should generate slug from English title', async () => {
+      mockPayloadFind.mockResolvedValue({ docs: [] })
 
-      // Should contain the slugified title and a timestamp suffix
-      expect(result.slug).toMatch(/^first-lesson-[0-9]{6}$/)
+      const mockData = { title: 'First Lesson' }
+      // @ts-expect-error - Hook has complex signature
+      const result = await beforeChangeHook({
+        data: mockData,
+        operation: 'create',
+        req: mockReq,
+      })
+
+      expect(result.slug).toBe('first-lesson')
     })
 
-    it('should NOT overwrite existing slug on update', () => {
+    it('should NOT overwrite existing slug on update', async () => {
       const mockData = { title: 'New Title', slug: 'existing-lesson-slug' }
       // @ts-expect-error - Hook has complex signature
-      const result = beforeChangeHook({ data: mockData })
+      const result = await beforeChangeHook({
+        data: mockData,
+        operation: 'update',
+        req: mockReq,
+      })
 
       expect(result.slug).toBe('existing-lesson-slug')
+    })
+
+    it('should strip -copy suffix and regenerate slug', async () => {
+      mockPayloadFind.mockResolvedValue({ docs: [] })
+
+      const mockData = { title: 'First Lesson', slug: 'first-lesson-copy' }
+      // @ts-expect-error - Hook has complex signature
+      const result = await beforeChangeHook({
+        data: mockData,
+        operation: 'create',
+        req: mockReq,
+      })
+
+      expect(result.slug).toBe('first-lesson')
+    })
+
+    it('should strip repeated -copy-copy suffixes and regenerate', async () => {
+      mockPayloadFind.mockResolvedValue({ docs: [] })
+
+      const mockData = {
+        title: 'First Lesson',
+        slug: 'first-lesson-copy-copy-copy',
+      }
+      // @ts-expect-error - Hook has complex signature
+      const result = await beforeChangeHook({
+        data: mockData,
+        operation: 'create',
+        req: mockReq,
+      })
+
+      expect(result.slug).toBe('first-lesson')
+    })
+
+    it('should add numeric suffix when slug already exists', async () => {
+      mockPayloadFind
+        .mockResolvedValueOnce({ docs: [{ id: 'other-id' }] }) // first-lesson taken
+        .mockResolvedValueOnce({ docs: [] }) // first-lesson-1 available
+
+      const mockData = { title: 'First Lesson' }
+      // @ts-expect-error - Hook has complex signature
+      const result = await beforeChangeHook({
+        data: mockData,
+        operation: 'create',
+        req: mockReq,
+      })
+
+      expect(result.slug).toBe('first-lesson-1')
+    })
+
+    it('should allow own slug on update', async () => {
+      mockPayloadFind.mockResolvedValue({ docs: [{ id: 'my-id' }] })
+
+      const mockData = { title: 'First Lesson' }
+      // @ts-expect-error - Hook has complex signature
+      const result = await beforeChangeHook({
+        data: mockData,
+        operation: 'update',
+        originalDoc: { id: 'my-id' },
+        req: mockReq,
+      })
+
+      expect(result.slug).toBe('first-lesson')
     })
   })
 })

--- a/tests/unit/fields/formatSlug.test.ts
+++ b/tests/unit/fields/formatSlug.test.ts
@@ -1,6 +1,12 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 
-import { formatSlug, stripCopySuffix } from '@/server/payload/fields/formatSlug'
+import { formatSlug, formatSlugAsync, stripCopySuffix } from '@/server/payload/fields/formatSlug'
+
+// Mock the translation module
+vi.mock('@/server/payload/fields/translateForSlug', () => ({
+  containsHebrew: (input: string) => /[\u0590-\u05FF]/.test(input),
+  translateHebrewForSlug: vi.fn().mockResolvedValue('hello world'),
+}))
 
 describe('formatSlug', () => {
   describe('Hebrew transliteration', () => {
@@ -102,8 +108,41 @@ describe('formatSlug', () => {
   })
 })
 
+describe('formatSlugAsync', () => {
+  it('should translate Hebrew title to English via OpenAI and slugify', async () => {
+    // Mock returns 'hello world' for any Hebrew input
+    const result = await formatSlugAsync('שלום עולם')
+    expect(result).toBe('hello-world')
+  })
+
+  it('should pass English titles through without translation', async () => {
+    const result = await formatSlugAsync('First Lesson')
+    expect(result).toBe('first-lesson')
+  })
+
+  it('should fall back to transliteration when translation returns null', async () => {
+    const { translateHebrewForSlug } = await import('@/server/payload/fields/translateForSlug')
+    vi.mocked(translateHebrewForSlug).mockResolvedValueOnce(null)
+
+    const result = await formatSlugAsync('שלום עולם')
+    expect(result).toBe('shlvm-avlm')
+  })
+})
+
 describe('stripCopySuffix', () => {
-  it('should strip single -copy suffix', () => {
+  it('should strip Payload " - Copy" suffix', () => {
+    expect(stripCopySuffix('bdykt-ytsyrt-slvg - Copy')).toBe('bdykt-ytsyrt-slvg')
+  })
+
+  it('should strip Payload " - Copy (2)" suffix', () => {
+    expect(stripCopySuffix('my-lesson - Copy (2)')).toBe('my-lesson')
+  })
+
+  it('should strip repeated " - Copy" suffixes', () => {
+    expect(stripCopySuffix('my-lesson - Copy - Copy')).toBe('my-lesson')
+  })
+
+  it('should strip lowercase -copy suffix', () => {
     expect(stripCopySuffix('my-lesson-copy')).toBe('my-lesson')
   })
 
@@ -115,15 +154,11 @@ describe('stripCopySuffix', () => {
     expect(stripCopySuffix('my-lesson-copy-2')).toBe('my-lesson')
   })
 
-  it('should strip mixed -copy and -copy-N suffixes', () => {
-    expect(stripCopySuffix('my-lesson-copy-copy-2-copy')).toBe('my-lesson')
-  })
-
-  it('should not modify slug without -copy suffix', () => {
+  it('should not modify slug without copy suffix', () => {
     expect(stripCopySuffix('my-lesson')).toBe('my-lesson')
   })
 
-  it('should not strip -copy from middle of slug', () => {
+  it('should not strip copy from middle of slug', () => {
     expect(stripCopySuffix('copy-lesson')).toBe('copy-lesson')
   })
 })

--- a/tests/unit/fields/formatSlug.test.ts
+++ b/tests/unit/fields/formatSlug.test.ts
@@ -1,32 +1,33 @@
 import { describe, it, expect } from 'vitest'
 
-import { formatSlug } from '@/server/payload/fields/formatSlug'
+import { formatSlug, stripCopySuffix } from '@/server/payload/fields/formatSlug'
 
 describe('formatSlug', () => {
-  describe('Hebrew support', () => {
-    it('should produce non-empty slug for Hebrew-only title (via fallback)', () => {
-      // Note: slugify with strict:true and locale:'he' strips Hebrew characters,
-      // resulting in an empty string. The fallback mechanism ensures non-empty slugs.
+  describe('Hebrew transliteration', () => {
+    it('should transliterate Hebrew-only title to Latin slug', () => {
       const result = formatSlug('שלום עולם')
-      expect(result).toBeDefined()
-      expect(result.length).toBeGreaterThan(0)
-      // Fallback should be used since slugify returns empty for Hebrew with strict mode
-      expect(result).toMatch(/^item-[a-z0-9]+$/)
+      expect(result).toBe('shlvm-avlm')
     })
 
-    it('should produce non-empty slug for mixed Hebrew/English title', () => {
+    it('should transliterate mixed Hebrew/English title', () => {
       const result = formatSlug('כיתה 8 - Algebra בסיסי')
-      expect(result).toBeDefined()
-      expect(result.length).toBeGreaterThan(0)
+      expect(result).toBe('kyth-8-algebra-bsysy')
     })
 
     it('should handle Hebrew with diacritics/niqqud', () => {
-      // With strict mode, Hebrew is stripped → empty → fallback
       const result = formatSlug('שָׁלוֹם עוֹלָם')
-      expect(result).toBeDefined()
-      expect(result.length).toBeGreaterThan(0)
-      // Should use fallback since Hebrew is stripped
-      expect(result).toMatch(/^item-[a-z0-9]+$/)
+      // Niqqud stripped, then Hebrew transliterated
+      expect(result).toBe('shlvm-avlm')
+    })
+
+    it('should transliterate final-form letters (sofit)', () => {
+      const result = formatSlug('חשבון')
+      expect(result).toBe('chshbvn')
+    })
+
+    it('should transliterate lesson-style Hebrew title', () => {
+      const result = formatSlug('שיעור ראשון')
+      expect(result).toBe('shyavr-rshvn')
     })
   })
 
@@ -55,12 +56,6 @@ describe('formatSlug', () => {
   })
 
   describe('fallback behavior', () => {
-    it('should return transformed punctuation (not fallback) when slugify produces non-empty result', () => {
-      // slugify transforms !@#$% to "dollarpercent" (not empty), so it's returned as-is
-      const result = formatSlug('!@#$%')
-      expect(result).toBe('dollarpercent')
-    })
-
     it('should return provided fallback for whitespace-only input', () => {
       const result = formatSlug('   ', 'whitespace-fallback')
       expect(result).toBe('whitespace-fallback')
@@ -104,5 +99,31 @@ describe('formatSlug', () => {
       const result = formatSlug('test-slug-682076 ')
       expect(result).toBe('test-slug-682076')
     })
+  })
+})
+
+describe('stripCopySuffix', () => {
+  it('should strip single -copy suffix', () => {
+    expect(stripCopySuffix('my-lesson-copy')).toBe('my-lesson')
+  })
+
+  it('should strip repeated -copy suffixes', () => {
+    expect(stripCopySuffix('my-lesson-copy-copy-copy')).toBe('my-lesson')
+  })
+
+  it('should strip -copy-2 suffixes', () => {
+    expect(stripCopySuffix('my-lesson-copy-2')).toBe('my-lesson')
+  })
+
+  it('should strip mixed -copy and -copy-N suffixes', () => {
+    expect(stripCopySuffix('my-lesson-copy-copy-2-copy')).toBe('my-lesson')
+  })
+
+  it('should not modify slug without -copy suffix', () => {
+    expect(stripCopySuffix('my-lesson')).toBe('my-lesson')
+  })
+
+  it('should not strip -copy from middle of slug', () => {
+    expect(stripCopySuffix('copy-lesson')).toBe('copy-lesson')
   })
 })


### PR DESCRIPTION
…on (#758)

Add Hebrew-to-Latin transliteration in formatSlug so Hebrew lesson names produce readable URL slugs instead of falling back to timestamps. Fix duplication creating repeated -copy suffixes by detecting and stripping them, then regenerating from title with uniqueness checking.