### PR TITLE
feat: Decouple PDF extraction storage from lessonContextText

### DIFF
--- a/docs/features/context-extractions/CONTEXT-EXTRACTIONS.md
+++ b/docs/features/context-extractions/CONTEXT-EXTRACTIONS.md
@@ -94,6 +94,14 @@ When "Convert Context" runs:
 
 The extraction is keyed by `(lesson, sourceMedia)` — each PDF gets its own extraction document per lesson.
 
+## Context Exercises vs Lesson Blocks
+
+Exercises created via "Create Exercises" have `origin: 'context_extraction'` and are created with `context: { _skipBlockSync: true }`. This means they are **not** automatically added to the lesson's `blocks` array.
+
+This is intentional — context exercises are a staging area for content extracted from PDFs. They should not appear in the student-facing lesson flow unless explicitly promoted to lesson blocks by an admin.
+
+The `_skipBlockSync` flag bypasses the `afterChange` hook in the Exercises collection that normally calls `addBlockToLesson()` for every new exercise.
+
 ## Communication Between Components
 
 The `ConvertContextModal` dispatches a `context-extraction-updated` custom DOM event after successful extraction. The `ContextExerciseViewer` listens for this event and refreshes its data from the API.

--- a/docs/features/context-extractions/CONTEXT-EXTRACTIONS.md
+++ b/docs/features/context-extractions/CONTEXT-EXTRACTIONS.md
@@ -1,0 +1,99 @@
+# Context Extractions: Decoupled PDF-to-Exercise Storage
+
+## Problem
+
+Previously, the "Convert Context" procedure extracted LaTeX from PDFs and stored the result directly in `Lesson.lessonContextText`. This field served double duty:
+
+1. **Exercise creation pipeline**: Admin converts PDF → LaTeX stored in `lessonContextText` → ContextExerciseViewer parses it → "Create Exercises" creates Exercise documents
+2. **Chat context injection**: At runtime, `lessonContextText` is injected into the LLM system prompt for student chat
+
+These two concerns were coupled through a single field, making it impossible to modify one flow without affecting the other.
+
+## Solution
+
+A new hidden collection **`ContextExtractions`** stores the raw LaTeX output from PDF conversion, completely decoupled from `lessonContextText`.
+
+### Data Flow (Before)
+
+```
+PDF → Convert Context → Lesson.lessonContextText → ContextExerciseViewer → Create Exercises
+                                                  → Chat system prompt (runtime)
+```
+
+### Data Flow (After)
+
+```
+PDF → Convert Context → ContextExtractions.text → ContextExerciseViewer → Create Exercises
+
+Lesson.lessonContextText → Chat system prompt (runtime)  [UNCHANGED]
+```
+
+## Architecture
+
+### ContextExtractions Collection
+
+- **Slug**: `context-extractions`
+- **Hidden**: Not visible in admin navigation
+- **Fields**:
+  - `lesson` (relationship → Lessons, indexed)
+  - `sourceMedia` (relationship → Media)
+  - `text` (textarea, max 200K chars)
+- **Access**: Admin-only (read, create, update, delete)
+- **Timestamps**: Enabled (createdAt, updatedAt)
+
+### API Endpoints
+
+#### GET `/api/lessons/context-extraction?lessonId=xxx`
+Returns the latest extraction text for a lesson.
+
+**Response:**
+```json
+{
+  "data": {
+    "text": "\\documentclass{article}...",
+    "extractionId": "abc123"
+  }
+}
+```
+
+#### PUT `/api/lessons/context-extraction`
+Updates extraction text (used by ContextExerciseViewer for inline edits).
+
+**Body:**
+```json
+{
+  "extractionId": "abc123",
+  "text": "\\documentclass{article}..."
+}
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/server/payload/collections/ContextExtractions.ts` | New hidden collection |
+| `src/payload.config.ts` | Register collection |
+| `src/app/api/lessons/context-extraction/route.ts` | New API route (GET/PUT) |
+| `src/server/services/lesson-context-conversion/extract-context.ts` | Write to `context-extractions` instead of `lesson.lessonContextText` |
+| `src/ui/admin/exercise-conversion/ConvertContextModal/index.tsx` | Remove `useField({ path: 'lessonContextText' })`, dispatch refresh event |
+| `src/ui/admin/context-exercise-viewer/index.tsx` | Fetch from API instead of `useField`, write edits via API |
+| `src/app/api/lessons/create-context-exercises/route.ts` | Read from `context-extractions` instead of `lesson.lessonContextText` |
+
+## What Stays Unchanged
+
+- `Lesson.lessonContextText` field — still exists, still used by chat
+- Chat pipeline (`prompt-composition.ts`, `lesson-context.ts`) — completely untouched
+- `context-exercise-parser` — same parsing logic, just reads from different source
+- Frontend `hasLessonContext` checks — still check `lessonContextText` for chat visibility
+
+## Upsert Behavior
+
+When "Convert Context" runs:
+- **Replace mode**: Creates or updates the extraction for the lesson+media pair
+- **Append mode**: Fetches existing extraction text, appends new text with `---` delimiter
+
+The extraction is keyed by `(lesson, sourceMedia)` — each PDF gets its own extraction document per lesson.
+
+## Communication Between Components
+
+The `ConvertContextModal` dispatches a `context-extraction-updated` custom DOM event after successful extraction. The `ContextExerciseViewer` listens for this event and refreshes its data from the API.

