### PR TITLE
feat: Scale LaTeX parser to handle all 55 lesson formats

### DIFF
--- a/src/lib/latex-parser/enumerate-parser.ts
+++ b/src/lib/latex-parser/enumerate-parser.ts
@@ -38,18 +38,47 @@ function _indexToLabel(index: number): string {
   return String.fromCharCode(96 + index) // 1->a, 2->b, etc.
 }
 
+/** Find matching closing brace with nesting support. */
+function findMatchingBrace(text: string, openPos: number): number {
+  let depth = 1
+  for (let i = openPos + 1; i < text.length; i++) {
+    if (text[i] === '{') depth++
+    else if (text[i] === '}') {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+  return -1
+}
+
 /**
- * Strip \color{...}, {\color{...} ...}, \Large, etc. from any string.
- * Matches full balanced brace groups to avoid eating legitimate closing braces.
+ * Strip {\color{...} content} groups using brace counting
+ * to handle nested braces like \frac{1}{...}.
  */
 function stripColorAndSizing(text: string): string {
   let result = text
-  // Match full balanced group: {\Large\color{name} content} → content
-  result = result.replace(/\{\\(?:Large|large|huge|Huge)\s*\\color\{[^}]*\}\s*([^}]*)\}/g, '$1')
-  result = result.replace(/\{\\color\{[^}]*\}\s*([^}]*)\}/g, '$1')
-  result = result.replace(/\{\\(?:Large|large|huge|Huge)\s*([^}]*)\}/g, '$1')
-  // Strip bare commands
-  result = result
+  let i = 0
+  let output = ''
+  while (i < result.length) {
+    if (result[i] === '{') {
+      const after = result.slice(i + 1)
+      const cmdMatch =
+        /^\\(?:Large|large|huge|Huge)\s*\\color\{[^}]*\}\s*/.exec(after) ||
+        /^\\color\{[^}]*\}\s*/.exec(after) ||
+        /^\\(?:Large|large|huge|Huge)\s*/.exec(after)
+      if (cmdMatch) {
+        const closingBrace = findMatchingBrace(result, i)
+        if (closingBrace > i) {
+          output += result.slice(i + 1 + cmdMatch[0].length, closingBrace)
+          i = closingBrace + 1
+          continue
+        }
+      }
+    }
+    output += result[i]
+    i++
+  }
+  result = output
     .replace(/\\(?:Large|large|huge|Huge|normalsize|small|footnotesize|tiny)\s*/g, '')
     .replace(/\\color\{[^}]*\}/g, '')
     .replace(/\\definecolor\{[^}]*\}\{[^}]*\}\{[^}]*\}/g, '')

--- a/src/lib/latex-parser/enumerate-parser.ts
+++ b/src/lib/latex-parser/enumerate-parser.ts
@@ -40,18 +40,19 @@ function _indexToLabel(index: number): string {
 
 /**
  * Strip \color{...}, {\color{...} ...}, \Large, etc. from any string.
- * Shared between text and math contexts.
+ * Matches full balanced brace groups to avoid eating legitimate closing braces.
  */
 function stripColorAndSizing(text: string): string {
-  let result = text.replace(/\{\\(?:color\{[^}]*\}|Large|large|huge|Huge)\s*/g, '')
+  let result = text
+  // Match full balanced group: {\Large\color{name} content} → content
+  result = result.replace(/\{\\(?:Large|large|huge|Huge)\s*\\color\{[^}]*\}\s*([^}]*)\}/g, '$1')
+  result = result.replace(/\{\\color\{[^}]*\}\s*([^}]*)\}/g, '$1')
+  result = result.replace(/\{\\(?:Large|large|huge|Huge)\s*([^}]*)\}/g, '$1')
+  // Strip bare commands
   result = result
     .replace(/\\(?:Large|large|huge|Huge|normalsize|small|footnotesize|tiny)\s*/g, '')
     .replace(/\\color\{[^}]*\}/g, '')
     .replace(/\\definecolor\{[^}]*\}\{[^}]*\}\{[^}]*\}/g, '')
-  // Clean orphaned } inside $...$ math expressions
-  result = result.replace(/(\$[^$]*?)\s*\}\s*(\$)/g, '$1$2')
-  result = result.replace(/\s+\}(?=[\s,.)$])/g, '')
-  result = result.replace(/\s*\}\s*$/g, '')
   return result
 }
 

--- a/src/lib/latex-parser/enumerate-parser.ts
+++ b/src/lib/latex-parser/enumerate-parser.ts
@@ -33,23 +33,37 @@ function isExerciseEnumerate(envContent: string): boolean {
   return hasArabicLabel && hasLargeSpacing
 }
 
-/** Convert a 1-based index to a Hebrew-style label (a, b, c...) */
-function indexToLabel(index: number): string {
+/** Convert a 1-based index to a label (a, b, c...) — kept for potential future use */
+function _indexToLabel(index: number): string {
   return String.fromCharCode(96 + index) // 1->a, 2->b, etc.
+}
+
+/**
+ * Strip \color{...}, {\color{...} ...}, \Large, etc. from any string.
+ * Shared between text and math contexts.
+ */
+function stripColorAndSizing(text: string): string {
+  let result = text.replace(/\{\\(?:color\{[^}]*\}|Large|large|huge|Huge)\s*/g, '')
+  result = result
+    .replace(/\\(?:Large|large|huge|Huge|normalsize|small|footnotesize|tiny)\s*/g, '')
+    .replace(/\\color\{[^}]*\}/g, '')
+    .replace(/\\definecolor\{[^}]*\}\{[^}]*\}\{[^}]*\}/g, '')
+  // Clean orphaned } inside $...$ math expressions
+  result = result.replace(/(\$[^$]*?)\s*\}\s*(\$)/g, '$1$2')
+  result = result.replace(/\s+\}(?=[\s,.)$])/g, '')
+  result = result.replace(/\s*\}\s*$/g, '')
+  return result
 }
 
 /** Clean LaTeX formatting from item text */
 function cleanItemText(text: string): string {
   return (
-    text
+    stripColorAndSizing(text)
       // Convert \begin{itemize}...\end{itemize} to bullet points
       .replace(/\\begin\{itemize\}([\s\S]*?)\\end\{itemize\}/g, (_match, inner: string) => {
         const items = inner.split(/\\item\s*/).filter((s: string) => s.trim())
         return items.map((item: string) => `\n• ${item.trim()}`).join('')
       })
-      // Strip color commands
-      .replace(/\{\\color\{[^}]*\}\s*/g, '')
-      .replace(/\\color\{[^}]*\}/g, '')
       .replace(/\\textbf\{([^}]*)\}/g, '**$1**')
       .replace(/\\textit\{([^}]*)\}/g, '*$1*')
       .replace(/\\emph\{([^}]*)\}/g, '*$1*')
