### PR TITLE
Exercise UI/UX redesign with animations

### DIFF
--- a/.ai-docs/indexes/pattern-index.json
+++ b/.ai-docs/indexes/pattern-index.json
@@ -55,6 +55,7 @@
         "src/app/(frontend)/courses/_components/ChapterPageBreadcrumb/index.tsx",
         "src/app/(frontend)/courses/_components/ChaptersSectionTitle/index.tsx",
         "src/app/(frontend)/courses/_components/CourseCard/index.tsx",
+        "src/app/(frontend)/courses/_components/CourseCardGrid/index.tsx",
         "src/app/(frontend)/courses/_components/CourseCatalogHeader/index.tsx",
         "src/app/(frontend)/courses/_components/CourseShopHeader/index.tsx",
         "src/app/(frontend)/courses/_components/CoursesHero/index.tsx",
@@ -70,6 +71,7 @@
         "src/app/(frontend)/login/LoginForm.tsx",
         "src/app/(frontend)/login/LoginPageContent.tsx",
         "src/app/(frontend)/not-found.tsx",
+        "src/app/(frontend)/offline/page.tsx",
         "src/app/(frontend)/onboarding/persona/PersonaSelectionStep.tsx",
         "src/app/(frontend)/posts/[slug]/page.client.tsx",
         "src/app/(frontend)/posts/page.client.tsx",
@@ -84,6 +86,7 @@
         "src/app/(frontend)/stats/_components/StatsDashboard.tsx",
         "src/app/(frontend)/stats/_components/SummaryCards.tsx",
         "src/app/(frontend)/study-plan/_components/DayCard.tsx",
+        "src/app/(frontend)/study-plan/_components/LessonSelector/index.tsx",
         "src/app/(frontend)/study-plan/_components/StudyPlanPage.tsx",
         "src/app/(frontend)/study-plan/_components/useStudyPlan.ts",
         "src/app/(frontend)/study/_components/StudyContent/index.tsx",
@@ -124,7 +127,9 @@
         "src/ui/admin/AdminChat/SidebarLink/index.tsx",
         "src/ui/admin/AnswerSpecJsonField/index.tsx",
         "src/ui/admin/CascadeDeleteButton/index.tsx",
+        "src/ui/admin/ContentNavigation/index.tsx",
         "src/ui/admin/ExerciseContentEditor/BlockTypeSelector.tsx",
+        "src/ui/admin/ExerciseContentEditor/FullJsonEditor.tsx",
         "src/ui/admin/ExerciseContentEditor/JSONInspector.tsx",
         "src/ui/admin/ExerciseContentEditor/RichTextEditor.tsx",
         "src/ui/admin/ExerciseContentEditor/components/axis/AsymptotesPanel.tsx",
@@ -158,6 +163,7 @@
         "src/ui/admin/ExerciseContentEditor/editors/MatchingEditor.tsx",
         "src/ui/admin/ExerciseContentEditor/editors/McqEditor.tsx",
         "src/ui/admin/ExerciseContentEditor/editors/MediaBlockEditor.tsx",
+        "src/ui/admin/ExerciseContentEditor/editors/MultiAxisEditor.tsx",
         "src/ui/admin/ExerciseContentEditor/editors/QuestionBlockWrapper.tsx",
         "src/ui/admin/ExerciseContentEditor/editors/SvgEditor.tsx",
         "src/ui/admin/ExerciseContentEditor/editors/TableEditor.tsx",
@@ -234,13 +240,20 @@
         "src/ui/web/chat/hooks/useTTS.ts",
         "src/ui/web/chat/hooks/useTeacherProfileLabel.ts",
         "src/ui/web/components/HealthBadge.tsx",
+        "src/ui/web/components/accent-picker.tsx",
         "src/ui/web/components/accordion.tsx",
+        "src/ui/web/components/animated-counter.tsx",
         "src/ui/web/components/avatar.tsx",
         "src/ui/web/components/checkbox.tsx",
         "src/ui/web/components/command.tsx",
+        "src/ui/web/components/confetti.stories.tsx",
+        "src/ui/web/components/confetti.tsx",
         "src/ui/web/components/dialog.tsx",
         "src/ui/web/components/dropdown-menu.tsx",
         "src/ui/web/components/label.tsx",
+        "src/ui/web/components/motion.tsx",
+        "src/ui/web/components/onboarding-tip.tsx",
+        "src/ui/web/components/page-transition.tsx",
         "src/ui/web/components/resizable-pane.tsx",
         "src/ui/web/components/select.tsx",
         "src/ui/web/components/sheet.tsx",
@@ -286,6 +299,7 @@
         "src/ui/web/heros/HighImpact/index.tsx",
         "src/ui/web/heros/PostHero/index.tsx",
         "src/ui/web/homepage/GreetingFlow/index.tsx",
+        "src/ui/web/homepage/LandingPage/index.tsx",
         "src/ui/web/homepage/NavigationBar/index.tsx",
         "src/ui/web/homepage/TopicCard/index.tsx",
         "src/ui/web/media/AudioMedia/index.tsx",
@@ -382,6 +396,7 @@
         "src/app/(frontend)/stats/_components/SummaryCards.tsx",
         "src/app/(frontend)/study-plan/_components/DayCard.tsx",
         "src/app/(frontend)/study-plan/_components/EmptyPlanState.tsx",
+        "src/app/(frontend)/study-plan/_components/LessonSelector/index.tsx",
         "src/app/(frontend)/study-plan/_components/StudyPlanPage.tsx",
         "src/app/(frontend)/study/_components/StudyContent/index.tsx",
         "src/ui/web/LanguageSwitcher/index.tsx",
@@ -399,6 +414,7 @@
         "src/ui/web/header/MobileMenu/index.tsx",
         "src/ui/web/header/Nav/index.tsx",
         "src/ui/web/homepage/GreetingFlow/index.tsx",
+        "src/ui/web/homepage/LandingPage/index.tsx",
         "src/ui/web/homepage/NavigationBar/index.tsx",
         "src/ui/web/providers/I18n/index.tsx",
         "src/ui/web/shared/ContentStatusBadge/index.tsx",
@@ -411,6 +427,9 @@
       "pattern": "tailwind-component",
       "description": "Component using Tailwind CSS utilities",
       "files": [
+        "src/app/(frontend)/account/_components/PreferencesSection.tsx",
+        "src/app/(frontend)/account/_components/TeachersProfileSection.tsx",
+        "src/app/(frontend)/ask/_components/AskContent/index.tsx",
         "src/app/(frontend)/ask/_components/AskConversationGrid/index.tsx",
         "src/app/(frontend)/ask/_components/AskDrawingCanvas/index.tsx",
         "src/app/(frontend)/ask/_components/AskExerciseCard/index.tsx",
@@ -418,15 +437,26 @@
         "src/app/(frontend)/courses/[courseSlug]/_components/ConversationCard/index.tsx",
         "src/app/(frontend)/courses/[courseSlug]/_components/CourseLessonCard/index.tsx",
         "src/app/(frontend)/courses/[courseSlug]/_components/CourseTabs/index.tsx",
+        "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/ExercisesPager/index.tsx",
+        "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/LessonPager/index.tsx",
+        "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/ViewToggle.tsx",
         "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/ExerciseHeader/index.tsx",
         "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/MathPalette/index.tsx",
         "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/NotebookWorkspace/index.tsx",
+        "src/app/(frontend)/courses/_components/BackToChapter/index.tsx",
+        "src/app/(frontend)/courses/_components/Breadcrumb/index.tsx",
+        "src/app/(frontend)/courses/_components/ChapterCard/index.tsx",
         "src/app/(frontend)/courses/_components/CourseCard/index.tsx",
+        "src/app/(frontend)/courses/_components/EmptyState/index.tsx",
         "src/app/(frontend)/courses/_components/LessonCard/index.tsx",
         "src/app/(frontend)/courses/_components/LessonHeader/index.tsx",
         "src/app/(frontend)/courses/_components/PlanCard/index.tsx",
         "src/app/(frontend)/layout.tsx",
-        "src/app/(frontend)/study/_components/StudyContent/index.tsx",
+        "src/app/(frontend)/onboarding/persona/PersonaSelectionStep.tsx",
+        "src/app/(frontend)/stats/_components/DashboardFilters.tsx",
+        "src/app/(frontend)/study-plan/_components/DayCard.tsx",
+        "src/app/(frontend)/study-plan/_components/LessonSelector/index.tsx",
+        "src/app/(frontend)/study-plan/_components/StudyPlanPage.tsx",
         "src/infra/loading/components/RouteLoadingIndicator.tsx",
         "src/infra/loading/components/Spinner.tsx",
         "src/infra/loading/components/SystemLink.tsx",
@@ -438,15 +468,19 @@
         "src/ui/web/Card/index.tsx",
         "src/ui/web/CollectionArchive/index.tsx",
         "src/ui/web/Link/index.tsx",
+        "src/ui/web/PageRange/index.tsx",
         "src/ui/web/Pagination/index.tsx",
         "src/ui/web/RichText/index.tsx",
         "src/ui/web/SafeHtml/index.tsx",
+        "src/ui/web/TelescopeLogo/index.tsx",
         "src/ui/web/auth/GoogleLoginButton.tsx",
         "src/ui/web/chat/ChatErrorSurface/index.tsx",
         "src/ui/web/chat/ChatInterface/index.tsx",
         "src/ui/web/chat/ChatMessageContent/index.tsx",
+        "src/ui/web/chat/ChatQuotaBar/index.tsx",
         "src/ui/web/chat/TTSButton/index.tsx",
         "src/ui/web/components/accent-card.tsx",
+        "src/ui/web/components/accent-picker.tsx",
         "src/ui/web/components/accordion.tsx",
         "src/ui/web/components/avatar.tsx",
         "src/ui/web/components/badge.tsx",
@@ -462,12 +496,14 @@
         "src/ui/web/components/icon-badge.tsx",
         "src/ui/web/components/input.tsx",
         "src/ui/web/components/label.tsx",
+        "src/ui/web/components/onboarding-tip.tsx",
         "src/ui/web/components/page-section.tsx",
         "src/ui/web/components/pagination.tsx",
         "src/ui/web/components/progress.tsx",
         "src/ui/web/components/resizable-pane.tsx",
         "src/ui/web/components/select.tsx",
         "src/ui/web/components/sheet.tsx",
+        "src/ui/web/components/skeleton.tsx",
         "src/ui/web/components/split-pane-layout.tsx",
         "src/ui/web/components/tab-bar.tsx",
         "src/ui/web/components/tabs.tsx",
@@ -481,6 +517,7 @@
         "src/ui/web/exerciserenderer/blocks/SvgRenderer/index.tsx",
         "src/ui/web/exerciserenderer/components/FeedbackDisplay/index.tsx",
         "src/ui/web/exerciserenderer/components/HelpSystem/HelpSystemButtons.tsx",
+        "src/ui/web/exerciserenderer/components/HelpSystem/HelpSystemContent.tsx",
         "src/ui/web/exerciserenderer/components/MediaAttachments/index.tsx",
         "src/ui/web/exerciserenderer/components/QuestionCard/index.tsx",
         "src/ui/web/exerciserenderer/components/VideoPlayer/index.tsx",
@@ -490,6 +527,10 @@
         "src/ui/web/exerciserenderer/questions/TableQuestion/ExerciseTable.tsx",
         "src/ui/web/exerciserenderer/questions/TableQuestion/index.tsx",
         "src/ui/web/exerciserenderer/questions/TrueFalseQuestion/index.tsx",
+        "src/ui/web/header/Component.client.tsx",
+        "src/ui/web/header/CourseSearch/index.tsx",
+        "src/ui/web/header/MobileMenu/index.tsx",
+        "src/ui/web/homepage/LandingPage/index.tsx",
         "src/ui/web/homepage/NavigationBar/index.tsx",
         "src/ui/web/media/AudioMedia/index.tsx",
         "src/ui/web/media/DocumentMedia/index.tsx",
@@ -514,6 +555,7 @@
         "src/ui/web/shared/MathInput/MathField.tsx",
         "src/ui/web/shared/MathInput/MathFieldToolbar.tsx",
         "src/ui/web/shared/MathMarkdown/index.tsx",
+        "src/ui/web/shared/ProgressCircle/index.tsx",
         "src/ui/web/shared/TypingAnimation/index.tsx",
         "src/ui/web/shared/Typography/Heading.tsx",
         "src/ui/web/shared/Typography/Text.tsx"
@@ -591,6 +633,7 @@
         "src/app/api/chapters/by-grade/route.ts",
         "src/app/api/conversations/by-context/route.ts",
         "src/app/api/course-search/route.ts",
+        "src/app/api/course-syllabus/route.ts",
         "src/app/api/entitlements/check/route.ts",
         "src/app/api/entitlements/redeem/route.ts",
         "src/app/api/example/route.ts",
@@ -624,6 +667,7 @@
         "src/app/api/agent/reset-chat/route.ts",
         "src/app/api/blob/upload-token/route.ts",
         "src/app/api/course-search/route.ts",
+        "src/app/api/course-syllabus/route.ts",
         "src/app/api/entitlements/redeem/route.ts",
         "src/app/api/exercises/[id]/blocks/[blockId]/route.ts",
         "src/app/api/exercises/convert/single/create/route.ts",
@@ -644,6 +688,11 @@
       "pattern": "copilotkit-runtime",
       "description": "No description available",
       "files": ["src/app/api/copilotkit/route.ts"]
+    },
+    "course-syllabus": {
+      "pattern": "course-syllabus",
+      "description": "No description available",
+      "files": ["src/app/api/course-syllabus/route.ts"]
     },
     "validation": {
       "pattern": "validation",
@@ -1526,7 +1575,7 @@
       "path": "src/app/(frontend)/account/_components/PreferencesSection.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": ["next/link"]
     },
