### PR TITLE
feat: Increase lessonContextText limit from 100K to 200K chars

### DIFF
--- a/src/infra/llm/lesson-context.ts
+++ b/src/infra/llm/lesson-context.ts
@@ -10,7 +10,7 @@
  * @pattern single-responsibility, runtime-injection
  */
 
-export const LESSON_CONTEXT_MAX_CHARS = 100_000 // ~50K tokens
+export const LESSON_CONTEXT_MAX_CHARS = 200_000 // ~100K tokens
 export const LESSON_CONTEXT_BLOCK_START = 'LESSON_CONTEXT_START'
 export const LESSON_CONTEXT_BLOCK_END = 'LESSON_CONTEXT_END'
 

--- a/src/server/payload/collections/Lessons.ts
+++ b/src/server/payload/collections/Lessons.ts
@@ -338,7 +338,7 @@ export const Lessons: CollectionConfig = {
     {
       name: 'lessonContextText',
       type: 'textarea',
-      maxLength: 100_000, // Match LESSON_CONTEXT_MAX_CHARS in src/lib/ai/lesson-context.ts
+      maxLength: 200_000, // Match LESSON_CONTEXT_MAX_CHARS in src/infra/llm/lesson-context.ts
       admin: {
         description:
           'AI context text for this lesson. Injected into chat prompts at runtime. NOT indexed or searchable.',

--- a/src/server/services/lesson-context-conversion/extract-context.ts
+++ b/src/server/services/lesson-context-conversion/extract-context.ts
@@ -23,7 +23,7 @@ import type { Payload, User } from 'payload'
 const PAGE_CONCURRENCY = 3
 
 // Warning threshold for combined LaTeX size
-const LATEX_SIZE_WARNING_THRESHOLD = 80000
+const LATEX_SIZE_WARNING_THRESHOLD = 160000
 
 export interface ExtractContextInput {
   lessonId: string


### PR DESCRIPTION
Support ~30-page PDF extractions without hitting the field size limit.