### PR TITLE
feat: Add registration popup funnel tracking for Mixpanel

### DIFF
--- a/src/app/(frontend)/signup/SignupForm.tsx
+++ b/src/app/(frontend)/signup/SignupForm.tsx
@@ -92,6 +92,13 @@ function SignupFormContent() {
         alias(result.data.userId, getOrCreateAnonymousId())
         identify(result.data.userId, userProperties)
 
+        // Track registration popup funnel action if user came from a popup
+        systemEventBus.emit(SYSTEM_EVENTS.REGISTRATION_POPUP_ACTION, {
+          outcome: 'Registered',
+          method: 'Email',
+          page_path: returnTo,
+        })
+
         // Now emit events — they will fire under the identified user
         systemEventBus.emit(SYSTEM_EVENTS.REGISTRATION_COMPLETED, {
           user_id: result.data.userId,
@@ -134,7 +141,7 @@ function SignupFormContent() {
 
           <Button type="submit" className="w-full" disabled={isLoading}>
             {isLoading ? (
-              <span className="flex items-center gap-2">
+              <span className="flex items-center gap-content-gap-xs">
                 <Spinner size="sm" />
                 {t('creatingAccount')}
               </span>

--- a/src/app/api/oauth/google/callback/oauth_callback_helpers.ts
+++ b/src/app/api/oauth/google/callback/oauth_callback_helpers.ts
@@ -194,6 +194,15 @@ export async function createNewOAuthUser(
     // Redirect new OAuth users to persona selection (onboarding step)
     res.headers.set('Location', new URL(getOnboardingRedirect(returnTo), req.url).toString())
     setAuthCookie(res, payload, token)
+
+    // Set short-lived cookie so client can fire registration funnel events
+    res.cookies.set('new_oauth_registration', '1', {
+      maxAge: 300,
+      path: '/',
+      httpOnly: false,
+      sameSite: 'lax',
+    })
+
     return res
   } catch (error) {
     logOAuthError('session_issuance_failed', error, correlationId)

--- a/src/infra/analytics/components/UserIdentificationTracker.tsx
+++ b/src/infra/analytics/components/UserIdentificationTracker.tsx
@@ -3,7 +3,8 @@
 import { detectBrowserLocale } from '@/i18n/config'
 import { SYSTEM_EVENTS, systemEventBus } from '@/infra/system-events'
 import { useEffect } from 'react'
-import { identify } from '../core/tracker'
+import { alias, identify } from '../core/tracker'
+import { getOrCreateAnonymousId } from '../utils/anonymous-id'
 import {
   getCachedUserProperties,
   shouldRefreshUserProperties,
@@ -97,8 +98,31 @@ export function UserIdentificationTracker() {
               // Cache user properties for future sessions
               updateCachedUserProperties(userProperties)
 
-              // Identify user with full properties (login only needs identify, not alias)
-              identify(user.id, userProperties)
+              // Check if this is a new Google OAuth registration (cookie set by OAuth callback)
+              const isNewOAuthRegistration = document.cookie.includes('new_oauth_registration=1')
+
+              if (isNewOAuthRegistration) {
+                // New OAuth user: alias anonymous history, then identify
+                alias(user.id, getOrCreateAnonymousId())
+                identify(user.id, { ...userProperties, is_new_user: true })
+
+                // Fire registration funnel events
+                systemEventBus.emit(SYSTEM_EVENTS.REGISTRATION_POPUP_ACTION, {
+                  outcome: 'Registered',
+                  method: 'Google',
+                })
+
+                systemEventBus.emit(SYSTEM_EVENTS.REGISTRATION_COMPLETED, {
+                  user_id: user.id,
+                  auth_method: 'google',
+                })
+
+                // Clear the cookie
+                document.cookie = 'new_oauth_registration=; max-age=0; path=/'
+              } else {
+                // Existing user login: identify only (no alias)
+                identify(user.id, userProperties)
+              }
 
               // Emit user_resolved after identify so events fire under the real user
               systemEventBus.emit(SYSTEM_EVENTS.USER_RESOLVED, {

--- a/src/infra/analytics/contracts/destinations.ts
+++ b/src/infra/analytics/contracts/destinations.ts
@@ -45,6 +45,8 @@ export const eventDestinations: Record<ProductEvent, AnalyticsDestination[]> = {
 
   // Registration Events
   [PRODUCT_EVENTS.REGISTRATION_PROMPT_SHOWN]: ['mixpanel'], // Product funnel
+  [PRODUCT_EVENTS.REGISTRATION_POPUP_SHOWN]: ['mixpanel'], // Registration popup funnel
+  [PRODUCT_EVENTS.REGISTRATION_POPUP_ACTION]: ['mixpanel'], // Registration popup action
   [PRODUCT_EVENTS.REGISTRATION_COMPLETED]: ['ga4', 'mixpanel'], // Conversion event (both)
 
   // Exercise Help System (Mixpanel only - detailed product analytics)

--- a/src/infra/analytics/contracts/events.ts
+++ b/src/infra/analytics/contracts/events.ts
@@ -39,6 +39,8 @@ export const PRODUCT_EVENTS = {
 
   // Registration Events
   REGISTRATION_PROMPT_SHOWN: 'registration_prompt_shown',
+  REGISTRATION_POPUP_SHOWN: 'registration_popup_shown', // Mixpanel - popup shown to anon user
+  REGISTRATION_POPUP_ACTION: 'registration_popup_action', // Mixpanel - user action on popup
   REGISTRATION_COMPLETED: 'registration_completed', // GA4 + Mixpanel
 
   // Exercise Help System Events (Mixpanel only)

--- a/src/infra/analytics/contracts/schemas.ts
+++ b/src/infra/analytics/contracts/schemas.ts
@@ -190,6 +190,32 @@ export const RegistrationPromptShownSchema = z.object({
 })
 
 /**
+ * registration_popup_shown - Auth gate popup shown to anonymous user
+ * Destination: Mixpanel
+ * Priority: P0
+ */
+export const RegistrationPopupShownSchema = z.object({
+  page_path: z.string().describe('Page URL where the popup was shown'),
+  trigger_type: z
+    .enum(['mandatory', 'gated', 'warning'])
+    .describe('Which access gate triggered the popup'),
+  course_slug: z.string().optional().describe('Course where popup appeared'),
+})
+
+/**
+ * registration_popup_action - User action on registration popup
+ * Destination: Mixpanel
+ * Priority: P0
+ */
+export const RegistrationPopupActionSchema = z.object({
+  outcome: z
+    .enum(['Registered', 'Did Not Register'])
+    .describe('Whether the user registered or dismissed'),
+  method: z.string().optional().describe('Registration method (Email, Google)'),
+  page_path: z.string().optional().describe('Page URL where action was taken'),
+})
+
+/**
  * registration_completed - Track successful signup
  * Destination: GA4 + Mixpanel
  * Priority: P0
@@ -489,6 +515,8 @@ export const eventSchemas = {
   [PRODUCT_EVENTS.PHOTO_SENT_TO_CHAT]: PhotoSentToChatSchema,
   [PRODUCT_EVENTS.LOGIN_MODAL_SHOWN]: LoginModalShownSchema,
   [PRODUCT_EVENTS.REGISTRATION_PROMPT_SHOWN]: RegistrationPromptShownSchema,
+  [PRODUCT_EVENTS.REGISTRATION_POPUP_SHOWN]: RegistrationPopupShownSchema,
+  [PRODUCT_EVENTS.REGISTRATION_POPUP_ACTION]: RegistrationPopupActionSchema,
   [PRODUCT_EVENTS.REGISTRATION_COMPLETED]: RegistrationCompletedSchema,
 
   // Exercise Help System Events
@@ -540,6 +568,8 @@ export type ChatMessageSentProperties = z.infer<typeof ChatMessageSentSchema>
 export type PhotoSentToChatProperties = z.infer<typeof PhotoSentToChatSchema>
 export type LoginModalShownProperties = z.infer<typeof LoginModalShownSchema>
 export type RegistrationPromptShownProperties = z.infer<typeof RegistrationPromptShownSchema>
+export type RegistrationPopupShownProperties = z.infer<typeof RegistrationPopupShownSchema>
+export type RegistrationPopupActionProperties = z.infer<typeof RegistrationPopupActionSchema>
 export type RegistrationCompletedProperties = z.infer<typeof RegistrationCompletedSchema>
 
 // Exercise Help System
@@ -591,6 +621,8 @@ export type EventProperties =
   | PhotoSentToChatProperties
   | LoginModalShownProperties
   | RegistrationPromptShownProperties
+  | RegistrationPopupShownProperties
+  | RegistrationPopupActionProperties
   | RegistrationCompletedProperties
   | HintClickedProperties
   | GuidingQuestionClickedProperties

--- a/src/infra/analytics/system-events-subscriber.ts
+++ b/src/infra/analytics/system-events-subscriber.ts
@@ -205,6 +205,33 @@ export function initAnalyticsSubscriber(): () => void {
       })
     }),
 
+    // Registration Popup Funnel
+    safeSubscribe(SYSTEM_EVENTS.REGISTRATION_POPUP_SHOWN, (envelope) => {
+      const payload = envelope.payload as {
+        page_path?: string
+        trigger_type?: string
+        course_slug?: string
+      }
+      analytics.track(PRODUCT_EVENTS.REGISTRATION_POPUP_SHOWN, {
+        page_path: payload.page_path,
+        trigger_type: payload.trigger_type,
+        course_slug: payload.course_slug,
+      })
+    }),
+
+    safeSubscribe(SYSTEM_EVENTS.REGISTRATION_POPUP_ACTION, (envelope) => {
+      const payload = envelope.payload as {
+        outcome?: string
+        method?: string
+        page_path?: string
+      }
+      analytics.track(PRODUCT_EVENTS.REGISTRATION_POPUP_ACTION, {
+        outcome: payload.outcome,
+        method: payload.method,
+        page_path: payload.page_path,
+      })
+    }),
+
     // Registration Funnel
     safeSubscribe(SYSTEM_EVENTS.REGISTRATION_PROMPT_SHOWN, (envelope) => {
       const payload = envelope.payload as {

--- a/src/infra/system-events/events.ts
+++ b/src/infra/system-events/events.ts
@@ -31,6 +31,10 @@ export const SYSTEM_EVENTS = {
   LOGIN_MODAL_SHOWN: 'system.login_modal_shown',
   /** Registration prompt shown to user */
   REGISTRATION_PROMPT_SHOWN: 'system.registration_prompt_shown',
+  /** Registration popup shown to anonymous user (auth gate) */
+  REGISTRATION_POPUP_SHOWN: 'system.registration_popup_shown',
+  /** User took action on registration popup (registered or dismissed) */
+  REGISTRATION_POPUP_ACTION: 'system.registration_popup_action',
   /** User completed registration */
   REGISTRATION_COMPLETED: 'system.registration_completed',
 

--- a/src/infra/system-events/schemas.ts
+++ b/src/infra/system-events/schemas.ts
@@ -210,6 +210,34 @@ export const RegistrationPromptShownSchema = z
 export type RegistrationPromptShownPayload = z.infer<typeof RegistrationPromptShownSchema>
 
 // ============================================================================
+// Registration Popup Shown Event
+// ============================================================================
+
+export const RegistrationPopupShownSchema = z
+  .object({
+    page_path: z.string().min(1, 'page_path is required'),
+    trigger_type: z.enum(['mandatory', 'gated', 'warning']),
+    course_slug: z.string().optional(),
+  })
+  .strict()
+
+export type RegistrationPopupShownPayload = z.infer<typeof RegistrationPopupShownSchema>
+
+// ============================================================================
+// Registration Popup Action Event
+// ============================================================================
+
+export const RegistrationPopupActionSchema = z
+  .object({
+    outcome: z.enum(['Registered', 'Did Not Register']),
+    method: z.string().optional(),
+    page_path: z.string().optional(),
+  })
+  .strict()
+
+export type RegistrationPopupActionPayload = z.infer<typeof RegistrationPopupActionSchema>
+
+// ============================================================================
 // Registration Completed Event
 // ============================================================================
 
@@ -420,6 +448,8 @@ export const eventSchemas = {
   [SYSTEM_EVENTS.PHOTO_SENT_TO_CHAT]: PhotoSentToChatSchema,
   [SYSTEM_EVENTS.LOGIN_MODAL_SHOWN]: LoginModalShownSchema,
   [SYSTEM_EVENTS.REGISTRATION_PROMPT_SHOWN]: RegistrationPromptShownSchema,
+  [SYSTEM_EVENTS.REGISTRATION_POPUP_SHOWN]: RegistrationPopupShownSchema,
+  [SYSTEM_EVENTS.REGISTRATION_POPUP_ACTION]: RegistrationPopupActionSchema,
   [SYSTEM_EVENTS.REGISTRATION_COMPLETED]: RegistrationCompletedSchema,
 
   // Exercise Help System

--- a/src/infra/system-events/types.ts
+++ b/src/infra/system-events/types.ts
@@ -37,6 +37,8 @@ import type {
   PageViewedPayload,
   PdfViewedPayload,
   RegistrationCompletedPayload,
+  RegistrationPopupActionPayload,
+  RegistrationPopupShownPayload,
   RegistrationPromptShownPayload,
   SessionStartedPayload,
   SiteInitPayload,
@@ -87,6 +89,8 @@ export type SystemEventPayloads = {
   'system.photo_sent_to_chat': PhotoSentToChatPayload
   'system.login_modal_shown': LoginModalShownPayload
   'system.registration_prompt_shown': RegistrationPromptShownPayload
+  'system.registration_popup_shown': RegistrationPopupShownPayload
+  'system.registration_popup_action': RegistrationPopupActionPayload
   'system.registration_completed': RegistrationCompletedPayload
 
   // Exercise Help System

--- a/src/ui/web/auth/AccessGateProvider.tsx
+++ b/src/ui/web/auth/AccessGateProvider.tsx
@@ -75,6 +75,15 @@ export function AccessGateProvider({
         course_slug: courseSlug,
         current_page: pathname,
       })
+
+      // Fire registration popup shown for anonymous users only (not paid modal which is for authenticated users)
+      if (triggerType !== 'paid') {
+        systemEventBus.emit(SYSTEM_EVENTS.REGISTRATION_POPUP_SHOWN, {
+          page_path: pathname,
+          trigger_type: triggerType,
+          course_slug: courseSlug,
+        })
+      }
     }
 
     // Reset when all modals close so it fires again on next appearance
@@ -86,7 +95,18 @@ export function AccessGateProvider({
   return (
     <>
       {/* Dismissible warning modal - user can close and keep browsing */}
-      <Dialog open={showWarningModal} onOpenChange={(open) => !open && dismissWarning()}>
+      <Dialog
+        open={showWarningModal}
+        onOpenChange={(open) => {
+          if (!open) {
+            systemEventBus.emit(SYSTEM_EVENTS.REGISTRATION_POPUP_ACTION, {
+              outcome: 'Did Not Register',
+              page_path: pathname,
+            })
+            dismissWarning()
+          }
+        }}
+      >
         <DialogContent allowDismiss={true} className="sm:max-w-md">
           <DialogHeader className="text-center sm:text-center">
             <DialogTitle className="text-heading-xl">{t('gatedWarningTitle')}</DialogTitle>

--- a/src/ui/web/auth/AuthGateModal.tsx
+++ b/src/ui/web/auth/AuthGateModal.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 
+import { SYSTEM_EVENTS, systemEventBus } from '@/infra/system-events'
 import {
   Dialog,
   DialogContent,
@@ -22,6 +23,13 @@ interface AuthGateModalProps {
 export function AuthGateModal({ isOpen, title, description, returnTo }: AuthGateModalProps) {
   const t = useTranslations('accessControl')
 
+  const handleBrowseCoursesClick = () => {
+    systemEventBus.emit(SYSTEM_EVENTS.REGISTRATION_POPUP_ACTION, {
+      outcome: 'Did Not Register',
+      page_path: returnTo,
+    })
+  }
+
   return (
     <Dialog open={isOpen}>
       <DialogContent allowDismiss={false} className="sm:max-w-md">
@@ -33,6 +41,7 @@ export function AuthGateModal({ isOpen, title, description, returnTo }: AuthGate
           <GoogleLoginButton returnTo={returnTo} className="w-full" />
           <Link
             href="/courses"
+            onClick={handleBrowseCoursesClick}
             className="text-body-sm text-muted-foreground underline hover:text-foreground transition-all duration-normal"
           >
             {t('browseCourses')}

--- a/tests/unit/system-events/contracts.test.ts
+++ b/tests/unit/system-events/contracts.test.ts
@@ -279,7 +279,7 @@ describe('Schema Validation', () => {
 describe('Schema Registry', () => {
   it('contains all system events', () => {
     const eventNames = Object.keys(eventSchemas)
-    expect(eventNames.length).toBe(37)
+    expect(eventNames.length).toBe(39)
   })
 
   it('maps each event name to its schema', () => {


### PR DESCRIPTION
Add two new Mixpanel events to track the registration popup conversion funnel:
- registration_popup_shown: fires when auth gate popup appears for anonymous users
- registration_popup_action: fires with outcome "Registered" or "Did Not Register"

Includes identity linking (alias/identify) for Google OAuth new user registrations via a short-lived cookie detected by UserIdentificationTracker on the client.