@@ -1542,15 +1591,15 @@
       "path": "src/app/(frontend)/account/_components/TeachersProfileSection.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["react", "sonner"]
+      "dependencies": ["react", "sonner", "lucide-react"]
     },
     "src/app/(frontend)/ask/_components/AskContent/index.tsx": {
       "path": "src/app/(frontend)/ask/_components/AskContent/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": ["react", "lucide-react"]
     },
@@ -1576,7 +1625,7 @@
       "domain": "general",
       "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["lucide-react", "react"]
+      "dependencies": ["next/image", "lucide-react", "react"]
     },
     "src/app/(frontend)/ask/_components/AskPageClient/index.tsx": {
       "path": "src/app/(frontend)/ask/_components/AskPageClient/index.tsx",
@@ -1640,7 +1689,7 @@
       "domain": "general",
       "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["lucide-react", "react"]
+      "dependencies": ["lucide-react", "react", "framer-motion"]
     },
     "src/app/(frontend)/courses/[courseSlug]/_components/CourseTabs/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/CourseTabs/index.tsx",
@@ -1648,7 +1697,7 @@
       "domain": "general",
       "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": []
+      "dependencies": ["framer-motion"]
     },
     "src/app/(frontend)/courses/[courseSlug]/_components/ExamReminderBubble/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/_components/ExamReminderBubble/index.tsx",
@@ -1694,9 +1743,9 @@
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/ExercisesPager/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": ["react", "framer-motion"]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/LessonAnalytics.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/LessonAnalytics.tsx",
@@ -1718,9 +1767,9 @@
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/LessonPager/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": ["react", "framer-motion"]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/LessonPager/useLessonPager.ts": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/LessonPager/useLessonPager.ts",
@@ -1750,9 +1799,9 @@
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/ViewToggle.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": ["react", "lucide-react"]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/complete/CompleteContent.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/complete/CompleteContent.tsx",
@@ -1760,7 +1809,7 @@
       "domain": "general",
       "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": ["react", "lucide-react", "framer-motion"]
     },
     "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/ExerciseHeader/index.tsx": {
       "path": "src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/ExerciseHeader/index.tsx",
@@ -1838,7 +1887,7 @@
       "path": "src/app/(frontend)/courses/_components/BackToChapter/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -1850,11 +1899,19 @@
       "aiSummary": "",
       "dependencies": []
     },
+    "src/app/(frontend)/courses/_components/Breadcrumb/index.tsx": {
+      "path": "src/app/(frontend)/courses/_components/Breadcrumb/index.tsx",
+      "type": "unknown",
+      "domain": "general",
+      "patterns": ["tailwind-component"],
+      "aiSummary": "",
+      "dependencies": ["next/link"]
+    },
     "src/app/(frontend)/courses/_components/ChapterCard/index.tsx": {
       "path": "src/app/(frontend)/courses/_components/ChapterCard/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -1889,6 +1946,14 @@
       "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": ["lucide-react", "react", "sonner"]
+    },
+    "src/app/(frontend)/courses/_components/CourseCardGrid/index.tsx": {
+      "path": "src/app/(frontend)/courses/_components/CourseCardGrid/index.tsx",
+      "type": "unknown",
+      "domain": "general",
+      "patterns": ["client-component"],
+      "aiSummary": "",
+      "dependencies": []
     },
     "src/app/(frontend)/courses/_components/CourseCatalogHeader/index.tsx": {
       "path": "src/app/(frontend)/courses/_components/CourseCatalogHeader/index.tsx",
@@ -1926,9 +1991,9 @@
       "path": "src/app/(frontend)/courses/_components/EmptyState/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": []
+      "dependencies": ["lucide-react"]
     },
     "src/app/(frontend)/courses/_components/ExerciseCard/index.tsx": {
       "path": "src/app/(frontend)/courses/_components/ExerciseCard/index.tsx",
@@ -2016,7 +2081,7 @@
       "domain": "general",
       "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["lucide-react"]
+      "dependencies": ["lucide-react", "framer-motion"]
     },
     "src/app/(frontend)/next/preview/route.ts": {
       "path": "src/app/(frontend)/next/preview/route.ts",
@@ -2048,13 +2113,21 @@
       "aiSummary": "",
       "dependencies": ["next/link", "react"]
     },
+    "src/app/(frontend)/offline/page.tsx": {
+      "path": "src/app/(frontend)/offline/page.tsx",
+      "type": "unknown",
+      "domain": "general",
+      "patterns": ["client-component"],
+      "aiSummary": "",
+      "dependencies": []
+    },
     "src/app/(frontend)/onboarding/persona/PersonaSelectionStep.tsx": {
       "path": "src/app/(frontend)/onboarding/persona/PersonaSelectionStep.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["react", "sonner"]
+      "dependencies": ["react", "sonner", "lucide-react"]
     },
     "src/app/(frontend)/posts/[slug]/page.client.tsx": {
       "path": "src/app/(frontend)/posts/[slug]/page.client.tsx",
@@ -2102,7 +2175,7 @@
       "domain": "general",
       "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": ["react", "framer-motion"]
     },
     "src/app/(frontend)/stats/_components/ActivityTimeline.tsx": {
       "path": "src/app/(frontend)/stats/_components/ActivityTimeline.tsx",
@@ -2110,7 +2183,7 @@
       "domain": "general",
       "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": ["react", "framer-motion"]
     },
     "src/app/(frontend)/stats/_components/CategoryProgress.tsx": {
       "path": "src/app/(frontend)/stats/_components/CategoryProgress.tsx",
@@ -2124,7 +2197,7 @@
       "path": "src/app/(frontend)/stats/_components/DashboardFilters.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": []
     },
@@ -2142,7 +2215,7 @@
       "domain": "general",
       "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": ["react", "framer-motion"]
     },
     "src/app/(frontend)/stats/_components/SummaryCards.tsx": {
       "path": "src/app/(frontend)/stats/_components/SummaryCards.tsx",
@@ -2156,17 +2229,17 @@
       "path": "src/app/(frontend)/study/_components/StudyContent/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["tailwind-component", "i18n-component", "client-component"],
+      "patterns": ["i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["lucide-react", "sonner", "react"]
+      "dependencies": ["lucide-react", "framer-motion", "react"]
     },
     "src/app/(frontend)/study-plan/_components/DayCard.tsx": {
       "path": "src/app/(frontend)/study-plan/_components/DayCard.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": ["react", "lucide-react", "next/link"]
     },
     "src/app/(frontend)/study-plan/_components/EmptyPlanState.tsx": {
       "path": "src/app/(frontend)/study-plan/_components/EmptyPlanState.tsx",
@@ -2176,11 +2249,19 @@
       "aiSummary": "",
       "dependencies": ["lucide-react"]
     },
+    "src/app/(frontend)/study-plan/_components/LessonSelector/index.tsx": {
+      "path": "src/app/(frontend)/study-plan/_components/LessonSelector/index.tsx",
+      "type": "unknown",
+      "domain": "general",
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
+      "aiSummary": "",
+      "dependencies": ["react", "lucide-react"]
+    },
     "src/app/(frontend)/study-plan/_components/StudyPlanPage.tsx": {
       "path": "src/app/(frontend)/study-plan/_components/StudyPlanPage.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": ["lucide-react", "react"]
     },
@@ -2303,6 +2384,14 @@
       "patterns": ["api-endpoint", "authenticated-endpoint", "validated-endpoint"],
       "aiSummary": "",
       "dependencies": ["next/server", "zod", "payload", "@payload-config"]
+    },
+    "src/app/api/course-syllabus/route.ts": {
+      "path": "src/app/api/course-syllabus/route.ts",
+      "type": "api-route",
+      "domain": "courses",
+      "patterns": ["course-syllabus", "api-endpoint", "validated-endpoint"],
+      "aiSummary": "Returns full syllabus (chapters + lessons) for a course",
+      "dependencies": ["next/server", "zod"]
     },
     "src/app/api/entitlements/check/route.ts": {
       "path": "src/app/api/entitlements/check/route.ts",
@@ -4008,6 +4097,14 @@
       "aiSummary": "",
       "dependencies": ["@payloadcms/ui", "next/navigation", "react"]
     },
+    "src/ui/admin/ContentNavigation/index.tsx": {
+      "path": "src/ui/admin/ContentNavigation/index.tsx",
+      "type": "unknown",
+      "domain": "general",
+      "patterns": ["client-component"],
+      "aiSummary": "",
+      "dependencies": ["@payloadcms/ui", "react"]
+    },
     "src/ui/admin/ExerciseContentEditor/BlockTypeSelector.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/BlockTypeSelector.tsx",
       "type": "unknown",
@@ -4015,6 +4112,14 @@
       "patterns": ["client-component"],
       "aiSummary": "",
       "dependencies": ["react"]
