### PR TITLE
Fix dot default color and line label positioning

### DIFF
--- a/src/infra/contracts/graphics/textColors.ts
+++ b/src/infra/contracts/graphics/textColors.ts
@@ -88,6 +88,19 @@ export function getDefaultCanvasElementColor(): string {
   return CSS_VAR_FALLBACKS['--foreground']
 }
 
+/**
+ * Color palette using hardcoded fallback values instead of CSS variable resolution.
+ * Use this in the Payload admin panel where :root CSS variables belong to the
+ * admin theme (e.g. --foreground is white in dark mode) and don't match the
+ * geometry canvas's white background.
+ */
+export function getCanvasColorPalette(): ReadonlyArray<{ label: string; hex: string }> {
+  return PALETTE_VARS.map(({ label, cssVar }) => ({
+    label,
+    hex: CSS_VAR_FALLBACKS[cssVar] ?? '#000000',
+  }))
+}
+
 /** Default canvas background resolved from --card CSS variable */
 export function getDefaultCanvasBackground(): string {
   return cssVarToHex('--card')

--- a/src/ui/admin/ExerciseContentEditor/components/geometry/GeometryCanvas.tsx
+++ b/src/ui/admin/ExerciseContentEditor/components/geometry/GeometryCanvas.tsx
@@ -343,14 +343,29 @@ function syncLineLabels(
 
     const f = fromEl as unknown as { X: () => number; Y: () => number }
     const t = toEl as unknown as { X: () => number; Y: () => number }
-    const offset = line.label.position === 'b' ? -1.5 : 1.5
+    const offsetDist = line.label.position === 'b' ? -1.5 : line.label.position === 'm' ? 0 : 1.5
     const el = board.create(
       'text',
-      [() => (f.X() + t.X()) / 2, () => (f.Y() + t.Y()) / 2 + offset, line.label.value],
+      [
+        () => {
+          const dx = t.X() - f.X()
+          const dy = t.Y() - f.Y()
+          const len = Math.sqrt(dx * dx + dy * dy) || 1
+          return (f.X() + t.X()) / 2 + (-dy / len) * offsetDist
+        },
+        () => {
+          const dx = t.X() - f.X()
+          const dy = t.Y() - f.Y()
+          const len = Math.sqrt(dx * dx + dy * dy) || 1
+          return (f.Y() + t.Y()) / 2 + (dx / len) * offsetDist
+        },
+        line.label.value,
+      ],
       {
         fontSize: line.label.fontSize || 12,
         anchorX: 'middle',
         anchorY: 'middle',
+        display: 'internal',
         rotate: () => {
           const dx = t.X() - f.X()
           const dy = t.Y() - f.Y()

--- a/src/ui/admin/ExerciseContentEditor/components/geometry/LinesPanel.tsx
+++ b/src/ui/admin/ExerciseContentEditor/components/geometry/LinesPanel.tsx
@@ -99,6 +99,28 @@ export const LinesPanel: React.FC<LinesPanelProps> = ({ lines, points, onChange 
                 }
               />
             </div>
+            {line.label?.value && (
+              <div className="panel-field">
+                <span className="panel-field-label">Label Pos</span>
+                <select
+                  className="panel-field-select"
+                  value={line.label?.position || 't'}
+                  onChange={(e) =>
+                    handleUpdate(index, {
+                      label: {
+                        ...line.label,
+                        value: line.label?.value || '',
+                        position: e.target.value as 't' | 'b' | 'm',
+                      },
+                    })
+                  }
+                >
+                  <option value="t">Above</option>
+                  <option value="m">On line</option>
+                  <option value="b">Below</option>
+                </select>
+              </div>
+            )}
             <button
               type="button"
               className="panel-remove-btn"

--- a/src/ui/admin/ExerciseContentEditor/components/geometry/PointsPanel.tsx
+++ b/src/ui/admin/ExerciseContentEditor/components/geometry/PointsPanel.tsx
@@ -4,8 +4,8 @@ import React from 'react'
 import type { GeometrySpecV1 } from '@/infra/contracts/graphics/geometry.v1'
 import {
   cssVarToHex,
-  getDefaultTextColor,
-  getTextColorPalette,
+  getCanvasColorPalette,
+  getDefaultCanvasElementColor,
 } from '@/infra/contracts/graphics/textColors'
 import { Plus, Trash2 } from 'lucide-react'
 
@@ -16,7 +16,7 @@ interface PointsPanelProps {
   onChange: (points: GeoPoint[]) => void
 }
 
-const DEFAULT_POINT_SIZE = 1
+const DEFAULT_POINT_SIZE = 4
 const DEFAULT_POINT_POSITION = 'r' as const
 
 const COMPASS_CELLS = [
@@ -47,7 +47,7 @@ export const PointsPanel: React.FC<PointsPanelProps> = ({ points, onChange }) =>
       x: 0,
       y: 0,
       visible: true,
-      color: getDefaultTextColor(),
+      color: getDefaultCanvasElementColor(),
       size: DEFAULT_POINT_SIZE,
       position: DEFAULT_POINT_POSITION,
     }
@@ -98,11 +98,11 @@ export const PointsPanel: React.FC<PointsPanelProps> = ({ points, onChange }) =>
             <div className="panel-field">
               <span className="panel-field-label">Color</span>
               <div className="color-swatches-row">
-                {getTextColorPalette().map((colorOption) => (
+                {getCanvasColorPalette().map((colorOption) => (
                   <button
                     key={colorOption.hex}
                     type="button"
-                    className={`color-swatch ${point.color === colorOption.hex || (!point.color && colorOption.hex === getDefaultTextColor()) ? 'color-swatch--selected' : ''}`}
+                    className={`color-swatch ${point.color === colorOption.hex || (!point.color && colorOption.hex === getDefaultCanvasElementColor()) ? 'color-swatch--selected' : ''}`}
                     style={{ backgroundColor: colorOption.hex }}
                     title={colorOption.label}
                     onClick={() => handleUpdate(index, { color: colorOption.hex })}

--- a/src/ui/web/exerciserenderer/graphics/geometryElements.ts
+++ b/src/ui/web/exerciserenderer/graphics/geometryElements.ts
@@ -58,13 +58,21 @@ function renderLines(board: JXG.Board, lines: LineSpec[], pointMap: Map<string, 
     board.create('segment', [from, to], attrs)
 
     if (line.label?.value) {
-      const midX = (from.X() + to.X()) / 2
-      const midY = (from.Y() + to.Y()) / 2
-      const offset = line.label.position === 'b' ? -0.5 : 0.5
-      board.create('text', [midX, midY + offset, line.label.value], {
+      const dx = to.X() - from.X()
+      const dy = to.Y() - from.Y()
+      const len = Math.sqrt(dx * dx + dy * dy) || 1
+      const offsetDist = line.label.position === 'b' ? -0.5 : line.label.position === 'm' ? 0 : 0.5
+      const midX = (from.X() + to.X()) / 2 + (-dy / len) * offsetDist
+      const midY = (from.Y() + to.Y()) / 2 + (dx / len) * offsetDist
+      let deg = (Math.atan2(dy, dx) * 180) / Math.PI
+      if (deg > 90) deg -= 180
+      if (deg < -90) deg += 180
+      board.create('text', [midX, midY, line.label.value], {
         fontSize: line.label.fontSize ?? 12,
         anchorX: 'middle',
         anchorY: 'middle',
+        display: 'internal',
+        rotate: deg,
       })
     }
   }


### PR DESCRIPTION
## Summary
- Fix new points defaulting to white by using hardcoded canvas color palette instead of reading CSS vars from :root (which resolves to Payload admin theme colors, not geometry canvas colors)
- Add line label position dropdown (Above / On line / Below) with perpendicular offset so labels move correctly on sloped lines
- Add `display: 'internal'` to line label text so JSXGraph rotation works
- Same fixes applied to web renderer

## Root cause
`cssVarToHex('--foreground')` reads from `:root` where Payload admin's own `--foreground` lives (white in dark mode). The `.geometry-editor` CSS scope remaps it, but `getComputedStyle(document.documentElement)` doesn't see scoped variables. New `getCanvasColorPalette()` uses hardcoded fallbacks that match the white canvas.

## Test plan
- [ ] Create new point - should be dark/black, not white
- [ ] Color palette swatches show correct colors (not white for "Black")
- [ ] Add label to a line, change position between Above/On line/Below
- [ ] Label follows line slope (rotated text)
- [ ] Label offset is perpendicular to line, not just vertical
- [ ] Web renderer shows same label behavior