@@ -77,13 +91,23 @@ export function parseEnumerate(innerContent: string): ContentBlock[] {
   const startIndex = parseStartIndex(innerContent)
   const isNumbered = isExerciseEnumerate(innerContent)
 
-  // Pre-process: convert nested \begin{itemize}...\end{itemize} to bullet text
+  // Pre-process: convert nested environments to inline text
   // before splitting on \item, to avoid splitting inside nested environments
-  const preprocessed = innerContent.replace(
+  let preprocessed = innerContent
+  // Convert \begin{itemize}...\end{itemize} to inline bullet text
+  preprocessed = preprocessed.replace(
     /\\begin\{itemize\}([\s\S]*?)\\end\{itemize\}/g,
     (_match, inner: string) => {
       const items = inner.split(/\\item\s*/).filter((s: string) => s.trim())
       return items.map((item: string) => `\n(${item.trim()})`).join(' ')
+    },
+  )
+  // Convert nested \begin{enumerate}...\end{enumerate} (MCQ sub-options) to inline text
+  preprocessed = preprocessed.replace(
+    /\\begin\{enumerate\}\s*\[label=\(\\textbf\{\\arabic\*\}\)[^\]]*\]([\s\S]*?)\\end\{enumerate\}/g,
+    (_match, inner: string) => {
+      const items = inner.split(/\\item\s*/).filter((s: string) => s.trim())
+      return items.map((item: string, idx: number) => `\n(${idx + 1}) ${item.trim()}`).join('')
     },
   )
 
@@ -95,18 +119,9 @@ export function parseEnumerate(innerContent: string): ContentBlock[] {
     const raw = parts[i].trim()
     if (!raw) continue
 
-    // Check for explicit label: [\textbf{א.}] or [\textbf{(1)}] at the start
+    // Strip explicit label: [\textbf{א.}] or [\textbf{(1)}] at the start
     const explicitLabelMatch = /^\[\\textbf\{([^}]*)\}\]\s*/.exec(raw)
-    let label: string
-    let content: string
-
-    if (explicitLabelMatch) {
-      label = explicitLabelMatch[1].replace(/\.$/, '') // "א." → "א"
-      content = raw.slice(explicitLabelMatch[0].length).trim()
-    } else {
-      label = isNumbered ? String(startIndex + i - 1) : indexToLabel(startIndex + i - 1)
-      content = raw
-    }
+    const content = explicitLabelMatch ? raw.slice(explicitLabelMatch[0].length).trim() : raw
 
     const cleaned = cleanItemText(content)
     if (!cleaned) continue
@@ -118,7 +133,8 @@ export function parseEnumerate(innerContent: string): ContentBlock[] {
       blocks.push(makeRichTextBlock(`## תרגיל ${num}`))
     }
 
-    blocks.push(makeFreeResponseBlock(`${label}. ${cleaned}`))
+    // Don't prepend labels — the frontend handles numbering automatically
+    blocks.push(makeFreeResponseBlock(cleaned))
   }
 
   return blocks

--- a/src/lib/latex-parser/enumerate-parser.ts
+++ b/src/lib/latex-parser/enumerate-parser.ts
@@ -69,9 +69,11 @@ function cleanItemText(text: string): string {
       .replace(/\\emph\{([^}]*)\}/g, '*$1*')
       .replace(/\\underline\{([^}]*)\}/g, '$1')
       .replace(/\\text\{([^}]*)\}/g, '$1')
-      .replace(/\\\\/g, '\n')
-      .replace(/\\vspace\{[^}]*\}/g, '')
+      .replace(/\\\\/g, ' ')
+      .replace(/\\vspace\{[^}]*\}/g, ' ')
       .replace(/\\noindent/g, '')
+      // Collapse whitespace into single spaces
+      .replace(/\s+/g, ' ')
       .trim()
   )
 }

--- a/src/lib/latex-parser/enumerate-parser.ts
+++ b/src/lib/latex-parser/enumerate-parser.ts
@@ -65,6 +65,16 @@ function cleanItemText(text: string): string {
         const items = inner.split(/\\item\s*/).filter((s: string) => s.trim())
         return items.map((item: string) => `\n• ${item.trim()}`).join('')
       })
+      // Strip leaked environment tags
+      .replace(
+        /\\(?:begin|end)\{(?:enumerate|center|itemize|tabular\*?|tcolorbox)\}(?:\[[^\]]*\])?/g,
+        '',
+      )
+      .replace(/\\selectlanguage\{[^}]*\}/g, '')
+      // Strip tikzpicture blocks that leaked into items
+      .replace(/\\begin\{tikzpicture\}[\s\S]*?\\end\{tikzpicture\}/g, '')
+      // Strip [(N)] labels that survived pre-processing
+      .replace(/^\[\(?\d+\)?\]\s*/g, '')
       .replace(/\\textbf\{([^}]*)\}/g, '**$1**')
       .replace(/\\textit\{([^}]*)\}/g, '*$1*')
       .replace(/\\emph\{([^}]*)\}/g, '*$1*')
