### PR TITLE
fix(ci): Upload build artifact on main push for QA Scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,9 @@ jobs:
         run: pnpm build
 
       - name: Upload build artifact
-        if: github.event_name == 'workflow_dispatch' && inputs.run_e2e_tests == true
+        if: >-
+          (github.event_name == 'workflow_dispatch' && inputs.run_e2e_tests == true) ||
+          (github.event_name == 'push' && github.ref == 'refs/heads/main')
         uses: actions/upload-artifact@v4
         with:
           name: next-build


### PR DESCRIPTION
## Summary
- QA Scenarios (full) runs on every push to main but the build artifact (`next-build`) was only uploaded on `workflow_dispatch` events
- This caused `Artifact not found for name: next-build` errors on every main push
- Now uploads the artifact on main pushes as well

## Test plan
- [ ] CI checks pass on this PR
- [ ] After merge, the next push-to-main CI run should have QA Scenarios (full) pass