### PR TITLE
chore(ci): Reduce artifact retention to 3 days

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           name: coverage-report
           path: coverage/
-          retention-days: 7
+          retention-days: 3
 
       - name: Check for TODO/FIXME in production code
         run: |
@@ -288,7 +288,7 @@ jobs:
         with:
           name: playwright-report-${{ strategy.job-index }}
           path: playwright-report/
-          retention-days: 7
+          retention-days: 3
 
       - name: Upload test results
         if: failure()
@@ -296,7 +296,7 @@ jobs:
         with:
           name: playwright-traces-${{ strategy.job-index }}
           path: test-results/
-          retention-days: 7
+          retention-days: 3
 
   qa-scenarios-core:
     name: QA Scenarios (core)

--- a/.github/workflows/cody.yml
+++ b/.github/workflows/cody.yml
@@ -579,7 +579,7 @@ jobs:
         with:
           name: cody-${{ needs.parse.outputs.task_id }}-${{ github.run_id }}
           path: .tasks/${{ needs.parse.outputs.task_id }}/
-          retention-days: 7
+          retention-days: 3
 
       # Upload LLM recordings if in record mode
       - name: Upload LLM recordings
@@ -589,7 +589,7 @@ jobs:
         with:
           name: llm-recordings
           path: scripts/system-test/recordings/
-          retention-days: 30
+          retention-days: 3
 
       # Clean workspace for self-hosted runners (no-op on GitHub-hosted since VM is discarded)
       - name: Cleanup workspace (self-hosted)

--- a/.github/workflows/kody.yml
+++ b/.github/workflows/kody.yml
@@ -293,7 +293,7 @@ jobs:
         with:
           name: kody-tasks-${{ github.event.inputs.task_id || needs.parse.outputs.task_id }}
           path: .tasks/
-          retention-days: 7
+          retention-days: 3
 
   # ─── Error Notifications ─────────────────────────────────────────────────────
   notify-parse-error:


### PR DESCRIPTION
Artifact storage quota was hit (455 GB), blocking CI builds. Reduced all retention-days from 7-30 days to 3 days to prevent recurrence.