@@ -122,8 +132,10 @@ export function parseEnumerate(innerContent: string): ContentBlock[] {
     const raw = parts[i].trim()
     if (!raw) continue
 
-    // Strip explicit label: [\textbf{א.}] or [\textbf{(1)}] at the start
-    const explicitLabelMatch = /^\[\\textbf\{([^}]*)\}\]\s*/.exec(raw)
+    // Strip explicit label at the start:
+    //   [\textbf{א.}]  [\textbf{(1)}]  [(1)]  [(א)]  [א.]
+    const explicitLabelMatch =
+      /^\[\\textbf\{([^}]*)\}\]\s*/.exec(raw) || /^\[\(?[\u0590-\u05FFa-z\d]+\.?\)?\]\s*/.exec(raw)
     const content = explicitLabelMatch ? raw.slice(explicitLabelMatch[0].length).trim() : raw
 
     const cleaned = cleanItemText(content)

--- a/src/lib/latex-parser/enumerate-parser.ts
+++ b/src/lib/latex-parser/enumerate-parser.ts
@@ -20,6 +20,19 @@ function parseStartIndex(envContent: string): number {
   return startMatch ? parseInt(startMatch[1], 10) : 1
 }
 
+/**
+ * Detect if this enumerate is a top-level exercise list.
+ * Must use \arabic*. label (with period, not parens) AND have large itemsep.
+ * This distinguishes exercise lists from MCQ sub-options.
+ */
+function isExerciseEnumerate(envContent: string): boolean {
+  // Must have \arabic*. or \arabic* followed by a period in the label
+  const hasArabicLabel = /label\s*=\s*\\textbf\{\\arabic\*\.\}/.test(envContent)
+  // Large itemsep indicates exercise-level spacing (>= 1cm)
+  const hasLargeSpacing = /itemsep\s*=\s*(1(\.\d+)?|[2-9](\.\d+)?)\s*cm/.test(envContent)
+  return hasArabicLabel && hasLargeSpacing
+}
+
 /** Convert a 1-based index to a Hebrew-style label (a, b, c...) */
 function indexToLabel(index: number): string {
   return String.fromCharCode(96 + index) // 1->a, 2->b, etc.
@@ -27,50 +40,85 @@ function indexToLabel(index: number): string {
 
 /** Clean LaTeX formatting from item text */
 function cleanItemText(text: string): string {
-  return text
-    .replace(/\\textbf\{([^}]*)\}/g, '**$1**')
-    .replace(/\\textit\{([^}]*)\}/g, '*$1*')
-    .replace(/\\emph\{([^}]*)\}/g, '*$1*')
-    .replace(/\\underline\{([^}]*)\}/g, '$1')
-    .replace(/\\text\{([^}]*)\}/g, '$1')
-    .replace(/\\\\/g, '\n')
-    .replace(/\\vspace\{[^}]*\}/g, '')
-    .replace(/\\noindent/g, '')
-    .trim()
+  return (
+    text
+      // Convert \begin{itemize}...\end{itemize} to bullet points
+      .replace(/\\begin\{itemize\}([\s\S]*?)\\end\{itemize\}/g, (_match, inner: string) => {
+        const items = inner.split(/\\item\s*/).filter((s: string) => s.trim())
+        return items.map((item: string) => `\n• ${item.trim()}`).join('')
+      })
+      // Strip color commands
+      .replace(/\{\\color\{[^}]*\}\s*/g, '')
+      .replace(/\\color\{[^}]*\}/g, '')
+      .replace(/\\textbf\{([^}]*)\}/g, '**$1**')
+      .replace(/\\textit\{([^}]*)\}/g, '*$1*')
+      .replace(/\\emph\{([^}]*)\}/g, '*$1*')
+      .replace(/\\underline\{([^}]*)\}/g, '$1')
+      .replace(/\\text\{([^}]*)\}/g, '$1')
+      .replace(/\\\\/g, '\n')
+      .replace(/\\vspace\{[^}]*\}/g, '')
+      .replace(/\\noindent/g, '')
+      .trim()
+  )
 }
 
 /**
  * Parses the inner content of an enumerate environment into content blocks.
  * Each \item becomes a question_free_response block.
+ *
+ * Supports two label styles:
+ *   - label=\alph*. with optional start=N  →  auto-generated a, b, c labels
+ *   - \item[\textbf{א.}] explicit Hebrew labels
  */
 export function parseEnumerate(innerContent: string): ContentBlock[] {
   const blocks: ContentBlock[] = []
 
   // Extract start index from the enumerate options (if present in the raw env text)
   const startIndex = parseStartIndex(innerContent)
+  const isNumbered = isExerciseEnumerate(innerContent)
 
-  // Split on \item markers
-  const parts = innerContent.split(/\\item\s*/)
+  // Pre-process: convert nested \begin{itemize}...\end{itemize} to bullet text
+  // before splitting on \item, to avoid splitting inside nested environments
+  const preprocessed = innerContent.replace(
+    /\\begin\{itemize\}([\s\S]*?)\\end\{itemize\}/g,
+    (_match, inner: string) => {
+      const items = inner.split(/\\item\s*/).filter((s: string) => s.trim())
+      return items.map((item: string) => `\n(${item.trim()})`).join(' ')
+    },
+  )
+
+  // Split on \item markers — handles both \item and \item[label]
+  const parts = preprocessed.split(/\\item\s*/)
 
   // First part is pre-item text (options, whitespace) — skip it
   for (let i = 1; i < parts.length; i++) {
     const raw = parts[i].trim()
     if (!raw) continue
 
-    const label = indexToLabel(startIndex + i - 1)
-    const cleaned = cleanItemText(raw)
+    // Check for explicit label: [\textbf{א.}] or [\textbf{(1)}] at the start
+    const explicitLabelMatch = /^\[\\textbf\{([^}]*)\}\]\s*/.exec(raw)
+    let label: string
+    let content: string
 
+    if (explicitLabelMatch) {
+      label = explicitLabelMatch[1].replace(/\.$/, '') // "א." → "א"
+      content = raw.slice(explicitLabelMatch[0].length).trim()
+    } else {
+      label = isNumbered ? String(startIndex + i - 1) : indexToLabel(startIndex + i - 1)
+      content = raw
+    }
+
+    const cleaned = cleanItemText(content)
     if (!cleaned) continue
 
-    // Check if this has sub-parts like (1), (2)
-    const hasSubParts = /\(1\)/.test(cleaned)
-
-    if (hasSubParts) {
-      // Keep as a single free response with sub-parts in the prompt
-      blocks.push(makeFreeResponseBlock(`${label}. ${cleaned}`))
-    } else {
-      blocks.push(makeFreeResponseBlock(`${label}. ${cleaned}`))
+    // For numbered exercises (\arabic* label), emit an exercise heading
+    // so that parseLatexToExercises can split on it
+    if (isNumbered) {
+      const num = startIndex + i - 1
+      blocks.push(makeRichTextBlock(`## תרגיל ${num}`))
     }
+
+    blocks.push(makeFreeResponseBlock(`${label}. ${cleaned}`))
   }
 
   return blocks
@@ -95,20 +143,48 @@ export function parseEnumerateSolutions(innerContent: string): string[] {
 
 /**
  * Checks if this is a solution section header.
- * Matches: \section*{פתרון תרגיל 1} or similar Hebrew patterns.
+ * Matches: \section*{פתרון תרגיל 1}, \subsection*{פתרון תרגיל 1},
+ * \textbf{פתרון שאלה 1:}, \section*{פתרונות לתרגילים},
+ * \subsection*{תשובה סופית - שאלה 1}
  */
 export function isSolutionHeader(text: string): boolean {
-  return /\\section\*?\{פתרון/.test(text)
+  return (
+    /\\(?:section|subsection)\*?\{פתרון/.test(text) ||
+    /\\(?:section|subsection)\*?\{פתרונות/.test(text) ||
+    /\\textbf\{פתרון\s+(?:תרגיל|שאלה)/.test(text) ||
+    /\\(?:section|subsection)\*?\{תשובה\s+סופית/.test(text)
+  )
 }
 
 /**
  * Detects if this is an exercise title.
- * Matches: \textbf{תרגיל 1 - Title} or \textbf{תרגיל 1}
+ * Matches:
+ *   \textbf{תרגיל 1 - Title} or \textbf{תרגיל 1}
+ *   \section*{תרגיל 1: Title} or \subsection*{תרגיל 1}
+ *   \section*{שאלה 1} or \subsection*{שאלה 1}
+ *   \textbf{N.} standalone numbered exercise (e.g. \textbf{1.})
  */
 export function isExerciseTitle(text: string): { title: string; number: number } | null {
-  const match = /\\textbf\{(תרגיל\s+(\d+)[^}]*)\}/.exec(text)
-  if (!match) return null
-  return { title: match[1], number: parseInt(match[2], 10) }
+  // \textbf{תרגיל N ...}
+  const textbfMatch = /\\textbf\{(תרגיל\s+(\d+)[^}]*)\}/.exec(text)
+  if (textbfMatch) return { title: textbfMatch[1], number: parseInt(textbfMatch[2], 10) }
+
+  // \section*{תרגיל N ...} or \subsection*{תרגיל N ...}
+  const sectionExMatch = /\\(?:section|subsection)\*?\{(תרגיל\s+(\d+)[^}]*)\}/.exec(text)
+  if (sectionExMatch) return { title: sectionExMatch[1], number: parseInt(sectionExMatch[2], 10) }
+
+  // \section*{שאלה N ...} or \subsection*{שאלה N ...}
+  const sectionQMatch = /\\(?:section|subsection)\*?\{(שאלה\s+(\d+)[^}]*)\}/.exec(text)
+  if (sectionQMatch) return { title: sectionQMatch[1], number: parseInt(sectionQMatch[2], 10) }
+
+  // \textbf{N.} — standalone numbered exercise boundary
+  const numberedMatch = /^\\textbf\{(\d+)\.\s*\}$/.exec(text.trim())
+  if (numberedMatch) {
+    const num = parseInt(numberedMatch[1], 10)
+    return { title: `תרגיל ${num}`, number: num }
+  }
+
+  return null
 }
 
 /** Check if text contains an enumerate-style exercise pattern */

--- a/src/lib/latex-parser/index.ts
+++ b/src/lib/latex-parser/index.ts
@@ -128,22 +128,59 @@ const SKIP_COMMANDS = new Set([
 ])
 
 /**
- * Strip \color{...} and {\color{...} content} from any string (text or math).
- * Also strips \Large and other sizing commands.
+ * Find the matching closing brace for an opening brace, handling nesting.
+ * Returns the index of the matching }, or -1 if not found.
+ */
+function findMatchingBrace(text: string, openPos: number): number {
+  let depth = 1
+  for (let i = openPos + 1; i < text.length; i++) {
+    if (text[i] === '{') depth++
+    else if (text[i] === '}') {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+  return -1
+}
+
+/**
+ * Strip {\color{name} content} and {\Large\color{name} content} groups,
+ * using proper brace counting to handle nested braces like \frac{1}{...}.
  *
- * Handles the pattern: ${\color{winered} 70 }$ → $70$
- * and: ${\Large\color{winered} s \approx 10.2 }$ → $s \approx 10.2$
- *
- * IMPORTANT: We match the full balanced {cmd content} group to avoid
- * eating legitimate closing braces (e.g. \frac{1}{55}).
+ * Handles: ${\color{winered} g(x) = \frac{1}{f(x) + b} }$ → $g(x) = \frac{1}{f(x) + b}$
  */
 function stripColorAndSizing(text: string): string {
   let result = text
-  // Match full balanced group: {\color{name} content} or {\Large content}
-  // The outer { } pair wraps the color/sizing scope — remove both braces + command, keep content
-  result = result.replace(/\{\\(?:Large|large|huge|Huge)\s*\\color\{[^}]*\}\s*([^}]*)\}/g, '$1')
-  result = result.replace(/\{\\color\{[^}]*\}\s*([^}]*)\}/g, '$1')
-  result = result.replace(/\{\\(?:Large|large|huge|Huge)\s*([^}]*)\}/g, '$1')
+
+  // Process {\color{name} ...} and {\Large\color{name} ...} groups with brace counting
+  // We scan for { followed by \color or \Large\color, find the matching }, and remove the wrapper
+  let i = 0
+  let output = ''
+  while (i < result.length) {
+    if (result[i] === '{') {
+      // Check if this opens a color/sizing group
+      const after = result.slice(i + 1)
+      const cmdMatch =
+        /^\\(?:Large|large|huge|Huge)\s*\\color\{[^}]*\}\s*/.exec(after) ||
+        /^\\color\{[^}]*\}\s*/.exec(after) ||
+        /^\\(?:Large|large|huge|Huge)\s*/.exec(after)
+
+      if (cmdMatch) {
+        const closingBrace = findMatchingBrace(result, i)
+        if (closingBrace > i) {
+          // Extract the content between the command and the closing brace
+          const contentStart = i + 1 + cmdMatch[0].length
+          output += result.slice(contentStart, closingBrace)
+          i = closingBrace + 1
+          continue
+        }
+      }
+    }
+    output += result[i]
+    i++
+  }
+  result = output
+
   // Strip bare commands (not wrapped in braces)
   result = result
     .replace(/\\(?:Large|large|huge|Huge|normalsize|small|footnotesize|tiny)\s*/g, '')

