### PR TITLE
feat: Inject exercise-specific LaTeX blocks into chat context instead…

### DIFF
--- a/src/infra/llm/exercise-context.ts
+++ b/src/infra/llm/exercise-context.ts
@@ -1,208 +1,214 @@
 /**
- * Exercise Context Formatting Utility
+ * Exercise Context Injection
  *
- * Formats exercise content into a readable message for the LLM.
- * - Strips solutions and correct answers (prevent leakage)
- * - Includes hints (helps LLM guide student)
- * - Caps output at 2000 characters
+ * Serializes an exercise's ContentBlock[] into a text format suitable for
+ * LLM injection. Replaces the full lessonContextText with a focused,
+ * exercise-specific context when the chat is scoped to an exercise.
+ *
+ * @fileType ai-utility
+ * @domain chat
+ * @pattern single-responsibility, runtime-injection
  */
+import type { ContentBlock } from '@/server/payload/collections/Exercises/types'
 
-import type {
-  LatexBlock,
-  QuestionAxisBlock,
-  QuestionFreeResponseBlock,
-  QuestionGeometryBlock,
-  QuestionMatchingBlock,
-  QuestionSelectMcqBlock,
-  QuestionSelectTrueFalseBlock,
-  QuestionTableBlock,
-  RichTextBlock,
-  SvgBlock,
-} from '@/server/payload/collections/Exercises/types'
-
-export interface MediaItem {
-  id: string
-  url?: string | null
-  filename?: string
-  mimeType?: string
-  altText?: string
-}
-
-const MAX_OUTPUT_LENGTH = 2000
-const TRUNCATE_SUFFIX = '...'
+import { parseContextText } from '@/lib/context-exercise-parser'
 
 /**
- * Format exercise content blocks into a readable message for the LLM.
+ * Format exercise content blocks into a readable message for client-side context injection.
+ * Used by useNotebookChat to send exercise context as a hidden message.
  */
 export function formatExerciseContextMessage(
   exerciseTitle: string,
-  blocks: Array<{
-    id: string
-    type: string
-    [key: string]: unknown
-  }>,
-  mediaMap?: Record<string, MediaItem>,
+  blocks: Array<{ id: string; type: string; [key: string]: unknown }>,
+  _mediaMap?: Record<string, unknown>,
 ): string {
-  const parts: string[] = []
+  const serialized = serializeContentBlocks(blocks as unknown as ContentBlock[])
+  const parts = [
+    '[EXERCISE CONTEXT]',
+    `Exercise: "${exerciseTitle}"`,
+    '',
+    serialized || '[No content blocks]',
+    '',
+    '[END EXERCISE CONTEXT]',
+  ]
+  return parts.join('\n')
+}
 
-  // Header
-  parts.push('[EXERCISE CONTEXT]')
-  parts.push(`Exercise: "${exerciseTitle}"`)
-  parts.push('')
-  parts.push('Content Blocks:')
-  parts.push('')
+export const EXERCISE_CONTEXT_BLOCK_START = 'EXERCISE_CONTEXT_START'
+export const EXERCISE_CONTEXT_BLOCK_END = 'EXERCISE_CONTEXT_END'
+export const EXERCISE_CONTEXT_MAX_CHARS = 50_000 // ~25K tokens
+const DEFAULT_PREAMBLE_MAX_CHARS = 2_000
 
