### PR TITLE
fix(ci): Deploy to production only on main branch pushes

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -2,7 +2,7 @@ name: Build & Deploy to Vercel
 
 on:
   push:
-    branches: [dev]
+    branches: [main]
     paths:
       - 'src/**'
       - 'app/**'


### PR DESCRIPTION
Changes vercel-deploy.yml to trigger on 'main' instead of 'dev'. Dev pushes will no longer auto-deploy to production.