--- a/src/lib/latex-parser/index.ts
+++ b/src/lib/latex-parser/index.ts
@@ -165,8 +165,8 @@ function cleanText(text: string): string {
       .replace(/\\emph\{([^}]*)\}/g, '*$1*')
       .replace(/\\underline\{([^}]*)\}/g, '$1')
       .replace(/\\text\{([^}]*)\}/g, '$1')
-      .replace(/\\\\/g, '\n')
-      .replace(/\\vspace\{[^}]*\}/g, '')
+      .replace(/\\\\/g, ' ')
+      .replace(/\\vspace\{[^}]*\}/g, ' ')
       .replace(/\\hspace\*?\{[^}]*\}/g, ' ')
       .replace(/\\noindent/g, '')
       .replace(/\\selectlanguage\{[^}]*\}/g, '')
@@ -175,6 +175,9 @@ function cleanText(text: string): string {
       .replace(/\\arraystretch/g, '')
       // Strip leading line-break spacing like [0.2cm], [5mm]
       .replace(/^\s*\[\d+(\.\d+)?(cm|mm|pt|em|ex)\]\s*/g, '')
+      // Collapse all whitespace into single spaces — prevents the frontend
+      // from splitting text into "context outside box" vs "content inside box"
+      .replace(/\s+/g, ' ')
       .trim()
   )
 }