-  // Format each block
-  let currentLength = parts.join('\n').length
-  let blockIndex = 0
-
-  for (const block of blocks) {
-    // Check if we're at the limit
-    const remaining = MAX_OUTPUT_LENGTH - currentLength
-    if (remaining < 50) {
-      break
-    }
-
-    blockIndex++
-    const line = formatBlock(block, blockIndex, mediaMap, remaining)
-
-    if (line) {
-      parts.push(line)
-      currentLength += line.length + 1 // +1 for newline
-    }
-  }
-
-  // Footer
-  parts.push('')
-  parts.push('[END EXERCISE CONTEXT]')
-
-  const result = parts.join('\n')
-  return result.length > MAX_OUTPUT_LENGTH
-    ? result.substring(0, MAX_OUTPUT_LENGTH - TRUNCATE_SUFFIX.length) + TRUNCATE_SUFFIX
-    : result
+/**
+ * Serialize an InlineRichText prompt to plain string.
+ */
+function inlineToString(
+  irt: { type: 'rich_text'; format: string; value: string } | undefined,
+): string {
+  return irt?.value ?? ''
 }
 
 /**
- * Format a single content block into a readable line.
+ * Serialize a single ContentBlock into a human-readable text representation.
+ *
+ * SECURITY: The following fields are intentionally EXCLUDED to prevent answer leakage:
+ * - answer (correctOptionIds, acceptedAnswers, correctPairs, etc.)
+ * - hint, solution, fullSolution
+ * - table.answers, table.solutionFill
+ * - correctHotspotIds (SVG)
+ * Any new ContentBlock type MUST be reviewed for answer leakage before adding here.
  */
