### PR TITLE
feat: Advanced HTML rendering with interactive elements

### DIFF
--- a/src/server/payload/collections/Exercises/schemas.ts
+++ b/src/server/payload/collections/Exercises/schemas.ts
@@ -484,46 +484,15 @@ export const QuestionMultiAxisBlockSchema = z
 // Zod: HTML Block (WYSIWYG content stored as sanitized HTML string)
 // ---------------------------------
 
-// Allowlist of tags Quill can produce + safe formatting tags
-const HTML_ALLOWED_TAGS = new Set([
-  'p',
-  'br',
-  'hr',
-  'span',
-  'h1',
-  'h2',
-  'h3',
-  'h4',
-  'h5',
-  'h6',
-  'strong',
-  'b',
-  'em',
-  'i',
-  'u',
-  's',
-  'del',
-  'ins',
-  'mark',
-  'sub',
-  'sup',
-  'ul',
-  'ol',
-  'li',
-  'blockquote',
-  'pre',
-  'code',
-  'a',
-  'img',
-  'div',
-  'section',
-  'table',
-  'thead',
-  'tbody',
-  'tr',
-  'th',
-  'td',
-])
+// Allowlist of tags permitted inside HTML blocks. Sourced from the shared
+// SafeHtml sanitizer config so the server-side validator and the client-side
+// DOMPurify sanitizer cannot drift. Includes advanced authoring elements
+// (details/summary/dialog, button with data-action, semantic layout tags).
+import { SAFE_HTML_PURIFY_CONFIG } from '@/ui/web/SafeHtml/sanitize-config'
+
+const HTML_ALLOWED_TAGS = new Set<string>(
+  SAFE_HTML_PURIFY_CONFIG.ALLOWED_TAGS.map((t) => t.toLowerCase()),
+)
 
 // Patterns that are dangerous regardless of tag allowlist
 const DANGEROUS_HTML_PATTERNS = [

--- a/src/ui/admin/ExerciseContentEditor/editors/HtmlBlockEditor.tsx
+++ b/src/ui/admin/ExerciseContentEditor/editors/HtmlBlockEditor.tsx
@@ -5,6 +5,8 @@ import DOMPurify from 'dompurify'
 import dynamic from 'next/dynamic'
 import React, { useMemo, useState } from 'react'
 import 'react-quill-new/dist/quill.snow.css'
+import { SAFE_HTML_PURIFY_CONFIG } from '@/ui/web/SafeHtml/sanitize-config'
+import { SafeHtml } from '@/ui/web/SafeHtml'
 
 const ReactQuill = dynamic(() => import('react-quill-new'), { ssr: false })
 
@@ -35,61 +37,7 @@ const QUILL_FORMATS = [
   'direction',
 ]
 
-const SANITIZE_CONFIG = {
-  ALLOWED_TAGS: [
-    'p',
-    'br',
-    'hr',
-    'span',
-    'h1',
-    'h2',
-    'h3',
-    'h4',
-    'h5',
-    'h6',
-    'strong',
-    'b',
-    'em',
-    'i',
-    'u',
-    's',
-    'del',
-    'ins',
-    'mark',
-    'sub',
-    'sup',
-    'ul',
-    'ol',
-    'li',
-    'blockquote',
-    'pre',
-    'code',
-    'a',
-    'img',
-    'div',
-    'section',
-    'table',
-    'thead',
-    'tbody',
-    'tr',
-    'th',
-    'td',
-  ],
-  ALLOWED_ATTR: [
-    'href',
-    'src',
-    'alt',
-    'title',
-    'class',
-    'id',
-    'rel',
-    'width',
-    'height',
-    'colspan',
-    'rowspan',
-    'dir',
-  ],
-}
+type EditorMode = 'visual' | 'source' | 'preview'
 
 interface HtmlBlockEditorProps {
   block: HtmlBlock
@@ -97,7 +45,7 @@ interface HtmlBlockEditorProps {
 }
 
 export const HtmlBlockEditor: React.FC<HtmlBlockEditorProps> = ({ block, onChange }) => {
-  const [showSource, setShowSource] = useState(false)
+  const [mode, setMode] = useState<EditorMode>('visual')
 
   // Memoize to prevent Quill re-initialization on re-render
   const modules = useMemo(() => QUILL_MODULES, [])
@@ -111,31 +59,48 @@ export const HtmlBlockEditor: React.FC<HtmlBlockEditorProps> = ({ block, onChang
     onChange({ ...block, html: e.target.value })
   }
 
-  const handleToggleSource = () => {
-    // Sanitize when leaving source view to strip any dangerous content pasted as raw HTML
-    if (showSource && block.html) {
-      const sanitized = DOMPurify.sanitize(block.html, SANITIZE_CONFIG)
+  const switchMode = (next: EditorMode) => {
+    // When leaving source view, sanitize so any dangerous raw HTML pasted
+    // by the author is stripped before it hits the database.
+    if (mode === 'source' && next !== 'source' && block.html) {
+      const sanitized = DOMPurify.sanitize(block.html, SAFE_HTML_PURIFY_CONFIG)
       if (sanitized !== block.html) {
         onChange({ ...block, html: sanitized })
       }
     }
-    setShowSource(!showSource)
+    setMode(next)
   }
 
   return (
     <div className="html-block-editor">
       <div className="html-block-editor-header">
         <span className="html-block-editor-label">HTML Block</span>
-        <button
-          type="button"
-          className={`html-editor-source-toggle ${showSource ? 'html-editor-source-toggle--active' : ''}`}
-          onClick={handleToggleSource}
-        >
-          {showSource ? 'Visual Editor' : 'HTML Source'}
-        </button>
+        <div className="html-block-editor-mode-switch">
+          <button
+            type="button"
+            className={`html-editor-source-toggle ${mode === 'visual' ? 'html-editor-source-toggle--active' : ''}`}
+            onClick={() => switchMode('visual')}
+          >
+            Visual
+          </button>
+          <button
+            type="button"
+            className={`html-editor-source-toggle ${mode === 'source' ? 'html-editor-source-toggle--active' : ''}`}
+            onClick={() => switchMode('source')}
+          >
+            HTML Source
+          </button>
+          <button
+            type="button"
+            className={`html-editor-source-toggle ${mode === 'preview' ? 'html-editor-source-toggle--active' : ''}`}
+            onClick={() => switchMode('preview')}
+          >
+            Render Preview
+          </button>
+        </div>
       </div>
 
-      {showSource ? (
+      {mode === 'source' && (
         <textarea
           className="html-block-source-textarea"
           value={block.html}
@@ -143,7 +108,9 @@ export const HtmlBlockEditor: React.FC<HtmlBlockEditorProps> = ({ block, onChang
           placeholder="Enter raw HTML here..."
           rows={12}
         />
-      ) : (
+      )}
+
+      {mode === 'visual' && (
         <ReactQuill
           theme="snow"
           value={block.html}
@@ -152,6 +119,12 @@ export const HtmlBlockEditor: React.FC<HtmlBlockEditorProps> = ({ block, onChang
           formats={QUILL_FORMATS}
           placeholder="Start typing your content here..."
         />
+      )}
+
+      {mode === 'preview' && (
+        <div className="html-block-preview-pane">
+          <SafeHtml html={block.html} enableProse />
+        </div>
       )}
     </div>
   )

--- a/src/ui/admin/ExerciseContentEditor/editors/HtmlBlockEditor.tsx
+++ b/src/ui/admin/ExerciseContentEditor/editors/HtmlBlockEditor.tsx
@@ -39,13 +39,58 @@ const QUILL_FORMATS = [
 
 type EditorMode = 'visual' | 'source' | 'preview'
 
+/**
+ * Tags Quill can round-trip without data loss. Anything outside this set
+ * (e.g. <details>, <dialog>, <button>, <section>, inline `style="..."`)
+ * gets stripped or rewritten when Quill imports the HTML, so we refuse
+ * to switch into Visual mode and force the author to stay in Source.
+ */
+const QUILL_SAFE_TAGS = new Set([
+  'p',
+  'br',
+  'span',
+  'h1',
+  'h2',
+  'h3',
+  'strong',
+  'b',
+  'em',
+  'i',
+  'u',
+  's',
+  'ol',
+  'ul',
+  'li',
+  'blockquote',
+  'pre',
+  'code',
+  'a',
+  'img',
+])
+
+function htmlIsQuillSafe(html: string): boolean {
+  if (!html) return true
+  // Reject any inline style attribute — Quill drops them.
+  if (/\sstyle\s*=/i.test(html)) return false
+  const tagPattern = /<\/?([a-z][a-z0-9]*)\b[^>]*>/gi
+  let match
+  while ((match = tagPattern.exec(html)) !== null) {
+    if (!QUILL_SAFE_TAGS.has(match[1].toLowerCase())) return false
+  }
+  return true
+}
+
 interface HtmlBlockEditorProps {
   block: HtmlBlock
   onChange: (block: HtmlBlock) => void
 }
 
 export const HtmlBlockEditor: React.FC<HtmlBlockEditorProps> = ({ block, onChange }) => {
-  const [mode, setMode] = useState<EditorMode>('visual')
+  // Default to Source mode when the existing content has advanced HTML —
+  // dropping authors into Visual would silently destroy their markup.
+  const [mode, setMode] = useState<EditorMode>(() =>
+    htmlIsQuillSafe(block.html) ? 'visual' : 'source',
+  )
 
   // Memoize to prevent Quill re-initialization on re-render
   const modules = useMemo(() => QUILL_MODULES, [])
@@ -60,6 +105,18 @@ export const HtmlBlockEditor: React.FC<HtmlBlockEditorProps> = ({ block, onChang
   }
 
   const switchMode = (next: EditorMode) => {
+    // Block switching to Visual when content has advanced HTML — Quill would
+    // strip styles, <details>, <dialog>, <button>, etc. and silently destroy
+    // the author's work. Force them back to Source instead.
+    if (next === 'visual' && !htmlIsQuillSafe(block.html)) {
+      window.alert(
+        'This block uses advanced HTML (inline styles, <details>, <dialog>, <button>, ' +
+          'or other tags Quill cannot represent). Visual mode would discard those ' +
+          'features, so it stays disabled. Use HTML Source to edit and Render Preview ' +
+          'to verify the result.',
+      )
+      return
+    }
     // When leaving source view, sanitize so any dangerous raw HTML pasted
     // by the author is stripped before it hits the database.
     if (mode === 'source' && next !== 'source' && block.html) {
@@ -71,6 +128,8 @@ export const HtmlBlockEditor: React.FC<HtmlBlockEditorProps> = ({ block, onChang
     setMode(next)
   }
 
+  const visualDisabled = !htmlIsQuillSafe(block.html)
+
   return (
     <div className="html-block-editor">
       <div className="html-block-editor-header">
@@ -80,6 +139,12 @@ export const HtmlBlockEditor: React.FC<HtmlBlockEditorProps> = ({ block, onChang
             type="button"
             className={`html-editor-source-toggle ${mode === 'visual' ? 'html-editor-source-toggle--active' : ''}`}
             onClick={() => switchMode('visual')}
+            disabled={visualDisabled}
+            title={
+              visualDisabled
+                ? 'Visual editor disabled — content uses advanced HTML Quill cannot render.'
+                : undefined
+            }
           >
             Visual
           </button>

--- a/src/ui/admin/ExerciseContentEditor/index.css
+++ b/src/ui/admin/ExerciseContentEditor/index.css
@@ -1777,6 +1777,18 @@
   background: var(--theme-elevation-200);
 }
 
+.html-block-editor-mode-switch {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.html-block-preview-pane {
+  padding: 1rem;
+  min-height: 200px;
+  background: var(--theme-elevation-0);
+  border-top: 1px dashed var(--theme-elevation-150);
+}
+
 .html-block-source-textarea {
   width: 100%;
   min-height: 200px;

--- a/src/ui/web/SafeHtml/handleButtonAction.ts
+++ b/src/ui/web/SafeHtml/handleButtonAction.ts
@@ -1,0 +1,66 @@
+/**
+ * Handles clicks on user-authored <button> elements inside sanitized HTML
+ * content. Authors wire actions via `data-*` attributes rather than inline
+ * `on*` handlers (which the sanitizer strips).
+ *
+ * Supported actions:
+ *   data-action="external-link"  data-href="https://..."
+ *       → Opens the URL in a new tab with `noopener,noreferrer`.
+ *   data-action="open-modal"     data-target="#dialog-id"
+ *       → Finds the <dialog> by id inside the container and calls showModal().
+ *   data-action="toast-success"  data-message="Well done!"
+ *       → Dispatches a `safe-html:toast` CustomEvent that app-level toast
+ *         listeners (see Sonner integration) can subscribe to.
+ */
+export function handleSafeHtmlButtonClick(event: MouseEvent, container: HTMLElement): void {
+  const target = event.target as HTMLElement | null
+  if (!target) return
+
+  const button = target.closest('button[data-action]') as HTMLButtonElement | null
+  if (!button || !container.contains(button)) return
+
+  const action = button.dataset.action
+  if (!action) return
+
+  event.preventDefault()
+
+  switch (action) {
+    case 'external-link': {
+      const href = button.dataset.href
+      if (!href) return
+      // Only allow http/https to avoid javascript: / data: URIs sneaking in
+      // via data-* attributes (DOMPurify does not scan those).
+      try {
+        const url = new URL(href, window.location.origin)
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') return
+        window.open(url.toString(), '_blank', 'noopener,noreferrer')
+      } catch {
+        // Invalid URL — silently ignore.
+      }
+      return
+    }
+    case 'open-modal': {
+      const selector = button.dataset.target
+      if (!selector) return
+      const dialog = container.querySelector(selector) as HTMLDialogElement | null
+      if (dialog && typeof dialog.showModal === 'function') {
+        dialog.showModal()
+      }
+      return
+    }
+    case 'toast-success': {
+      const message = button.dataset.message ?? ''
+      container.dispatchEvent(
+        new CustomEvent('safe-html:toast', {
+          bubbles: true,
+          detail: { variant: 'success', message },
+        }),
+      )
+      return
+    }
+    default:
+      // Unknown action — ignore rather than throw, so authors can roll out
+      // new actions without breaking existing content.
+      return
+  }
+}

--- a/src/ui/web/SafeHtml/index.tsx
+++ b/src/ui/web/SafeHtml/index.tsx
@@ -32,6 +32,12 @@ export function SafeHtml({ html, className, style, enableProse = false }: SafeHt
       if (node.tagName === 'A' && node.getAttribute('target')) {
         node.setAttribute('rel', 'noopener noreferrer')
       }
+      // Force every <button> to type="button" so author content cannot
+      // accidentally submit a surrounding form (e.g. the Payload admin
+      // editor's form, which would save/publish the document on click).
+      if (node.tagName === 'BUTTON') {
+        node.setAttribute('type', 'button')
+      }
     })
     setIsMounted(true)
     return () => {

--- a/src/ui/web/SafeHtml/index.tsx
+++ b/src/ui/web/SafeHtml/index.tsx
@@ -1,64 +1,10 @@
 'use client'
 
 import DOMPurify from 'dompurify'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { cn } from '@/infra/utils/ui'
-
-const PURIFY_CONFIG = {
-  ALLOWED_TAGS: [
-    'p',
-    'br',
-    'hr',
-    'span',
-    'h1',
-    'h2',
-    'h3',
-    'h4',
-    'h5',
-    'h6',
-    'strong',
-    'b',
-    'em',
-    'i',
-    'u',
-    's',
-    'del',
-    'ins',
-    'mark',
-    'sub',
-    'sup',
-    'ul',
-    'ol',
-    'li',
-    'blockquote',
-    'pre',
-    'code',
-    'a',
-    'img',
-    'div',
-    'section',
-    'table',
-    'thead',
-    'tbody',
-    'tr',
-    'th',
-    'td',
-  ],
-  ALLOWED_ATTR: [
-    'href',
-    'src',
-    'alt',
-    'title',
-    'class',
-    'target',
-    'rel',
-    'width',
-    'height',
-    'colspan',
-    'rowspan',
-    'dir',
-  ],
-}
+import { SAFE_HTML_PURIFY_CONFIG } from './sanitize-config'
+import { handleSafeHtmlButtonClick } from './handleButtonAction'
 
 /** Default prose classes applied when enableProse is true */
 const PROSE_CLASSES = 'prose prose-slate dark:prose-invert max-w-none'
@@ -79,6 +25,7 @@ interface SafeHtmlProps {
 
 export function SafeHtml({ html, className, style, enableProse = false }: SafeHtmlProps) {
   const [isMounted, setIsMounted] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
     DOMPurify.addHook('afterSanitizeAttributes', (node) => {
@@ -94,8 +41,17 @@ export function SafeHtml({ html, className, style, enableProse = false }: SafeHt
 
   const cleanHtml = useMemo(() => {
     if (!isMounted || !html?.trim()) return ''
-    return DOMPurify.sanitize(html, PURIFY_CONFIG)
+    return DOMPurify.sanitize(html, SAFE_HTML_PURIFY_CONFIG)
   }, [isMounted, html])
+
+  // Event delegation for author-wired <button data-action="..."> elements.
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container || !cleanHtml) return
+    const onClick = (event: MouseEvent) => handleSafeHtmlButtonClick(event, container)
+    container.addEventListener('click', onClick)
+    return () => container.removeEventListener('click', onClick)
+  }, [cleanHtml])
 
   if (!cleanHtml) return null
 
@@ -103,6 +59,7 @@ export function SafeHtml({ html, className, style, enableProse = false }: SafeHt
 
   return (
     <div
+      ref={containerRef}
       className={mergedClassName || undefined}
       style={style}
       dangerouslySetInnerHTML={{ __html: cleanHtml }}

--- a/src/ui/web/SafeHtml/sanitize-config.ts
+++ b/src/ui/web/SafeHtml/sanitize-config.ts
@@ -115,6 +115,4 @@ export const SAFE_HTML_PURIFY_CONFIG = {
   ALLOW_ARIA_ATTR: true,
   // Keep content inside elements that get stripped (defensive default).
   KEEP_CONTENT: true,
-  // Never allow MathML/SVG here — exercises use dedicated SVG/Latex blocks.
-  USE_PROFILES: { html: true },
 }

--- a/src/ui/web/SafeHtml/sanitize-config.ts
+++ b/src/ui/web/SafeHtml/sanitize-config.ts
@@ -1,0 +1,120 @@
+/**
+ * Shared DOMPurify configuration for rendering user-authored HTML content.
+ *
+ * This whitelist is intentionally broad to support rich authoring (gradients,
+ * shadows, flex/grid layouts, interactive disclosures, dialogs, and action
+ * buttons) while still blocking XSS vectors. Specifically:
+ *
+ * - `script`, `iframe`, `object`, `embed`, `form`, and event handler
+ *   attributes (`on*`) are NOT allowed.
+ * - `style` is permitted but DOMPurify's built-in CSS parser strips
+ *   `expression(...)`, `javascript:` URLs, and other dangerous values.
+ * - `href`/`src` values are run through DOMPurify's URL sanitizer
+ *   (no `javascript:` URIs).
+ */
+export const SAFE_HTML_PURIFY_CONFIG = {
+  ALLOWED_TAGS: [
+    // Text / structure
+    'p',
+    'br',
+    'hr',
+    'span',
+    'div',
+    'section',
+    'article',
+    'header',
+    'footer',
+    'main',
+    'aside',
+    'nav',
+    'figure',
+    'figcaption',
+    // Headings
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    // Inline formatting
+    'strong',
+    'b',
+    'em',
+    'i',
+    'u',
+    's',
+    'del',
+    'ins',
+    'mark',
+    'sub',
+    'sup',
+    'small',
+    'abbr',
+    'cite',
+    'q',
+    // Lists
+    'ul',
+    'ol',
+    'li',
+    'dl',
+    'dt',
+    'dd',
+    // Quotes / code
+    'blockquote',
+    'pre',
+    'code',
+    'kbd',
+    'samp',
+    // Media
+    'a',
+    'img',
+    // Tables
+    'table',
+    'thead',
+    'tbody',
+    'tfoot',
+    'tr',
+    'th',
+    'td',
+    'caption',
+    'colgroup',
+    'col',
+    // Interactive disclosure / dialog
+    'details',
+    'summary',
+    'dialog',
+    // Action buttons (no <form>/<input> — button is stand-alone)
+    'button',
+  ],
+  ALLOWED_ATTR: [
+    'href',
+    'src',
+    'alt',
+    'title',
+    'class',
+    'id',
+    'target',
+    'rel',
+    'width',
+    'height',
+    'colspan',
+    'rowspan',
+    'dir',
+    'lang',
+    'role',
+    // CSS whitelist (DOMPurify still filters the value against its CSS parser)
+    'style',
+    // Interactive element state
+    'open',
+    // <button> needs explicit type to avoid implicit submit; `disabled` for styling
+    'type',
+    'disabled',
+  ],
+  // Allow `data-*` and `aria-*` attributes for action wiring + accessibility.
+  ALLOW_DATA_ATTR: true,
+  ALLOW_ARIA_ATTR: true,
+  // Keep content inside elements that get stripped (defensive default).
+  KEEP_CONTENT: true,
+  // Never allow MathML/SVG here — exercises use dedicated SVG/Latex blocks.
+  USE_PROFILES: { html: true },
+}

--- a/src/ui/web/exerciserenderer/blocks/HtmlBlockRenderer/index.tsx
+++ b/src/ui/web/exerciserenderer/blocks/HtmlBlockRenderer/index.tsx
@@ -22,6 +22,11 @@ export function HtmlBlockRenderer({ block }: HtmlBlockRendererProps) {
       if (node.tagName === 'A' && node.getAttribute('target')) {
         node.setAttribute('rel', 'noopener noreferrer')
       }
+      // Force every <button> to type="button" so author content cannot
+      // accidentally submit a surrounding form.
+      if (node.tagName === 'BUTTON') {
+        node.setAttribute('type', 'button')
+      }
     })
     setIsMounted(true)
     return () => {

--- a/src/ui/web/exerciserenderer/blocks/HtmlBlockRenderer/index.tsx
+++ b/src/ui/web/exerciserenderer/blocks/HtmlBlockRenderer/index.tsx
@@ -1,7 +1,9 @@
 'use client'
 
 import DOMPurify from 'dompurify'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { SAFE_HTML_PURIFY_CONFIG } from '@/ui/web/SafeHtml/sanitize-config'
+import { handleSafeHtmlButtonClick } from '@/ui/web/SafeHtml/handleButtonAction'
 
 interface HtmlBlockRendererProps {
   block: {
@@ -10,64 +12,9 @@ interface HtmlBlockRendererProps {
   }
 }
 
-const PURIFY_CONFIG = {
-  ALLOWED_TAGS: [
-    'p',
-    'br',
-    'hr',
-    'span',
-    'h1',
-    'h2',
-    'h3',
-    'h4',
-    'h5',
-    'h6',
-    'strong',
-    'b',
-    'em',
-    'i',
-    'u',
-    's',
-    'del',
-    'ins',
-    'mark',
-    'sub',
-    'sup',
-    'ul',
-    'ol',
-    'li',
-    'blockquote',
-    'pre',
-    'code',
-    'a',
-    'img',
-    'div',
-    'section',
-    'table',
-    'thead',
-    'tbody',
-    'tr',
-    'th',
-    'td',
-  ],
-  ALLOWED_ATTR: [
-    'href',
-    'src',
-    'alt',
-    'title',
-    'class',
-    'target',
-    'rel',
-    'width',
-    'height',
-    'colspan',
-    'rowspan',
-    'dir',
-  ],
-}
-
 export function HtmlBlockRenderer({ block }: HtmlBlockRendererProps) {
   const [isMounted, setIsMounted] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
     // Force rel="noopener noreferrer" on links with target attribute to prevent tabnapping
@@ -84,10 +31,24 @@ export function HtmlBlockRenderer({ block }: HtmlBlockRendererProps) {
 
   const cleanHtml = useMemo(() => {
     if (!isMounted || !block.html?.trim()) return ''
-    return DOMPurify.sanitize(block.html, PURIFY_CONFIG)
+    return DOMPurify.sanitize(block.html, SAFE_HTML_PURIFY_CONFIG)
   }, [isMounted, block.html])
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container || !cleanHtml) return
+    const onClick = (event: MouseEvent) => handleSafeHtmlButtonClick(event, container)
+    container.addEventListener('click', onClick)
+    return () => container.removeEventListener('click', onClick)
+  }, [cleanHtml])
 
   if (!cleanHtml) return null
 
-  return <div className="html-block-content" dangerouslySetInnerHTML={{ __html: cleanHtml }} />
+  return (
+    <div
+      ref={containerRef}
+      className="html-block-content"
+      dangerouslySetInnerHTML={{ __html: cleanHtml }}
+    />
+  )
 }


### PR DESCRIPTION
Expand sanitizer whitelist to allow style/data-*/aria-*, disclosure and dialog elements, and action buttons wired via data-action.

Consolidate HTML sanitizer config into shared SafeHtml/sanitize-config used by SafeHtml, HtmlBlockRenderer, and the admin editor.

Add click delegation handler for button actions: external-link, open-modal, toast-success, with URL protocol guard.

Add Render Preview mode to the admin HtmlBlockEditor so authors can see the sanitized output before saving.