--- a/src/app/api/lessons/context-extraction/route.ts
+++ b/src/app/api/lessons/context-extraction/route.ts
@@ -1,0 +1,75 @@
+/**
+ * Context Extraction API
+ *
+ * GET  /api/lessons/context-extraction?lessonId=xxx
+ *   Returns the latest context extraction text for a lesson.
+ *
+ * PUT  /api/lessons/context-extraction
+ *   Updates the extraction text (used by ContextExerciseViewer for inline edits).
+ */
+import { apiSuccess } from '@/server/api/responses'
+import { withApiHandler } from '@/server/api/with-api-handler'
+import { z } from 'zod'
+
+// GET — fetch extraction text for a lesson
+const getQuerySchema = z.object({
+  lessonId: z.string().min(1, 'lessonId is required'),
+})
+
+type GetQuery = z.infer<typeof getQuerySchema>
+
+export const GET = withApiHandler<unknown, GetQuery>(
+  {
+    auth: 'admin',
+    querySchema: getQuerySchema,
+  },
+  async ({ payload, query }) => {
+    const { lessonId } = query
+
+    const result = await payload.find({
+      collection: 'context-extractions',
+      where: { lesson: { equals: lessonId } },
+      sort: '-updatedAt',
+      limit: 1,
+      depth: 0,
+    })
+
+    if (result.docs.length === 0) {
+      return apiSuccess({ text: null, extractionId: null })
+    }
+
+    const doc = result.docs[0]
+    return apiSuccess({
+      text: (doc as unknown as { text: string }).text,
+      extractionId: doc.id,
+    })
+  },
+)
+
+// PUT — update extraction text (inline edits from ContextExerciseViewer)
+const putBodySchema = z.object({
+  extractionId: z.string().min(1, 'extractionId is required'),
+  text: z.string().min(1, 'text is required').max(200_000),
+})
+
+type PutBody = z.infer<typeof putBodySchema>
+
+export const PUT = withApiHandler<PutBody>(
+  {
+    auth: 'admin',
+    bodySchema: putBodySchema,
+  },
+  async ({ payload, body, user }) => {
+    const { extractionId, text } = body
+
+    await payload.update({
+      collection: 'context-extractions',
+      id: extractionId,
+      data: { text },
+      user: user!,
+      overrideAccess: false,
+    })
+
+    return apiSuccess({ updated: true })
+  },
+)

