### PR TITLE
fix(geometry-editor): Respect canvas.boundingBox to display negative …

### DIFF
--- a/src/ui/admin/ExerciseContentEditor/components/geometry/GeometryCanvas.tsx
+++ b/src/ui/admin/ExerciseContentEditor/components/geometry/GeometryCanvas.tsx
@@ -174,9 +174,12 @@ export const GeometryCanvas: React.FC<GeometryCanvasProps> = ({
   }, [])
 
   const { canvas } = geometry
+  // Respect the geometry's own boundingBox (needed for content with negative
+  // coordinates) — mirror the renderer logic so editor and rendered output
+  // share the same viewport. Fall back to width/height-based box when unset.
   const bbox = useMemo<[number, number, number, number]>(
-    () => [0, canvas.height, canvas.width, 0],
-    [canvas.width, canvas.height],
+    () => canvas.boundingBox ?? [0, canvas.height, canvas.width, 0],
+    [canvas.boundingBox, canvas.width, canvas.height],
   )
 
   return (


### PR DESCRIPTION
…coordinates

The admin GeometryCanvas was hardcoding the viewport to

[0, canvas.height, canvas.width, 0], ignoring canvas.boundingBox.

Content with negative coordinates (e.g. AI-imported geometries with

points at (-6, 14)) got clumped into the positive quadrant corner.

The renderer already used canvas.boundingBox as the override — this

brings the editor in line so both share the same viewport.