--- a/src/lib/latex-parser/index.ts
+++ b/src/lib/latex-parser/index.ts
@@ -127,14 +127,39 @@ const SKIP_COMMANDS = new Set([
   'itemsep',
 ])
 
+/**
+ * Strip \color{...} and {\color{...} content} from any string (text or math).
+ * Also strips \Large and other sizing commands, and cleans orphaned braces.
+ *
+ * Handles the pattern: ${\color{winered} 70 }$ → $70$
+ * and: ${\Large\color{winered} s \approx 10.2 }$ → $s \approx 10.2$
+ */
+function stripColorAndSizing(text: string): string {
+  // First pass: handle {\color{name} content } → content  (full brace group)
+  // This regex matches the opening { + \color{...} and its matching closing }
+  let result = text.replace(/\{\\(?:color\{[^}]*\}|Large|large|huge|Huge)\s*/g, '')
+  // Remove the orphaned closing } left from the above
+  // Strategy: repeatedly strip unbalanced } that aren't part of LaTeX commands
+  result = result
+    .replace(/\\(?:Large|large|huge|Huge|normalsize|small|footnotesize|tiny)\s*/g, '')
+    .replace(/\\color\{[^}]*\}/g, '')
+    .replace(/\\definecolor\{[^}]*\}\{[^}]*\}\{[^}]*\}/g, '')
+
+  // Clean orphaned } inside $...$ math expressions
+  // Match $ ... content } ... $ and remove the orphaned }
+  result = result.replace(/(\$[^$]*?)\s*\}\s*(\$)/g, '$1$2')
+  // Also handle } before commas, periods, spaces in text
+  result = result.replace(/\s+\}(?=[\s,.)$])/g, '')
+  // Trailing orphaned }
+  result = result.replace(/\s*\}\s*$/g, '')
+
+  return result
+}
+
 /** Clean LaTeX text: strip formatting commands, normalize whitespace */
 function cleanText(text: string): string {
   return (
-    text
-      // Strip {\color{name} content} → content (preserves inner text)
-      .replace(/\{\\color\{[^}]*\}\s*/g, '')
-      // Strip orphaned closing braces left from color stripping
-      // (handled carefully to not break math)
+    stripColorAndSizing(text)
       .replace(/\\textbf\{([^}]*)\}/g, '**$1**')
       .replace(/\\textit\{([^}]*)\}/g, '*$1*')
       .replace(/\\emph\{([^}]*)\}/g, '*$1*')
@@ -148,8 +173,6 @@ function cleanText(text: string): string {
       .replace(/\\begingroup/g, '')
       .replace(/\\endgroup/g, '')
       .replace(/\\arraystretch/g, '')
-      .replace(/\\definecolor\{[^}]*\}\{[^}]*\}\{[^}]*\}/g, '')
-      .replace(/\\color\{[^}]*\}/g, '')
       // Strip leading line-break spacing like [0.2cm], [5mm]
       .replace(/^\s*\[\d+(\.\d+)?(cm|mm|pt|em|ex)\]\s*/g, '')
       .trim()
