### PR TITLE
fix: Normalize formatting in kody.config.json

### DIFF
--- a/kody.config.json
+++ b/kody.config.json
@@ -38,22 +38,22 @@
     "provider": "minimax"
   },
   "stages": {
-    "taskify":    { "maxTurns": 300, "maxBudgetUsd": 15.00 },
-    "plan":       { "maxTurns": 300, "maxBudgetUsd": 10.00 },
-    "build":      { "maxTurns": 1000, "maxBudgetUsd": 50.00 },
-    "verify":     { "maxTurns": 200, "maxBudgetUsd": 5.00 },
-    "review":     { "maxTurns": 300, "maxBudgetUsd": 10.00 },
-    "review-fix": { "maxTurns": 600, "maxBudgetUsd": 30.00 },
-    "ship":       { "maxTurns": 200, "maxBudgetUsd": 5.00 }
+    "taskify": { "maxTurns": 300, "maxBudgetUsd": 15.0 },
+    "plan": { "maxTurns": 300, "maxBudgetUsd": 10.0 },
+    "build": { "maxTurns": 1000, "maxBudgetUsd": 50.0 },
+    "verify": { "maxTurns": 200, "maxBudgetUsd": 5.0 },
+    "review": { "maxTurns": 300, "maxBudgetUsd": 10.0 },
+    "review-fix": { "maxTurns": 600, "maxBudgetUsd": 30.0 },
+    "ship": { "maxTurns": 200, "maxBudgetUsd": 5.0 }
   },
   "timeouts": {
-    "taskify":    6000,
-    "plan":       6000,
-    "build":      24000,
-    "verify":     3000,
-    "review":     6000,
+    "taskify": 6000,
+    "plan": 6000,
+    "build": 24000,
+    "verify": 3000,
+    "review": 6000,
     "review-fix": 12000,
-    "ship":       2400
+    "ship": 2400
   },
   "devServer": {
     "command": "pnpm dev",


### PR DESCRIPTION
## Summary
- Run Prettier on `kody.config.json` to fix irregular whitespace in `stages` and `timeouts` sections
- Aligns `kody.config.json` with the Prettier code style required by CI

## Test plan
- [x] `pnpm format:check` passes
- [x] Pre-push verification passes