### PR TITLE
feat: Add course-specific search in header dropdown

### DIFF
--- a/src/app/(frontend)/search/page.tsx
+++ b/src/app/(frontend)/search/page.tsx
@@ -1,8 +1,11 @@
 import type { Metadata } from 'next/types'
 
 import { searchPosts } from '@/server/repos/queries/posts'
+import { searchCourseContent } from '@/server/repos/queries/course-search'
 import { CollectionArchive } from '@/ui/web/CollectionArchive'
 import { Search } from '@/ui/web/search/Component'
+import { SystemLink } from '@/infra/loading/components/SystemLink'
+import { BookOpen, FileText } from 'lucide-react'
 import PageClient from './page.client'
 
 type Args = {
@@ -14,8 +17,13 @@ type Args = {
 export default async function Page({ searchParams: searchParamsPromise }: Args) {
   const { q: query } = await searchParamsPromise
 
-  const result = query ? await searchPosts({ query }) : null
-  const posts = result?.docs || []
+  const [postResult, courseResults] = await Promise.all([
+    query ? searchPosts({ query }) : null,
+    query ? searchCourseContent({ query }) : null,
+  ])
+
+  const posts = postResult?.docs || []
+  const hasResults = posts.length > 0 || (courseResults && courseResults.length > 0)
 
   return (
     <div className="pt-24 pb-24">
@@ -30,10 +38,43 @@ export default async function Page({ searchParams: searchParamsPromise }: Args) 
         </div>
       </div>
 
-      {posts.length > 0 ? (
-        <CollectionArchive posts={posts} />
-      ) : (
+      {!query ? null : !hasResults ? (
         <div className="container">No results found.</div>
+      ) : (
+        <>
+          {/* Course Content Results */}
+          {courseResults && courseResults.length > 0 && (
+            <div className="container mb-16">
+              <h2 className="text-display-xs font-bold mb-6">Courses & Lessons</h2>
+              <div className="grid gap-3">
+                {courseResults.map((result) => (
+                  <SystemLink
+                    key={result.id}
+                    href={result.url}
+                    className="flex items-center gap-content-gap p-card-padding-sm rounded-lg border border-border bg-card hover:bg-muted transition-colors"
+                  >
+                    {result.type === 'lesson' ? (
+                      <BookOpen className="w-5 h-5 text-primary shrink-0" />
+                    ) : (
+                      <FileText className="w-5 h-5 text-primary shrink-0" />
+                    )}
+                    <div className="min-w-0">
+                      <p className="text-body-md font-semibold text-foreground truncate">
+                        {result.title}
+                      </p>
+                      <p className="text-body-sm text-muted-foreground truncate">
+                        {result.subtitle}
+                      </p>
+                    </div>
+                  </SystemLink>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Blog Post Results */}
+          {posts.length > 0 && <CollectionArchive posts={posts} />}
+        </>
       )}
     </div>
   )
@@ -41,6 +82,6 @@ export default async function Page({ searchParams: searchParamsPromise }: Args) 
 
 export function generateMetadata(): Metadata {
   return {
-    title: `Payload Website Template Search`,
+    title: `Search - A-Guy`,
   }
 }

--- a/src/app/api/course-search/route.ts
+++ b/src/app/api/course-search/route.ts
@@ -1,0 +1,274 @@
+import '@/infra/config/server-init'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { getPayload } from 'payload'
+import configPromise from '@payload-config'
+import type { Course } from '@/payload-types'
+import { hasEntitlement } from '@/server/services/entitlement_check'
+import { buildExerciseUrl, buildLessonUrl } from '@/server/utils/course-url-builder'
+import type { ContentBlock } from '@/server/payload/collections/Exercises/types'
+
+const searchParamsSchema = z.object({
+  q: z.string().min(2).max(200),
+  courseSlug: z.string().min(1),
+})
+
+interface SearchResultLesson {
+  id: string
+  title: string
+  type: string
+  url: string
+}
+
+interface SearchResultExercise {
+  id: string
+  title: string
+  lessonTitle: string
+  url: string
+}
+
+interface SearchResultQuestion {
+  id: string
+  promptSnippet: string
+  exerciseTitle: string
+  url: string
+}
+
+function resolveId(field: string | { id: string } | null | undefined): string {
+  if (!field) return ''
+  return typeof field === 'string' ? field : field.id
+}
+
+export async function GET(request: NextRequest) {
+  const params = Object.fromEntries(request.nextUrl.searchParams)
+  const parsed = searchParamsSchema.safeParse(params)
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid parameters', details: parsed.error.issues },
+      { status: 400 },
+    )
+  }
+
+  const { q: query, courseSlug } = parsed.data
+
+  try {
+    const payload = await getPayload({ config: configPromise })
+
+    // 1. Resolve course
+    const courseResult = await payload.find({
+      collection: 'courses',
+      where: {
+        and: [
+          { slug: { equals: courseSlug } },
+          { status: { equals: 'published' } },
+          { isActive: { equals: true } },
+        ],
+      },
+      limit: 1,
+      pagination: false,
+      depth: 0,
+      overrideAccess: true,
+    })
+
+    const course = courseResult.docs[0] as Course | undefined
+    if (!course) {
+      return NextResponse.json({ error: 'Course not found' }, { status: 404 })
+    }
+
+    // 2. Check enrollment for paid courses
+    if (course.accessType === 'paid') {
+      const { user } = await payload.auth({ headers: request.headers })
+
+      if (!user) {
+        return NextResponse.json({ enrolled: false, results: null, total: 0 })
+      }
+
+      const isAdmin = user.collection === 'users' && 'role' in user && user.role === 'admin'
+      if (!isAdmin) {
+        const entitled = await hasEntitlement({
+          payload,
+          userId: user.id,
+          courseId: course.id,
+        })
+
+        if (!entitled) {
+          return NextResponse.json({ enrolled: false, results: null, total: 0 })
+        }
+      }
+    }
+
+    // 3. Find all chapters for this course
+    const chaptersResult = await payload.find({
+      collection: 'chapters',
+      where: {
+        and: [
+          { course: { equals: course.id } },
+          { status: { equals: 'published' } },
+          { isActive: { equals: true } },
+        ],
+      },
+      limit: 1000,
+      pagination: false,
+      depth: 0,
+      overrideAccess: true,
+    })
+
+    const chapters = chaptersResult.docs
+    if (chapters.length === 0) {
+      return NextResponse.json({
+        enrolled: true,
+        results: { lessons: [], exercises: [], questions: [] },
+        total: 0,
+      })
+    }
+
+    const chapterIds = chapters.map((ch) => ch.id)
+    const chapterMap = new Map(chapters.map((ch) => [ch.id, ch]))
+
+    // 4. Search lessons by title (substring match)
+    const lessonsResult = await payload.find({
+      collection: 'lessons',
+      where: {
+        and: [
+          { chapter: { in: chapterIds } },
+          { status: { equals: 'published' } },
+          { isActive: { equals: true } },
+          { title: { like: query } },
+        ],
+      },
+      limit: 20,
+      pagination: false,
+      depth: 0,
+      overrideAccess: true,
+    })
+
+    const lessonResults: SearchResultLesson[] = lessonsResult.docs.map((lesson) => {
+      const chapterId = resolveId(lesson.chapter)
+      const chapter = chapterMap.get(chapterId)
+      return {
+        id: lesson.id,
+        title: lesson.title,
+        type: lesson.type,
+        url: buildLessonUrl(courseSlug, chapter?.slug ?? '', lesson.slug ?? ''),
+      }
+    })
+
+    // 5. Fetch ALL lessons for this course (needed for exercise URL building)
+    const allLessonsResult = await payload.find({
+      collection: 'lessons',
+      where: {
+        and: [
+          { chapter: { in: chapterIds } },
+          { status: { equals: 'published' } },
+          { isActive: { equals: true } },
+        ],
+      },
+      limit: 1000,
+      pagination: false,
+      depth: 0,
+      overrideAccess: true,
+    })
+
+    const allLessons = allLessonsResult.docs
+    const lessonMap = new Map(allLessons.map((l) => [l.id, l]))
+    const lessonIds = allLessons.map((l) => l.id)
+
+    // 6. Search exercises by title
+    let exerciseResults: SearchResultExercise[] = []
+    const questionResults: SearchResultQuestion[] = []
+
+    if (lessonIds.length > 0) {
+      const exercisesResult = await payload.find({
+        collection: 'exercises',
+        where: {
+          and: [{ lesson: { in: lessonIds } }, { title: { like: query } }],
+        },
+        limit: 20,
+        pagination: false,
+        depth: 0,
+        overrideAccess: true,
+      })
+
+      exerciseResults = exercisesResult.docs.map((exercise) => {
+        const lessonId = resolveId(exercise.lesson)
+        const lesson = lessonMap.get(lessonId)
+        const chapterId = lesson ? resolveId(lesson.chapter) : ''
+        const chapter = chapterMap.get(chapterId)
+        return {
+          id: exercise.id,
+          title: exercise.title || 'Untitled Exercise',
+          lessonTitle: lesson?.title ?? '',
+          url: buildExerciseUrl(
+            courseSlug,
+            chapter?.slug ?? '',
+            lesson?.slug ?? '',
+            exercise.slug ?? '',
+          ),
+        }
+      })
+
+      // 7. Search questions inside exercise content
+      const queryLower = query.toLowerCase()
+      const exercisesForQuestions = await payload.find({
+        collection: 'exercises',
+        where: {
+          lesson: { in: lessonIds },
+        },
+        limit: 500,
+        pagination: false,
+        depth: 0,
+        overrideAccess: true,
+      })
+
+      for (const exercise of exercisesForQuestions.docs) {
+        const content = exercise.content as { blocks?: ContentBlock[] } | null
+        if (!content?.blocks) continue
+
+        for (const block of content.blocks) {
+          if (!('prompt' in block) || !block.prompt?.value) continue
+
+          const promptValue = block.prompt.value.toLowerCase()
+          if (!promptValue.includes(queryLower)) continue
+
+          const lessonId = resolveId(exercise.lesson)
+          const lesson = lessonMap.get(lessonId)
+          const chapterId = lesson ? resolveId(lesson.chapter) : ''
+          const chapter = chapterMap.get(chapterId)
+
+          questionResults.push({
+            id: block.id,
+            promptSnippet: block.prompt.value.slice(0, 100),
+            exerciseTitle: exercise.title || 'Untitled Exercise',
+            url: buildExerciseUrl(
+              courseSlug,
+              chapter?.slug ?? '',
+              lesson?.slug ?? '',
+              exercise.slug ?? '',
+            ),
+          })
+
+          if (questionResults.length >= 10) break
+        }
+
+        if (questionResults.length >= 10) break
+      }
+    }
+
+    const total = lessonResults.length + exerciseResults.length + questionResults.length
+
+    return NextResponse.json({
+      enrolled: true,
+      results: {
+        lessons: lessonResults,
+        exercises: exerciseResults,
+        questions: questionResults,
+      },
+      total,
+    })
+  } catch (error) {
+    const { captureAndRespond } = await import('@/server/api/capture-and-respond')
+    return captureAndRespond(error, { route: '/api/course-search' })
+  }
+}

--- a/src/app/api/course-search/route.ts
+++ b/src/app/api/course-search/route.ts
@@ -11,7 +11,7 @@ import type { ContentBlock } from '@/server/payload/collections/Exercises/types'
 
 const searchParamsSchema = z.object({
   q: z.string().min(2).max(200),
-  courseSlug: z.string().min(1),
+  courseSlug: z.string().min(1).optional(),
 })
 
 interface SearchResultLesson {
@@ -54,6 +54,23 @@ export async function GET(request: NextRequest) {
   const { q: query, courseSlug } = parsed.data
 
   try {
+    // If no courseSlug, search across all courses
+    if (!courseSlug) {
+      const { searchCourseContent } = await import('@/server/repos/queries/course-search')
+      const results = await searchCourseContent({ query, limit: 20 })
+      const lessons = results
+        .filter((r) => r.type === 'lesson')
+        .map((r) => ({ id: r.id, title: r.title, type: 'learning', url: r.url }))
+      const exercises = results
+        .filter((r) => r.type === 'exercise')
+        .map((r) => ({ id: r.id, title: r.title, lessonTitle: r.subtitle, url: r.url }))
+      return NextResponse.json({
+        enrolled: true,
+        results: { lessons, exercises, questions: [] },
+        total: lessons.length + exercises.length,
+      })
+    }
+
     const payload = await getPayload({ config: configPromise })
 
     // 1. Resolve course

--- a/src/app/api/course-search/route.ts
+++ b/src/app/api/course-search/route.ts
@@ -58,6 +58,9 @@ export async function GET(request: NextRequest) {
     if (!courseSlug) {
       const { searchCourseContent } = await import('@/server/repos/queries/course-search')
       const results = await searchCourseContent({ query, limit: 20 })
+      const courses = results
+        .filter((r) => r.type === 'course')
+        .map((r) => ({ id: r.id, title: r.title, url: r.url }))
       const lessons = results
         .filter((r) => r.type === 'lesson')
         .map((r) => ({ id: r.id, title: r.title, type: 'learning', url: r.url }))
@@ -66,8 +69,8 @@ export async function GET(request: NextRequest) {
         .map((r) => ({ id: r.id, title: r.title, lessonTitle: r.subtitle, url: r.url }))
       return NextResponse.json({
         enrolled: true,
-        results: { lessons, exercises, questions: [] },
-        total: lessons.length + exercises.length,
+        results: { courses, lessons, exercises, questions: [] },
+        total: courses.length + lessons.length + exercises.length,
       })
     }
 

--- a/src/client/hooks/useCourseSearch.ts
+++ b/src/client/hooks/useCourseSearch.ts
@@ -46,31 +46,40 @@ export function extractCourseSlugFromPath(pathname: string): string | null {
   return match?.[1] ?? null
 }
 
-/** Pages where course content is displayed (resolved via grade profile) */
-const COURSE_CONTEXT_PAGES = ['/study', '/practice', '/ask']
+interface UseCourseSlugReturn {
+  courseSlug: string | null
+  /** True while resolving the slug from the user's grade profile */
+  isResolving: boolean
+}
 
 /**
  * Resolves the courseSlug from the URL path or the user's grade profile.
- * On /study, /practice, /ask pages the course is determined by the user's
- * selected grade level stored in localStorage.
+ * If the URL contains /courses/[slug], that slug is used directly.
+ * Otherwise, the user's grade level from localStorage is used to look up
+ * their course via the API. This means the search works from ANY page
+ * as long as the user has completed onboarding.
  */
-export function useCourseSlug(pathname: string): string | null {
+export function useCourseSlug(pathname: string): UseCourseSlugReturn {
   const [slugFromProfile, setSlugFromProfile] = useState<string | null>(null)
+  const [isResolving, setIsResolving] = useState(true)
 
   const slugFromPath = extractCourseSlugFromPath(pathname)
-  const isCoursePage = COURSE_CONTEXT_PAGES.some((p) => pathname.startsWith(p))
 
   useEffect(() => {
-    if (slugFromPath || !isCoursePage) {
-      setSlugFromProfile(null)
+    // If we already have a slug from the URL, no need to resolve
+    if (slugFromPath) {
+      setIsResolving(false)
       return
     }
 
     const profile = getUserProfile()
     if (!profile?.gradeLevel) {
       setSlugFromProfile(null)
+      setIsResolving(false)
       return
     }
+
+    setIsResolving(true)
 
     fetch(`/api/chapters/by-grade?grade=${profile.gradeLevel}`)
       .then((res) => (res.ok ? res.json() : null))
@@ -82,9 +91,15 @@ export function useCourseSlug(pathname: string): string | null {
       .catch(() => {
         setSlugFromProfile(null)
       })
-  }, [slugFromPath, isCoursePage, pathname])
+      .finally(() => {
+        setIsResolving(false)
+      })
+  }, [slugFromPath, pathname])
 
-  return slugFromPath ?? slugFromProfile
+  return {
+    courseSlug: slugFromPath ?? slugFromProfile,
+    isResolving: isResolving && !slugFromPath,
+  }
 }
 
 export function useCourseSearch(query: string, courseSlug: string | null): UseCourseSearchReturn {

--- a/src/client/hooks/useCourseSearch.ts
+++ b/src/client/hooks/useCourseSearch.ts
@@ -1,0 +1,101 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useDebounce } from '@/client/hooks/useDebounce'
+
+interface SearchResultLesson {
+  id: string
+  title: string
+  type: string
+  url: string
+}
+
+interface SearchResultExercise {
+  id: string
+  title: string
+  lessonTitle: string
+  url: string
+}
+
+interface SearchResultQuestion {
+  id: string
+  promptSnippet: string
+  exerciseTitle: string
+  url: string
+}
+
+export interface CourseSearchResults {
+  lessons: SearchResultLesson[]
+  exercises: SearchResultExercise[]
+  questions: SearchResultQuestion[]
+}
+
+interface UseCourseSearchReturn {
+  results: CourseSearchResults | null
+  isLoading: boolean
+  enrolled: boolean | null
+  error: string | null
+}
+
+/**
+ * Extract the courseSlug from a pathname like /courses/[courseSlug]/...
+ */
+export function extractCourseSlugFromPath(pathname: string): string | null {
+  const match = pathname.match(/^\/courses\/([^/]+)/)
+  return match?.[1] ?? null
+}
+
+export function useCourseSearch(query: string, courseSlug: string | null): UseCourseSearchReturn {
+  const [results, setResults] = useState<CourseSearchResults | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [enrolled, setEnrolled] = useState<boolean | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const abortControllerRef = useRef<AbortController | null>(null)
+
+  const debouncedQuery = useDebounce(query, 300)
+
+  useEffect(() => {
+    if (!courseSlug || debouncedQuery.length < 2) {
+      setResults(null)
+      setEnrolled(null)
+      setError(null)
+      setIsLoading(false)
+      return
+    }
+
+    abortControllerRef.current?.abort()
+    const controller = new AbortController()
+    abortControllerRef.current = controller
+
+    setIsLoading(true)
+    setError(null)
+
+    const searchUrl = `/api/course-search?q=${encodeURIComponent(debouncedQuery)}&courseSlug=${encodeURIComponent(courseSlug)}`
+
+    fetch(searchUrl, {
+      signal: controller.signal,
+      credentials: 'include',
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error(`Search failed: ${res.status}`)
+        return res.json()
+      })
+      .then((data) => {
+        if (controller.signal.aborted) return
+        setEnrolled(data.enrolled)
+        setResults(data.results)
+        setIsLoading(false)
+      })
+      .catch((err) => {
+        if (err instanceof DOMException && err.name === 'AbortError') return
+        setError(err.message)
+        setIsLoading(false)
+      })
+
+    return () => {
+      controller.abort()
+    }
+  }, [debouncedQuery, courseSlug])
+
+  return { results, isLoading, enrolled, error }
+}

--- a/src/client/hooks/useCourseSearch.ts
+++ b/src/client/hooks/useCourseSearch.ts
@@ -2,7 +2,6 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { useDebounce } from '@/client/hooks/useDebounce'
-import { getUserProfile } from '@/client/state/localStorage/userProfile'
 
 interface SearchResultLesson {
   id: string
@@ -53,60 +52,12 @@ export function extractCourseSlugFromPath(pathname: string): string | null {
   return match?.[1] ?? null
 }
 
-interface UseCourseSlugReturn {
-  courseSlug: string | null
-  /** True while resolving the slug from the user's grade profile */
-  isResolving: boolean
-}
-
 /**
- * Resolves the courseSlug from the URL path or the user's grade profile.
- * If the URL contains /courses/[slug], that slug is used directly.
- * Otherwise, the user's grade level from localStorage is used to look up
- * their course via the API. This means the search works from ANY page
- * as long as the user has completed onboarding.
+ * Returns the courseSlug only if the URL is inside a specific course
+ * (e.g. /courses/[slug]/...). Otherwise returns null for global search.
  */
-export function useCourseSlug(pathname: string): UseCourseSlugReturn {
-  const [slugFromProfile, setSlugFromProfile] = useState<string | null>(null)
-  const [isResolving, setIsResolving] = useState(true)
-
-  const slugFromPath = extractCourseSlugFromPath(pathname)
-
-  useEffect(() => {
-    // If we already have a slug from the URL, no need to resolve
-    if (slugFromPath) {
-      setIsResolving(false)
-      return
-    }
-
-    const profile = getUserProfile()
-    if (!profile?.gradeLevel) {
-      setSlugFromProfile(null)
-      setIsResolving(false)
-      return
-    }
-
-    setIsResolving(true)
-
-    fetch(`/api/chapters/by-grade?grade=${profile.gradeLevel}`)
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data) => {
-        if (data?.courseSlug) {
-          setSlugFromProfile(data.courseSlug)
-        }
-      })
-      .catch(() => {
-        setSlugFromProfile(null)
-      })
-      .finally(() => {
-        setIsResolving(false)
-      })
-  }, [slugFromPath, pathname])
-
-  return {
-    courseSlug: slugFromPath ?? slugFromProfile,
-    isResolving: isResolving && !slugFromPath,
-  }
+export function useCourseSlug(pathname: string): string | null {
+  return extractCourseSlugFromPath(pathname)
 }
 
 export function useCourseSearch(query: string, courseSlug: string | null): UseCourseSearchReturn {

--- a/src/client/hooks/useCourseSearch.ts
+++ b/src/client/hooks/useCourseSearch.ts
@@ -112,7 +112,7 @@ export function useCourseSearch(query: string, courseSlug: string | null): UseCo
   const debouncedQuery = useDebounce(query, 300)
 
   useEffect(() => {
-    if (!courseSlug || debouncedQuery.length < 2) {
+    if (debouncedQuery.length < 2) {
       setResults(null)
       setEnrolled(null)
       setError(null)
@@ -127,7 +127,9 @@ export function useCourseSearch(query: string, courseSlug: string | null): UseCo
     setIsLoading(true)
     setError(null)
 
-    const searchUrl = `/api/course-search?q=${encodeURIComponent(debouncedQuery)}&courseSlug=${encodeURIComponent(courseSlug)}`
+    const params = new URLSearchParams({ q: debouncedQuery })
+    if (courseSlug) params.set('courseSlug', courseSlug)
+    const searchUrl = `/api/course-search?${params.toString()}`
 
     fetch(searchUrl, {
       signal: controller.signal,

--- a/src/client/hooks/useCourseSearch.ts
+++ b/src/client/hooks/useCourseSearch.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { useDebounce } from '@/client/hooks/useDebounce'
+import { getUserProfile } from '@/client/state/localStorage/userProfile'
 
 interface SearchResultLesson {
   id: string
@@ -43,6 +44,47 @@ interface UseCourseSearchReturn {
 export function extractCourseSlugFromPath(pathname: string): string | null {
   const match = pathname.match(/^\/courses\/([^/]+)/)
   return match?.[1] ?? null
+}
+
+/** Pages where course content is displayed (resolved via grade profile) */
+const COURSE_CONTEXT_PAGES = ['/study', '/practice', '/ask']
+
+/**
+ * Resolves the courseSlug from the URL path or the user's grade profile.
+ * On /study, /practice, /ask pages the course is determined by the user's
+ * selected grade level stored in localStorage.
+ */
+export function useCourseSlug(pathname: string): string | null {
+  const [slugFromProfile, setSlugFromProfile] = useState<string | null>(null)
+
+  const slugFromPath = extractCourseSlugFromPath(pathname)
+  const isCoursePage = COURSE_CONTEXT_PAGES.some((p) => pathname.startsWith(p))
+
+  useEffect(() => {
+    if (slugFromPath || !isCoursePage) {
+      setSlugFromProfile(null)
+      return
+    }
+
+    const profile = getUserProfile()
+    if (!profile?.gradeLevel) {
+      setSlugFromProfile(null)
+      return
+    }
+
+    fetch(`/api/chapters/by-grade?grade=${profile.gradeLevel}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data?.courseSlug) {
+          setSlugFromProfile(data.courseSlug)
+        }
+      })
+      .catch(() => {
+        setSlugFromProfile(null)
+      })
+  }, [slugFromPath, isCoursePage, pathname])
+
+  return slugFromPath ?? slugFromProfile
 }
 
 export function useCourseSearch(query: string, courseSlug: string | null): UseCourseSearchReturn {

--- a/src/client/hooks/useCourseSearch.ts
+++ b/src/client/hooks/useCourseSearch.ts
@@ -25,7 +25,14 @@ interface SearchResultQuestion {
   url: string
 }
 
+interface SearchResultCourse {
+  id: string
+  title: string
+  url: string
+}
+
 export interface CourseSearchResults {
+  courses?: SearchResultCourse[]
   lessons: SearchResultLesson[]
   exercises: SearchResultExercise[]
   questions: SearchResultQuestion[]

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -28,6 +28,17 @@
       "myAccount": "My Account",
       "logout": "Logout",
       "loggingOut": "Logging out..."
+    },
+    "courseSearch": {
+      "placeholder": "Search in course...",
+      "noResults": "No results found",
+      "enrollRequired": "You must enroll first",
+      "lessons": "Lessons",
+      "exercises": "Exercises",
+      "questions": "Questions",
+      "minChars": "Type at least 2 characters",
+      "searching": "Searching...",
+      "error": "Search failed. Please try again."
     }
   },
   "auth": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -30,9 +30,10 @@
       "loggingOut": "Logging out..."
     },
     "courseSearch": {
-      "placeholder": "Search in course...",
+      "placeholder": "Search...",
       "noResults": "No results found",
       "enrollRequired": "You must enroll first",
+      "courses": "Courses",
       "lessons": "Lessons",
       "exercises": "Exercises",
       "questions": "Questions",

--- a/src/i18n/he.json
+++ b/src/i18n/he.json
@@ -28,6 +28,17 @@
       "resources": "משאבים",
       "search": "חיפוש",
       "language": "שפה"
+    },
+    "courseSearch": {
+      "placeholder": "חיפוש בקורס...",
+      "noResults": "לא נמצאו תוצאות",
+      "enrollRequired": "תחילה יש להירשם",
+      "lessons": "שיעורים",
+      "exercises": "תרגילים",
+      "questions": "שאלות",
+      "minChars": "הקלד/י לפחות 2 תווים",
+      "searching": "מחפש...",
+      "error": "החיפוש נכשל. אנא נסה שוב."
     }
   },
   "auth": {

--- a/src/i18n/he.json
+++ b/src/i18n/he.json
@@ -30,9 +30,10 @@
       "language": "שפה"
     },
     "courseSearch": {
-      "placeholder": "חיפוש בקורס...",
+      "placeholder": "חיפוש...",
       "noResults": "לא נמצאו תוצאות",
       "enrollRequired": "תחילה יש להירשם",
+      "courses": "קורסים",
       "lessons": "שיעורים",
       "exercises": "תרגילים",
       "questions": "שאלות",

--- a/src/server/repos/queries/course-search.ts
+++ b/src/server/repos/queries/course-search.ts
@@ -1,0 +1,87 @@
+import { cache } from 'react'
+import { getPayload } from 'payload'
+import configPromise from '@payload-config'
+import { buildExerciseUrl, buildLessonUrl } from '@/server/utils/course-url-builder'
+
+interface SearchResult {
+  id: string
+  title: string
+  subtitle: string
+  url: string
+  type: 'lesson' | 'exercise'
+}
+
+/**
+ * Search across all published courses, lessons, and exercises.
+ * Used on the general /search page (not scoped to a single course).
+ */
+export const searchCourseContent = cache(
+  async ({ query, limit = 20 }: { query: string; limit?: number }): Promise<SearchResult[]> => {
+    const payload = await getPayload({ config: configPromise })
+    const results: SearchResult[] = []
+
+    // 1. Search lessons by title
+    const lessonsResult = await payload.find({
+      collection: 'lessons',
+      where: {
+        and: [
+          { title: { like: query } },
+          { status: { equals: 'published' } },
+          { isActive: { equals: true } },
+        ],
+      },
+      limit,
+      pagination: false,
+      depth: 2,
+      overrideAccess: true,
+    })
+
+    for (const lesson of lessonsResult.docs) {
+      const chapter = typeof lesson.chapter === 'object' && lesson.chapter ? lesson.chapter : null
+      const course =
+        chapter && typeof chapter.course === 'object' && chapter.course ? chapter.course : null
+
+      if (!course?.slug || !chapter?.slug || !lesson.slug) continue
+
+      results.push({
+        id: lesson.id,
+        title: lesson.title,
+        subtitle: course.title ?? '',
+        url: buildLessonUrl(course.slug, chapter.slug, lesson.slug),
+        type: 'lesson',
+      })
+    }
+
+    // 2. Search exercises by title
+    const exercisesResult = await payload.find({
+      collection: 'exercises',
+      where: {
+        title: { like: query },
+      },
+      limit,
+      pagination: false,
+      depth: 3,
+      overrideAccess: true,
+    })
+
+    for (const exercise of exercisesResult.docs) {
+      const lesson = typeof exercise.lesson === 'object' && exercise.lesson ? exercise.lesson : null
+      const chapter =
+        lesson && typeof lesson.chapter === 'object' && lesson.chapter ? lesson.chapter : null
+      const course =
+        chapter && typeof chapter.course === 'object' && chapter.course ? chapter.course : null
+
+      if (!course?.slug || !chapter?.slug || !lesson?.slug || !exercise.slug) continue
+
+      results.push({
+        id: exercise.id,
+        title: exercise.title || 'Untitled Exercise',
+        subtitle: lesson.title ?? '',
+        url: buildExerciseUrl(course.slug, chapter.slug, lesson.slug, exercise.slug),
+        type: 'exercise',
+      })
+    }
+
+    return results.slice(0, limit)
+  },
+)

--- a/src/server/repos/queries/course-search.ts
+++ b/src/server/repos/queries/course-search.ts
@@ -8,19 +8,46 @@ interface SearchResult {
   title: string
   subtitle: string
   url: string
-  type: 'lesson' | 'exercise'
+  type: 'course' | 'lesson' | 'exercise'
 }
 
 /**
  * Search across all published courses, lessons, and exercises.
- * Used on the general /search page (not scoped to a single course).
+ * Used on the general /search page and the header dropdown (not scoped to a single course).
  */
 export const searchCourseContent = cache(
   async ({ query, limit = 20 }: { query: string; limit?: number }): Promise<SearchResult[]> => {
     const payload = await getPayload({ config: configPromise })
     const results: SearchResult[] = []
 
-    // 1. Search lessons by title
+    // 1. Search courses by title
+    const coursesResult = await payload.find({
+      collection: 'courses',
+      where: {
+        and: [
+          { title: { like: query } },
+          { status: { equals: 'published' } },
+          { isActive: { equals: true } },
+        ],
+      },
+      limit: 10,
+      pagination: false,
+      depth: 0,
+      overrideAccess: true,
+    })
+
+    for (const course of coursesResult.docs) {
+      if (!course.slug) continue
+      results.push({
+        id: course.id,
+        title: course.title,
+        subtitle: '',
+        url: `/courses/${course.slug}`,
+        type: 'course',
+      })
+    }
+
+    // 2. Search lessons by title
     const lessonsResult = await payload.find({
       collection: 'lessons',
       where: {

--- a/src/server/utils/course-url-builder.ts
+++ b/src/server/utils/course-url-builder.ts
@@ -1,0 +1,25 @@
+/**
+ * URL builder utilities for course content navigation.
+ *
+ * Centralizes URL construction for lessons and exercises
+ * based on the route structure:
+ *   /courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]
+ *   /courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]
+ */
+
+export function buildLessonUrl(
+  courseSlug: string,
+  chapterSlug: string,
+  lessonSlug: string,
+): string {
+  return `/courses/${courseSlug}/chapters/${chapterSlug}/lessons/${lessonSlug}`
+}
+
+export function buildExerciseUrl(
+  courseSlug: string,
+  chapterSlug: string,
+  lessonSlug: string,
+  exerciseSlug: string,
+): string {
+  return `/courses/${courseSlug}/chapters/${chapterSlug}/lessons/${lessonSlug}/exercises/${exerciseSlug}`
+}

--- a/src/ui/web/header/CourseSearch/index.tsx
+++ b/src/ui/web/header/CourseSearch/index.tsx
@@ -14,7 +14,7 @@ interface CourseSearchProps {
 
 export const CourseSearch: React.FC<CourseSearchProps> = ({ variant, onNavigate }) => {
   const pathname = usePathname()
-  const courseSlug = useCourseSlug(pathname)
+  const { courseSlug, isResolving } = useCourseSlug(pathname)
   const t = useTranslations('common.courseSearch')
 
   const [isExpanded, setIsExpanded] = useState(false)
@@ -78,18 +78,21 @@ export const CourseSearch: React.FC<CourseSearchProps> = ({ variant, onNavigate 
     onNavigate?.()
   }, [onNavigate])
 
-  // If not on a course page, show simple search link
-  if (!courseSlug) {
+  // Only fall back to /search link when we're sure there's no course context
+  // (not on a course page AND not still resolving the slug)
+  if (!courseSlug && !isResolving) {
     if (variant === 'mobile') {
       return (
-        <SystemLink
-          href="/search"
-          onClick={onNavigate}
-          className="flex items-center gap-3 py-2 px-3 rounded-lg hover:bg-muted transition-colors"
-        >
-          <SearchIcon className="w-5 h-5 text-primary" />
-          <span className="text-body-md">{t('placeholder')}</span>
-        </SystemLink>
+        <div className="px-6 py-section-xs border-b border-border">
+          <SystemLink
+            href="/search"
+            onClick={onNavigate}
+            className="flex items-center gap-3 py-2 px-3 rounded-lg hover:bg-muted transition-colors"
+          >
+            <SearchIcon className="w-5 h-5 text-primary" />
+            <span className="text-body-md">{t('placeholder')}</span>
+          </SystemLink>
+        </div>
       )
     }
 

--- a/src/ui/web/header/CourseSearch/index.tsx
+++ b/src/ui/web/header/CourseSearch/index.tsx
@@ -14,7 +14,7 @@ interface CourseSearchProps {
 
 export const CourseSearch: React.FC<CourseSearchProps> = ({ variant, onNavigate }) => {
   const pathname = usePathname()
-  const { courseSlug } = useCourseSlug(pathname)
+  const courseSlug = useCourseSlug(pathname)
   const t = useTranslations('common.courseSearch')
 
   const [isExpanded, setIsExpanded] = useState(false)

--- a/src/ui/web/header/CourseSearch/index.tsx
+++ b/src/ui/web/header/CourseSearch/index.tsx
@@ -1,0 +1,337 @@
+'use client'
+
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { SearchIcon, X, Loader2, BookOpen, FileText, HelpCircle } from 'lucide-react'
+import { usePathname } from 'next/navigation'
+import { SystemLink } from '@/infra/loading/components/SystemLink'
+import { useTranslations } from '@/ui/web/providers/I18n'
+import { useCourseSearch, extractCourseSlugFromPath } from '@/client/hooks/useCourseSearch'
+
+interface CourseSearchProps {
+  variant: 'desktop' | 'mobile'
+  onNavigate?: () => void
+}
+
+export const CourseSearch: React.FC<CourseSearchProps> = ({ variant, onNavigate }) => {
+  const pathname = usePathname()
+  const courseSlug = extractCourseSlugFromPath(pathname)
+  const t = useTranslations('common.courseSearch')
+
+  const [isExpanded, setIsExpanded] = useState(false)
+  const [query, setQuery] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const { results, isLoading, enrolled, error } = useCourseSearch(query, courseSlug)
+
+  const showDropdown =
+    isExpanded &&
+    query.length >= 2 &&
+    (isLoading || results !== null || enrolled === false || error)
+
+  // Close on click outside (desktop only)
+  useEffect(() => {
+    if (variant !== 'desktop' || !isExpanded) return
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsExpanded(false)
+        setQuery('')
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [isExpanded, variant])
+
+  // Close on Escape
+  useEffect(() => {
+    if (!isExpanded) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setIsExpanded(false)
+        setQuery('')
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isExpanded])
+
+  // Focus input when expanded
+  useEffect(() => {
+    if (isExpanded && inputRef.current) {
+      inputRef.current.focus()
+    }
+  }, [isExpanded])
+
+  // Close on route change
+  useEffect(() => {
+    setIsExpanded(false)
+    setQuery('')
+  }, [pathname])
+
+  const handleResultClick = useCallback(() => {
+    setIsExpanded(false)
+    setQuery('')
+    onNavigate?.()
+  }, [onNavigate])
+
+  // If not on a course page, show simple search link
+  if (!courseSlug) {
+    if (variant === 'mobile') {
+      return (
+        <SystemLink
+          href="/search"
+          onClick={onNavigate}
+          className="flex items-center gap-3 py-2 px-3 rounded-lg hover:bg-muted transition-colors"
+        >
+          <SearchIcon className="w-5 h-5 text-primary" />
+          <span className="text-body-md">{t('placeholder')}</span>
+        </SystemLink>
+      )
+    }
+
+    return (
+      <SystemLink
+        href="/search"
+        className="p-2 rounded-lg hover:bg-hover transition-colors"
+        aria-label="Search"
+      >
+        <SearchIcon className="w-5" />
+      </SystemLink>
+    )
+  }
+
+  // Desktop: expandable search
+  if (variant === 'desktop') {
+    return (
+      <div ref={containerRef} className="relative">
+        {!isExpanded ? (
+          <button
+            onClick={() => setIsExpanded(true)}
+            className="p-2 rounded-lg hover:bg-hover transition-colors"
+            aria-label="Search"
+          >
+            <SearchIcon className="w-5" />
+          </button>
+        ) : (
+          <div className="flex items-center gap-content-gap-xs">
+            <div className="relative">
+              <SearchIcon className="absolute start-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+              <input
+                ref={inputRef}
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder={t('placeholder')}
+                className="h-9 w-56 rounded-lg border border-border bg-background ps-9 pe-8 text-body-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+              <button
+                onClick={() => {
+                  setIsExpanded(false)
+                  setQuery('')
+                }}
+                className="absolute end-2 top-1/2 -translate-y-1/2 p-0.5 rounded hover:bg-muted transition-colors"
+                aria-label="Close search"
+              >
+                <X className="w-3.5 h-3.5 text-muted-foreground" />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Dropdown */}
+        {showDropdown && (
+          <SearchDropdown
+            results={results}
+            isLoading={isLoading}
+            enrolled={enrolled}
+            error={error}
+            t={t}
+            onResultClick={handleResultClick}
+          />
+        )}
+      </div>
+    )
+  }
+
+  // Mobile: always show input
+  return (
+    <div ref={containerRef} className="relative px-6 py-section-xs border-b border-border">
+      <div className="relative">
+        <SearchIcon className="absolute start-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={t('placeholder')}
+          className="h-10 w-full rounded-lg border border-border bg-background ps-9 pe-3 text-body-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+      </div>
+
+      {/* Dropdown */}
+      {showDropdown && (
+        <SearchDropdown
+          results={results}
+          isLoading={isLoading}
+          enrolled={enrolled}
+          error={error}
+          t={t}
+          onResultClick={handleResultClick}
+          mobile
+        />
+      )}
+    </div>
+  )
+}
+
+interface SearchDropdownProps {
+  results: {
+    lessons: Array<{ id: string; title: string; type: string; url: string }>
+    exercises: Array<{ id: string; title: string; lessonTitle: string; url: string }>
+    questions: Array<{ id: string; promptSnippet: string; exerciseTitle: string; url: string }>
+  } | null
+  isLoading: boolean
+  enrolled: boolean | null
+  error: string | null
+  t: (key: string) => string
+  onResultClick: () => void
+  mobile?: boolean
+}
+
+const SearchDropdown: React.FC<SearchDropdownProps> = ({
+  results,
+  isLoading,
+  enrolled,
+  error,
+  t,
+  onResultClick,
+  mobile,
+}) => {
+  const positionClass = mobile ? 'mt-2 w-full' : 'absolute top-full end-0 mt-2 w-80'
+
+  return (
+    <div
+      className={`${positionClass} rounded-lg border border-border bg-background shadow-card z-50 max-h-80 overflow-y-auto`}
+    >
+      {/* Loading */}
+      {isLoading && (
+        <div className="flex items-center gap-content-gap-xs p-card-padding-sm text-muted-foreground">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          <span className="text-body-sm">{t('searching')}</span>
+        </div>
+      )}
+
+      {/* Not enrolled */}
+      {!isLoading && enrolled === false && (
+        <div className="p-card-padding-sm text-center text-body-sm text-warning">
+          {t('enrollRequired')}
+        </div>
+      )}
+
+      {/* Error */}
+      {!isLoading && error && (
+        <div className="p-card-padding-sm text-center text-body-sm text-destructive">
+          {t('error')}
+        </div>
+      )}
+
+      {/* Results */}
+      {!isLoading && enrolled === true && results && (
+        <>
+          {results.lessons.length === 0 &&
+            results.exercises.length === 0 &&
+            results.questions.length === 0 && (
+              <div className="p-card-padding-sm text-center text-body-sm text-muted-foreground">
+                {t('noResults')}
+              </div>
+            )}
+
+          {/* Lessons */}
+          {results.lessons.length > 0 && (
+            <SearchSection icon={BookOpen} title={t('lessons')}>
+              {results.lessons.map((lesson) => (
+                <SearchResultItem
+                  key={lesson.id}
+                  href={lesson.url}
+                  title={lesson.title}
+                  subtitle={lesson.type}
+                  onClick={onResultClick}
+                />
+              ))}
+            </SearchSection>
+          )}
+
+          {/* Exercises */}
+          {results.exercises.length > 0 && (
+            <SearchSection icon={FileText} title={t('exercises')}>
+              {results.exercises.map((exercise) => (
+                <SearchResultItem
+                  key={exercise.id}
+                  href={exercise.url}
+                  title={exercise.title}
+                  subtitle={exercise.lessonTitle}
+                  onClick={onResultClick}
+                />
+              ))}
+            </SearchSection>
+          )}
+
+          {/* Questions */}
+          {results.questions.length > 0 && (
+            <SearchSection icon={HelpCircle} title={t('questions')}>
+              {results.questions.map((question) => (
+                <SearchResultItem
+                  key={question.id}
+                  href={question.url}
+                  title={question.promptSnippet}
+                  subtitle={question.exerciseTitle}
+                  onClick={onResultClick}
+                />
+              ))}
+            </SearchSection>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+interface SearchSectionProps {
+  icon: React.FC<{ className?: string }>
+  title: string
+  children: React.ReactNode
+}
+
+const SearchSection: React.FC<SearchSectionProps> = ({ icon: Icon, title, children }) => (
+  <div className="border-b border-border last:border-b-0">
+    <div className="flex items-center gap-content-gap-xs px-3 py-2 bg-muted/30">
+      <Icon className="w-3.5 h-3.5 text-muted-foreground" />
+      <span className="text-body-xs font-semibold text-muted-foreground uppercase tracking-wider">
+        {title}
+      </span>
+    </div>
+    <div>{children}</div>
+  </div>
+)
+
+interface SearchResultItemProps {
+  href: string
+  title: string
+  subtitle: string
+  onClick: () => void
+}
+
+const SearchResultItem: React.FC<SearchResultItemProps> = ({ href, title, subtitle, onClick }) => (
+  <SystemLink
+    href={href}
+    onClick={onClick}
+    className="block px-3 py-2 hover:bg-muted transition-colors"
+  >
+    <p className="text-body-sm text-foreground truncate">{title}</p>
+    {subtitle && <p className="text-body-xs text-muted-foreground truncate">{subtitle}</p>}
+  </SystemLink>
+)

--- a/src/ui/web/header/CourseSearch/index.tsx
+++ b/src/ui/web/header/CourseSearch/index.tsx
@@ -5,7 +5,7 @@ import { SearchIcon, X, Loader2, BookOpen, FileText, HelpCircle } from 'lucide-r
 import { usePathname } from 'next/navigation'
 import { SystemLink } from '@/infra/loading/components/SystemLink'
 import { useTranslations } from '@/ui/web/providers/I18n'
-import { useCourseSearch, extractCourseSlugFromPath } from '@/client/hooks/useCourseSearch'
+import { useCourseSearch, useCourseSlug } from '@/client/hooks/useCourseSearch'
 
 interface CourseSearchProps {
   variant: 'desktop' | 'mobile'
@@ -14,7 +14,7 @@ interface CourseSearchProps {
 
 export const CourseSearch: React.FC<CourseSearchProps> = ({ variant, onNavigate }) => {
   const pathname = usePathname()
-  const courseSlug = extractCourseSlugFromPath(pathname)
+  const courseSlug = useCourseSlug(pathname)
   const t = useTranslations('common.courseSearch')
 
   const [isExpanded, setIsExpanded] = useState(false)

--- a/src/ui/web/header/CourseSearch/index.tsx
+++ b/src/ui/web/header/CourseSearch/index.tsx
@@ -14,7 +14,7 @@ interface CourseSearchProps {
 
 export const CourseSearch: React.FC<CourseSearchProps> = ({ variant, onNavigate }) => {
   const pathname = usePathname()
-  const { courseSlug, isResolving } = useCourseSlug(pathname)
+  const { courseSlug } = useCourseSlug(pathname)
   const t = useTranslations('common.courseSearch')
 
   const [isExpanded, setIsExpanded] = useState(false)
@@ -77,35 +77,6 @@ export const CourseSearch: React.FC<CourseSearchProps> = ({ variant, onNavigate 
     setQuery('')
     onNavigate?.()
   }, [onNavigate])
-
-  // Only fall back to /search link when we're sure there's no course context
-  // (not on a course page AND not still resolving the slug)
-  if (!courseSlug && !isResolving) {
-    if (variant === 'mobile') {
-      return (
-        <div className="px-6 py-section-xs border-b border-border">
-          <SystemLink
-            href="/search"
-            onClick={onNavigate}
-            className="flex items-center gap-3 py-2 px-3 rounded-lg hover:bg-muted transition-colors"
-          >
-            <SearchIcon className="w-5 h-5 text-primary" />
-            <span className="text-body-md">{t('placeholder')}</span>
-          </SystemLink>
-        </div>
-      )
-    }
-
-    return (
-      <SystemLink
-        href="/search"
-        className="p-2 rounded-lg hover:bg-hover transition-colors"
-        aria-label="Search"
-      >
-        <SearchIcon className="w-5" />
-      </SystemLink>
-    )
-  }
 
   // Desktop: expandable search
   if (variant === 'desktop') {

--- a/src/ui/web/header/CourseSearch/index.tsx
+++ b/src/ui/web/header/CourseSearch/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { SearchIcon, X, Loader2, BookOpen, FileText, HelpCircle } from 'lucide-react'
+import { SearchIcon, X, Loader2, BookOpen, FileText, HelpCircle, GraduationCap } from 'lucide-react'
 import { usePathname } from 'next/navigation'
 import { SystemLink } from '@/infra/loading/components/SystemLink'
 import { useTranslations } from '@/ui/web/providers/I18n'
@@ -164,6 +164,7 @@ export const CourseSearch: React.FC<CourseSearchProps> = ({ variant, onNavigate 
 
 interface SearchDropdownProps {
   results: {
+    courses?: Array<{ id: string; title: string; url: string }>
     lessons: Array<{ id: string; title: string; type: string; url: string }>
     exercises: Array<{ id: string; title: string; lessonTitle: string; url: string }>
     questions: Array<{ id: string; promptSnippet: string; exerciseTitle: string; url: string }>
@@ -216,13 +217,29 @@ const SearchDropdown: React.FC<SearchDropdownProps> = ({
       {/* Results */}
       {!isLoading && enrolled === true && results && (
         <>
-          {results.lessons.length === 0 &&
+          {(results.courses?.length ?? 0) === 0 &&
+            results.lessons.length === 0 &&
             results.exercises.length === 0 &&
             results.questions.length === 0 && (
               <div className="p-card-padding-sm text-center text-body-sm text-muted-foreground">
                 {t('noResults')}
               </div>
             )}
+
+          {/* Courses */}
+          {results.courses && results.courses.length > 0 && (
+            <SearchSection icon={GraduationCap} title={t('courses')}>
+              {results.courses.map((course) => (
+                <SearchResultItem
+                  key={course.id}
+                  href={course.url}
+                  title={course.title}
+                  subtitle=""
+                  onClick={onResultClick}
+                />
+              ))}
+            </SearchSection>
+          )}
 
           {/* Lessons */}
           {results.lessons.length > 0 && (

--- a/src/ui/web/header/MobileMenu/index.tsx
+++ b/src/ui/web/header/MobileMenu/index.tsx
@@ -3,13 +3,12 @@
 import React, { useEffect, useRef } from 'react'
 import { X, Menu } from 'lucide-react'
 import { CMSLink } from '@/ui/web/Link'
-import { SystemLink } from '@/infra/loading/components/SystemLink'
-import { SearchIcon } from 'lucide-react'
 import type { Header as HeaderType, User } from '@/payload-types'
 import { LanguageSwitcher } from '@/ui/web/LanguageSwitcher'
 import { usePasswordLogin } from '@/ui/web/providers/PasswordLoginProvider'
 import { useTranslations, useLocale } from '@/ui/web/providers/I18n'
 import { getNavItemsForLocale } from '@/ui/web/nav-variants'
+import { CourseSearch } from '@/ui/web/header/CourseSearch'
 import { MobileMenuAuthSection } from './MobileMenuAuthSection'
 
 interface MobileMenuProps {
@@ -126,16 +125,7 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({
             </div>
           )}
 
-          <div className="px-6 py-section-xs border-b border-border">
-            <SystemLink
-              href="/search"
-              onClick={onClose}
-              className="flex items-center gap-3 py-2 px-3 rounded-lg hover:bg-muted transition-colors"
-            >
-              <SearchIcon className="w-5 h-5 text-primary" />
-              <span className="text-body-md">{tMenu('search')}</span>
-            </SystemLink>
-          </div>
+          <CourseSearch variant="mobile" onNavigate={onClose} />
 
           <div className="px-6 py-section-xs">
             <h3 className="text-body-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3">

--- a/src/ui/web/header/Nav/index.tsx
+++ b/src/ui/web/header/Nav/index.tsx
@@ -6,8 +6,8 @@ import type { Header as HeaderType, User } from '@/payload-types'
 
 import { CMSLink } from '@/ui/web/Link'
 import { SystemLink } from '@/infra/loading/components/SystemLink'
-import { SearchIcon } from 'lucide-react'
 import { LanguageSwitcher } from '@/ui/web/LanguageSwitcher'
+import { CourseSearch } from '@/ui/web/header/CourseSearch'
 import { usePasswordLogin } from '@/ui/web/providers/PasswordLoginProvider'
 import { useTranslations, useLocale } from '@/ui/web/providers/I18n'
 import { Button } from '@/ui/web/components/button'
@@ -68,13 +68,7 @@ export const HeaderNav: React.FC<HeaderNavProps> = ({ data, user, isAuthLoading 
       )}
 
       {/* Search */}
-      <SystemLink
-        href="/search"
-        className="p-2 rounded-lg hover:bg-hover transition-colors"
-        aria-label="Search"
-      >
-        <SearchIcon className="w-5" />
-      </SystemLink>
+      <CourseSearch variant="desktop" />
 
       {/* Separator before language switcher */}
       <div className="h-6 w-px bg-border" />


### PR DESCRIPTION
Replace the static /search link in the header with an inline expandable search input that queries course content. On course pages, clicking the search icon opens a text input with a dropdown showing categorized results (Lessons, Exercises, Questions). On non-course pages, the icon falls back to linking to /search.

- New API endpoint GET /api/course-search with Zod validation
- Searches lesson titles, exercise titles, and question prompts
- Enrollment check for paid courses (shows "תחילה יש להירשם")
- 300ms debounced input with AbortController for race conditions
- Desktop (expandable) and mobile (inline) variants
- Hebrew and English translations