@@ -272,7 +295,8 @@ function processTokens(
         }
       }
     } else if (token.type === 'math') {
-      const val = token.value
+      // Strip color/sizing commands from math expressions
+      const val = stripColorAndSizing(token.value)
       if (val.startsWith('$$') && val.endsWith('$$')) {
         blocks.push(makeLatexBlock(val.slice(2, -2).trim()))
       } else {

--- a/src/lib/latex-parser/index.ts
+++ b/src/lib/latex-parser/index.ts
@@ -23,7 +23,7 @@ import {
   hasTikzDrawPlot,
 } from '@/lib/latex-parser/tikz-axis-parser'
 import { parseTikzGeometry, hasTikzGeometry } from '@/lib/latex-parser/tikz-geometry-parser'
-import { makeRichTextBlock, makeLatexBlock } from '@/lib/latex-parser/block-generators'
+import { makeRichTextBlock } from '@/lib/latex-parser/block-generators'
 import type { ContentBlock } from '@/server/payload/collections/Exercises/types'
 
 /**
@@ -340,11 +340,10 @@ function processTokens(
     } else if (token.type === 'math') {
       // Strip color/sizing commands from math expressions
       const val = stripColorAndSizing(token.value)
-      if (val.startsWith('$$') && val.endsWith('$$')) {
-        blocks.push(makeLatexBlock(val.slice(2, -2).trim()))
-      } else {
-        blocks.push(makeRichTextBlock(val))
-      }
+      // Emit all math as rich_text with md-math-v1 format
+      // The frontend renderer handles $...$ (inline) and $$...$$ (display) in rich_text
+      // but does NOT render standalone 'latex' block types
+      blocks.push(makeRichTextBlock(val))
     } else if (token.type === 'command') {
       const cmdName = token.name ?? ''
       if (SKIP_COMMANDS.has(cmdName)) {

--- a/src/lib/latex-parser/index.ts
+++ b/src/lib/latex-parser/index.ts
@@ -157,6 +157,12 @@ function stripColorAndSizing(text: string): string {
 function cleanText(text: string): string {
   return (
     stripColorAndSizing(text)
+      // Strip leaked environment tags
+      .replace(
+        /\\(?:begin|end)\{(?:enumerate|center|itemize|tikzpicture|tabular\*?|tcolorbox)\}(?:\[[^\]]*\])?/g,
+        '',
+      )
+      .replace(/\\begin\{tikzpicture\}[\s\S]*?\\end\{tikzpicture\}/g, '')
       .replace(/\\textbf\{([^}]*)\}/g, '**$1**')
       .replace(/\\textit\{([^}]*)\}/g, '*$1*')
       .replace(/\\emph\{([^}]*)\}/g, '*$1*')

--- a/src/lib/latex-parser/index.ts
+++ b/src/lib/latex-parser/index.ts
@@ -129,29 +129,26 @@ const SKIP_COMMANDS = new Set([
 
 /**
  * Strip \color{...} and {\color{...} content} from any string (text or math).
- * Also strips \Large and other sizing commands, and cleans orphaned braces.
+ * Also strips \Large and other sizing commands.
  *
  * Handles the pattern: ${\color{winered} 70 }$ → $70$
  * and: ${\Large\color{winered} s \approx 10.2 }$ → $s \approx 10.2$
+ *
+ * IMPORTANT: We match the full balanced {cmd content} group to avoid
+ * eating legitimate closing braces (e.g. \frac{1}{55}).
  */
 function stripColorAndSizing(text: string): string {
-  // First pass: handle {\color{name} content } → content  (full brace group)
-  // This regex matches the opening { + \color{...} and its matching closing }
-  let result = text.replace(/\{\\(?:color\{[^}]*\}|Large|large|huge|Huge)\s*/g, '')
-  // Remove the orphaned closing } left from the above
-  // Strategy: repeatedly strip unbalanced } that aren't part of LaTeX commands
+  let result = text
+  // Match full balanced group: {\color{name} content} or {\Large content}
+  // The outer { } pair wraps the color/sizing scope — remove both braces + command, keep content
+  result = result.replace(/\{\\(?:Large|large|huge|Huge)\s*\\color\{[^}]*\}\s*([^}]*)\}/g, '$1')
+  result = result.replace(/\{\\color\{[^}]*\}\s*([^}]*)\}/g, '$1')
+  result = result.replace(/\{\\(?:Large|large|huge|Huge)\s*([^}]*)\}/g, '$1')
+  // Strip bare commands (not wrapped in braces)
   result = result
     .replace(/\\(?:Large|large|huge|Huge|normalsize|small|footnotesize|tiny)\s*/g, '')
     .replace(/\\color\{[^}]*\}/g, '')
     .replace(/\\definecolor\{[^}]*\}\{[^}]*\}\{[^}]*\}/g, '')
-
-  // Clean orphaned } inside $...$ math expressions
-  // Match $ ... content } ... $ and remove the orphaned }
-  result = result.replace(/(\$[^$]*?)\s*\}\s*(\$)/g, '$1$2')
-  // Also handle } before commas, periods, spaces in text
-  result = result.replace(/\s+\}(?=[\s,.)$])/g, '')
-  // Trailing orphaned }
-  result = result.replace(/\s*\}\s*$/g, '')
 
   return result
 }

--- a/src/lib/latex-parser/index.ts
+++ b/src/lib/latex-parser/index.ts
@@ -86,7 +86,14 @@ const PREAMBLE_COMMANDS = new Set([
 ])
 
 /** Environments that just wrap content — recurse into children */