+    },
+    "src/ui/admin/ExerciseContentEditor/FullJsonEditor.tsx": {
+      "path": "src/ui/admin/ExerciseContentEditor/FullJsonEditor.tsx",
+      "type": "unknown",
+      "domain": "general",
+      "patterns": ["client-component"],
+      "aiSummary": "",
+      "dependencies": ["lucide-react", "react"]
     },
     "src/ui/admin/ExerciseContentEditor/JSONInspector.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/JSONInspector.tsx",
@@ -4280,6 +4385,14 @@
       "aiSummary": "",
       "dependencies": ["@payloadcms/ui", "next/image", "react", "lucide-react"]
     },
+    "src/ui/admin/ExerciseContentEditor/editors/MultiAxisEditor.tsx": {
+      "path": "src/ui/admin/ExerciseContentEditor/editors/MultiAxisEditor.tsx",
+      "type": "unknown",
+      "domain": "general",
+      "patterns": ["client-component"],
+      "aiSummary": "",
+      "dependencies": ["react", "lucide-react"]
+    },
     "src/ui/admin/ExerciseContentEditor/editors/QuestionBlockWrapper.tsx": {
       "path": "src/ui/admin/ExerciseContentEditor/editors/QuestionBlockWrapper.tsx",
       "type": "unknown",
@@ -4390,7 +4503,7 @@
       "domain": "general",
       "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": ["react", "@payloadcms/ui", "lucide-react"]
+      "dependencies": ["react", "@payloadcms/ui", "next/navigation"]
     },
     "src/ui/admin/MediaPreview/AudioPreview.tsx": {
       "path": "src/ui/admin/MediaPreview/AudioPreview.tsx",
@@ -4776,6 +4889,14 @@
       "aiSummary": "",
       "dependencies": ["@payloadcms/live-preview-react", "next/navigation", "react"]
     },
+    "src/ui/web/PageRange/index.tsx": {
+      "path": "src/ui/web/PageRange/index.tsx",
+      "type": "unknown",
+      "domain": "general",
+      "patterns": ["tailwind-component"],
+      "aiSummary": "",
+      "dependencies": ["react"]
+    },
     "src/ui/web/Pagination/index.tsx": {
       "path": "src/ui/web/Pagination/index.tsx",
       "type": "unknown",
@@ -4799,6 +4920,14 @@
       "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
       "dependencies": ["dompurify", "react"]
+    },
+    "src/ui/web/TelescopeLogo/index.tsx": {
+      "path": "src/ui/web/TelescopeLogo/index.tsx",
+      "type": "unknown",
+      "domain": "general",
+      "patterns": ["tailwind-component"],
+      "aiSummary": "",
+      "dependencies": ["next/image", "react"]
     },
     "src/ui/web/UserDropdown/index.tsx": {
       "path": "src/ui/web/UserDropdown/index.tsx",
@@ -4860,7 +4989,7 @@
       "path": "src/ui/web/chat/ChatQuotaBar/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": ["react"]
     },
@@ -4920,6 +5049,14 @@
       "aiSummary": "",
       "dependencies": ["react"]
     },
+    "src/ui/web/components/accent-picker.tsx": {
+      "path": "src/ui/web/components/accent-picker.tsx",
+      "type": "unknown",
+      "domain": "general",
+      "patterns": ["tailwind-component", "client-component"],
+      "aiSummary": "",
+      "dependencies": ["react", "lucide-react"]
+    },
     "src/ui/web/components/accordion.tsx": {
       "path": "src/ui/web/components/accordion.tsx",
       "type": "unknown",
@@ -4927,6 +5064,14 @@
       "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
       "dependencies": ["react", "@radix-ui/react-accordion", "lucide-react"]
+    },
+    "src/ui/web/components/animated-counter.tsx": {
+      "path": "src/ui/web/components/animated-counter.tsx",
+      "type": "unknown",
+      "domain": "general",
+      "patterns": ["client-component"],
+      "aiSummary": "",
+      "dependencies": ["react", "framer-motion"]
     },
     "src/ui/web/components/avatar.tsx": {
       "path": "src/ui/web/components/avatar.tsx",
@@ -4984,6 +5129,22 @@
       "aiSummary": "",
       "dependencies": ["react", "cmdk", "lucide-react"]
     },
+    "src/ui/web/components/confetti.stories.tsx": {
+      "path": "src/ui/web/components/confetti.stories.tsx",
+      "type": "unknown",
+      "domain": "general",
+      "patterns": ["client-component"],
+      "aiSummary": "",
+      "dependencies": ["@storybook/react", "react"]
+    },
+    "src/ui/web/components/confetti.tsx": {
+      "path": "src/ui/web/components/confetti.tsx",
+      "type": "unknown",
+      "domain": "general",
+      "patterns": ["client-component"],
+      "aiSummary": "",
+      "dependencies": ["react", "framer-motion"]
+    },
     "src/ui/web/components/dialog.tsx": {
       "path": "src/ui/web/components/dialog.tsx",
       "type": "unknown",
@@ -5040,6 +5201,22 @@
       "aiSummary": "",
       "dependencies": ["@radix-ui/react-label", "class-variance-authority", "react"]
     },
+    "src/ui/web/components/motion.tsx": {
+      "path": "src/ui/web/components/motion.tsx",
+      "type": "unknown",
+      "domain": "general",
+      "patterns": ["client-component"],
+      "aiSummary": "",
+      "dependencies": ["framer-motion", "react"]
+    },
+    "src/ui/web/components/onboarding-tip.tsx": {
+      "path": "src/ui/web/components/onboarding-tip.tsx",
+      "type": "unknown",
+      "domain": "general",
+      "patterns": ["tailwind-component", "client-component"],
+      "aiSummary": "",
+      "dependencies": ["react", "framer-motion", "lucide-react"]
+    },
     "src/ui/web/components/page-section.tsx": {
       "path": "src/ui/web/components/page-section.tsx",
       "type": "unknown",
@@ -5047,6 +5224,14 @@
       "patterns": ["tailwind-component"],
       "aiSummary": "",
       "dependencies": ["react"]
+    },
+    "src/ui/web/components/page-transition.tsx": {
+      "path": "src/ui/web/components/page-transition.tsx",
+      "type": "unknown",
+      "domain": "general",
+      "patterns": ["client-component"],
+      "aiSummary": "",
+      "dependencies": ["framer-motion", "react"]
     },
     "src/ui/web/components/pagination.tsx": {
       "path": "src/ui/web/components/pagination.tsx",
@@ -5093,6 +5278,14 @@
         "react"
       ]
     },
+    "src/ui/web/components/skeleton.tsx": {
+      "path": "src/ui/web/components/skeleton.tsx",
+      "type": "unknown",
+      "domain": "general",
+      "patterns": ["tailwind-component"],
+      "aiSummary": "",
+      "dependencies": []
+    },
     "src/ui/web/components/split-pane-layout.tsx": {
       "path": "src/ui/web/components/split-pane-layout.tsx",
       "type": "unknown",
@@ -5107,7 +5300,7 @@
       "domain": "general",
       "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["framer-motion", "lucide-react", "react"]
+      "dependencies": ["lucide-react", "react"]
     },
     "src/ui/web/components/tabs.tsx": {
       "path": "src/ui/web/components/tabs.tsx",
@@ -5227,7 +5420,7 @@
       "domain": "general",
       "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": ["react", "framer-motion", "lucide-react"]
     },
     "src/ui/web/exerciserenderer/components/HelpSystem/HelpSystemButtons.tsx": {
       "path": "src/ui/web/exerciserenderer/components/HelpSystem/HelpSystemButtons.tsx",
@@ -5235,15 +5428,15 @@
       "domain": "general",
       "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": ["react", "framer-motion", "lucide-react"]
     },
     "src/ui/web/exerciserenderer/components/HelpSystem/HelpSystemContent.tsx": {
       "path": "src/ui/web/exerciserenderer/components/HelpSystem/HelpSystemContent.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": ["react", "framer-motion", "lucide-react"]
     },
     "src/ui/web/exerciserenderer/components/HelpSystem/index.tsx": {
       "path": "src/ui/web/exerciserenderer/components/HelpSystem/index.tsx",
@@ -5251,7 +5444,7 @@
       "domain": "general",
       "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": ["react", "framer-motion"]
     },
     "src/ui/web/exerciserenderer/components/MediaAttachments/index.tsx": {
       "path": "src/ui/web/exerciserenderer/components/MediaAttachments/index.tsx",
@@ -5267,7 +5460,7 @@
       "domain": "general",
       "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": ["react", "framer-motion", "lucide-react"]
     },
     "src/ui/web/exerciserenderer/components/VideoPlayer/index.tsx": {
       "path": "src/ui/web/exerciserenderer/components/VideoPlayer/index.tsx",
@@ -5307,7 +5500,7 @@
       "domain": "general",
       "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": ["react", "framer-motion", "lucide-react"]
     },
     "src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingColumn.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingColumn.tsx",
@@ -5323,7 +5516,7 @@
       "domain": "general",
       "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": ["react", "framer-motion", "lucide-react"]
     },
     "src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingLines.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingLines.tsx",
@@ -5331,7 +5524,7 @@
       "domain": "general",
       "patterns": ["client-component"],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": ["react", "framer-motion"]
     },
     "src/ui/web/exerciserenderer/questions/MatchingQuestion/index.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/MatchingQuestion/index.tsx",
@@ -5347,7 +5540,7 @@
       "domain": "general",
       "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": ["react", "framer-motion", "lucide-react"]
     },
     "src/ui/web/exerciserenderer/questions/TableQuestion/ExerciseTable.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/TableQuestion/ExerciseTable.tsx",
@@ -5355,7 +5548,7 @@
       "domain": "general",
       "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["react"]
+      "dependencies": ["react", "framer-motion", "lucide-react"]
     },
     "src/ui/web/exerciserenderer/questions/TableQuestion/index.tsx": {
       "path": "src/ui/web/exerciserenderer/questions/TableQuestion/index.tsx",
@@ -5371,7 +5564,7 @@
       "domain": "general",
       "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react"]
+      "dependencies": ["react", "framer-motion", "lucide-react"]
     },
     "src/ui/web/footer/RowLabel.tsx": {
       "path": "src/ui/web/footer/RowLabel.tsx",
@@ -5401,7 +5594,7 @@
       "path": "src/ui/web/header/Component.client.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
       "dependencies": ["next/navigation", "react"]
     },
@@ -5409,9 +5602,9 @@
       "path": "src/ui/web/header/CourseSearch/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["react", "lucide-react", "next/navigation"]
+      "dependencies": ["react", "next/navigation", "framer-motion"]
     },
     "src/ui/web/header/MobileMenu/MobileMenuAuthSection.tsx": {
       "path": "src/ui/web/header/MobileMenu/MobileMenuAuthSection.tsx",
@@ -5425,7 +5618,7 @@
       "path": "src/ui/web/header/MobileMenu/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["i18n-component", "client-component"],
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
       "dependencies": ["react", "lucide-react"]
     },
@@ -5477,13 +5670,21 @@
       "aiSummary": "",
       "dependencies": ["react"]
     },
