### PR TITLE
feat: Add LaTeX block UI (admin editor + frontend renderer)

### DIFF
--- a/src/ui/admin/ExerciseContentEditor/BlockTypeSelector.tsx
+++ b/src/ui/admin/ExerciseContentEditor/BlockTypeSelector.tsx
@@ -10,6 +10,7 @@ import {
   LayoutGrid,
   LineChart,
   List,
+  Sigma,
   Table as TableIcon,
   Triangle,
   X,
@@ -71,6 +72,12 @@ export const BlockTypeSelector: React.FC<BlockTypeSelectorProps> = ({
       label: 'HTML Block',
       description: 'Rich WYSIWYG content (headings, lists, images, links)',
       icon: <Code size={20} />,
+    },
+    {
+      type: 'latex',
+      label: 'LaTeX',
+      description: 'Raw LaTeX code block with preview',
+      icon: <Sigma size={20} />,
     },
     {
       type: 'question_matching',

--- a/src/ui/admin/ExerciseContentEditor/editors/LatexBlockEditor.tsx
+++ b/src/ui/admin/ExerciseContentEditor/editors/LatexBlockEditor.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import type { LatexBlock } from '@/server/payload/collections/Exercises/types'
+import { MathMarkdown } from '@/ui/web/shared/MathMarkdown'
+import React, { useState } from 'react'
+
+interface LatexBlockEditorProps {
+  block: LatexBlock
+  onChange: (block: LatexBlock) => void
+}
+
+export const LatexBlockEditor: React.FC<LatexBlockEditorProps> = ({ block, onChange }) => {
+  const [showPreview, setShowPreview] = useState(false)
+
+  const handleLatexChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    onChange({ ...block, latex: e.target.value })
+  }
+
+  const handleRenderModeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    onChange({ ...block, renderMode: e.target.value as 'block' | 'inline' })
+  }
+
+  const renderMode = block.renderMode ?? 'block'
+  const wrappedLatex = renderMode === 'inline' ? `$${block.latex}$` : `$$\n${block.latex}\n$$`
+
+  return (
+    <div className="latex-block-editor">
+      <div className="latex-block-editor-header">
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <label style={{ fontSize: '13px', fontWeight: 500 }}>Render Mode:</label>
+          <select
+            value={renderMode}
+            onChange={handleRenderModeChange}
+            style={{ fontSize: '13px', padding: '2px 6px' }}
+          >
+            <option value="block">Block (display math)</option>
+            <option value="inline">Inline</option>
+          </select>
+        </div>
+        <button
+          type="button"
+          className={`html-editor-source-toggle ${showPreview ? 'html-editor-source-toggle--active' : ''}`}
+          onClick={() => setShowPreview(!showPreview)}
+        >
+          {showPreview ? 'Edit' : 'Preview'}
+        </button>
+      </div>
+
+      {showPreview ? (
+        <div
+          style={{
+            padding: '16px',
+            border: '1px solid var(--theme-elevation-150)',
+            borderRadius: '4px',
+            minHeight: '80px',
+            background: 'var(--theme-elevation-50)',
+          }}
+        >
+          {block.latex ? (
+            <MathMarkdown content={wrappedLatex} />
+          ) : (
+            <p style={{ color: 'var(--theme-elevation-400)', fontStyle: 'italic' }}>
+              No LaTeX content to preview
+            </p>
+          )}
+        </div>
+      ) : (
+        <textarea
+          className="html-block-source-textarea"
+          value={block.latex}
+          onChange={handleLatexChange}
+          placeholder="Enter LaTeX code here, e.g. \frac{a}{b} or \int_0^1 f(x)\,dx"
+          rows={8}
+          style={{ fontFamily: 'monospace' }}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/ui/admin/ExerciseContentEditor/editors/LatexBlockEditor.tsx
+++ b/src/ui/admin/ExerciseContentEditor/editors/LatexBlockEditor.tsx
@@ -21,12 +21,12 @@ export const LatexBlockEditor: React.FC<LatexBlockEditorProps> = ({ block, onCha
 
   return (
     <div className="latex-block-editor">
-      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '8px' }}>
-        <label style={{ fontSize: '13px', fontWeight: 500 }}>Render Mode:</label>
+      <div className="flex items-center gap-content-gap-xs mb-2">
+        <label className="text-label">Render Mode:</label>
         <select
           value={renderMode}
           onChange={handleRenderModeChange}
-          style={{ fontSize: '13px', padding: '2px 6px' }}
+          className="text-label px-1 py-0.5"
         >
           <option value="block">Block (display math)</option>
           <option value="inline">Inline</option>
@@ -34,12 +34,11 @@ export const LatexBlockEditor: React.FC<LatexBlockEditorProps> = ({ block, onCha
       </div>
 
       <textarea
-        className="html-block-source-textarea"
+        className="html-block-source-textarea font-mono"
         value={block.latex}
         onChange={handleLatexChange}
         placeholder="Enter LaTeX code here..."
         rows={8}
-        style={{ fontFamily: 'monospace' }}
       />
     </div>
   )

--- a/src/ui/admin/ExerciseContentEditor/editors/LatexBlockEditor.tsx
+++ b/src/ui/admin/ExerciseContentEditor/editors/LatexBlockEditor.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import type { LatexBlock } from '@/server/payload/collections/Exercises/types'
-import { MathMarkdown } from '@/ui/web/shared/MathMarkdown'
-import React, { useState } from 'react'
+import React from 'react'
 
 interface LatexBlockEditorProps {
   block: LatexBlock
@@ -10,8 +9,6 @@ interface LatexBlockEditorProps {
 }
 
 export const LatexBlockEditor: React.FC<LatexBlockEditorProps> = ({ block, onChange }) => {
-  const [showPreview, setShowPreview] = useState(false)
-
   const handleLatexChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     onChange({ ...block, latex: e.target.value })
   }
@@ -21,59 +18,29 @@ export const LatexBlockEditor: React.FC<LatexBlockEditorProps> = ({ block, onCha
   }
 
   const renderMode = block.renderMode ?? 'block'
-  const wrappedLatex = renderMode === 'inline' ? `$${block.latex}$` : `$$\n${block.latex}\n$$`
 
   return (
     <div className="latex-block-editor">
-      <div className="latex-block-editor-header">
-        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-          <label style={{ fontSize: '13px', fontWeight: 500 }}>Render Mode:</label>
-          <select
-            value={renderMode}
-            onChange={handleRenderModeChange}
-            style={{ fontSize: '13px', padding: '2px 6px' }}
-          >
-            <option value="block">Block (display math)</option>
-            <option value="inline">Inline</option>
-          </select>
-        </div>
-        <button
-          type="button"
-          className={`html-editor-source-toggle ${showPreview ? 'html-editor-source-toggle--active' : ''}`}
-          onClick={() => setShowPreview(!showPreview)}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '8px' }}>
+        <label style={{ fontSize: '13px', fontWeight: 500 }}>Render Mode:</label>
+        <select
+          value={renderMode}
+          onChange={handleRenderModeChange}
+          style={{ fontSize: '13px', padding: '2px 6px' }}
         >
-          {showPreview ? 'Edit' : 'Preview'}
-        </button>
+          <option value="block">Block (display math)</option>
+          <option value="inline">Inline</option>
+        </select>
       </div>
 
-      {showPreview ? (
-        <div
-          style={{
-            padding: '16px',
-            border: '1px solid var(--theme-elevation-150)',
-            borderRadius: '4px',
-            minHeight: '80px',
-            background: 'var(--theme-elevation-50)',
-          }}
-        >
-          {block.latex ? (
-            <MathMarkdown content={wrappedLatex} />
-          ) : (
-            <p style={{ color: 'var(--theme-elevation-400)', fontStyle: 'italic' }}>
-              No LaTeX content to preview
-            </p>
-          )}
-        </div>
-      ) : (
-        <textarea
-          className="html-block-source-textarea"
-          value={block.latex}
-          onChange={handleLatexChange}
-          placeholder="Enter LaTeX code here, e.g. \frac{a}{b} or \int_0^1 f(x)\,dx"
-          rows={8}
-          style={{ fontFamily: 'monospace' }}
-        />
-      )}
+      <textarea
+        className="html-block-source-textarea"
+        value={block.latex}
+        onChange={handleLatexChange}
+        placeholder="Enter LaTeX code here..."
+        rows={8}
+        style={{ fontFamily: 'monospace' }}
+      />
     </div>
   )
 }

--- a/src/ui/admin/ExerciseContentEditor/index.tsx
+++ b/src/ui/admin/ExerciseContentEditor/index.tsx
@@ -13,6 +13,7 @@ import { FreeResponseEditor } from './editors/FreeResponseEditor'
 import { MultiAxisEditor } from './editors/MultiAxisEditor'
 import { GeometryEditor } from './editors/GeometryEditor'
 import { HtmlBlockEditor } from './editors/HtmlBlockEditor'
+import { LatexBlockEditor } from './editors/LatexBlockEditor'
 import { InlineRichTextEditor } from './editors/InlineRichTextEditor'
 import { MatchingEditor } from './editors/MatchingEditor'
 import { McqEditor } from './editors/McqEditor'
@@ -414,6 +415,7 @@ function getBlockTypeLabel(block: ContentBlock): string {
   if (block.type === 'question_matching') return 'Matching'
   if (block.type === 'svg') return 'SVG Image'
   if (block.type === 'media') return 'Media'
+  if (block.type === 'latex') return 'LaTeX'
   if (block.type === 'question_geometry') return 'Geometry'
   if (block.type === 'question_axis') return 'Axis Graph'
   if (block.type === 'question_multi_axis') return 'Multi Axis Graph'
@@ -603,6 +605,27 @@ function renderQuestionEditor(
       >
         <AxisEditor
           block={block as import('@/server/payload/collections/Exercises/types').QuestionAxisBlock}
+          onChange={onChange}
+        />
+      </QuestionBlockWrapper>
+    )
+  }
+  if (block.type === 'latex') {
+    return (
+      <QuestionBlockWrapper
+        blockType={getBlockTypeLabel(block)}
+        block={block}
+        onBlockChange={onChange}
+        onMoveUp={onMoveUp}
+        onMoveDown={onMoveDown}
+        onDuplicate={onDuplicate}
+        onDelete={onDelete}
+        canMoveUp={blockIndex > 0}
+        canMoveDown={blockIndex < blockCount - 1}
+        canDelete={blockCount > 1}
+      >
+        <LatexBlockEditor
+          block={block as import('@/server/payload/collections/Exercises/types').LatexBlock}
           onChange={onChange}
         />
       </QuestionBlockWrapper>

--- a/src/ui/web/exerciserenderer/ExerciseRenderer/index.tsx
+++ b/src/ui/web/exerciserenderer/ExerciseRenderer/index.tsx
@@ -37,6 +37,7 @@ import { SvgRenderer } from '../blocks/SvgRenderer'
 import { GeometryRenderer } from '../blocks/GeometryRenderer'
 import { AxisRenderer } from '../blocks/AxisRenderer'
 import { GraphWithPrompt } from '../blocks/GraphWithPrompt'
+import { LatexBlockRenderer } from '../blocks/LatexBlockRenderer'
 import { MultiAxisRenderer } from '../blocks/MultiAxisRenderer'
 import { TrueFalseQuestion } from '../questions/TrueFalseQuestion'
 import { McqQuestion } from '../questions/McqQuestion'
@@ -404,7 +405,7 @@ export function ExerciseRenderer({
                       key={q.id}
                       title={`שאלה ${qLabel}`}
                       className={cn(
-                        'w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-bold transition-all duration-300',
+                        'w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-bold transition-all duration-slow',
                         !isChecked && 'bg-muted border border-border/40 text-muted-foreground',
                         isChecked &&
                           !isCorrect &&
@@ -429,8 +430,8 @@ export function ExerciseRenderer({
         <Confetti active={showAllCorrectConfetti} duration={3000} />
         {allQuestionsCorrect && (
           <FadeIn>
-            <div className="rounded-2xl bg-gradient-to-r from-success/15 via-success/10 to-success/15 border-2 border-success/30 p-5 text-center flex flex-col items-center gap-2 shadow-card">
-              <div className="flex items-center gap-2">
+            <div className="rounded-2xl bg-gradient-to-r from-success/15 via-success/10 to-success/15 border-2 border-success/30 p-5 text-center flex flex-col items-center gap-content-gap-xs shadow-card">
+              <div className="flex items-center gap-content-gap-xs">
                 <Sparkles className="w-6 h-6 text-success" />
                 <span className="text-heading-lg font-black text-success">{t('correct')}</span>
                 <Sparkles className="w-6 h-6 text-success" />
@@ -529,6 +530,17 @@ export function ExerciseRenderer({
                   <FadeIn key={block.id}>
                     <div className="prose prose-slate dark:prose-invert max-w-none text-foreground leading-relaxed">
                       <RichTextRenderer block={block} />
+                    </div>
+                  </FadeIn>
+                )
+              }
+
+              // LaTeX block - render math via KaTeX
+              if (block.type === 'latex') {
+                return (
+                  <FadeIn key={block.id}>
+                    <div className="prose prose-slate dark:prose-invert max-w-none text-foreground leading-relaxed">
+                      <LatexBlockRenderer block={block} />
                     </div>
                   </FadeIn>
                 )

--- a/src/ui/web/exerciserenderer/blocks/LatexBlockRenderer/index.tsx
+++ b/src/ui/web/exerciserenderer/blocks/LatexBlockRenderer/index.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import type { LatexBlock } from '@/server/payload/collections/Exercises/types'
+import { MathMarkdown } from '@/ui/web/shared/MathMarkdown'
+import React from 'react'
+
+interface LatexBlockRendererProps {
+  block: LatexBlock
+}
+
+export const LatexBlockRenderer: React.FC<LatexBlockRendererProps> = ({ block }) => {
+  const renderMode = block.renderMode ?? 'block'
+  const wrapped = renderMode === 'inline' ? `$${block.latex}$` : `$$\n${block.latex}\n$$`
+
+  return <MathMarkdown content={wrapped} />
+}

--- a/src/ui/web/exerciserenderer/types.ts
+++ b/src/ui/web/exerciserenderer/types.ts
@@ -5,6 +5,7 @@
  */
 
 import type {
+  LatexBlock,
   QuestionMatchingBlock,
   SvgBlock,
   MatchingOption,
@@ -14,6 +15,7 @@ import type {
 } from '@/server/payload/collections/Exercises/types'
 
 export type {
+  LatexBlock,
   QuestionMatchingBlock,
   SvgBlock,
   MatchingOption,
@@ -171,7 +173,13 @@ export interface HtmlBlock {
   html: string
 }
 
-export type ContentBlock = RichTextBlock | HtmlBlock | QuestionBlock | SvgBlock | MediaBlock
+export type ContentBlock =
+  | RichTextBlock
+  | LatexBlock
+  | HtmlBlock
+  | QuestionBlock
+  | SvgBlock
+  | MediaBlock
 
 /**
  * Help system state per question


### PR DESCRIPTION
Complete the LaTeX block implementation by adding the missing UI layer:
- Admin BlockTypeSelector entry with Sigma icon
- LatexBlockEditor with edit/preview toggle and render mode selector
- LatexBlockRenderer using MathMarkdown/KaTeX for frontend display
- Wire both into ExerciseContentEditor and ExerciseRenderer