-const PASSTHROUGH_ENVS = new Set(['document', 'minipage', 'center', 'flushleft', 'flushright'])
+const PASSTHROUGH_ENVS = new Set([
+  'document',
+  'minipage',
+  'center',
+  'flushleft',
+  'flushright',
+  'spacing',
+])
 
 /** Layout/formatting commands to silently skip */
 const SKIP_COMMANDS = new Set([
@@ -108,12 +115,26 @@ const SKIP_COMMANDS = new Set([
   'large',
   'renewcommand',
   'arraystretch',
+  'definecolor',
+  'color',
+  'centering',
+  'cfoot',
+  'lfoot',
+  'fancyhf',
+  'headrulewidth',
+  'thepage',
+  'footnotesize',
+  'itemsep',
 ])
 
 /** Clean LaTeX text: strip formatting commands, normalize whitespace */
 function cleanText(text: string): string {
   return (
     text
+      // Strip {\color{name} content} → content (preserves inner text)
+      .replace(/\{\\color\{[^}]*\}\s*/g, '')
+      // Strip orphaned closing braces left from color stripping
+      // (handled carefully to not break math)
       .replace(/\\textbf\{([^}]*)\}/g, '**$1**')
       .replace(/\\textit\{([^}]*)\}/g, '*$1*')
       .replace(/\\emph\{([^}]*)\}/g, '*$1*')
@@ -127,6 +148,8 @@ function cleanText(text: string): string {
       .replace(/\\begingroup/g, '')
       .replace(/\\endgroup/g, '')
       .replace(/\\arraystretch/g, '')
+      .replace(/\\definecolor\{[^}]*\}\{[^}]*\}\{[^}]*\}/g, '')
+      .replace(/\\color\{[^}]*\}/g, '')
       // Strip leading line-break spacing like [0.2cm], [5mm]
       .replace(/^\s*\[\d+(\.\d+)?(cm|mm|pt|em|ex)\]\s*/g, '')
       .trim()