-function formatBlock(
-  block: {
-    id: string
-    type: string
-    [key: string]: unknown
-  },
-  index: number,
-  mediaMap?: Record<string, MediaItem>,
-  maxLength?: number,
-): string | null {
+function serializeBlock(block: ContentBlock): string {
   switch (block.type) {
-    case 'rich_text':
-      return formatRichTextBlock(block as unknown as RichTextBlock, index, maxLength)
+    case 'latex':
+      return block.latex
 
-    case 'question_select':
-      if ((block as unknown as QuestionSelectTrueFalseBlock).variant === 'true_false') {
-        return formatTrueFalseBlock(block as unknown as QuestionSelectTrueFalseBlock, index)
+    case 'rich_text':
+      return block.value
+
+    case 'question_select': {
+      const prompt = inlineToString(block.prompt)
+      if (block.variant === 'true_false') {
+        return `${prompt}\n(True / False)`
       }
-      return formatMcqBlock(block as unknown as QuestionSelectMcqBlock, index)
+      // MCQ — list options without revealing correct answer
+      const options = block.answer.options
+        .map((opt, i) => {
+          const letter = String.fromCharCode(65 + i)
+          return `  ${letter}) ${inlineToString(opt.content)}`
+        })
+        .join('\n')
+      return `${prompt}\n${options}`
+    }
 
     case 'question_free_response':
-      return formatFreeResponseBlock(block as unknown as QuestionFreeResponseBlock, index)
+      return inlineToString(block.prompt)
 
-    case 'question_table':
-      return formatTableBlock(block as unknown as QuestionTableBlock, index)
+    case 'question_table': {
+      const prompt = inlineToString(block.prompt)
+      const { headers, rowsData } = block.table
+      const headerRow = headers.length > 0 ? `| ${headers.join(' | ')} |` : ''
+      const separator = headers.length > 0 ? `| ${headers.map(() => '---').join(' | ')} |` : ''
+      const rows = rowsData.map((row) => `| ${row.join(' | ')} |`).join('\n')
+      return [prompt, headerRow, separator, rows].filter(Boolean).join('\n')
+    }
 
-    case 'latex':
-      return formatLatexBlock(block as unknown as LatexBlock, index)
-
-    case 'question_matching':
-      return formatMatchingBlock(block as unknown as QuestionMatchingBlock, index)
-
-    case 'svg':
-      return formatSvgBlock(block as unknown as SvgBlock, index)
+    case 'question_matching': {
+      const prompt = inlineToString(block.prompt)
+      const left = block.leftColumn.map((o) => `  - ${inlineToString(o.content)}`).join('\n')
+      const right = block.rightColumn.map((o) => `  - ${inlineToString(o.content)}`).join('\n')
+      return `${prompt}\nColumn A:\n${left}\nColumn B:\n${right}`
+    }
 
     case 'question_geometry':
-      return formatGeometryBlock(block as unknown as QuestionGeometryBlock, index)
+      return `${inlineToString(block.prompt)}\n[Geometry diagram]`
 
     case 'question_axis':
-      return formatAxisBlock(block as unknown as QuestionAxisBlock, index)
+      return `${inlineToString(block.prompt)}\n[Graph diagram]`
+
+    case 'question_multi_axis': {
+      const prompt = block.prompt ? inlineToString(block.prompt) : ''
+      return `${prompt}\n[Multiple graphs: ${block.graphs.length} diagrams]`.trim()
+    }
+
+    case 'svg':
+      return block.altText || '[SVG diagram]'
+
+    case 'html':
+      return block.html
+        .replace(/<[^>]+>/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+
+    case 'media':
+      return '[Media attachment]'
 
     default:
-      return `${index}. [${block.type}]`
+      return ''
   }
-}
-
-function formatRichTextBlock(block: RichTextBlock, index: number, maxLength?: number): string {
-  const preview = truncateText(block.value, maxLength ? maxLength - 50 : 150)
-  const mediaInfo = block.mediaIds.length > 0 ? ` | Media: ${block.mediaIds.length} item(s)` : ''
-  return `${index}. [RichText] ${preview}${mediaInfo}`
-}
-
-function formatTrueFalseBlock(block: QuestionSelectTrueFalseBlock, index: number): string {
-  const prompt = truncateText(block.prompt.value, 100)
-  const options = block.options.map((o) => o.label.value).join(', ')
-  const hint = block.hint ? ` | Hint: ${truncateText(block.hint.value, 50)}` : ''
-  return `${index}. [Question: True/False] ${prompt} | Options: ${options}${hint}`
-}
-
-function formatMcqBlock(block: QuestionSelectMcqBlock, index: number): string {
-  const prompt = truncateText(block.prompt.value, 100)
-  const options = block.answer.options.map((o) => truncateText(o.content.value, 30)).join(', ')
-  const hint = block.hint ? ` | Hint: ${truncateText(block.hint.value, 50)}` : ''
-  return `${index}. [Question: MCQ] ${prompt} | Options: ${options}${hint}`
-}
-
-function formatFreeResponseBlock(block: QuestionFreeResponseBlock, index: number): string {
-  const prompt = truncateText(block.prompt.value, 100)
-  const answerCount = block.answer.acceptedAnswers.length
-  const hint = block.hint ? ` | Hint: ${truncateText(block.hint.value, 50)}` : ''
-  return `${index}. [Question: FreeResponse] ${prompt} | Accepted: ${answerCount} answer(s)${hint}`
-}
-
-function formatTableBlock(block: QuestionTableBlock, index: number): string {
-  const prompt = truncateText(block.prompt.value, 80)
-  const rows = block.table.rowsData.length
-  const cols = block.table.headers.length
-  const hint = block.hint ? ` | Hint: ${truncateText(block.hint.value, 50)}` : ''
-  return `${index}. [Question: Table] ${prompt} | ${cols} columns × ${rows} rows${hint}`
-}
-
-function formatLatexBlock(block: LatexBlock, index: number): string {
-  const preview = truncateText(block.latex, 100)
-  return `${index}. [LaTeX] ${preview}`
-}
-
-function formatMatchingBlock(block: QuestionMatchingBlock, index: number): string {
-  const prompt = truncateText(block.prompt.value, 80)
-  const leftCount = block.leftColumn.length
-  const rightCount = block.rightColumn.length
-  const pairs = block.correctPairs.length
-  const hint = block.hint ? ` | Hint: ${truncateText(block.hint.value, 50)}` : ''
-  return `${index}. [Question: Matching] ${prompt} | ${leftCount} items → ${rightCount} targets | ${pairs} pairs${hint}`
-}
-
-function formatSvgBlock(block: SvgBlock, index: number): string {
-  const description = block.altText || 'Diagram'
-  return `${index}. [SVG] ${description}`
-}
-
-function formatGeometryBlock(block: QuestionGeometryBlock, index: number): string {
-  const prompt = truncateText(block.prompt.value, 100)
-  const hint = block.hint ? ` | Hint: ${truncateText(block.hint.value, 50)}` : ''
-  return `${index}. [Question: Geometry] ${prompt}${hint}`
-}
-
-function formatAxisBlock(block: QuestionAxisBlock, index: number): string {
-  const prompt = truncateText(block.prompt.value, 100)
-  const hint = block.hint ? ` | Hint: ${truncateText(block.hint.value, 50)}` : ''
-  return `${index}. [Question: Axis] ${prompt}${hint}`
 }
 
 /**
- * Truncate text to a maximum length with ellipsis if needed.
+ * Serialize an exercise's ContentBlock[] into a text representation
+ * suitable for LLM context injection.
+ *
+ * @param blocks - The exercise's content blocks
+ * @returns Serialized text, or empty string if no blocks
  */
-function truncateText(text: string, maxLength: number): string {
-  if (text.length <= maxLength) {
-    return text
+export function serializeContentBlocks(blocks: ContentBlock[]): string {
+  if (!blocks || blocks.length === 0) return ''
+
+  return blocks
+    .map((block) => serializeBlock(block))
+    .filter(Boolean)
+    .join('\n\n')
+}
+
+/**
+ * Extract the LaTeX preamble (text before the first exercise) from lessonContextText.
+ * This typically contains document class, package declarations, and section headers.
+ *
+ * @param lessonContextText - The full lesson context LaTeX text
+ * @param maxChars - Maximum characters to include (default 2000)
+ * @returns The preamble text, or empty string if none found
+ */
+export function extractLessonPreamble(
+  lessonContextText: string,
+  maxChars: number = DEFAULT_PREAMBLE_MAX_CHARS,
+): string {
+  if (!lessonContextText?.trim()) return ''
+
+  const segments = parseContextText(lessonContextText)
+  if (segments.length === 0 || segments[0].exercises.length === 0) return ''
+
+  const firstExerciseStart = segments[0].exercises[0].startIndex
+  if (firstExerciseStart <= 0) return ''
+
+  const preamble = segments[0].originalText.slice(0, firstExerciseStart).trim()
+  if (preamble.length <= maxChars) return preamble
+  return preamble.slice(0, maxChars) + '\n[... preamble truncated]'
+}
+
+/**
+ * Build a system prompt with exercise-specific context injected.
+ *
+ * @param baseSystemPrompt - The base system prompt to enhance
+ * @param exerciseTitle - Title of the current exercise
+ * @param serializedBlocks - Serialized content blocks text
+ * @param preamble - Optional lesson/course preamble for shared context
+ * @returns Enhanced system prompt with exercise context
+ * @throws Error if the combined context exceeds EXERCISE_CONTEXT_MAX_CHARS
+ */
+export function buildExerciseContextPrompt(
+  baseSystemPrompt: string,
+  exerciseTitle: string,
+  serializedBlocks: string,
+  preamble?: string,
+): string {
+  if (!serializedBlocks.trim()) return baseSystemPrompt
+
+  const contextParts = [`## Current Exercise: ${exerciseTitle}`, '']
+
+  if (preamble?.trim()) {
+    contextParts.push('### Lesson Context')
+    contextParts.push(preamble.trim())
+    contextParts.push('')
   }
-  return text.substring(0, maxLength - 3) + '...'
+
+  contextParts.push('### Exercise Content')
+  contextParts.push(serializedBlocks.trim())
+
+  const contextBody = contextParts.join('\n')
+
+  if (contextBody.length > EXERCISE_CONTEXT_MAX_CHARS) {
+    throw new Error('Exercise context exceeds maximum allowed size')
+  }
+
+  return [
+    baseSystemPrompt,
+    '',
+    EXERCISE_CONTEXT_BLOCK_START,
+    contextBody,
+    EXERCISE_CONTEXT_BLOCK_END,
+  ].join('\n')
 }

--- a/src/infra/llm/exercise-reference-parser.ts
+++ b/src/infra/llm/exercise-reference-parser.ts
@@ -1,0 +1,65 @@
+/**
+ * Exercise Reference Parser
+ *
+ * Parses student chat messages for explicit exercise references.
+ * Supports Hebrew and English patterns.
+ *
+ * @fileType ai-utility
+ * @domain chat
+ * @pattern single-responsibility
+ */
+
+export interface ExerciseReference {
+  exerciseNumber: number
+  originalText: string
+}
+
+/**
+ * Regex patterns that match exercise references in student messages.
+ * Each pattern must have a capture group for the exercise number.
+ */
+const EXERCISE_PATTERNS: RegExp[] = [
+  // Hebrew: תרגיל 5, תרגיל5
+  /תרגיל\s*(\d+)/g,
+  // Hebrew: שאלה 5, שאלה5
+  /שאלה\s*(\d+)/g,
+  // English: exercise 5, Exercise 5
+  /exercise\s+(\d+)/gi,
+  // English: question 5, Question 5
+  /question\s+(\d+)/gi,
+  // Abbreviated: ex. 5, ex 5, Ex.5 (must be at word boundary on both sides)
+  /\bex\.?\s*(\d+)\b/gi,
+  // Abbreviated: q. 5, q 5, Q.5 (require dot or space after q to avoid false positives)
+  /\bq[.\s]\s*(\d+)\b/gi,
+]
+
+/**
+ * Parse a student message for exercise number references.
+ *
+ * @param message - The student's chat message
+ * @returns Deduplicated list of exercise references found, empty if none
+ */
+export function parseExerciseReferences(message: string): ExerciseReference[] {
+  if (!message?.trim()) return []
+
+  const seen = new Set<number>()
+  const results: ExerciseReference[] = []
+
+  for (const pattern of EXERCISE_PATTERNS) {
+    // Reset lastIndex for global regexes
+    pattern.lastIndex = 0
+    let match: RegExpExecArray | null
+    while ((match = pattern.exec(message)) !== null) {
+      const num = parseInt(match[1], 10)
+      if (num > 0 && !seen.has(num)) {
+        seen.add(num)
+        results.push({
+          exerciseNumber: num,
+          originalText: match[0],
+        })
+      }
+    }
+  }
+
+  return results
+}

--- a/src/infra/llm/prompt-composer.server.ts
+++ b/src/infra/llm/prompt-composer.server.ts
@@ -7,6 +7,9 @@
  */
 import { buildLessonContextPrompt } from './lesson-context'
 
+// Exercise context is pre-built by buildExerciseContextPrompt() and passed as a string.
+// We simply append it to the prompt when present.
+
 export const SYSTEM_PROMPT_SEPARATOR = '\n\n---\n\n'
 
 /**
@@ -82,8 +85,9 @@ IMPORTANT:
  *
  * @param systemPrompts - Array of system prompt templates (can be empty)
  * @param lessonPromptTemplate - Resolved lesson prompt template
- * @param lessonContextText - Optional lesson context to inject
+ * @param lessonContextText - Optional lesson context to inject (skipped when exerciseContextText is provided)
  * @param teacherProfileBlock - Optional teacher profile block to inject
+ * @param exerciseContextText - Optional pre-built exercise context (takes priority over lessonContextText)
  * @returns Final composed system instructions string
  */
 export function composeSystemInstructions(
@@ -91,6 +95,7 @@ export function composeSystemInstructions(
   lessonPromptTemplate: string,
   lessonContextText?: string,
   teacherProfileBlock?: string,
+  exerciseContextText?: string,
 ): string {
   // Step 1: Join system prompts (if any)
   const systemPart =
@@ -112,6 +117,10 @@ export function composeSystemInstructions(
   // Step 5: Append mandatory image handling instructions
   const withImageHandling = withMathFormatting + '\n\n' + IMAGE_HANDLING_INSTRUCTIONS
 
-  // Step 6: Inject lesson context (reuse existing function)
+  // Step 6: Inject context — exercise-specific context takes priority over lesson context
+  if (exerciseContextText?.trim()) {
+    // Exercise context is pre-built with delimiters; just append it
+    return withImageHandling + '\n' + exerciseContextText
+  }
   return buildLessonContextPrompt(withImageHandling, lessonContextText)
 }

--- a/src/server/payload/endpoints/agent/chat.ts
+++ b/src/server/payload/endpoints/agent/chat.ts
@@ -49,14 +49,17 @@ import type { Logger } from 'pino'
 import { z } from 'zod'
 
 import {
+  buildExerciseContext,
   composeFullSystemInstructions,
   extractContextCandidate,
+  fetchExerciseBlocks,
   fetchLessonContextForContext,
   getOrCreateConversation,
   parseRequestBody,
   processChatAssetAttachments,
   processMediaAttachments,
   resolveContext,
+  resolveExerciseFromMessage,
   retrieveMemories,
   scheduleMemoryExtraction,
   scheduleSummaryMaintenance,
@@ -703,6 +706,44 @@ async function handleContextScopedChat(
     validated.courseId,
   )
 
+  // Resolve exercise-specific context (implicit or explicit flow)
+  let exerciseContextText: string | undefined
+
+  // Implicit flow: exerciseId present in request
+  if (validated.exerciseId) {
+    const exerciseResult = await fetchExerciseBlocks(
+      req.payload,
+      validated.exerciseId,
+      { id: ownerId },
+      logger as Logger,
+    )
+    if (exerciseResult) {
+      exerciseContextText = buildExerciseContext(
+        exerciseResult,
+        lessonContext.lessonContextText,
+        lessonContext.courseContextText,
+      )
+    }
+  }
+
+  // Explicit flow: parse message for exercise references (only when no implicit context)
+  if (!exerciseContextText && validated.lessonId) {
+    const exerciseResult = await resolveExerciseFromMessage(
+      req.payload,
+      validated.message,
+      validated.lessonId,
+      { id: ownerId },
+      logger as Logger,
+    )
+    if (exerciseResult) {
+      exerciseContextText = buildExerciseContext(
+        exerciseResult,
+        lessonContext.lessonContextText,
+        lessonContext.courseContextText,
+      )
+    }
+  }
+
   let composedInstructions
   try {
     composedInstructions = await composeFullSystemInstructions(
@@ -713,6 +754,7 @@ async function handleContextScopedChat(
       lessonContext.coursePrompt,
       lessonContext.courseContextText,
       userId,
+      exerciseContextText,
     )
   } catch (error) {
     if (error instanceof Error && error.message.includes('exceeds maximum')) {

--- a/src/server/payload/endpoints/agent/chat/pipeline.ts
+++ b/src/server/payload/endpoints/agent/chat/pipeline.ts
@@ -19,13 +19,16 @@ import type { PayloadRequest } from 'payload'
 import type { Logger } from 'pino'
 import { z } from 'zod'
 import {
+  buildExerciseContext,
   composeFullSystemInstructions,
   extractContextCandidate,
+  fetchExerciseBlocks,
   fetchLessonContextForContext,
   getOrCreateConversation,
   processChatAssetAttachments,
   processMediaAttachments,
   resolveContext,
+  resolveExerciseFromMessage,
   retrieveMemories,
   validateContextAccess,
   validateContextExists,
@@ -224,6 +227,44 @@ export async function runChatPipeline(
     validated.courseId,
   )
 
+  // Resolve exercise-specific context (implicit or explicit flow)
+  let exerciseContextText: string | undefined
+
+  // Implicit flow: exerciseId present in request
+  if (validated.exerciseId) {
+    const exerciseResult = await fetchExerciseBlocks(
+      req.payload,
+      validated.exerciseId,
+      { id: ownerId },
+      reqLogger as Logger,
+    )
+    if (exerciseResult) {
+      exerciseContextText = buildExerciseContext(
+        exerciseResult,
+        lessonContext.lessonContextText,
+        lessonContext.courseContextText,
+      )
+    }
+  }
+
+  // Explicit flow: parse message for exercise references (only when no implicit context)
+  if (!exerciseContextText && validated.lessonId) {
+    const exerciseResult = await resolveExerciseFromMessage(
+      req.payload,
+      validated.message,
+      validated.lessonId,
+      { id: ownerId },
+      reqLogger as Logger,
+    )
+    if (exerciseResult) {
+      exerciseContextText = buildExerciseContext(
+        exerciseResult,
+        lessonContext.lessonContextText,
+        lessonContext.courseContextText,
+      )
+    }
+  }
+
   let composedInstructions
   try {
     composedInstructions = await composeFullSystemInstructions(
@@ -234,6 +275,7 @@ export async function runChatPipeline(
       lessonContext.coursePrompt,
       lessonContext.courseContextText,
       req.user?.id,
+      exerciseContextText,
     )
   } catch (error) {
     if (error instanceof Error && error.message.includes('exceeds maximum')) {

--- a/src/server/payload/endpoints/agent/chat/prompt-composition.ts
+++ b/src/server/payload/endpoints/agent/chat/prompt-composition.ts
@@ -5,11 +5,18 @@
 import type { Payload } from 'payload'
 import type { Logger } from 'pino'
 
+import {
+  buildExerciseContextPrompt,
+  extractLessonPreamble,
+  serializeContentBlocks,
+} from '@/infra/llm/exercise-context'
+import { parseExerciseReferences } from '@/infra/llm/exercise-reference-parser'
 import { composeSystemInstructions } from '@/infra/llm/prompt-composer.server'
 import { resolveAgentSystemPrompt } from '@/infra/llm/prompt-resolver.server'
 import { fetchPublishedSystemPrompts } from '@/infra/llm/system-prompts.server'
 import { buildTeacherProfileBlock } from '@/infra/llm/teacher-profile-block'
 import type { Prompt } from '@/payload-types'
+import type { ContentBlock, ContentData } from '@/server/payload/collections/Exercises/types'
 import { resolveTeacherProfile } from '@/server/services/teacher-profile-resolver'
 
 import type { ResolvedContext } from './context-resolution'
@@ -195,6 +202,159 @@ async function fetchCourseContext(
   }
 }
 
+// ---------------------------------------------------------------
+// Exercise-specific context fetching
+// ---------------------------------------------------------------
+
+export interface ExerciseContextResult {
+  exerciseTitle: string
+  serializedBlocks: string
+}
+
+/**
+ * Fetch an exercise's content blocks and serialize them for LLM injection.
+ * Returns null if the exercise has no content blocks.
+ */
+export async function fetchExerciseBlocks(
+  payload: Payload,
+  exerciseId: string,
+  user: { id: string },
+  reqLogger: Logger,
+): Promise<ExerciseContextResult | null> {
+  try {
+    const exercise = await payload.findByID({
+      collection: 'exercises',
+      id: exerciseId,
+      depth: 0,
+      user,
+      overrideAccess: true, // Student may not have direct read access
+    })
+
+    const title = (exercise as unknown as { title?: string }).title || 'Exercise'
+    const content = (exercise as unknown as { content?: ContentData }).content
+    const blocks = content?.blocks as ContentBlock[] | undefined
+
+    if (!blocks || blocks.length === 0) {
+      reqLogger.debug(
+        { exerciseId },
+        'Exercise has no content blocks, falling back to lesson context',
+      )
+      return null
+    }
+
+    const serializedBlocks = serializeContentBlocks(blocks)
+    if (!serializedBlocks) return null
+
+    reqLogger.info(
+      { exerciseId, blockCount: blocks.length, serializedLength: serializedBlocks.length },
+      'Serialized exercise blocks for context injection',
+    )
+
+    return { exerciseTitle: title, serializedBlocks }
+  } catch (error) {
+    reqLogger.warn(
+      { err: error, exerciseId },
+      'Failed to fetch exercise blocks, falling back to lesson context',
+    )
+    return null
+  }
+}
+
+/**
+ * Resolve an exercise by number within a lesson.
+ * Used for the explicit flow: student says "help with question 5".
+ */
+export async function resolveExerciseFromMessage(
+  payload: Payload,
+  message: string,
+  lessonId: string,
+  user: { id: string },
+  reqLogger: Logger,
+): Promise<ExerciseContextResult | null> {
+  const refs = parseExerciseReferences(message)
+  if (refs.length === 0) return null
+
+  // For multiple references, serialize all of them
+  const exerciseNumbers = refs.map((r) => r.exerciseNumber)
+  reqLogger.info({ exerciseNumbers, lessonId }, 'Detected exercise references in message')
+
+  try {
+    // Fetch all exercises for this lesson, sorted by display order
+    const exercisesResult = await payload.find({
+      collection: 'exercises',
+      where: { lesson: { equals: lessonId } },
+      sort: 'order',
+      limit: 100,
+      depth: 0,
+      overrideAccess: true,
+    })
+
+    const exercises = exercisesResult.docs
+    if (exercises.length === 0) return null
+
+    // Map 1-indexed exercise numbers to exercises
+    const allParts: string[] = []
+    const allTitles: string[] = []
+
+    for (const num of exerciseNumbers) {
+      const exercise = exercises[num - 1] // 1-indexed
+      if (!exercise) {
+        reqLogger.debug(
+          { exerciseNumber: num, totalExercises: exercises.length },
+          'Exercise number out of range',
+        )
+        continue
+      }
+
+      const title = (exercise as unknown as { title?: string }).title || `Exercise ${num}`
+      const content = (exercise as unknown as { content?: ContentData }).content
+      const blocks = content?.blocks as ContentBlock[] | undefined
+
+      if (blocks && blocks.length > 0) {
+        const serialized = serializeContentBlocks(blocks)
+        if (serialized) {
+          allParts.push(`## Exercise ${num}: ${title}\n\n${serialized}`)
+          allTitles.push(title)
+        }
+      }
+    }
+
+    if (allParts.length === 0) return null
+
+    return {
+      exerciseTitle: allTitles.length === 1 ? allTitles[0] : allTitles.join(', '),
+      serializedBlocks: allParts.join('\n\n---\n\n'),
+    }
+  } catch (error) {
+    reqLogger.warn({ err: error, lessonId }, 'Failed to resolve exercise from message')
+    return null
+  }
+}
+
+/**
+ * Build exercise context text from exercise blocks + preamble.
+ * Returns undefined if no exercise context is available.
+ */
+export function buildExerciseContext(
+  exerciseResult: ExerciseContextResult,
+  lessonContextText?: string,
+  courseContextText?: string,
+): string {
+  // Prefer courseContextText as preamble; fall back to lesson preamble extraction
+  const preamble = courseContextText?.trim()
+    ? courseContextText.trim()
+    : lessonContextText
+      ? extractLessonPreamble(lessonContextText)
+      : undefined
+
+  return buildExerciseContextPrompt(
+    '',
+    exerciseResult.exerciseTitle,
+    exerciseResult.serializedBlocks,
+    preamble,
+  )
+}
+
 /**
  * Fetch lesson context based on resolved context type
  * Also fetches course context if courseId is provided
@@ -263,6 +423,7 @@ export async function composeFullSystemInstructions(
   coursePrompt?: Prompt | null,
   courseContextText?: string,
   userId?: string,
+  exerciseContextText?: string,
 ): Promise<ComposedSystemInstructions> {
   // Fetch published system prompts (always included)
   const systemPromptsResult = await fetchPublishedSystemPrompts(payload)
@@ -311,12 +472,13 @@ export async function composeFullSystemInstructions(
   )
 
   // Compose final system instructions: system prompts + teacher profile + lesson/course prompt + lesson/course context
-  // Priority: lesson context > course context
+  // Priority: exercise context > lesson context > course context
   const instructions = composeSystemInstructions(
     systemPromptsResult.templates,
     promptResolution.template,
-    lessonContextText || courseContextText,
+    exerciseContextText ? undefined : lessonContextText || courseContextText,
     teacherProfileBlock,
+    exerciseContextText,
   )
 
   return {


### PR DESCRIPTION
… of full PDF

Replace the full lessonContextText (up to 200K chars) with focused, exercise-specific content blocks when the chat is scoped to an exercise. This reduces token waste and improves AI response accuracy by eliminating noise from unrelated exercises.

- Implicit flow: when exerciseId is present, serialize that exercise's content.blocks[]
- Explicit flow: parse student messages for exercise references (Hebrew/English)
- Include course/lesson preamble alongside exercise blocks for shared context
- Graceful fallback to lessonContextText when exercise has no blocks
- Answers, solutions, and hints are excluded from serialized output (security)

Closes #1195