### PR TITLE
fix: Add context_extraction origin to Exercises collection

### DIFF
--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1569,7 +1569,7 @@ export interface Exercise {
    * User who created this document
    */
   createdBy?: (string | null) | User;
-  origin: 'manual' | 'conversion' | 'import';
+  origin: 'manual' | 'conversion' | 'import' | 'context_extraction';
   /**
    * Original PDF media for conversion exercises
    */

--- a/src/server/payload/collections/Exercises/index.ts
+++ b/src/server/payload/collections/Exercises/index.ts
@@ -357,6 +357,7 @@ export const Exercises: CollectionConfig = {
             { label: 'Manual', value: 'manual' },
             { label: 'Conversion', value: 'conversion' },
             { label: 'Import', value: 'import' },
+            { label: 'Context Extraction', value: 'context_extraction' },
           ],
           defaultValue: 'manual',
           required: true,


### PR DESCRIPTION
Add 'context_extraction' as a valid origin option for exercises 