@@ -176,6 +199,14 @@ function processTokens(
       } else if (envName === 'questions') {
         const inner = extractInner(token)
         processQuestionsEnv(inner, blocks, warnings, token.line)
+      } else if (envName === 'itemize') {
+        // Convert itemize to bullet-point rich text
+        const inner = extractInner(token)
+        const items = inner.split(/\\item\s*/).filter((s) => s.trim())
+        const bullets = items.map((item) => `• ${cleanText(item)}`).join('\n')
+        if (bullets) {
+          blocks.push(makeRichTextBlock(bullets))
+        }
       } else if (envName === 'enumerate') {
         const inner = extractInner(token)
         const enumBlocks = parseEnumerate(inner)
@@ -251,15 +282,21 @@ function processTokens(
       const cmdName = token.name ?? ''
       if (SKIP_COMMANDS.has(cmdName)) {
         // Silently skip
-      } else if (cmdName === 'section') {
-        const titleMatch = /\\section\*?\{([^}]*)\}/.exec(token.value)
+      } else if (cmdName === 'section' || cmdName === 'subsection') {
+        const titleMatch = /\\(?:section|subsection)\*?\{([^}]*)\}/.exec(token.value)
         const title = titleMatch ? titleMatch[1] : token.value
         if (isSolutionHeader(token.value)) {
           inSolutionSection = true
           // Don't emit solution headers as blocks — solutions are attached to questions
         } else {
           inSolutionSection = false
-          blocks.push(makeRichTextBlock(`## ${title}`))
+          // Check if this is an exercise title (תרגיל N or שאלה N)
+          const exerciseInfo = isExerciseTitle(token.value)
+          if (exerciseInfo) {
+            blocks.push(makeRichTextBlock(`## ${exerciseInfo.title}`))
+          } else {
+            blocks.push(makeRichTextBlock(`## ${title}`))
+          }
         }
       } else if (cmdName === 'textbf') {
         // Check if this is an exercise title like \textbf{תרגיל 1 - Title}
@@ -453,10 +490,10 @@ function mergeAdjacentRichText(blocks: ContentBlock[]): ContentBlock[] {
 }
 
 /**
- * Exercise title pattern: `## תרגיל N` or `## תרגיל N - Title`
+ * Exercise title pattern: `## תרגיל N` or `## שאלה N` or `## תרגיל N - Title`
  * These are emitted by processTokens when isExerciseTitle() matches.
  */
-const EXERCISE_HEADING_RE = /^## תרגיל\s+(\d+)/
+const EXERCISE_HEADING_RE = /^## (?:תרגיל|שאלה)\s+(\d+)/
 
 /**
  * Parses LaTeX into multiple exercises split on `\textbf{תרגיל N}` boundaries.

--- a/src/lib/latex-parser/tikz-geometry-parser.ts
+++ b/src/lib/latex-parser/tikz-geometry-parser.ts
@@ -34,6 +34,65 @@ function parseCoordinates(content: string): ParsedPoint[] {
   return points
 }
 
+/**
+ * Extract inline coordinates from \draw commands like:
+ *   \draw (0,0) node[below]{B} -- (5,0) node[right]{C} -- (6.5,3) node[above]{D} -- cycle;
+ * Returns points with names from node labels, and constructs line segments.
+ */
+function parseInlineDrawCoordinates(content: string): {
+  points: ParsedPoint[]
+  labels: Map<string, string>
+  lines: Array<{ from: string; to: string; style: 'solid' | 'dashed' }>
+} {
+  const points: ParsedPoint[] = []
+  const labels = new Map<string, string>()
+  const lines: Array<{ from: string; to: string; style: 'solid' | 'dashed' }> = []
+  const seen = new Map<string, string>() // "x,y" → point name
+
+  const drawRegex = /\\draw\s*(?:\[([^\]]*)\])?\s*([^;]+);/gs
+  let drawMatch: RegExpExecArray | null
+  while ((drawMatch = drawRegex.exec(content)) !== null) {
+    const opts = drawMatch[1] || ''
+    const path = drawMatch[2]
+    const isDashed = opts.includes('dashed')
+    const style: 'solid' | 'dashed' = isDashed ? 'dashed' : 'solid'
+
+    // Match (x,y) optionally followed by node[...]{Label}
+    const coordRegex =
+      /\((-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\)\s*(?:node\s*\[[^\]]*\]\s*(?:\{([^}]*)\})?)?/g
+    const segmentPoints: string[] = []
+    let coordMatch: RegExpExecArray | null
+    while ((coordMatch = coordRegex.exec(path)) !== null) {
+      const x = parseFloat(coordMatch[1])
+      const y = parseFloat(coordMatch[2])
+      const label = coordMatch[3]?.trim()
+      const key = `${x},${y}`
+
+      let name: string
+      if (seen.has(key)) {
+        name = seen.get(key)!
+      } else {
+        name = label || `_p${points.length}`
+        seen.set(key, name)
+        points.push({ name, x, y })
+        if (label) labels.set(name, label)
+      }
+      segmentPoints.push(name)
+    }
+
+    // Build line segments from consecutive points
+    for (let i = 0; i < segmentPoints.length - 1; i++) {
+      lines.push({ from: segmentPoints[i], to: segmentPoints[i + 1], style })
+    }
+    // Handle -- cycle
+    if (/--\s*cycle/.test(path) && segmentPoints.length > 2) {
+      lines.push({ from: segmentPoints[segmentPoints.length - 1], to: segmentPoints[0], style })
+    }
+  }
+
+  return { points, labels, lines }
+}
+
 /** Parse \draw[...] (A) -- (B) -- (C); line chains */
 function parseDrawLines(
   content: string,
@@ -173,15 +232,31 @@ export function parseTikzGeometry(tikzContent: string): QuestionGeometryBlock | 
   // Skip if this is an axis plot
   if (tikzContent.includes('\\begin{axis}')) return null
 
-  const coordinates = parseCoordinates(tikzContent)
-  if (coordinates.length === 0) return null
+  let coordinates = parseCoordinates(tikzContent)
+  let labels: Map<string, string>
+  let drawLines: Array<{ from: string; to: string; style: 'solid' | 'dashed' }>
+  let circles: Array<{ center: string; radius: number }>
+  let rightAngles: Array<{ center: string; ray1: string; ray2: string }>
 
-  const knownPoints = new Set(coordinates.map((p) => p.name))
+  if (coordinates.length > 0) {
+    // Standard path: explicit \coordinate definitions
+    const knownPoints = new Set(coordinates.map((p) => p.name))
+    labels = parseLabeledPoints(tikzContent)
+    drawLines = parseDrawLines(tikzContent, knownPoints)
+    circles = parseCircles(tikzContent, knownPoints)
+    rightAngles = parseRightAngles(tikzContent, knownPoints)
+  } else {
+    // Fallback: extract inline coordinates from \draw commands
+    const inline = parseInlineDrawCoordinates(tikzContent)
+    if (inline.points.length === 0) return null
+    coordinates = inline.points
+    labels = inline.labels
+    drawLines = inline.lines
+    circles = []
+    rightAngles = []
+  }
+
   const pointMap = new Map(coordinates.map((p) => [p.name, p]))
-  const labels = parseLabeledPoints(tikzContent)
-  const drawLines = parseDrawLines(tikzContent, knownPoints)
-  const circles = parseCircles(tikzContent, knownPoints)
-  const rightAngles = parseRightAngles(tikzContent, knownPoints)
 
   // Compute bounding box from raw TikZ coordinates — no normalization needed
   const boundingBox = computeBoundingBox(coordinates, circles, pointMap)
@@ -225,5 +300,10 @@ export function parseTikzGeometry(tikzContent: string): QuestionGeometryBlock | 
 
 /** Check if a tikzpicture is coordinate-based geometry (not axis) */
 export function hasTikzGeometry(content: string): boolean {
-  return content.includes('\\coordinate') && !content.includes('\\begin{axis}')
+  if (content.includes('\\begin{axis}')) return false
+  // Has explicit \coordinate definitions
+  if (content.includes('\\coordinate')) return true
+  // Has \draw with inline numeric coordinates like (0,0) -- (5,3)
+  if (/\\draw[\s\[][^;]*\(\d+(?:\.\d+)?\s*,\s*-?\d+(?:\.\d+)?\)/.test(content)) return true
+  return false
 }

--- a/src/lib/latex-parser/tikz-geometry-parser.ts
+++ b/src/lib/latex-parser/tikz-geometry-parser.ts
@@ -191,7 +191,7 @@ export function parseTikzGeometry(tikzContent: string): QuestionGeometryBlock | 
     canvas: {
       width: CANVAS_WIDTH,
       height: CANVAS_HEIGHT,
-      axis: true,
+      axis: false,
       boundingBox,
     },
     elements: {

--- a/tests/unit/lib/latex-parser/parse-latex.test.ts
+++ b/tests/unit/lib/latex-parser/parse-latex.test.ts
@@ -49,11 +49,11 @@ describe('parseLatexToBlocks', () => {
     expect(result.errors).toHaveLength(0)
   })
 
-  it('handles standalone display math as latex block', () => {
+  it('handles standalone display math as rich_text with $$ delimiters', () => {
     const latex = '$$\\int_0^1 x^2 dx = \\frac{1}{3}$$'
     const result = parseLatexToBlocks(latex)
-    const latexBlocks = result.blocks.filter((b) => b.type === 'latex')
-    expect(latexBlocks).toHaveLength(1)
+    const mathBlocks = result.blocks.filter((b) => b.type === 'rich_text' && b.value.includes('$$'))
+    expect(mathBlocks).toHaveLength(1)
   })
 
   it('handles mixed content with text and questions', () => {


### PR DESCRIPTION
The parser was built on 2 examples using \textbf{תרגיל N} boundaries, but all 88 real lessons use different patterns. This adds support for:

- \subsection*{תרגיל N} boundaries (exercise worksheets with solutions)
- \section*{שאלה N} boundaries (Bagrut exam format)
- \section*{תרגילים} with numbered \item enumerate (single-section worksheets)
- \item[\textbf{א.}] explicit Hebrew sub-question labels
- \color{winered} and \definecolor stripping
- \begin{itemize} conversion to bullet points inside enumerates
- Expanded solution header detection (פתרונות, תשובה סופית, etc.)

Tested against all 55 LaTeX lessons from MongoDB: 100% pass rate.