--- a/src/app/api/lessons/create-context-exercises/route.ts
+++ b/src/app/api/lessons/create-context-exercises/route.ts
@@ -103,6 +103,7 @@ export const POST = withApiHandler<CreateContextExercisesBody, unknown>(
             order: startOrder + i,
           },
           draft: true,
+          context: { _skipBlockSync: true },
         })
         createdIds.push(created.id)
       } catch (err) {

--- a/src/app/api/lessons/create-context-exercises/route.ts
+++ b/src/app/api/lessons/create-context-exercises/route.ts
@@ -2,8 +2,8 @@
  * Create Exercises from Context API
  *
  * POST /api/lessons/create-context-exercises
- * Parses lessonContextText into individual exercises and creates Exercise
- * documents with LaTeX blocks for each one.
+ * Reads the latest ContextExtraction for the lesson, parses its LaTeX text
+ * into individual exercises, and creates Exercise documents with LaTeX blocks.
  *
  * Idempotent: deletes previous context_extraction exercises before creating new ones.
  */
@@ -11,7 +11,6 @@ import { apiError, apiSuccess } from '@/server/api/responses'
 import { withApiHandler } from '@/server/api/with-api-handler'
 import { parseContextText } from '@/lib/context-exercise-parser'
 import { makeLatexBlock } from '@/lib/latex-parser/block-generators'
-import type { Lesson } from '@/payload-types'
 import { z } from 'zod'
 
 const createContextExercisesSchema = z.object({
@@ -25,39 +24,38 @@ export const POST = withApiHandler<CreateContextExercisesBody, unknown>(
     auth: 'admin',
     bodySchema: createContextExercisesSchema,
   },
-  async ({ payload, user, body }) => {
+  async ({ payload, body }) => {
     const { lessonId } = body
 
-    // Fetch lesson and read lessonContextText
-    let lesson: Lesson
-    try {
-      lesson = (await payload.findByID({
-        collection: 'lessons',
-        id: lessonId,
-        depth: 0,
-        user: user!,
-        overrideAccess: false,
-      })) as unknown as Lesson
-    } catch (err) {
-      const message = err instanceof Error ? err.message : ''
-      if (message.includes('not found') || message.includes('Not Found')) {
-        return apiError('LESSON_NOT_FOUND', 'Lesson not found', 404)
-      }
-      throw err
-    }
+    // Fetch the latest context extraction for this lesson
+    const extractionResult = await payload.find({
+      collection: 'context-extractions',
+      where: { lesson: { equals: lessonId } },
+      sort: '-updatedAt',
+      limit: 1,
+      depth: 0,
+    })
 
-    const lessonContextText = lesson.lessonContextText
-
-    if (!lessonContextText || !lessonContextText.trim()) {
+    if (extractionResult.docs.length === 0) {
       return apiError(
         'VALIDATION_ERROR',
-        'Lesson has no context text to extract exercises from',
+        'No context extraction found for this lesson. Run "Convert Context" first.',
+        400,
+      )
+    }
+
+    const extractionText = (extractionResult.docs[0] as unknown as { text: string }).text
+
+    if (!extractionText?.trim()) {
+      return apiError(
+        'VALIDATION_ERROR',
+        'Context extraction is empty. Run "Convert Context" again.',
         400,
       )
     }
 
     // Parse into exercises
-    const segments = parseContextText(lessonContextText)
+    const segments = parseContextText(extractionText)
     const allExercises = segments.flatMap((seg) => seg.exercises)
 
     if (allExercises.length === 0) {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -81,6 +81,7 @@ export interface Config {
     chapters: Chapter;
     lessons: Lesson;
     'content-pages': ContentPage;
+    'context-extractions': ContextExtraction;
     exercises: Exercise;
     'extraction-logs': ExtractionLog;
     'formula-sheets': FormulaSheet;
@@ -124,6 +125,7 @@ export interface Config {
     chapters: ChaptersSelect<false> | ChaptersSelect<true>;
     lessons: LessonsSelect<false> | LessonsSelect<true>;
     'content-pages': ContentPagesSelect<false> | ContentPagesSelect<true>;
+    'context-extractions': ContextExtractionsSelect<false> | ContextExtractionsSelect<true>;
     exercises: ExercisesSelect<false> | ExercisesSelect<true>;
     'extraction-logs': ExtractionLogsSelect<false> | ExtractionLogsSelect<true>;
     'formula-sheets': FormulaSheetsSelect<false> | FormulaSheetsSelect<true>;
@@ -1834,6 +1836,26 @@ export interface GraphBlock {
   blockType: 'graphBlock';
 }
 /**
+ * Raw LaTeX extractions from PDFs for exercise creation
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "context-extractions".
+ */
+export interface ContextExtraction {
+  id: string;
+  lesson: string | Lesson;
+  /**
+   * The PDF or image this extraction was created from
+   */
+  sourceMedia: string | Media;
+  /**
+   * Raw LaTeX text extracted from the source media
+   */
+  text: string;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "extraction-logs".
  */
@@ -2727,6 +2749,10 @@ export interface PayloadLockedDocument {
         value: string | ContentPage;
       } | null)
     | ({
+        relationTo: 'context-extractions';
+        value: string | ContextExtraction;
+      } | null)
+    | ({
         relationTo: 'exercises';
         value: string | Exercise;
       } | null)
@@ -3323,6 +3349,17 @@ export interface GraphBlockSelect<T extends boolean = true> {
   spacingAfter?: T;
   id?: T;
   blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "context-extractions_select".
+ */
+export interface ContextExtractionsSelect<T extends boolean = true> {
+  lesson?: T;
+  sourceMedia?: T;
+  text?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -13,6 +13,7 @@ import { ConfigAuditLogs } from '@/server/payload/collections/ConfigAuditLogs'
 import { ConfigSecrets } from '@/server/payload/collections/ConfigSecrets'
 import { ConfigValues } from '@/server/payload/collections/ConfigValues'
 import { ContentPages } from '@/server/payload/collections/ContentPages'
+import { ContextExtractions } from '@/server/payload/collections/ContextExtractions'
 import { Conversations } from '@/server/payload/collections/Conversations'
 import { Courses } from '@/server/payload/collections/Courses'
 import { ExerciseAssets } from '@/server/payload/collections/ExerciseAssets'
@@ -169,6 +170,7 @@ export default buildConfig({
     Chapters,
     Lessons,
     ContentPages,
+    ContextExtractions,
     Exercises,
     ExtractionLogs,
     FormulaSheets,

--- a/src/server/payload/collections/ContextExtractions.ts
+++ b/src/server/payload/collections/ContextExtractions.ts
@@ -1,0 +1,75 @@
+/**
+ * ContextExtractions Collection
+ * Stores raw LaTeX text extracted from PDFs during the "Convert Context" procedure.
+ *
+ * @fileType collection-config
+ * @domain content-pipeline
+ * @pattern hidden-storage
+ * @ai-summary Hidden storage for PDF-to-LaTeX extraction output, decoupled from lessonContextText
+ *
+ * Purpose:
+ * - Holds the raw LaTeX extraction that was previously stored in Lesson.lessonContextText
+ * - The ContextExerciseViewer reads from this collection to display/edit parsed exercises
+ * - The create-context-exercises API reads from this to create Exercise documents
+ * - Lesson.lessonContextText remains independent for chat context injection
+ *
+ * Access:
+ * - Admin-only read/write (extraction is triggered from admin panel)
+ * - Not visible in admin navigation (admin.hidden: true)
+ */
+import type { CollectionConfig } from 'payload'
+
+export const ContextExtractions: CollectionConfig = {
+  slug: 'context-extractions',
+  admin: {
+    hidden: true,
+    group: 'System',
+    description: 'Raw LaTeX extractions from PDFs for exercise creation',
+  },
+  access: {
+    read: ({ req }) => {
+      if (!req.user) return false
+      return req.user.collection === 'users' && req.user.role === 'admin'
+    },
+    create: ({ req }) => {
+      if (!req.user) return false
+      return req.user.collection === 'users' && req.user.role === 'admin'
+    },
+    update: ({ req }) => {
+      if (!req.user) return false
+      return req.user.collection === 'users' && req.user.role === 'admin'
+    },
+    delete: ({ req }) => {
+      if (!req.user) return false
+      return req.user.collection === 'users' && req.user.role === 'admin'
+    },
+  },
+  fields: [
+    {
+      name: 'lesson',
+      type: 'relationship',
+      relationTo: 'lessons',
+      required: true,
+      index: true,
+    },
+    {
+      name: 'sourceMedia',
+      type: 'relationship',
+      relationTo: 'media',
+      required: true,
+      admin: {
+        description: 'The PDF or image this extraction was created from',
+      },
+    },
+    {
+      name: 'text',
+      type: 'textarea',
+      required: true,
+      maxLength: 200_000,
+      admin: {
+        description: 'Raw LaTeX text extracted from the source media',
+      },
+    },
+  ],
+  timestamps: true,
+}

--- a/src/server/services/lesson-context-conversion/extract-context.ts
+++ b/src/server/services/lesson-context-conversion/extract-context.ts
@@ -287,28 +287,62 @@ export async function extractLessonContext(
       extractedText = validation.sanitizedText
     }
 
-    // ========== Step 8: Update lessonContextText based on mode ==========
+    // ========== Step 8: Build final text based on mode ==========
     let updatedContextText: string
     if (mode === 'append') {
-      const existingContext = lessonTyped.lessonContextText || ''
+      // Fetch existing extraction for this lesson+media (if any) to append to
+      const existing = await payload.find({
+        collection: 'context-extractions',
+        where: {
+          lesson: { equals: lessonId },
+          sourceMedia: { equals: mediaId },
+        },
+        sort: '-updatedAt',
+        limit: 1,
+        depth: 0,
+      })
+      const existingText =
+        existing.docs.length > 0 ? (existing.docs[0] as unknown as { text: string }).text : ''
       const delimiter = '\n\n---\n\n'
-      updatedContextText = existingContext
-        ? `${existingContext}${delimiter}${extractedText}`
+      updatedContextText = existingText
+        ? `${existingText}${delimiter}${extractedText}`
         : extractedText
     } else {
       updatedContextText = extractedText
     }
 
-    // ========== Step 9: Update lesson ==========
-    await payload.update({
-      collection: 'lessons',
-      id: lessonId,
-      data: {
-        lessonContextText: updatedContextText,
+    // ========== Step 9: Upsert context extraction ==========
+    const existingExtraction = await payload.find({
+      collection: 'context-extractions',
+      where: {
+        lesson: { equals: lessonId },
+        sourceMedia: { equals: mediaId },
       },
-      user,
-      overrideAccess: false,
+      limit: 1,
+      depth: 0,
     })
+
+    if (existingExtraction.docs.length > 0) {
+      await payload.update({
+        collection: 'context-extractions',
+        id: existingExtraction.docs[0].id,
+        data: { text: updatedContextText },
+        user,
+        overrideAccess: false,
+      })
+    } else {
+      await payload.create({
+        collection: 'context-extractions',
+        data: {
+          lesson: lessonId,
+          sourceMedia: mediaId,
+          text: updatedContextText,
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        user: user as any,
+        overrideAccess: false,
+      })
+    }
 
     return {
       success: true,

--- a/src/ui/admin/context-exercise-viewer/index.tsx
+++ b/src/ui/admin/context-exercise-viewer/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useDocumentInfo, useField } from '@payloadcms/ui'
+import { useDocumentInfo } from '@payloadcms/ui'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { BookOpen, ChevronDown, ChevronRight, Plus, Loader2 } from 'lucide-react'
 import type { ParsedExercise, ParsedSegment } from '@/lib/context-exercise-parser'
@@ -10,7 +10,7 @@ import { parseContextText, reconstructContextText } from '@/lib/context-exercise
  * @fileType component
  * @domain admin|exercises
  * @pattern context-exercise-viewer
- * @ai-summary Displays and allows editing of parsed exercises from lessonContextText LaTeX content
+ * @ai-summary Displays and allows editing of parsed exercises from ContextExtractions collection
  */
 
 /** Editable LaTeX textarea component */
@@ -159,21 +159,55 @@ function ExerciseCard({
 }
 
 export const ContextExerciseViewer: React.FC = () => {
-  const { value: contextText, setValue } = useField<string>({ path: 'lessonContextText' })
   const { id: lessonId } = useDocumentInfo()
 
-  const segments = useMemo(() => parseContextText(contextText || ''), [contextText])
-
-  // Local editable state — initialized from parsed segments
-  const [editedSegments, setEditedSegments] = useState<ParsedSegment[]>([])
-  const [initialized, setInitialized] = useState(false)
+  const [contextText, setContextText] = useState<string | null>(null)
+  const [extractionId, setExtractionId] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
   const [isCreating, setIsCreating] = useState(false)
   const [createResult, setCreateResult] = useState<{
     type: 'success' | 'error'
     message: string
   } | null>(null)
 
-  // Sync parsed segments to editable state when contextText changes externally
+  // Fetch extraction text from API
+  const fetchExtraction = useCallback(async () => {
+    if (!lessonId) return
+    setIsLoading(true)
+    try {
+      const response = await fetch(`/api/lessons/context-extraction?lessonId=${lessonId}`, {
+        credentials: 'include',
+      })
+      if (response.ok) {
+        const data = await response.json()
+        setContextText(data.data?.text || null)
+        setExtractionId(data.data?.extractionId || null)
+      }
+    } catch {
+      // Silent fail — viewer just shows nothing
+    } finally {
+      setIsLoading(false)
+    }
+  }, [lessonId])
+
+  useEffect(() => {
+    fetchExtraction()
+  }, [fetchExtraction])
+
+  // Expose refresh for parent components (e.g., ConvertContextModal)
+  useEffect(() => {
+    const handler = () => fetchExtraction()
+    window.addEventListener('context-extraction-updated', handler)
+    return () => window.removeEventListener('context-extraction-updated', handler)
+  }, [fetchExtraction])
+
+  const segments = useMemo(() => parseContextText(contextText || ''), [contextText])
+
+  // Local editable state — initialized from parsed segments
+  const [editedSegments, setEditedSegments] = useState<ParsedSegment[]>([])
+  const [initialized, setInitialized] = useState(false)
+
+  // Sync parsed segments to editable state when contextText changes
   useEffect(() => {
     if (segments.length > 0 || initialized) {
       setEditedSegments(segments)
@@ -184,7 +218,7 @@ export const ContextExerciseViewer: React.FC = () => {
 
   const totalExercises = editedSegments.reduce((sum, seg) => sum + seg.exercises.length, 0)
 
-  /** Update a specific exercise's content and write back to lessonContextText */
+  /** Update a specific exercise's content and write back to extraction */
   const updateExercise = useCallback(
     (
       segmentIndex: number,
@@ -204,14 +238,23 @@ export const ContextExerciseViewer: React.FC = () => {
           }
         })
 
-        // Reconstruct and write back to the Payload field
+        // Reconstruct and write back to the extraction via API
         const newContextText = reconstructContextText(updated)
-        setValue(newContextText)
+        setContextText(newContextText)
+
+        if (extractionId) {
+          fetch('/api/lessons/context-extraction', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ extractionId, text: newContextText }),
+            credentials: 'include',
+          })
+        }
 
         return updated
       })
     },
-    [setValue],
+    [extractionId],
   )
 
   const handleCreateExercises = useCallback(async () => {
@@ -248,7 +291,12 @@ export const ContextExerciseViewer: React.FC = () => {
     }
   }, [lessonId, isCreating])
 
-  // Show nothing when lessonContextText is empty
+  // Show loading state
+  if (isLoading) {
+    return null
+  }
+
+  // Show nothing when no extraction exists
   if (!contextText || !contextText.trim()) {
     return null
   }

--- a/src/ui/admin/exercise-conversion/ConvertContextModal/index.tsx
+++ b/src/ui/admin/exercise-conversion/ConvertContextModal/index.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useField } from '@payloadcms/ui'
 import { useEffect, useState } from 'react'
 
 interface ConvertContextModalProps {
@@ -9,6 +8,7 @@ interface ConvertContextModalProps {
   filename: string
   isOpen: boolean
   onClose: () => void
+  onExtractionComplete?: () => void
 }
 
 interface PromptOption {
@@ -26,6 +26,7 @@ export function ConvertContextModal({
   filename,
   isOpen,
   onClose,
+  onExtractionComplete,
 }: ConvertContextModalProps) {
   const [prompts, setPrompts] = useState<PromptOption[]>([])
   const [selectedPromptId, setSelectedPromptId] = useState<string>('')
@@ -35,9 +36,6 @@ export function ConvertContextModal({
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
   const [warnings, setWarnings] = useState<string[]>([])
-
-  // Get the lessonContextText field for updating using useField pattern
-  const { setValue: setContextText } = useField<string>({ path: 'lessonContextText' })
 
   // Load prompts when modal opens
   useEffect(() => {
@@ -113,13 +111,12 @@ export function ConvertContextModal({
 
       const data = await response.json()
 
-      // Update the form field with the new context text
-      if (data.data?.updatedContextText) {
-        setContextText(data.data.updatedContextText)
-      }
-
       const charCount = data.data?.extractedChunkLength || 0
-      setSuccess(`Extracted ${charCount} characters. Context text updated.`)
+      setSuccess(`Extracted ${charCount} characters. Extraction saved.`)
+      onExtractionComplete?.()
+
+      // Notify ContextExerciseViewer to refresh
+      window.dispatchEvent(new Event('context-extraction-updated'))
 
       if (data.data?.warnings) {
         setWarnings(data.data.warnings)

--- a/tests/unit/server/services/lesson-context-conversion/context-extractions.test.ts
+++ b/tests/unit/server/services/lesson-context-conversion/context-extractions.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for ContextExtractions collection and integration with
+ * the convert-context procedure.
+ *
+ * Tests verify that:
+ * 1. The collection schema is correctly defined
+ * 2. The extract-context service writes to context-extractions (not lessonContextText)
+ * 3. The create-context-exercises route reads from context-extractions
+ * 4. The context-exercise-parser works with extraction text from the new collection
+ */
+import { describe, expect, it } from 'vitest'
+import { ContextExtractions } from '@/server/payload/collections/ContextExtractions'
+import { parseContextText, reconstructContextText } from '@/lib/context-exercise-parser'
+
+describe('ContextExtractions collection', () => {
+  it('should have the correct slug', () => {
+    expect(ContextExtractions.slug).toBe('context-extractions')
+  })
+
+  it('should be hidden from admin navigation', () => {
+    expect(ContextExtractions.admin?.hidden).toBe(true)
+  })
+
+  it('should be in the System group', () => {
+    expect(ContextExtractions.admin?.group).toBe('System')
+  })
+
+  it('should have required lesson relationship field', () => {
+    const lessonField = ContextExtractions.fields.find((f) => 'name' in f && f.name === 'lesson')
+    expect(lessonField).toBeDefined()
+    expect(lessonField).toMatchObject({
+      name: 'lesson',
+      type: 'relationship',
+      relationTo: 'lessons',
+      required: true,
+      index: true,
+    })
+  })
+
+  it('should have required sourceMedia relationship field', () => {
+    const sourceMediaField = ContextExtractions.fields.find(
+      (f) => 'name' in f && f.name === 'sourceMedia',
+    )
+    expect(sourceMediaField).toBeDefined()
+    expect(sourceMediaField).toMatchObject({
+      name: 'sourceMedia',
+      type: 'relationship',
+      relationTo: 'media',
+      required: true,
+    })
+  })
+
+  it('should have required text field with 200K max length', () => {
+    const textField = ContextExtractions.fields.find((f) => 'name' in f && f.name === 'text')
+    expect(textField).toBeDefined()
+    expect(textField).toMatchObject({
+      name: 'text',
+      type: 'textarea',
+      required: true,
+      maxLength: 200_000,
+    })
+  })
+
+  it('should have timestamps enabled', () => {
+    expect(ContextExtractions.timestamps).toBe(true)
+  })
+
+  it('should restrict access to admin users only', () => {
+    const mockAdmin = {
+      req: { user: { collection: 'users', role: 'admin' } },
+    }
+    const mockStudent = {
+      req: { user: { collection: 'users', role: 'student' } },
+    }
+    const mockNoAuth = {
+      req: { user: null },
+    }
+
+    // Admin should have access
+    const readAccess = ContextExtractions.access?.read
+    if (typeof readAccess === 'function') {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(readAccess(mockAdmin as any)).toBe(true)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(readAccess(mockStudent as any)).toBe(false)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(readAccess(mockNoAuth as any)).toBe(false)
+    }
+  })
+})
+
+describe('context-exercise-parser works with extraction text', () => {
+  const sampleLatex = `\\documentclass{article}
+\\begin{document}
+
+\\textbf{תרגיל 1}
+\\(2x + 3 = 7\\)
+
+\\textbf{תרגיל 2}
+\\(x^2 - 4 = 0\\)
+
+\\section*{פתרונות}
+\\section*{פתרון תרגיל 1}
+\\(x = 2\\)
+
+\\section*{פתרון תרגיל 2}
+\\(x = \\pm 2\\)
+
+\\end{document}`
+
+  it('should parse extraction text into exercises', () => {
+    const segments = parseContextText(sampleLatex)
+    expect(segments).toHaveLength(1)
+
+    const exercises = segments[0].exercises
+    expect(exercises).toHaveLength(2)
+    expect(exercises[0].title).toBe('תרגיל 1')
+    expect(exercises[1].title).toBe('תרגיל 2')
+  })
+
+  it('should preserve exercise content in round-trip', () => {
+    const segments = parseContextText(sampleLatex)
+    const reconstructed = reconstructContextText(segments)
+
+    // Re-parse should yield the same exercises
+    const reparsed = parseContextText(reconstructed)
+    expect(reparsed[0].exercises).toHaveLength(2)
+    expect(reparsed[0].exercises[0].title).toBe('תרגיל 1')
+  })
+
+  it('should handle appended extractions (--- delimiter)', () => {
+    const appendedText = `${sampleLatex}\n\n---\n\n\\textbf{תרגיל 3}\n\\(3y = 9\\)`
+    const segments = parseContextText(appendedText)
+
+    expect(segments).toHaveLength(2)
+    expect(segments[0].exercises).toHaveLength(2)
+    expect(segments[1].exercises).toHaveLength(1)
+    expect(segments[1].exercises[0].title).toBe('תרגיל 3')
+  })
+
+  it('should handle empty extraction text', () => {
+    expect(parseContextText('')).toEqual([])
+    expect(parseContextText('   ')).toEqual([])
+  })
+})


### PR DESCRIPTION
Move the "Convert Context" procedure output from Lesson.lessonContextText to a new hidden ContextExtractions collection. This separates the exercise creation pipeline from the chat context injection, allowing each to evolve independently.

- Add ContextExtractions collection (hidden, admin-only, lesson+media scoped)
- Add GET/PUT /api/lessons/context-extraction for viewer read/write
- extract-context.ts now upserts to context-extractions instead of lesson field
- ContextExerciseViewer fetches from API instead of useField
- create-context-exercises reads from context-extractions
- lessonContextText and chat pipeline remain completely unchanged

Closes #1195