+    "src/ui/web/homepage/LandingPage/index.tsx": {
+      "path": "src/ui/web/homepage/LandingPage/index.tsx",
+      "type": "unknown",
+      "domain": "general",
+      "patterns": ["tailwind-component", "i18n-component", "client-component"],
+      "aiSummary": "",
+      "dependencies": ["framer-motion", "lucide-react"]
+    },
     "src/ui/web/homepage/NavigationBar/index.tsx": {
       "path": "src/ui/web/homepage/NavigationBar/index.tsx",
       "type": "unknown",
       "domain": "general",
       "patterns": ["tailwind-component", "i18n-component", "client-component"],
       "aiSummary": "",
-      "dependencies": ["next/navigation"]
+      "dependencies": ["next/navigation", "framer-motion", "lucide-react"]
     },
     "src/ui/web/homepage/TopicCard/index.tsx": {
       "path": "src/ui/web/homepage/TopicCard/index.tsx",
@@ -5651,7 +5852,7 @@
       "domain": "formula-sheets",
       "patterns": ["content-renderer", "i18n-component", "client-component"],
       "aiSummary": "Client-side renderer for formula sheet content (PDF or HTML blocks)",
-      "dependencies": []
+      "dependencies": ["next/image"]
     },
     "src/ui/web/shared/Icon/Icon.tsx": {
       "path": "src/ui/web/shared/Icon/Icon.tsx",
@@ -5769,7 +5970,7 @@
       "path": "src/ui/web/shared/ProgressCircle/index.tsx",
       "type": "unknown",
       "domain": "general",
-      "patterns": ["client-component"],
+      "patterns": ["tailwind-component", "client-component"],
       "aiSummary": "",
       "dependencies": ["react"]
     },
@@ -5799,8 +6000,8 @@
     }
   },
   "metadata": {
-    "generatedAt": "2026-03-30T07:10:58.582Z",
-    "totalFiles": 534,
-    "totalPatterns": 135
+    "generatedAt": "2026-04-02T15:35:25.477Z",
+    "totalFiles": 553,
+    "totalPatterns": 136
   }
 }

--- a/src/ui/web/exerciserenderer/ExerciseRenderer/index.tsx
+++ b/src/ui/web/exerciserenderer/ExerciseRenderer/index.tsx
@@ -27,6 +27,10 @@ import type {
 } from '../types'
 import type { GeometrySpecV1, AxisSpecV1 } from '@/infra/contracts'
 import type { DisplaySize } from '../blocks/AxisRenderer'
+import { FadeIn } from '@/ui/web/components/motion'
+import { Confetti } from '@/ui/web/components/confetti'
+import { Progress } from '@/ui/web/components/progress'
+import { Sparkles } from 'lucide-react'
 import { HtmlBlockRenderer } from '../blocks/HtmlBlockRenderer'
 import { RichTextRenderer } from '../blocks/RichTextRenderer'
 import { SvgRenderer } from '../blocks/SvgRenderer'
@@ -212,14 +216,27 @@ export function ExerciseRenderer({
   const [isChecking, setIsChecking] = useState<Record<string, boolean>>({})
   const chatTriggeredRef = useRef<Set<string>>(new Set())
 
+  // Aggregate correctness tracking
+  const totalQuestions = questionBlocks.length
+  const correctCount = Object.values(checkResults).filter((r) => r.isCorrect).length
+  const allQuestionsCorrect = totalQuestions > 0 && correctCount === totalQuestions
+  const allCorrectFiredRef = useRef(false)
+  const [showAllCorrectConfetti, setShowAllCorrectConfetti] = useState(false)
+
   // Report aggregate correctness to parent when check results change
   useEffect(() => {
     if (!onResultsChange) return
-    const totalQuestions = questionBlocks.length
     const checkedCount = Object.keys(checkResults).length
-    const correctCount = Object.values(checkResults).filter((r) => r.isCorrect).length
     onResultsChange({ totalQuestions, checkedCount, correctCount })
-  }, [checkResults, onResultsChange, questionBlocks.length])
+  }, [checkResults, onResultsChange, totalQuestions, correctCount])
+
+  // Fire all-correct celebration once
+  useEffect(() => {
+    if (allQuestionsCorrect && !allCorrectFiredRef.current) {
+      allCorrectFiredRef.current = true
+      setShowAllCorrectConfetti(true)
+    }
+  }, [allQuestionsCorrect])
 
   // SVG hotspot state (interactive SVGs are separate from QuestionBlock flow)
   const [svgAnswers, setSvgAnswers] = useState<Record<string, UserAnswer>>({})
@@ -368,6 +385,31 @@ export function ExerciseRenderer({
           </div>
         )}
 
