### PR TITLE
fix(ci): Downgrade actions to v4 and reduce artifact storage

### DIFF
--- a/.github/workflows/ai-docs-refresh.yml
+++ b/.github/workflows/ai-docs-refresh.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -30,7 +30,7 @@ jobs:
           version: 9
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: pnpm

--- a/.github/workflows/atlas-integration.yml
+++ b/.github/workflows/atlas-integration.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -28,7 +28,7 @@ jobs:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'pnpm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -38,7 +38,7 @@ jobs:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
-        if: always()
+        if: failure()
         with:
           name: coverage-report
           path: coverage/
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -121,7 +121,7 @@ jobs:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -159,7 +159,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -169,7 +169,7 @@ jobs:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -181,24 +181,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .next
-          key: ${{ runner.os }}-next-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-next-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-next-
 
       - name: Build application
         run: pnpm build
-
-      - name: Upload build artifact
-        if: >-
-          (github.event_name == 'workflow_dispatch' && inputs.run_e2e_tests == true) ||
-          (github.event_name == 'push' && github.ref == 'refs/heads/main')
-        uses: actions/upload-artifact@v4
-        with:
-          name: next-build
-          path: .next/
-          retention-days: 1
-          if-no-files-found: error
-          include-hidden-files: true
 
   e2e-system-tests:
     name: E2E System Tests (${{ matrix.shard }})
@@ -232,7 +220,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -242,18 +230,19 @@ jobs:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'pnpm'
 
-      - name: Download build artifact
+      - name: Restore .next build from cache
         if: needs.build.result == 'success'
-        uses: actions/download-artifact@v4
+        uses: actions/cache/restore@v4
         with:
-          name: next-build
-          path: .next/
-          merge-multiple: false
+          path: .next
+          key: ${{ runner.os }}-next-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-next-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -329,7 +318,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -339,17 +328,18 @@ jobs:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'pnpm'
 
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
+      - name: Restore .next build from cache
+        uses: actions/cache/restore@v4
         with:
-          name: next-build
-          path: .next/
-          merge-multiple: false
+          path: .next
+          key: ${{ runner.os }}-next-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-next-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -412,7 +402,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -422,17 +412,18 @@ jobs:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'pnpm'
 
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
+      - name: Restore .next build from cache
+        uses: actions/cache/restore@v4
         with:
-          name: next-build
-          path: .next/
-          merge-multiple: false
+          path: .next
+          key: ${{ runner.os }}-next-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-next-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/deps-security-report.yml
+++ b/.github/workflows/deps-security-report.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -28,7 +28,7 @@ jobs:
           version: 9
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: pnpm
@@ -45,3 +45,4 @@ jobs:
           name: deps-security-report
           path: .ai-docs/reports/deps-security-report.md
           if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/doc-link-fixer.yml
+++ b/.github/workflows/doc-link-fixer.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -31,7 +31,7 @@ jobs:
           version: 9
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: pnpm

--- a/.github/workflows/merge-dev-to-main.yml
+++ b/.github/workflows/merge-dev-to-main.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/preview-validation.yml
+++ b/.github/workflows/preview-validation.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Wait for deployment to be fully ready
         run: sleep 15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Fetch all history for semantic-release
           token: ${{ secrets.GH_PAT }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
 

--- a/.github/workflows/repo-hygiene-report.yml
+++ b/.github/workflows/repo-hygiene-report.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -28,7 +28,7 @@ jobs:
           version: 9
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: pnpm
@@ -45,3 +45,4 @@ jobs:
           name: repo-hygiene-report
           path: .ai-docs/reports/repo-hygiene-report.md
           if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -42,7 +42,7 @@ jobs:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'pnpm'


### PR DESCRIPTION
## Summary
- Downgrade all `actions/checkout@v6` and `actions/setup-node@v6` references back to `@v4` across 11 workflow files (v6 doesn't exist, causing all CI jobs to fail)
- Replace `.next/` build artifact upload with cache-based sharing between jobs (reduces artifact storage usage)
- Make coverage report upload conditional on failure only
- Add `retention-days: 1` to report artifact uploads that were missing it

## Test plan
- [ ] CI passes the checkout step on this PR
- [ ] Verify no `@v6` references remain in workflow files
- [ ] Monitor artifact storage usage over the next day

🤖 Generated with [Claude Code](https://claude.com/claude-code)