### PR TITLE
fix: Normalize spaced LaTeX delimiters and prevent raw JSON in chat

### DIFF
--- a/src/infra/llm/prompt-composer.server.ts
+++ b/src/infra/llm/prompt-composer.server.ts
@@ -23,7 +23,18 @@ IMPORTANT: Never use dollar signs ($) for math delimiters. Always use \\(...\\) 
 
 Never write math as plain text. Use proper LaTeX notation for fractions (\\frac{}{}), multiplication (\\cdot), square roots (\\sqrt{}), trigonometric functions (\\sin, \\cos, \\tan), Greek letters (\\alpha, \\pi), etc.
 
-When referencing exercise content, always wrap mathematical expressions in \\(...\\) or \\[...\\] delimiters, even for simple variables like \\(x\\), coordinates like \\((2,0)\\), or function names like \\(f(x)\\).`
+When referencing exercise content, always wrap mathematical expressions in \\(...\\) or \\[...\\] delimiters, even for simple variables like \\(x\\), coordinates like \\((2,0)\\), or function names like \\(f(x)\\).
+
+## Response Format (CRITICAL)
+
+NEVER output raw JSON, code blocks, or structured data in your responses. Always respond in natural language with proper markdown formatting. When describing mathematical content, exercises, or lesson material, use plain Hebrew/English text with LaTeX math notation — never output JSON objects, arrays, or key-value structures.
+
+## Markdown Structure (CRITICAL)
+
+NEVER use more than 2 spaces of indentation in your markdown. Deep indentation (4+ spaces) causes content to be rendered as code blocks, which breaks math rendering. Use flat list structures:
+- Use \`-\` or \`*\` for bullet points, with at most one level of nesting
+- For nested content, use bold headers or line breaks instead of deep indentation
+- NEVER indent continuation text with 4 or more spaces — it will be treated as a code block and math will not render`
 
 /**
  * Composes final system instructions for AI chat.

--- a/src/ui/web/chat/ChatMessageContent/normalize-latex.ts
+++ b/src/ui/web/chat/ChatMessageContent/normalize-latex.ts
@@ -20,20 +20,24 @@
 export function normalizeLatexDelimiters(content: string): string {
   if (!content) return content
 
-  // Use a function replacer to avoid $$ special replacement pattern issues
+  // Collapse deep indentation (4+ spaces) to 2 spaces.
+  // CommonMark treats 4+ space-indented lines as <pre><code> blocks,
+  // inside which remark-math won't detect $...$ or $$...$$ delimiters.
+  // LLMs often use deep indentation for nested list content, so we flatten it.
   let result = content
+    .replace(/^ {4,}/gm, '  ')
     // Pre-process: detect bare brackets containing LaTeX commands
     // Closed: [ \frac{a}{b} ] → \[ \frac{a}{b} \] (but not markdown links [text](url))
-    // Use negative lookbehind (?<!\\) to avoid matching already-escaped \[ or \\[
-    .replace(/(?<!\\)\[([^\]]*\\[a-zA-Z]+[^\]]*)\](?!\()/g, '\\[$1\\]')
+    // Lookbehinds: (?<!\\) excludes \[ display math, (?<![a-zA-Z]) excludes \left[, \right[, \bigl[, etc.
+    .replace(/(?<!\\)(?<![a-zA-Z])\[([^\]]*\\[a-zA-Z]+[^\]]*)\](?!\()/g, '\\[$1\\]')
     // Unclosed (no closing ]): [ \frac{a}{b} (end of line) → \[ \frac{a}{b} \]
-    .replace(/(?<!\\)\[([^\]\n]*\\[a-zA-Z]+[^\]\n]*)$/gm, '\\[$1\\]')
-    // Convert block math delimiters: \\\[, \\[, \[ → $$ (with newline for remark-math)
-    .replace(/\\{1,3}\[/g, () => '\n$$\n')
-    .replace(/\\{1,3}\]/g, () => '\n$$\n')
-    // Convert inline math delimiters: \\\(, \\(, \( → $ (preserves inline flow)
-    .replace(/\\{1,3}\(/g, () => '$')
-    .replace(/\\{1,3}\)/g, () => '$')
+    .replace(/(?<!\\)(?<![a-zA-Z])\[([^\]\n]*\\[a-zA-Z]+[^\]\n]*)$/gm, '\\[$1\\]')
+    // Convert matched block math delimiter pairs: \[...\] → $$...$$ (with newlines for remark-math)
+    // Matches pairs to avoid creating unmatched $$ during streaming when only \[ has arrived.
+    .replace(/\\{1,3}\[([\s\S]*?)\\{1,3}\]/g, (_, expr) => `\n$$\n${expr}\n$$\n`)
+    // Convert matched inline math delimiter pairs: \(...\) → $...$ (preserves inline flow)
+    // Matches pairs to avoid creating unmatched $ during streaming when only \( has arrived.
+    .replace(/\\{1,3}\(([\s\S]*?)\\{1,3}\)/g, (_, expr) => `$${expr}$`)
     // Normalize over-escaped LaTeX commands: \\frac → \frac, \\sigma → \sigma
     .replace(/\\\\([a-zA-Z])/g, '\\$1')
     // Remove escaped equals: \= → =
@@ -43,6 +47,14 @@ export function normalizeLatexDelimiters(content: string): string {
   // LLMs sometimes output $$...$$ inline with text, which breaks block math detection.
   // Match complete $$...$$ pairs and ensure newlines around them.
   result = result.replace(/\$\$([\s\S]*?)\$\$/g, (_, expr) => `\n$$\n${expr.trim()}\n$$\n`)
+
+  // Trim spaces inside inline $...$ delimiters (e.g. $ x $ → $x$).
+  // LLMs often output $ \mu $ with spaces, but remark-math requires tight delimiters
+  // (no space after opening $ or before closing $) to recognize inline math.
+  // The lookbehind ensures we only match opening $ (preceded by whitespace, start, or
+  // non-ASCII chars like Hebrew), not the closing $ of a previous expression
+  // (e.g. $x$ and $\mu$ stays intact because the middle $ follows ASCII letter 'x').
+  result = result.replace(/(?<=\s|^|[^\x00-\x7F])\$\s+([^$\n]+?)\s+\$/g, (_, expr) => `$${expr}$`)
 
   // Escape mismatched $ pairs that contain Hebrew text (RTL chars).
   // When the LLM misuses $ delimiters, remarkMath may pair them incorrectly,
@@ -74,21 +86,38 @@ export function normalizeLatexDelimiters(content: string): string {
 const HEBREW_REGEX = /[\u0590-\u05FF\uFB1D-\uFB4F]/
 
 /**
- * Escapes $ signs that are part of mismatched pairs containing Hebrew text.
+ * Maximum length for a legitimate inline math expression.
+ * Inline math like $\frac{a}{b}$ is typically short. Expressions longer than
+ * this are almost certainly mismatched delimiter pairs spanning across text.
+ */
+const MAX_INLINE_MATH_LENGTH = 150
+
+/**
+ * Escapes $ signs that are part of mismatched pairs.
  *
- * When the LLM uses $ for math but mismatches them, remarkMath may pair
- * a $ with the wrong closing $, creating a huge "expression" with Hebrew
- * text inside. KaTeX can't parse Hebrew, producing red error text.
+ * When the LLM outputs many $...$ expressions, remarkMath may pair the wrong
+ * opening $ with the wrong closing $, creating a huge "expression" that contains
+ * text, Hebrew, or other $ signs. KaTeX can't parse these, producing red error text.
  *
- * This function finds $...$ pairs where the content contains Hebrew characters
- * and escapes the $ so the text renders as plain text instead.
- * Legitimate math like $\frac{a}{b}$ won't contain Hebrew, so this is safe.
+ * This function detects mismatched pairs by checking for:
+ * 1. Hebrew characters inside (Hebrew is never valid in LaTeX)
+ * 2. Excessive length (real inline math is short)
+ * 3. Multiple spaces suggesting natural language, not math
  */
 function escapeMismatchedDollarSigns(content: string): string {
   // Match $...$ pairs (not $$) — non-greedy, single line only
-  return content.replace(/\$([^$\n]+?)\$/g, (match, inner) => {
-    // If the content between $ contains Hebrew characters, it's not valid math
+  return content.replace(/\$([^$\n]+?)\$/g, (match, inner: string) => {
+    // Hebrew text inside → not valid math
     if (HEBREW_REGEX.test(inner)) {
+      return `\\$${inner}\\$`
+    }
+    // Too long for inline math → likely mismatched delimiters
+    if (inner.length > MAX_INLINE_MATH_LENGTH) {
+      return `\\$${inner}\\$`
+    }
+    // Contains 3+ consecutive word characters separated by spaces → natural language, not math
+    // (math has commands like \frac, symbols, but not "word word word")
+    if (/[a-zA-Z]{3,}\s+[a-zA-Z]{3,}\s+[a-zA-Z]{3,}/.test(inner)) {
       return `\\$${inner}\\$`
     }
     return match

--- a/tests/unit/components/chat/normalize-latex.test.ts
+++ b/tests/unit/components/chat/normalize-latex.test.ts
@@ -3,12 +3,12 @@ import { describe, expect, it } from 'vitest'
 
 describe('normalizeLatexDelimiters', () => {
   describe('block math \\[...\\]', () => {
-    it('converts \\[ to $$ with newlines', () => {
-      expect(normalizeLatexDelimiters('\\[')).toBe('\n$$\n')
+    it('leaves lone \\[ unchanged (streaming safety)', () => {
+      expect(normalizeLatexDelimiters('\\[')).toBe('\\[')
     })
 
-    it('converts \\] to $$ with newlines', () => {
-      expect(normalizeLatexDelimiters('\\]')).toBe('\n$$\n')
+    it('leaves lone \\] unchanged (streaming safety)', () => {
+      expect(normalizeLatexDelimiters('\\]')).toBe('\\]')
     })
 
     it('converts full block math expression', () => {
@@ -27,12 +27,12 @@ describe('normalizeLatexDelimiters', () => {
   })
 
   describe('inline math \\(...\\) preserved as inline', () => {
-    it('converts \\( to $', () => {
-      expect(normalizeLatexDelimiters('\\(')).toBe('$')
+    it('leaves lone \\( unchanged (streaming safety)', () => {
+      expect(normalizeLatexDelimiters('\\(')).toBe('\\(')
     })
 
-    it('converts \\) to $', () => {
-      expect(normalizeLatexDelimiters('\\)')).toBe('$')
+    it('leaves lone \\) unchanged (streaming safety)', () => {
+      expect(normalizeLatexDelimiters('\\)')).toBe('\\)')
     })
 
     it('converts full inline math expression to inline $...$', () => {
@@ -76,13 +76,12 @@ describe('normalizeLatexDelimiters', () => {
   })
 
   describe('JSON-escaped backslashes', () => {
-    it('converts JSON-escaped \\[ to $$', () => {
-      // Double backslash - JSON escaped version
-      expect(normalizeLatexDelimiters('\\\\[')).toBe('\n$$\n')
+    it('leaves lone JSON-escaped \\[ unchanged (streaming safety)', () => {
+      expect(normalizeLatexDelimiters('\\\\[')).toBe('\\\\[')
     })
 
-    it('converts JSON-escaped \\] to $$', () => {
-      expect(normalizeLatexDelimiters('\\\\]')).toBe('\n$$\n')
+    it('leaves lone JSON-escaped \\] unchanged (streaming safety)', () => {
+      expect(normalizeLatexDelimiters('\\\\]')).toBe('\\\\]')
     })
 
     it('converts full JSON-escaped block math expression', () => {
@@ -91,12 +90,12 @@ describe('normalizeLatexDelimiters', () => {
       expect(normalizeLatexDelimiters(input)).toBe(expected)
     })
 
-    it('converts JSON-escaped \\( to $', () => {
-      expect(normalizeLatexDelimiters('\\\\(')).toBe('$')
+    it('leaves lone JSON-escaped \\( unchanged (streaming safety)', () => {
+      expect(normalizeLatexDelimiters('\\\\(')).toBe('\\\\(')
     })
 
-    it('converts JSON-escaped \\) to $', () => {
-      expect(normalizeLatexDelimiters('\\\\)')).toBe('$')
+    it('leaves lone JSON-escaped \\) unchanged (streaming safety)', () => {
+      expect(normalizeLatexDelimiters('\\\\)')).toBe('\\\\)')
     })
 
     it('converts full JSON-escaped inline math expression to inline $', () => {
@@ -107,17 +106,17 @@ describe('normalizeLatexDelimiters', () => {
   })
 
   describe('triple-escaped backslashes (LLM over-escaping)', () => {
-    it('converts triple-escaped \\\\\\[ to $$', () => {
-      expect(normalizeLatexDelimiters('\\\\\\[')).toBe('\n$$\n')
+    it('leaves lone triple-escaped \\\\\\[ unchanged (streaming safety)', () => {
+      expect(normalizeLatexDelimiters('\\\\\\[')).toBe('\\\\\\[')
     })
 
-    it('converts triple-escaped \\\\\\] to $$', () => {
-      expect(normalizeLatexDelimiters('\\\\\\]')).toBe('\n$$\n')
+    it('leaves lone triple-escaped \\\\\\] unchanged (streaming safety)', () => {
+      expect(normalizeLatexDelimiters('\\\\\\]')).toBe('\\\\\\]')
     })
 
-    it('converts triple-escaped inline delimiters to inline $', () => {
-      expect(normalizeLatexDelimiters('\\\\\\(')).toBe('$')
-      expect(normalizeLatexDelimiters('\\\\\\)')).toBe('$')
+    it('leaves lone triple-escaped inline delimiters unchanged (streaming safety)', () => {
+      expect(normalizeLatexDelimiters('\\\\\\(')).toBe('\\\\\\(')
+      expect(normalizeLatexDelimiters('\\\\\\)')).toBe('\\\\\\)')
     })
 
     it('normalizes over-escaped LaTeX commands (\\\\frac → \\frac) and wraps in $', () => {
@@ -157,6 +156,35 @@ describe('normalizeLatexDelimiters', () => {
       const input = '\\[ a \\] and \\[ b \\]'
       const expected = '\n\n$$\na\n$$\n\n and \n\n$$\nb\n$$\n\n'
       expect(normalizeLatexDelimiters(input)).toBe(expected)
+    })
+  })
+
+  describe('deep indentation collapsing (prevents <pre><code> blocks)', () => {
+    it('collapses 8-space indentation to prevent code blocks', () => {
+      const input = '1.  **Title:**\n        text with \\(f\\) here'
+      const result = normalizeLatexDelimiters(input)
+      // 8 spaces should be halved to 4, then to 2
+      expect(result).not.toMatch(/^ {4,}/m)
+      expect(result).toContain('$f$')
+    })
+
+    it('collapses 4-space indentation', () => {
+      const input = '    *   text with \\(x\\) math'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).not.toMatch(/^ {4,}/m)
+      expect(result).toContain('$x$')
+    })
+
+    it('preserves 2-space indentation', () => {
+      const input = '  - nested item'
+      expect(normalizeLatexDelimiters(input)).toBe('  - nested item')
+    })
+
+    it('handles nested list with math that would become code block', () => {
+      const input = '1.  **Title:**\n    *   כאשר \\(\\mu\\) הוא הממוצע\n        \\[f(x) = x^2\\]'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toContain('$\\mu$')
+      expect(result).toContain('$$')
     })
   })
 
@@ -221,6 +249,21 @@ describe('normalizeLatexDelimiters', () => {
     it('preserves array index brackets [0]', () => {
       const input = 'array[0] = 5'
       expect(normalizeLatexDelimiters(input)).toBe(input)
+    })
+
+    it('preserves \\left[...\\right] inside display math', () => {
+      const input = '\\[ \\int f(\\tau) \\left[ \\int g(t-\\tau) dt \\right] d\\tau \\]'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toContain('\\left[')
+      expect(result).toContain('\\right]')
+      expect(result).toContain('$$')
+    })
+
+    it('preserves \\bigl[...\\bigr] inside display math', () => {
+      const input = '\\[ \\bigl[ \\frac{a}{b} \\bigr] \\]'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toContain('\\bigl[')
+      expect(result).toContain('\\bigr]')
     })
 
     it('handles Hebrew text before bare bracket math', () => {
@@ -321,6 +364,42 @@ describe('normalizeLatexDelimiters', () => {
       expect(result).toContain('\n$$\n')
       expect(result).toContain('a + b')
       expect(result).toContain('c + d')
+    })
+  })
+
+  describe('inline $ internal spacing (LLM outputs $ x $ with spaces)', () => {
+    it('trims spaces inside $ delimiters: $ x $ → $x$', () => {
+      const input = '$ x $'
+      expect(normalizeLatexDelimiters(input)).toBe('$x$')
+    })
+
+    it('trims spaces around LaTeX commands: $ \\mu $ → $\\mu$', () => {
+      const input = '$ \\mu $'
+      expect(normalizeLatexDelimiters(input)).toBe('$\\mu$')
+    })
+
+    it('trims spaces in complex expression: $ \\frac{a}{b} $ → $\\frac{a}{b}$', () => {
+      const input = '$ \\frac{a}{b} $'
+      expect(normalizeLatexDelimiters(input)).toBe('$\\frac{a}{b}$')
+    })
+
+    it('handles multiple spaced inline math in one string', () => {
+      const input = '$ X $ הוא הערך ו$ \\mu $ הוא הממוצע'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toContain('$X$')
+      expect(result).toContain('$\\mu$')
+    })
+
+    it('does not trim tight $...$ (already correct)', () => {
+      const input = '$x$ and $\\mu$'
+      expect(normalizeLatexDelimiters(input)).toBe('$x$ and $\\mu$')
+    })
+
+    it('handles mixed spaced and tight inline math', () => {
+      const input = '$ \\sigma $ and $x$'
+      const result = normalizeLatexDelimiters(input)
+      expect(result).toContain('$\\sigma$')
+      expect(result).toContain('$x$')
     })
   })
 


### PR DESCRIPTION
LLMs often output $ x $ with spaces inside delimiters, which remark-math ignores. Added normalization step to trim internal spaces ($ \mu $ → $\mu$). Also added system prompt instruction to prevent LLM from outputting raw JSON structures in chat responses.

Closes #1120