### PR TITLE
chore: 10x pipeline budget increase for all stages

### DIFF
--- a/kody.config.json
+++ b/kody.config.json
@@ -37,6 +37,24 @@
     "model": "MiniMax-M2.7-highspeed",
     "provider": "minimax"
   },
+  "stages": {
+    "taskify":    { "maxTurns": 300, "maxBudgetUsd": 15.00 },
+    "plan":       { "maxTurns": 300, "maxBudgetUsd": 10.00 },
+    "build":      { "maxTurns": 1000, "maxBudgetUsd": 50.00 },
+    "verify":     { "maxTurns": 200, "maxBudgetUsd": 5.00 },
+    "review":     { "maxTurns": 300, "maxBudgetUsd": 10.00 },
+    "review-fix": { "maxTurns": 600, "maxBudgetUsd": 30.00 },
+    "ship":       { "maxTurns": 200, "maxBudgetUsd": 5.00 }
+  },
+  "timeouts": {
+    "taskify":    6000,
+    "plan":       6000,
+    "build":      24000,
+    "verify":     3000,
+    "review":     6000,
+    "review-fix": 12000,
+    "ship":       2400
+  },
   "devServer": {
     "command": "pnpm dev",
     "url": "http://localhost:3000",


### PR DESCRIPTION
Temporarily increase pipeline budgets 10x for testing session-fix and timeout handling on issue #1206.