+        {/* Progress Bar — only when 2+ questions */}
+        {totalQuestions >= 2 && (
+          <div className="mb-2">
+            <Progress
+              value={totalQuestions > 0 ? (correctCount / totalQuestions) * 100 : 0}
+              className="h-[3px] rounded-none"
+            />
+            <p className="text-body-xs text-muted-foreground mt-1.5">
+              {correctCount} / {totalQuestions}
+            </p>
+          </div>
+        )}
+
+        {/* All-correct celebration */}
+        <Confetti active={showAllCorrectConfetti} duration={3000} />
+        {allQuestionsCorrect && (
+          <FadeIn>
+            <div className="rounded-xl bg-success/8 border border-success/20 p-card-padding-sm text-center flex items-center justify-center gap-content-gap-xs">
+              <Sparkles className="w-5 h-5 text-success" />
+              <span className="text-heading-sm font-bold text-success">{t('correct')}</span>
+              <Sparkles className="w-5 h-5 text-success" />
+            </div>
+          </FadeIn>
+        )}
+
         <div className="flex flex-col gap-content-gap-lg">
           {(() => {
             let questionIndex = 0
@@ -454,12 +496,11 @@ export function ExerciseRenderer({
               // Rich text block - just render content
               if (block.type === 'rich_text') {
                 return (
-                  <div
-                    key={block.id}
-                    className="prose prose-slate dark:prose-invert max-w-none text-foreground leading-relaxed"
-                  >
-                    <RichTextRenderer block={block} />
-                  </div>
+                  <FadeIn key={block.id}>
+                    <div className="prose prose-slate dark:prose-invert max-w-none text-foreground leading-relaxed">
+                      <RichTextRenderer block={block} />
+                    </div>
+                  </FadeIn>
                 )
               }
 
@@ -623,6 +664,7 @@ export function ExerciseRenderer({
                   questionLabel={questionLabel}
                   dir={dir}
                   helpSystem={helpSystemNode}
+                  animationDelay={questionIndex * 0.08}
                 >
                   {/* Render appropriate question component based on type */}
                   {question.type === 'question_select' && question.variant === 'true_false' && (

--- a/src/ui/web/exerciserenderer/blocks/SvgRenderer/index.tsx
+++ b/src/ui/web/exerciserenderer/blocks/SvgRenderer/index.tsx
@@ -110,7 +110,7 @@ export function SvgRenderer({
     : null
 
   return (
-    <div>
+    <div className="rounded-xl border border-border/20 overflow-hidden bg-card shadow-elevation-1 p-3">
       <div
         ref={containerRef}
         role={isInteractive ? 'application' : 'img'}

--- a/src/ui/web/exerciserenderer/components/FeedbackDisplay/index.tsx
+++ b/src/ui/web/exerciserenderer/components/FeedbackDisplay/index.tsx
@@ -1,14 +1,18 @@
 /**
  * Feedback Display Component
- * Shows feedback after a user checks their answer
+ * Shows animated feedback after a user checks their answer
  */
 
 'use client'
 
-import React from 'react'
+import React, { useRef, useState, useEffect } from 'react'
+import { motion } from 'framer-motion'
 import { cn } from '@/infra/utils/ui'
 import { CheckCircle2, XCircle } from 'lucide-react'
+import { Confetti } from '@/ui/web/components/confetti'
 import type { CheckResult } from '../../types'
+
+const EASE_OUT = [0.25, 0.46, 0.45, 0.94] as const
 
 interface FeedbackDisplayProps {
   checkResult: CheckResult
@@ -17,38 +21,70 @@ interface FeedbackDisplayProps {
 }
 
 export function FeedbackDisplay({ checkResult, correctText, incorrectText }: FeedbackDisplayProps) {
+  const hasFiredConfetti = useRef(false)
+  const [showConfetti, setShowConfetti] = useState(false)
+
+  useEffect(() => {
+    if (checkResult.isCorrect && !hasFiredConfetti.current) {
+      hasFiredConfetti.current = true
+      setShowConfetti(true)
+    }
+  }, [checkResult.isCorrect])
+
+  const shakeAnimation = !checkResult.isCorrect ? { x: [0, -6, 6, -4, 4, 0] } : {}
+
   return (
-    <div
-      className={cn(
-        'mt-card-padding p-card-padding-sm rounded-lg border-2 animate-in fade-in slide-in-from-bottom-2 duration-normal',
-        checkResult.isCorrect ? 'border-success bg-success/10' : 'border-error bg-error/10',
-      )}
-    >
-      <div className="flex items-center gap-content-gap-xs">
-        {checkResult.isCorrect ? (
-          <CheckCircle2 className="w-6 h-6 shrink-0 text-success" />
-        ) : (
-          <XCircle className="w-6 h-6 shrink-0 text-error" />
+    <>
+      <Confetti active={showConfetti} duration={2500} />
+      <motion.div
+        initial={{ opacity: 0, y: 10, scale: 0.98 }}
+        animate={{ opacity: 1, y: 0, scale: 1, ...shakeAnimation }}
+        exit={{ opacity: 0, y: -6 }}
+        transition={{ duration: 0.35, ease: EASE_OUT }}
+        className={cn(
+          'mt-4 p-card-padding-sm rounded-xl border',
+          checkResult.isCorrect ? 'border-success/20 bg-success/8' : 'border-error/20 bg-error/8',
         )}
-        <span
-          className={cn(
-            'font-semibold text-body-lg',
-            checkResult.isCorrect ? 'text-success' : 'text-error',
-          )}
-        >
-          {checkResult.isCorrect ? correctText : incorrectText}
-        </span>
-      </div>
-      {checkResult.message && (
-        <p
-          className={cn(
-            'mt-2 text-body-sm',
-            checkResult.isCorrect ? 'text-success/80' : 'text-error/80',
-          )}
-        >
-          {checkResult.message}
-        </p>
-      )}
-    </div>
+      >
+        <div className="flex items-center gap-3">
+          <motion.span
+            initial={{ scale: 0, rotate: -30 }}
+            animate={{ scale: 1, rotate: 0 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 15, delay: 0.15 }}
+            className={cn(
+              'flex items-center justify-center w-8 h-8 rounded-full shrink-0',
+              checkResult.isCorrect ? 'bg-success/15' : 'bg-error/15',
+            )}
+          >
+            {checkResult.isCorrect ? (
+              <CheckCircle2 className="w-5 h-5 text-success" />
+            ) : (
+              <XCircle className="w-5 h-5 text-error" />
+            )}
+          </motion.span>
+          <span
+            className={cn(
+              'font-bold text-heading-sm',
+              checkResult.isCorrect ? 'text-success' : 'text-error',
+            )}
+          >
+            {checkResult.isCorrect ? correctText : incorrectText}
+          </span>
+        </div>
+        {checkResult.message && (
+          <motion.p
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.2, duration: 0.25 }}
+            className={cn(
+              'mt-2 ms-11 text-body-sm',
+              checkResult.isCorrect ? 'text-success/70' : 'text-error/70',
+            )}
+          >
+            {checkResult.message}
+          </motion.p>
+        )}
+      </motion.div>
+    </>
   )
 }

--- a/src/ui/web/exerciserenderer/components/HelpSystem/HelpSystemButtons.tsx
+++ b/src/ui/web/exerciserenderer/components/HelpSystem/HelpSystemButtons.tsx
@@ -8,6 +8,7 @@
 'use client'
 
 import React from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
 import { cn } from '@/infra/utils/ui'
 import { Lightbulb, HelpCircle, CheckCircle2 } from 'lucide-react'
 import type { HelpUsageState } from '../../types'
@@ -34,53 +35,89 @@ export function HelpSystemButtons({
   solutionLabel,
 }: HelpSystemButtonsProps) {
   return (
-    <div className="flex flex-wrap gap-content-gap-xs">
-      {/* Hint Button - always visible, AI fallback when no backend content */}
-      <button
+    <div className="flex flex-wrap gap-content-gap-xs.5">
+      {/* Hint Button */}
+      <motion.button
         type="button"
         onClick={onHintClick}
+        whileHover={{ scale: 1.03 }}
+        whileTap={{ scale: 0.97 }}
         className={cn(
-          'flex items-center gap-1.5 px-4 py-2 rounded-xl text-body-xs transition-all duration-slow border shadow-elevation-1',
+          'flex items-center gap-content-gap-xs px-4 py-2 rounded-full text-body-xs font-medium transition-colors duration-normal border shadow-elevation-1',
+          'hover:-translate-y-0.5 hover:shadow-elevation-2',
           activeHelp === 'hint'
-            ? 'bg-warning/10 border-warning/30 text-warning'
-            : 'bg-card border-border text-muted-foreground hover:bg-muted hover:border-muted-foreground hover:shadow-elevation-3',
+            ? 'bg-warning/10 border-warning/30 text-warning shadow-[inset_0_0_8px_hsl(var(--warning)/0.12)]'
+            : 'bg-card border-border text-muted-foreground hover:bg-muted hover:border-muted-foreground',
         )}
       >
-        <Lightbulb className="w-4 h-4" />
-        {hintLabel}
-      </button>
-
-      {/* Guiding Question Button - always visible, AI fallback when no backend content */}
-      <button
-        type="button"
-        onClick={onGuidingClick}
-        className={cn(
-          'flex items-center gap-1.5 px-4 py-2 rounded-xl text-body-xs transition-all duration-slow border shadow-elevation-1',
-          activeHelp === 'guiding'
-            ? 'bg-accent/10 border-accent/30 text-accent'
-            : 'bg-card border-border text-muted-foreground hover:bg-muted hover:border-muted-foreground hover:shadow-elevation-3',
-        )}
-      >
-        <HelpCircle className="w-4 h-4" />
-        {guidingLabel}
-      </button>
-
-      {/* Solution Button - hidden until unlocked */}
-      {helpUsage.solutionUnlocked && (
-        <button
-          type="button"
-          onClick={onSolutionClick}
+        <span
           className={cn(
-            'flex items-center gap-1.5 px-4 py-2 rounded-xl text-body-xs transition-all duration-slow border shadow-elevation-1',
-            activeHelp === 'solution'
-              ? 'bg-primary/10 border-primary/30 text-primary'
-              : 'bg-card border-border text-muted-foreground hover:bg-muted hover:border-muted-foreground hover:shadow-elevation-3',
+            'flex items-center justify-center w-5 h-5 rounded-full',
+            activeHelp === 'hint' ? 'bg-warning/20' : 'bg-muted',
           )}
         >
-          <CheckCircle2 className="w-4 h-4" />
-          {solutionLabel}
-        </button>
-      )}
+          <Lightbulb className="w-3.5 h-3.5" />
+        </span>
+        {hintLabel}
+      </motion.button>
+
+      {/* Guiding Question Button */}
+      <motion.button
+        type="button"
+        onClick={onGuidingClick}
+        whileHover={{ scale: 1.03 }}
+        whileTap={{ scale: 0.97 }}
+        className={cn(
+          'flex items-center gap-content-gap-xs px-4 py-2 rounded-full text-body-xs font-medium transition-colors duration-normal border shadow-elevation-1',
+          'hover:-translate-y-0.5 hover:shadow-elevation-2',
+          activeHelp === 'guiding'
+            ? 'bg-accent/10 border-accent/30 text-accent shadow-[inset_0_0_8px_hsl(var(--accent)/0.12)]'
+            : 'bg-card border-border text-muted-foreground hover:bg-muted hover:border-muted-foreground',
+        )}
+      >
+        <span
+          className={cn(
+            'flex items-center justify-center w-5 h-5 rounded-full',
+            activeHelp === 'guiding' ? 'bg-accent/20' : 'bg-muted',
+          )}
+        >
+          <HelpCircle className="w-3.5 h-3.5" />
+        </span>
+        {guidingLabel}
+      </motion.button>
+
+      {/* Solution Button — hidden until unlocked */}
+      <AnimatePresence>
+        {helpUsage.solutionUnlocked && (
+          <motion.button
+            type="button"
+            onClick={onSolutionClick}
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.8 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+            whileHover={{ scale: 1.03 }}
+            whileTap={{ scale: 0.97 }}
+            className={cn(
+              'flex items-center gap-content-gap-xs px-4 py-2 rounded-full text-body-xs font-medium transition-colors duration-normal border shadow-elevation-1',
+              'hover:-translate-y-0.5 hover:shadow-elevation-2',
+              activeHelp === 'solution'
+                ? 'bg-primary/10 border-primary/30 text-primary shadow-[inset_0_0_8px_hsl(var(--primary)/0.12)]'
+                : 'bg-card border-border text-muted-foreground hover:bg-muted hover:border-muted-foreground',
+            )}
+          >
+            <span
+              className={cn(
+                'flex items-center justify-center w-5 h-5 rounded-full',
+                activeHelp === 'solution' ? 'bg-primary/20' : 'bg-muted',
+              )}
+            >
+              <CheckCircle2 className="w-3.5 h-3.5" />
+            </span>
+            {solutionLabel}
+          </motion.button>
+        )}
+      </AnimatePresence>
     </div>
   )
 }

--- a/src/ui/web/exerciserenderer/components/HelpSystem/HelpSystemContent.tsx
+++ b/src/ui/web/exerciserenderer/components/HelpSystem/HelpSystemContent.tsx
@@ -8,6 +8,7 @@
 'use client'
 
 import React from 'react'
+import { motion } from 'framer-motion'
 import { cn } from '@/infra/utils/ui'
 import { Lightbulb, HelpCircle, CheckCircle2 } from 'lucide-react'
 import { MathMarkdown } from '@/ui/web/shared/MathMarkdown'
@@ -26,18 +27,23 @@ const CONFIG = {
     icon: Lightbulb,
     gradientClass: 'bg-warning/5 border-warning/20',
     iconClass: 'text-warning',
+    pillClass: 'bg-warning/10 text-warning',
   },
   guiding: {
     icon: HelpCircle,
     gradientClass: 'bg-accent/5 border-accent/20',
     iconClass: 'text-accent',
+    pillClass: 'bg-accent/10 text-accent',
   },
   solution: {
     icon: CheckCircle2,
     gradientClass: 'bg-primary/5 border-primary/20',
     iconClass: 'text-primary',
+    pillClass: 'bg-primary/10 text-primary',
   },
 } as const
+
+const EASE_OUT = [0.25, 0.46, 0.45, 0.94] as const
 
 export function HelpSystemContent({
   type,
@@ -46,27 +52,42 @@ export function HelpSystemContent({
   guidingLabel,
   solutionLabel,
 }: HelpSystemContentProps) {
-  const { icon: Icon, gradientClass, iconClass } = CONFIG[type]
+  const { icon: Icon, gradientClass, iconClass, pillClass } = CONFIG[type]
   const label = type === 'hint' ? hintLabel : type === 'guiding' ? guidingLabel : solutionLabel
   const processed = preprocessNewlines(content)
 
   return (
-    <div
-      className={cn(
-        'p-card-padding-sm rounded-2xl border shadow-elevation-1 animate-in slide-in-from-top-2 duration-slow',
-        gradientClass,
-      )}
+    <motion.div
+      initial={{ opacity: 0, height: 0 }}
+      animate={{ opacity: 1, height: 'auto' }}
+      exit={{ opacity: 0, height: 0 }}
+      transition={{ duration: 0.3, ease: EASE_OUT }}
+      className="overflow-hidden"
     >
-      <div className="flex items-center gap-content-gap-xs mb-2">
-        <Icon className={cn('w-4 h-4', iconClass)} />
-        <span className="text-body-xs font-medium text-muted-foreground">{label}</span>
+      <div className={cn('p-card-padding-sm rounded-2xl border shadow-elevation-1', gradientClass)}>
+        <div className="flex items-center gap-content-gap-xs mb-3 pb-2 border-b border-current/10">
+          <span
+            className={cn(
+              'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-body-xs font-medium',
+              pillClass,
+            )}
+          >
+            <Icon className={cn('w-3.5 h-3.5', iconClass)} />
+            {label}
+          </span>
+        </div>
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.15, duration: 0.25 }}
+          className="prose prose-sm prose-slate dark:prose-invert max-w-none"
+        >
+          <MathMarkdown
+            content={processed}
+            className="text-body-sm leading-relaxed text-foreground"
+          />
+        </motion.div>
       </div>
-      <div className="prose prose-sm prose-slate dark:prose-invert max-w-none">
-        <MathMarkdown
-          content={processed}
-          className="text-body-sm leading-relaxed text-foreground"
-        />
-      </div>
-    </div>
+    </motion.div>
   )
 }

--- a/src/ui/web/exerciserenderer/components/HelpSystem/index.tsx
+++ b/src/ui/web/exerciserenderer/components/HelpSystem/index.tsx
@@ -8,6 +8,7 @@
 'use client'
 
 import React from 'react'
+import { AnimatePresence } from 'framer-motion'
 import type { HelpUsageState, QuestionBlock } from '../../types'
 import { HelpSystemButtons } from './HelpSystemButtons'
 import { HelpSystemContent } from './HelpSystemContent'
@@ -51,17 +52,19 @@ export function HelpSystem({
         solutionLabel={solutionLabel}
       />
 
-      {inlineContent && (
-        <div className="mt-3">
-          <HelpSystemContent
-            type="hint"
-            content={inlineContent}
-            hintLabel={hintLabel}
-            guidingLabel={guidingLabel}
-            solutionLabel={solutionLabel}
-          />
-        </div>
-      )}
+      <AnimatePresence>
+        {inlineContent && (
+          <div className="mt-3">
+            <HelpSystemContent
+              type="hint"
+              content={inlineContent}
+              hintLabel={hintLabel}
+              guidingLabel={guidingLabel}
+              solutionLabel={solutionLabel}
+            />
+          </div>
+        )}
+      </AnimatePresence>
     </div>
   )
 }

--- a/src/ui/web/exerciserenderer/components/QuestionCard/index.tsx
+++ b/src/ui/web/exerciserenderer/components/QuestionCard/index.tsx
@@ -6,12 +6,15 @@
 'use client'
 
 import React from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
 import { cn } from '@/infra/utils/ui'
 import { Button } from '@/ui/web/components/button'
 import { Card } from '@/ui/web/components/card'
 import { CheckCircle2, Loader2 } from 'lucide-react'
 import type { CheckResult } from '../../types'
 import { FeedbackDisplay } from '../FeedbackDisplay'
+
+const EASE_OUT = [0.25, 0.46, 0.45, 0.94] as const
 
 interface QuestionCardProps {
   children: React.ReactNode
@@ -28,6 +31,8 @@ interface QuestionCardProps {
   dir?: 'ltr' | 'rtl'
   /** Optional help system UI (hint/guiding/solution buttons) */
   helpSystem?: React.ReactNode
+  /** Delay for staggered entrance animation (seconds) */
+  animationDelay?: number
 }
 
 export function QuestionCard({
@@ -44,70 +49,100 @@ export function QuestionCard({
   questionLabel,
   dir = 'ltr',
   helpSystem,
+  animationDelay = 0,
 }: QuestionCardProps) {
+  const isCorrect = checked && checkResult?.isCorrect
+
   return (
-    <Card
-      className={cn(
-        'p-card-padding border-2 transition-all duration-normal',
-        checked && checkResult?.isCorrect && 'border-success/30 bg-success/5',
-      )}
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, ease: EASE_OUT, delay: animationDelay }}
     >
-      {/* Question Label */}
-      {questionLabel && (
-        <div
-          className={cn(
-            'w-full flex items-center mb-4',
-            dir === 'rtl'
-              ? 'justify-end text-right flex-row-reverse gap-content-gap-xs'
-              : 'justify-start text-left gap-content-gap-xs',
-          )}
-        >
-          <div className="w-5 h-5 rounded-full flex items-center justify-center bg-muted border border-border shadow-elevation-1">
-            <span className="font-bold text-body-xs">{questionLabel}</span>
-          </div>
-        </div>
-      )}
-
-      {/* Question Content */}
-      {children}
-
-      {/* Help System (hint/guiding/solution) */}
-      {helpSystem}
-
-      {/* Check Answer Button */}
-      {showCheckButton && (
-        <div className="mt-card-padding flex justify-end">
-          <Button
-            onClick={onCheckAnswer}
-            disabled={disabled || loading}
-            size="lg"
-            className={cn('font-semibold', disabled && 'bg-success hover:bg-success/90 text-white')}
-          >
-            {loading ? (
-              <>
-                <Loader2 className="w-5 h-5 me-2 animate-spin" />
-                {checkAnswerText}
-              </>
-            ) : disabled ? (
-              <>
-                <CheckCircle2 className="w-5 h-5 me-2" />
-                {correctText}
-              </>
-            ) : (
-              checkAnswerText
+      <Card
+        className={cn(
+          'p-card-padding shadow-elevation-1 transition-all duration-normal',
+          isCorrect && 'border-s-3 border-s-success bg-success/5',
+        )}
+      >
+        {/* Question Label */}
+        {questionLabel && (
+          <div
+            className={cn(
+              'w-full flex items-center mb-4',
+              dir === 'rtl'
+                ? 'justify-end text-right flex-row-reverse gap-content-gap-xs'
+                : 'justify-start text-left gap-content-gap-xs',
             )}
-          </Button>
-        </div>
-      )}
+          >
+            <motion.div
+              initial={{ scale: 0 }}
+              animate={{ scale: 1 }}
+              transition={{
+                type: 'spring',
+                stiffness: 400,
+                damping: 20,
+                delay: animationDelay + 0.2,
+              }}
+              className="w-7 h-7 rounded-lg flex items-center justify-center bg-primary/10 border border-primary/20 shadow-elevation-1"
+            >
+              <span className="font-bold text-body-sm text-primary">{questionLabel}</span>
+            </motion.div>
+          </div>
+        )}
 
-      {/* Feedback Display */}
-      {checked && checkResult && (
-        <FeedbackDisplay
-          checkResult={checkResult}
-          correctText={correctText}
-          incorrectText={incorrectText}
-        />
-      )}
-    </Card>
+        {/* Question Content */}
+        {children}
+
+        {/* Help System (hint/guiding/solution) */}
+        {helpSystem}
+
+        {/* Action Area */}
+        {(showCheckButton || (checked && checkResult)) && (
+          <div className="border-t border-border/20 pt-4 mt-5">
+            {/* Check Answer Button */}
+            {showCheckButton && (
+              <div className="flex justify-end">
+                <Button
+                  onClick={onCheckAnswer}
+                  disabled={disabled || loading}
+                  size="lg"
+                  className={cn(
+                    'rounded-xl font-bold text-body-md',
+                    disabled && 'bg-success hover:bg-success/90 text-white',
+                  )}
+                >
+                  {loading ? (
+                    <>
+                      <Loader2 className="w-5 h-5 me-2 animate-spin" />
+                      {checkAnswerText}
+                    </>
+                  ) : disabled ? (
+                    <>
+                      <CheckCircle2 className="w-5 h-5 me-2" />
+                      {correctText}
+                    </>
+                  ) : (
+                    checkAnswerText
+                  )}
+                </Button>
+              </div>
+            )}
+
+            {/* Feedback Display */}
+            <AnimatePresence mode="wait">
+              {checked && checkResult && (
+                <FeedbackDisplay
+                  key={checkResult.isCorrect ? 'correct' : 'incorrect'}
+                  checkResult={checkResult}
+                  correctText={correctText}
+                  incorrectText={incorrectText}
+                />
+              )}
+            </AnimatePresence>
+          </div>
+        )}
+      </Card>
+    </motion.div>
   )
 }

--- a/src/ui/web/exerciserenderer/questions/FreeResponseQuestion/index.tsx
+++ b/src/ui/web/exerciserenderer/questions/FreeResponseQuestion/index.tsx
@@ -2,16 +2,17 @@
  * Free Response Question Component
  * Auto-toggling write/view mode: focused = textarea, blurred = rendered math.
  * Textarea stays mounted (no remount hitch). View overlay hides/shows on top.
- * FormulaComposer opens as a popup. Formula button sits on the textbox edge.
+ * FormulaComposer opens as a popup. Formula button sits above the textbox edge.
  */
 
 'use client'
 
 import React, { useRef, useCallback, useLayoutEffect, useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
 import { Textarea } from '@/ui/web/components/textarea'
 import { MathMarkdown } from '@/ui/web/shared/MathMarkdown'
 import { FormulaComposer } from '@/ui/web/shared/MathInput/FormulaComposer'
-import { FunctionSquare } from 'lucide-react'
+import { FunctionSquare, Pencil } from 'lucide-react'
 import type { QuestionFreeResponseBlock, UserAnswer, CheckResult, RichTextBlock } from '../../types'
 import { RichTextRenderer } from '../../blocks/RichTextRenderer'
 
@@ -45,7 +46,7 @@ export function FreeResponseQuestion({
     mediaIds: question.prompt.mediaIds || [],
   }
 
-  const MAX_HEIGHT = 160
+  const MAX_HEIGHT = 200
 
   const autoResize = useCallback(() => {
     const el = textareaRef.current
@@ -101,7 +102,7 @@ export function FreeResponseQuestion({
         <RichTextRenderer block={promptBlock} />
       </div>
 
-      {/* Answer box with formula button on edge */}
+      {/* Answer box with formula button */}
       <div className="relative" data-math-controls>
         {/* Textarea — always mounted, hidden behind overlay when in view mode */}
         <Textarea
@@ -112,41 +113,61 @@ export function FreeResponseQuestion({
           onBlur={handleBlur}
           disabled={disabled}
           placeholder={t('enterAnswer')}
-          className="text-body-md min-h-0 resize-none overflow-hidden pe-10"
+          className="text-body-md min-h-0 resize-none overflow-hidden pe-10 rounded-xl border-2 border-border/30 shadow-elevation-1 focus:border-primary focus:shadow-[0_0_0_3px_hsl(var(--primary)/0.1)] transition-shadow duration-slow placeholder:text-muted-foreground/50 placeholder:italic"
           rows={1}
         />
 
         {/* View overlay: rendered content on top of textarea */}
-        {showViewOverlay && (
-          <div
-            onClick={switchToEditMode}
-            className="absolute inset-0 px-3 py-2 pe-10 rounded-md border border-input bg-background text-body-md leading-relaxed cursor-text overflow-hidden"
-          >
-            <MathMarkdown content={value} />
-          </div>
-        )}
+        <AnimatePresence>
+          {showViewOverlay && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.15 }}
+              onClick={switchToEditMode}
+              className="absolute inset-0 px-3 py-2 pe-10 rounded-xl border-2 border-border/30 bg-card text-body-md leading-relaxed cursor-text overflow-hidden shadow-elevation-1"
+            >
+              <MathMarkdown content={value} />
+              {/* Edit indicator */}
+              {!disabled && (
+                <span className="absolute top-2 end-2 text-muted-foreground/40">
+                  <Pencil className="w-3.5 h-3.5" />
+                </span>
+              )}
+            </motion.div>
+          )}
+        </AnimatePresence>
 
-        {/* Formula button on the edge — end = right in LTR, left in RTL */}
+        {/* Formula button — pill style */}
         {showMathTools && !disabled && (
           <button
             type="button"
             onClick={() => setComposerOpen(!composerOpen)}
-            className="absolute end-1.5 top-1/2 -translate-y-1/2 p-1.5 rounded-lg bg-primary/10 text-primary border border-primary/20 hover:bg-primary/20 transition-all duration-normal z-10"
+            className="absolute end-1.5 top-1/2 -translate-y-1/2 flex items-center gap-1 px-2 py-1 rounded-full bg-primary/10 text-primary border border-primary/20 hover:bg-primary/20 transition-all duration-normal z-10 text-body-xs font-medium"
             title={t('insertFormula')}
           >
-            <FunctionSquare className="w-4 h-4" />
+            <FunctionSquare className="w-3.5 h-3.5" />
           </button>
         )}
 
         {/* Popup formula composer */}
-        {composerOpen && (
-          <div className="absolute top-full mt-2 start-0 end-0 z-10">
-            <FormulaComposer
-              onInsert={handleFormulaInsert}
-              onClose={() => setComposerOpen(false)}
-            />
-          </div>
-        )}
+        <AnimatePresence>
+          {composerOpen && (
+            <motion.div
+              initial={{ opacity: 0, y: -4, scale: 0.97 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: -4, scale: 0.97 }}
+              transition={{ duration: 0.2 }}
+              className="absolute top-full mt-2 start-0 end-0 z-10"
+            >
+              <FormulaComposer
+                onInsert={handleFormulaInsert}
+                onClose={() => setComposerOpen(false)}
+              />
+            </motion.div>
+          )}
+        </AnimatePresence>
       </div>
     </div>
   )

--- a/src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingColumn.tsx
+++ b/src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingColumn.tsx
@@ -31,7 +31,7 @@ export function MatchingColumn({
 }: MatchingColumnProps) {
   return (
     <div className="flex-1 flex flex-col gap-content-gap-xs relative z-[2] min-w-[180px] max-w-[350px]">
-      <div className="font-bold text-center py-2 bg-muted rounded-t-md border-2 border-b-0 border-border text-body-sm">
+      <div className="bg-primary/6 border border-primary/15 rounded-xl py-2.5 font-bold text-center text-primary/80 text-body-sm">
         {header}
       </div>
       {items.map((item, i) => (

--- a/src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingItem.tsx
+++ b/src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingItem.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React from 'react'
+import { motion } from 'framer-motion'
 import { cn } from '@/infra/utils/ui'
 import { Check, X } from 'lucide-react'
 import type { RichTextBlock, MatchingOption } from '../../types'
@@ -19,6 +20,10 @@ interface MatchingItemProps {
   disabled: boolean
   onClick: (id: string) => void
   onRef: (id: string, el: HTMLButtonElement | null) => void
+}
+
+function hasResult(state: boolean | null): boolean {
+  return state !== null
 }
 
 export function MatchingItem({
@@ -43,29 +48,34 @@ export function MatchingItem({
   }
 
   return (
-    <button
+    <motion.button
       ref={(el) => onRef(item.id, el)}
       onClick={() => onClick(item.id)}
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, delay: index * 0.04 }}
+      whileHover={!disabled && !isSelected && !isConnected ? { y: -2 } : undefined}
+      whileTap={!disabled ? { scale: 0.97 } : undefined}
       className={cn(
-        'flex items-center gap-content-gap-xs px-3 py-2 rounded-md border-2 text-start',
+        'flex items-center gap-content-gap-xs p-3.5 rounded-xl border-2 text-start',
         'transition-all duration-normal min-h-[44px]',
-        'border-border bg-card',
+        'bg-card shadow-elevation-1',
         !disabled &&
           !isSelected &&
           !isConnected &&
-          'hover:border-primary/60 hover:shadow-elevation-3 hover:-translate-y-0.5 cursor-pointer',
+          'border-border/30 hover:border-primary/40 hover:shadow-card-hover cursor-pointer',
         canSelect && !isConnected && 'cursor-pointer',
-        isSelected && 'border-primary bg-primary/10 border-[3px] shadow-elevation-3',
-        isConnected && !isSelected && !hasResult(correctState) && 'border-primary/60 bg-primary/5',
-        disabled && 'cursor-not-allowed opacity-disabled',
-        correctState === true && 'border-success bg-success/10',
-        correctState === false && 'border-destructive bg-destructive/10',
+        isSelected && 'border-primary bg-primary/8 border-[3px] shadow-elevation-2',
+        isConnected && !isSelected && !hasResult(correctState) && 'border-primary/40 bg-primary/4',
+        disabled && 'cursor-not-allowed opacity-50',
+        correctState === true && 'border-success bg-success/8',
+        correctState === false && 'border-destructive bg-destructive/8',
       )}
       role="option"
       aria-selected={isSelected}
       disabled={disabled}
     >
-      <span className="font-bold text-body-lg text-muted-foreground min-w-[28px] shrink-0">
+      <span className="w-6 h-6 rounded-lg bg-muted flex items-center justify-center font-bold text-body-xs text-muted-foreground min-w-[24px] shrink-0 border border-border/20">
         {badge}
       </span>
       <span className="flex-1">
@@ -73,10 +83,6 @@ export function MatchingItem({
       </span>
       {correctState === true && <Check className="w-5 h-5 text-success shrink-0" />}
       {correctState === false && <X className="w-5 h-5 text-destructive shrink-0" />}
-    </button>
+    </motion.button>
   )
-}
-
-function hasResult(state: boolean | null): boolean {
-  return state !== null
 }

--- a/src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingLines.tsx
+++ b/src/ui/web/exerciserenderer/questions/MatchingQuestion/MatchingLines.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
 import type { LinePosition } from './matchingUtils'
 import { CONNECTION_COLORS } from './matchingUtils'
 
@@ -12,26 +13,32 @@ interface MatchingLinesProps {
 export function MatchingLines({ lines, getCorrectness }: MatchingLinesProps) {
   return (
     <svg className="absolute inset-0 w-full h-full pointer-events-none z-10">
-      {lines.map((pos, i) => {
-        const midX = (pos.x1 + pos.x2) / 2
-        const correctness = getCorrectness(pos.leftId, pos.rightId)
-        const strokeColor =
-          correctness === true
-            ? 'hsl(var(--success, 142 76% 36%))'
-            : correctness === false
-              ? 'hsl(var(--destructive))'
-              : CONNECTION_COLORS[i % CONNECTION_COLORS.length]
-        return (
-          <path
-            key={`${pos.leftId}-${pos.rightId}`}
-            d={`M ${pos.x1} ${pos.y1} C ${midX} ${pos.y1}, ${midX} ${pos.y2}, ${pos.x2} ${pos.y2}`}
-            stroke={strokeColor}
-            strokeWidth={3}
-            fill="none"
-            opacity={0.8}
-          />
-        )
-      })}
+      <AnimatePresence>
+        {lines.map((pos, i) => {
+          const midX = (pos.x1 + pos.x2) / 2
+          const correctness = getCorrectness(pos.leftId, pos.rightId)
+          const strokeColor =
+            correctness === true
+              ? 'hsl(var(--success, 142 76% 36%))'
+              : correctness === false
+                ? 'hsl(var(--destructive))'
+                : CONNECTION_COLORS[i % CONNECTION_COLORS.length]
+          return (
+            <motion.path
+              key={`${pos.leftId}-${pos.rightId}`}
+              d={`M ${pos.x1} ${pos.y1} C ${midX} ${pos.y1}, ${midX} ${pos.y2}, ${pos.x2} ${pos.y2}`}
+              stroke={strokeColor}
+              strokeWidth={3}
+              strokeLinecap="round"
+              fill="none"
+              initial={{ pathLength: 0, opacity: 0 }}
+              animate={{ pathLength: 1, opacity: 0.8 }}
+              exit={{ pathLength: 0, opacity: 0 }}
+              transition={{ duration: 0.4, ease: 'easeOut' }}
+            />
+          )
+        })}
+      </AnimatePresence>
     </svg>
   )
 }

--- a/src/ui/web/exerciserenderer/questions/MatchingQuestion/index.tsx
+++ b/src/ui/web/exerciserenderer/questions/MatchingQuestion/index.tsx
@@ -144,8 +144,10 @@ export function MatchingQuestion({
         <RichTextRenderer block={promptBlock} />
       </div>
 
-      <div className="flex items-center gap-content-gap-xs px-4 py-3 rounded-lg bg-primary/5 border border-primary/20 text-body-sm text-primary">
-        <Info className="w-4 h-4 shrink-0" />
+      <div className="flex items-center gap-content-gap-xs px-4 py-3 rounded-xl bg-muted/40 border border-border/20 text-body-sm text-muted-foreground">
+        <span className="flex items-center justify-center w-6 h-6 rounded-full bg-primary/10 shrink-0">
+          <Info className="w-3.5 h-3.5 text-primary" />
+        </span>
         {t('matchingInstruction')}
       </div>
 
@@ -180,7 +182,7 @@ export function MatchingQuestion({
       {connections.length > 0 && !disabled && (
         <button
           onClick={handleClearAll}
-          className="self-start text-body-sm text-muted-foreground hover:text-foreground transition-all duration-normal underline"
+          className="self-start inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-body-sm text-muted-foreground hover:bg-muted hover:text-foreground border border-transparent hover:border-border/20 transition-all duration-normal"
         >
           {t('matchingClear')}
         </button>

--- a/src/ui/web/exerciserenderer/questions/McqQuestion/index.tsx
+++ b/src/ui/web/exerciserenderer/questions/McqQuestion/index.tsx
@@ -1,11 +1,12 @@
 /**
  * Multiple Choice Question Component
- * Displays a question with multiple choice options (single or multi-select)
+ * Displays a question with multiple choice option cards (single or multi-select)
  */
 
 'use client'
 
 import React from 'react'
+import { motion } from 'framer-motion'
 import { cn } from '@/infra/utils/ui'
 import { Checkbox } from '@/ui/web/components/checkbox'
 import { AlertCircle } from 'lucide-react'
@@ -67,12 +68,12 @@ export function McqQuestion({
       <div className="text-body-md font-medium text-foreground leading-relaxed">
         <RichTextRenderer block={promptBlock} />
       </div>
-      <div className="flex items-center gap-1.5 text-body-sm text-muted-foreground">
-        <AlertCircle className="w-4 h-4" />
+      <div className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-muted text-muted-foreground text-body-xs border border-border/20 w-fit">
+        <AlertCircle className="w-3.5 h-3.5" />
         {question.answer.multiSelect ? t('selectMultiple') : t('selectOne')}
       </div>
-      <div className="flex flex-col gap-3">
-        {question.answer.options.map((option) => {
+      <div className="flex flex-col gap-3.5">
+        {question.answer.options.map((option, index) => {
           const isSelected = selectedIds.includes(option.id)
           // Transform fractions to display style for better readability in MCQ options
           const transformedValue = transformFractionsToDisplayStyle(option.content.value)
@@ -83,15 +84,21 @@ export function McqQuestion({
             mediaIds: option.content.mediaIds || [],
           }
           return (
-            <label
+            <motion.label
               key={option.id}
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3, delay: index * 0.06 }}
+              whileHover={!disabled ? { y: -2 } : undefined}
               className={cn(
-                'flex items-start gap-3 p-card-padding-sm rounded-lg border-2 transition-all duration-normal cursor-pointer',
-                'border-border bg-card',
-                !disabled && 'hover:border-muted-foreground hover:bg-muted',
+                'flex items-start gap-3 p-card-padding-sm rounded-xl border-2 transition-all duration-normal cursor-pointer',
+                'bg-card shadow-elevation-1',
                 'focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
-                isSelected && 'border-primary bg-primary/10 shadow-elevation-1',
-                disabled && 'opacity-disabled cursor-not-allowed',
+                !disabled &&
+                  !isSelected &&
+                  'border-border/30 hover:border-primary/20 hover:shadow-card-hover',
+                isSelected && 'border-primary bg-primary/6 shadow-elevation-2',
+                disabled && 'opacity-50 cursor-not-allowed',
               )}
               onClick={() => !question.answer.multiSelect && handleOptionClick(option.id)}
             >
@@ -105,18 +112,25 @@ export function McqQuestion({
               ) : (
                 <div
                   className={cn(
-                    'w-5 h-5 mt-0.5 rounded-full border-2 flex items-center justify-center transition-all',
+                    'w-6 h-6 mt-0.5 rounded-full border-2 flex items-center justify-center transition-all shrink-0',
                     'border-border bg-background',
-                    isSelected && 'border-primary bg-primary',
+                    isSelected && 'border-primary bg-primary ring-2 ring-primary/20 ring-offset-2',
                   )}
                 >
-                  {isSelected && <div className="w-2 h-2 rounded-full bg-primary-foreground" />}
+                  {isSelected && (
+                    <motion.div
+                      initial={{ scale: 0 }}
+                      animate={{ scale: 1 }}
+                      transition={{ type: 'spring', stiffness: 500, damping: 20 }}
+                      className="w-2.5 h-2.5 rounded-full bg-primary-foreground"
+                    />
+                  )}
                 </div>
               )}
               <div className="flex-1 text-body-lg text-foreground">
                 <RichTextRenderer block={optionBlock} />
               </div>
-            </label>
+            </motion.label>
           )
         })}
       </div>

--- a/src/ui/web/exerciserenderer/questions/TableQuestion/ExerciseTable.tsx
+++ b/src/ui/web/exerciserenderer/questions/TableQuestion/ExerciseTable.tsx
@@ -6,7 +6,9 @@
 'use client'
 
 import React from 'react'
+import { motion } from 'framer-motion'
 import { cn } from '@/infra/utils/ui'
+import { Check, X } from 'lucide-react'
 import { MathMarkdown } from '@/ui/web/shared/MathMarkdown'
 import type { TableBlock, TableCellResult } from '../../types'
 
@@ -45,15 +47,12 @@ export function ExerciseTable({
 }: ExerciseTableProps) {
   const resultMap = getCellResultMap(cellResults)
   const alignClass = { left: 'text-left', center: 'text-center', right: 'text-right' }
-  const borderCls = table.showBorders ? 'border border-border' : 'border-0'
+  const borderCls = table.showBorders ? 'border border-border/30' : 'border-0'
 
   return (
-    <div className="w-full overflow-x-auto">
+    <div className="w-full overflow-x-auto rounded-xl border border-border/20 shadow-elevation-1">
       <table
-        className={cn(
-          'w-full border-collapse table-fixed',
-          table.showBorders && 'shadow-elevation-1 rounded-md overflow-hidden',
-        )}
+        className={cn('w-full border-collapse table-fixed', table.showBorders && 'overflow-hidden')}
       >
         {table.showHeader && (
           <thead>
@@ -62,9 +61,10 @@ export function ExerciseTable({
                 <th
                   key={ci}
                   className={cn(
-                    'p-3 font-semibold bg-muted',
+                    'p-3.5 font-semibold text-body-sm bg-muted/50',
                     alignClass[getAlignment(table, ci)],
                     borderCls,
+                    'border-b-2 border-b-border/20',
                   )}
                 >
                   <MathMarkdown content={header} />
@@ -75,7 +75,13 @@ export function ExerciseTable({
         )}
         <tbody>
           {table.rowsData.map((row, ri) => (
-            <tr key={ri} className={ri % 2 === 1 ? 'bg-muted/30' : ''}>
+            <motion.tr
+              key={ri}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ duration: 0.2, delay: ri * 0.03 }}
+              className={ri % 2 === 1 ? 'bg-muted/15' : ''}
+            >
               {row.map((cell, ci) => {
                 const key = `${ri}-${ci}`
                 const fillable = isFillableCell(table, ri, ci)
@@ -83,7 +89,7 @@ export function ExerciseTable({
                 const align = getAlignment(table, ci)
 
                 return (
-                  <td key={ci} className={cn('p-3', alignClass[align], borderCls)}>
+                  <td key={ci} className={cn('p-3.5', alignClass[align], borderCls)}>
                     {fillable ? (
                       <FillableInput
                         cellKey={key}
@@ -101,7 +107,7 @@ export function ExerciseTable({
                   </td>
                 )
               })}
-            </tr>
+            </motion.tr>
           ))}
         </tbody>
       </table>
@@ -120,23 +126,46 @@ interface FillableInputProps {
 
 function FillableInput({ cellKey, value, onChange, result, disabled, align }: FillableInputProps) {
   return (
-    <input
-      type="text"
-      dir="ltr"
-      value={value}
-      onChange={(e) => onChange(cellKey, e.target.value)}
-      readOnly={disabled}
-      className={cn(
-        'w-full min-w-[120px] px-2 py-1.5 rounded-md border-2 text-body-sm',
-        'bg-background transition-colors duration-normal',
-        align === 'left' && 'text-left',
-        align === 'center' && 'text-center',
-        align === 'right' && 'text-right',
-        result === true && 'border-success bg-success/10 text-success-foreground',
-        result === false && 'border-destructive bg-destructive/10 text-destructive',
-        result === undefined && 'border-input focus:border-ring focus:outline-none',
-        disabled && 'opacity-disabled cursor-not-allowed',
+    <div className="relative">
+      <input
+        type="text"
+        dir="ltr"
+        value={value}
+        onChange={(e) => onChange(cellKey, e.target.value)}
+        readOnly={disabled}
+        className={cn(
+          'w-full min-w-[120px] px-3 py-2 rounded-lg border-2 text-body-sm',
+          'bg-background transition-all duration-normal',
+          align === 'left' && 'text-left',
+          align === 'center' && 'text-center',
+          align === 'right' && 'text-right',
+          result === true && 'border-success bg-success/6 text-success-foreground pe-8',
+          result === false && 'border-destructive bg-destructive/6 text-destructive pe-8',
+          result === undefined &&
+            'border-dashed border-primary/25 bg-primary/3 focus:border-solid focus:border-primary focus:bg-card focus:shadow-[0_0_0_3px_hsl(var(--primary)/0.08)] focus:outline-none',
+          disabled && 'opacity-50 cursor-not-allowed',
+        )}
+      />
+      {result === true && (
+        <motion.span
+          initial={{ scale: 0 }}
+          animate={{ scale: 1 }}
+          transition={{ type: 'spring', stiffness: 400, damping: 15 }}
+          className="absolute end-2 top-1/2 -translate-y-1/2 text-success"
+        >
+          <Check className="w-4 h-4" />
+        </motion.span>
       )}
-    />
+      {result === false && (
+        <motion.span
+          initial={{ scale: 0 }}
+          animate={{ scale: 1 }}
+          transition={{ type: 'spring', stiffness: 400, damping: 15 }}
+          className="absolute end-2 top-1/2 -translate-y-1/2 text-destructive"
+        >
+          <X className="w-4 h-4" />
+        </motion.span>
+      )}
+    </div>
   )
 }

--- a/src/ui/web/exerciserenderer/questions/TableQuestion/index.tsx
+++ b/src/ui/web/exerciserenderer/questions/TableQuestion/index.tsx
@@ -86,7 +86,7 @@ export function TableQuestion({
             disabled={allCorrect}
             size="lg"
             className={cn(
-              'font-semibold',
+              'rounded-xl font-bold text-body-md',
               allCorrect && 'bg-success hover:bg-success/90 text-white',
             )}
           >

--- a/src/ui/web/exerciserenderer/questions/TrueFalseQuestion/index.tsx
+++ b/src/ui/web/exerciserenderer/questions/TrueFalseQuestion/index.tsx
@@ -1,11 +1,12 @@
 /**
  * True/False Question Component
- * Displays a True/False question with immediate feedback
+ * Displays a True/False question with card-style options and animated feedback
  */
 
 'use client'
 
 import React from 'react'
+import { motion } from 'framer-motion'
 import { cn } from '@/infra/utils/ui'
 import { CheckCircle2, XCircle } from 'lucide-react'
 import type {
@@ -69,8 +70,8 @@ export function TrueFalseQuestion({
       <div className="text-body-md font-medium text-foreground leading-relaxed">
         <RichTextRenderer block={promptBlock} />
       </div>
-      <div className="flex gap-3">
-        {options.map((option) => {
+      <div className="grid grid-cols-2 gap-content-gap">
+        {options.map((option, index) => {
           const isSelected = value === option.value
           const showFeedback = checkResult !== null
 
@@ -79,44 +80,60 @@ export function TrueFalseQuestion({
             id: `${question.id}-option-${option.id}`,
             mediaIds: option.label.mediaIds || [],
           }
+
           return (
-            <button
+            <motion.button
               key={option.id}
               type="button"
               onClick={() => onChange({ type: 'true_false', value: option.value })}
               disabled={disabled}
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3, delay: index * 0.05 }}
+              whileHover={!disabled ? { y: -2 } : undefined}
+              whileTap={!disabled ? { scale: 0.97 } : undefined}
               className={cn(
-                'flex-1 relative overflow-hidden px-6 py-section-xs rounded-lg border-2 font-medium text-body-md transition-all duration-normal',
-                'border-border bg-card',
+                'relative overflow-hidden rounded-xl border-2 p-5 text-heading-sm font-bold transition-all duration-normal',
+                'bg-card shadow-elevation-1',
                 'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
-                !disabled && 'hover:border-muted-foreground hover:bg-muted cursor-pointer',
-                isSelected &&
-                  !showFeedback &&
-                  'border-primary bg-primary/10 text-primary shadow-elevation-1',
+                !disabled &&
+                  !isSelected &&
+                  'border-border/30 hover:border-primary/30 hover:shadow-card-hover cursor-pointer',
+                isSelected && !showFeedback && 'border-primary bg-primary/8 shadow-elevation-2',
                 showFeedback &&
                   isSelected &&
                   checkResult.isCorrect &&
-                  'border-success bg-success/10 text-success shadow-elevation-1',
+                  'border-success bg-success/8 shadow-elevation-2',
                 showFeedback &&
                   isSelected &&
                   !checkResult.isCorrect &&
-                  'border-destructive bg-destructive/10 text-destructive shadow-elevation-1',
-                disabled && 'opacity-disabled cursor-not-allowed',
+                  'border-destructive bg-destructive/8 shadow-elevation-2',
+                disabled && 'opacity-50 cursor-not-allowed',
               )}
             >
               <div className="flex items-center justify-center gap-content-gap-xs">
                 <RichTextRenderer block={labelBlock} />
-                {showFeedback && isSelected && (
-                  <span className="text-heading-xl font-bold">
-                    {checkResult.isCorrect ? (
-                      <CheckCircle2 className="w-5 h-5" />
-                    ) : (
-                      <XCircle className="w-5 h-5" />
-                    )}
-                  </span>
-                )}
               </div>
-            </button>
+
+              {/* Feedback badge overlay */}
+              {showFeedback && isSelected && (
+                <motion.span
+                  initial={{ scale: 0 }}
+                  animate={{ scale: 1 }}
+                  transition={{ type: 'spring', stiffness: 400, damping: 15 }}
+                  className={cn(
+                    'absolute -top-1.5 -end-1.5 w-6 h-6 rounded-full flex items-center justify-center',
+                    checkResult.isCorrect ? 'bg-success text-white' : 'bg-destructive text-white',
+                  )}
+                >
+                  {checkResult.isCorrect ? (
+                    <CheckCircle2 className="w-4 h-4" />
+                  ) : (
+                    <XCircle className="w-4 h-4" />
+                  )}
+                </motion.span>
+              )}
+            </motion.button>
           )
         })}
       </div>


### PR DESCRIPTION
## Summary
- Redesign all exercise components (QuestionCard, FeedbackDisplay, HelpSystem, True/False, MCQ, Free Response, Matching, Table, SVG Hotspot) with improved visual design and Framer Motion animations
- Add progress bar for multi-question exercises and all-correct confetti celebration
- Staggered entrance animations, hover micro-interactions, and satisfying feedback (confetti on correct, shake on incorrect)

## Changes
- **QuestionCard**: Softer card surface, icon-badge question labels, success accent bar, separator before actions, staggered fade-up entrance
- **FeedbackDisplay**: Icon-in-circle treatment, confetti burst on correct, horizontal shake on incorrect, spring-animated icons
- **HelpSystem**: Pill-shaped buttons with icon badges, AnimatePresence for solution unlock and content accordion
- **True/False**: Card-style options with shadow/lift, overlay feedback badge
- **MCQ**: Card-style option labels, pill instruction badge, animated radio dot, staggered entrance
- **Free Response**: Enhanced textarea with focus glow, AnimatePresence view/edit crossfade, animated formula composer
- **Matching**: Styled column headers, card-style items, SVG line draw animation (motion.path pathLength)
- **Table**: Card container, dashed-border fillable cells, animated per-cell feedback icons
- **SVG Hotspot**: Card container with rounded corners
- **ExerciseRenderer**: Progress bar, stagger orchestration, all-correct celebration

## Test plan
- [ ] Navigate to exercise pages with each question type (True/False, MCQ, Free Response, Matching, Table)
- [ ] Verify staggered entrance animations on page load
- [ ] Test answer selection and check: correct shows confetti + green feedback, incorrect shows shake + red feedback
- [ ] Test help system: hint → guiding → solution unlock animation
- [ ] Test matching: line draw animation on connect, exit on clear
- [ ] Complete all questions and verify all-correct celebration
- [ ] Test in RTL (Hebrew locale)
- [ ] Test on mobile viewport
- [ ] Verify light/dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)