### PR TITLE
feat: Send enrolled course to Mixpanel user profile

### DIFF
--- a/src/app/(frontend)/courses/_components/CourseCard/index.tsx
+++ b/src/app/(frontend)/courses/_components/CourseCard/index.tsx
@@ -4,6 +4,7 @@ import { getUserProfile, setUserProfile } from '@/client/state/localStorage/user
 import { useLoadingState } from '@/infra/loading/hooks/useLoadingState'
 import { useRouterWithLoading } from '@/infra/loading/hooks/useRouterWithLoading'
 import { LOADING_KEYS } from '@/infra/loading/keys'
+import { SYSTEM_EVENTS, systemEventBus } from '@/infra/system-events'
 import { cn } from '@/infra/utils/ui'
 import type { Course } from '@/payload-types'
 import { Button } from '@/ui/web/components/button'
@@ -87,6 +88,12 @@ export function CourseCard({ course, isOwned = false }: CourseCardProps) {
       gradeLevel,
       mood: existingProfile?.mood || '',
       lastVisit: new Date().toISOString(),
+    })
+
+    // Track course selection in analytics
+    systemEventBus.emit(SYSTEM_EVENTS.COURSE_ENTERED, {
+      course_id: course.id,
+      course_title: course.title,
     })
 
     // Navigate to home page after localStorage is updated

--- a/src/app/api/entitlements/redeem/route.ts
+++ b/src/app/api/entitlements/redeem/route.ts
@@ -140,7 +140,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: 'already_entitled' }, { status: 409 })
     }
 
-    return NextResponse.json({ success: true })
+    return NextResponse.json({ success: true, courseId })
   } catch (error) {
     payload.logger.error(
       { error, accessCodeId: accessCode.id, userId: user.id, courseId },

--- a/src/infra/analytics/components/UserIdentificationTracker.tsx
+++ b/src/infra/analytics/components/UserIdentificationTracker.tsx
@@ -80,6 +80,15 @@ export function UserIdentificationTracker() {
               // Add current login timestamp
               userProperties.last_login = new Date().toISOString()
 
+              // Add enrolled course ID to Mixpanel People profile
+              if (Array.isArray(user.courseEntitlements) && user.courseEntitlements.length > 0) {
+                const entry = user.courseEntitlements[0] as {
+                  course: string | { id: string }
+                }
+                userProperties.enrolled_course =
+                  typeof entry.course === 'string' ? entry.course : entry.course.id
+              }
+
               // Add locale if available from browser or user settings
               if (typeof window !== 'undefined') {
                 userProperties.locale = detectBrowserLocale()

--- a/src/infra/analytics/system-events-subscriber.ts
+++ b/src/infra/analytics/system-events-subscriber.ts
@@ -420,13 +420,20 @@ export function initAnalyticsSubscriber(): () => void {
         coupon_code?: string
         lesson_id?: string
         course_id?: string
+        course_slug?: string
       }
       analytics.track(PRODUCT_EVENTS.ACCESS_GRANTED, {
         access_type: payload.access_type,
         coupon_code: payload.coupon_code,
         lesson_id: payload.lesson_id,
         course_id: payload.course_id,
+        course_slug: payload.course_slug,
       })
+
+      // Re-fetch user data and update Mixpanel People profile with new entitlements
+      if (payload.course_id) {
+        refreshUserEntitlementsInMixpanel()
+      }
     }),
 
     // Exercise Quality Events
@@ -535,6 +542,32 @@ export function initAnalyticsSubscriber(): () => void {
   )
 
   return () => cleanup()
+}
+
+/**
+ * Re-fetches user data and updates Mixpanel People profile with current course entitlements.
+ * Called after ACCESS_GRANTED to ensure the user profile reflects the new entitlement immediately.
+ */
+async function refreshUserEntitlementsInMixpanel(): Promise<void> {
+  try {
+    const response = await fetch('/api/users/me', { credentials: 'include' })
+    if (!response.ok) return
+
+    const data = await response.json()
+    const user = data.user
+    if (!user?.id || !Array.isArray(user.courseEntitlements)) return
+
+    const entry = user.courseEntitlements[0] as {
+      course: string | { id: string }
+    }
+    const courseId = typeof entry.course === 'string' ? entry.course : entry.course.id
+
+    analytics.identify(user.id, {
+      enrolled_course: courseId,
+    })
+  } catch {
+    // Silently fail — analytics should never break the user flow
+  }
 }
 
 function cleanup(): void {

--- a/src/infra/analytics/system-events-subscriber.ts
+++ b/src/infra/analytics/system-events-subscriber.ts
@@ -101,6 +101,15 @@ export function initAnalyticsSubscriber(): () => void {
         course_title: payload.course_title,
         user_id: payload.user_id,
       })
+
+      // Update Mixpanel People profile with selected course
+      const userId = payload.user_id || sessionStorage.getItem('analytics_tracked_user_id')
+      if (payload.course_id && userId) {
+        analytics.identify(userId, {
+          selected_course: payload.course_id,
+          selected_course_title: payload.course_title,
+        })
+      }
     }),
 
     safeSubscribe(SYSTEM_EVENTS.LESSON_STARTED, (envelope) => {

--- a/src/infra/system-events/schemas.ts
+++ b/src/infra/system-events/schemas.ts
@@ -251,8 +251,9 @@ export const AccessGrantedSchema = z
   .object({
     access_type: z.enum(['free', 'coupon', 'paid']),
     coupon_code: z.string().optional(),
-    lesson_id: z.string().min(1, 'lesson_id is required'),
+    lesson_id: z.string().min(1, 'lesson_id is required').optional(),
     course_id: z.string().min(1, 'course_id is required'),
+    course_slug: z.string().optional(),
   })
   .strict()
 

--- a/src/ui/web/auth/AccessGateProvider.tsx
+++ b/src/ui/web/auth/AccessGateProvider.tsx
@@ -118,7 +118,12 @@ export function AccessGateProvider({
 
       {/* Paid content modal */}
       {showPaidModal && (
-        <PaidContentModal isAuthenticated={isAuthenticated} pathname={pathname} t={t} />
+        <PaidContentModal
+          isAuthenticated={isAuthenticated}
+          pathname={pathname}
+          courseSlug={courseSlug}
+          t={t}
+        />
       )}
 
       {isBlocked ? (
@@ -140,10 +145,12 @@ export function AccessGateProvider({
 function PaidContentModal({
   isAuthenticated,
   pathname,
+  courseSlug,
   t,
 }: {
   isAuthenticated?: boolean
   pathname: string
+  courseSlug: string
   t: (key: string) => string
 }) {
   const router = useRouter()
@@ -174,6 +181,14 @@ function PaidContentModal({
       const data = await res.json()
 
       if (data.success) {
+        // Emit ACCESS_GRANTED event so analytics tracks the entitlement
+        systemEventBus.emit(SYSTEM_EVENTS.ACCESS_GRANTED, {
+          access_type: 'coupon' as const,
+          coupon_code: trimmed,
+          course_id: data.courseId,
+          course_slug: courseSlug,
+        })
+
         setShowSuccess(true)
         setTimeout(() => {
           window.location.reload()


### PR DESCRIPTION
Course entitlement data was stored in the database but never sent to Mixpanel, making it invisible on user profiles. Now the enrolled_course property is set on login via UserIdentificationTracker and updated immediately on access code redemption via the ACCESS_GRANTED event.