### PR TITLE
fix(lessons): Show chat when lesson has exercises OR context text

### DIFF
--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/ExercisesPager/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/ExercisesPager/index.tsx
@@ -41,8 +41,8 @@ interface ExercisesPagerProps {
   lessonSlug: string
   lessonId: string
   mediaMap?: Record<string, MediaType>
-  /** Whether the lesson has exercises (controls chat visibility) */
-  hasExercises?: boolean
+  /** Whether to show the chat panel (true when lesson has exercises or context text) */
+  showChat?: boolean
   /** Formula sheet data (passed to ChatInterface) */
   formulaSheet?: import('@/payload-types').FormulaSheet | null
 }
@@ -56,7 +56,7 @@ export function ExercisesPager({
   lessonSlug,
   lessonId,
   mediaMap,
-  hasExercises,
+  showChat,
   formulaSheet,
 }: ExercisesPagerProps) {
   const t = useTranslations('courses')
@@ -217,7 +217,7 @@ export function ExercisesPager({
             >
               <div className="w-full p-card-padding-sm md:p-card-padding space-y-4">
                 {/* Breadcrumb step indicator */}
-                <div className="flex items-center gap-2 text-body-sm text-muted-foreground pt-3">
+                <div className="flex items-center gap-content-gap-xs text-body-sm text-muted-foreground pt-3">
                   <span className="truncate max-w-[200px]">{lessonTitle}</span>
                   <ChevronRight className="w-3 h-3 shrink-0 rtl:rotate-180" />
                   <span className="text-foreground font-medium">
@@ -271,7 +271,7 @@ export function ExercisesPager({
                   disabled={!canGoPrev || isNavigating}
                   aria-label="Previous page"
                   className={cn(
-                    'text-body-sm gap-2 min-h-[44px] cursor-pointer transition-all duration-normal',
+                    'text-body-sm gap-content-gap-xs min-h-[44px] cursor-pointer transition-all duration-normal',
                     !canGoPrev || isNavigating
                       ? 'text-muted-foreground/40'
                       : 'text-muted-foreground hover:text-foreground',
@@ -290,7 +290,7 @@ export function ExercisesPager({
                   onClick={handleNext}
                   disabled={!canGoNext || isNavigating}
                   aria-label="Next page"
-                  className="px-6 py-2 min-h-[44px] rounded-xl text-body-sm cursor-pointer gap-2"
+                  className="px-6 py-2 min-h-[44px] rounded-xl text-body-sm cursor-pointer gap-content-gap-xs"
                 >
                   {isNavigating ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
                   {t('exercisesPagerNext')}
@@ -301,7 +301,7 @@ export function ExercisesPager({
           </div>
         }
         chatContent={
-          hasExercises ? (
+          showChat ? (
             <ChatInterface
               lessonId={lessonId}
               exerciseId={currentExercise.id}
@@ -438,7 +438,7 @@ export function ExercisesPager({
 
                   {/* Summary stats */}
                   <div className="flex items-center justify-center gap-content-gap mb-10">
-                    <div className="inline-flex items-center gap-2 px-4 py-2 bg-secondary/5 rounded-xl border border-secondary/10">
+                    <div className="inline-flex items-center gap-content-gap-xs px-4 py-2 bg-secondary/5 rounded-xl border border-secondary/10">
                       <Layers className="w-4 h-4 text-secondary" />
                       <span className="text-secondary font-medium">{totalExercises}</span>
                       <span className="text-body-xs text-muted-foreground">{t('exercise')}</span>
@@ -465,7 +465,7 @@ export function ExercisesPager({
                   onClick={handlePrev}
                   disabled={isNavigating}
                   aria-label="Previous page"
-                  className="text-muted-foreground text-body-sm min-h-[44px] hover:text-foreground transition-colors duration-slow gap-2 cursor-pointer"
+                  className="text-muted-foreground text-body-sm min-h-[44px] hover:text-foreground transition-colors duration-slow gap-content-gap-xs cursor-pointer"
                 >
                   <ArrowRight className="w-4 h-4 rtl:rotate-0 ltr:rotate-180" />
                   {t('exercisesPagerPrev')}

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/LessonPager/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/LessonPager/index.tsx
@@ -50,8 +50,8 @@ interface LessonPagerProps {
   validFiles?: MediaType[]
   /** Lesson ID for chat context (defaults to lessonId) */
   chatLessonId?: string
-  /** Whether the lesson has exercises (controls chat visibility) */
-  hasExercises?: boolean
+  /** Whether to show the chat panel (true when lesson has exercises or context text) */
+  showChat?: boolean
   /** Formula sheet data (passed to ChatInterface) */
   formulaSheet?: import('@/payload-types').FormulaSheet | null
 }
@@ -68,7 +68,7 @@ export function LessonPager({
   contentPageBodies,
   validFiles,
   chatLessonId,
-  hasExercises,
+  showChat,
   formulaSheet,
 }: LessonPagerProps) {
   const t = useTranslations('courses')
@@ -242,7 +242,7 @@ export function LessonPager({
           </div>
         }
         chatContent={
-          hasExercises ? (
+          showChat ? (
             <ChatInterface
               lessonId={lessonId}
               exerciseId={exercise.id}
@@ -447,7 +447,7 @@ export function LessonPager({
           </div>
         }
         chatContent={
-          hasExercises ? (
+          showChat ? (
             <ChatInterface
               lessonId={chatLessonId ?? lessonId}
               translationNamespace="courses"

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/PdfLessonPager/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/PdfLessonPager/index.tsx
@@ -20,8 +20,8 @@ interface PdfLessonPagerProps {
   lessonSlug: string
   lessonId: string
   chatLessonId: string
-  /** Whether the lesson has exercises (controls chat visibility) */
-  hasExercises?: boolean
+  /** Whether to show the chat panel (true when lesson has exercises or context text) */
+  showChat?: boolean
   /** Formula sheet data (passed to ChatInterface) */
   formulaSheet?: import('@/payload-types').FormulaSheet | null
 }
@@ -35,7 +35,7 @@ export function PdfLessonPager({
   lessonSlug,
   lessonId,
   chatLessonId,
-  hasExercises,
+  showChat,
   formulaSheet,
 }: PdfLessonPagerProps) {
   const t = useTranslations('courses')
@@ -116,7 +116,7 @@ export function PdfLessonPager({
           </div>
         }
         chatContent={
-          hasExercises ? (
+          showChat ? (
             <ChatInterface
               lessonId={chatLessonId}
               translationNamespace="courses"

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/page.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/page.tsx
@@ -16,6 +16,7 @@ import { queryMediaByIds } from '@/server/repos/queries/media'
 import { isAuthenticatedServer } from '@/server/utils/access-gate-server'
 import { checkPaidAccess } from '@/server/utils/check-paid-access'
 import { AccessGateProvider } from '@/ui/web/auth/AccessGateProvider'
+import { ChatInterface } from '@/ui/web/chat'
 import { extractAllMediaIds } from '@/ui/web/exerciserenderer/utils/extractMediaIds'
 import { stripHtml } from '@/utils/strip-html'
 import { notFound } from 'next/navigation'
@@ -121,6 +122,8 @@ export default async function LessonPage({ params }: LessonPageProps) {
     }
   }
 
+  const hasLessonContext = Boolean(lesson.lessonContextText?.trim())
+
   // Resolve content files (PDFs, etc.) — needed by both blocks and legacy paths
   const validFiles =
     lesson.contentFiles
@@ -139,6 +142,7 @@ export default async function LessonPage({ params }: LessonPageProps) {
     const mediaMap =
       blockExercises.length > 0 ? await queryMediaByIds(extractAllMediaIds(blockExercises)) : {}
     const hasExercises = blockExercises.length > 0
+    const showChat = hasExercises || hasLessonContext
 
     // Pre-render content page bodies server-side
     const contentPageBodies: Record<string, React.ReactNode> = {}
@@ -180,7 +184,7 @@ export default async function LessonPage({ params }: LessonPageProps) {
           contentPageBodies={contentPageBodies}
           validFiles={validFiles}
           chatLessonId={lesson.id}
-          hasExercises={hasExercises}
+          showChat={showChat}
           formulaSheet={formulaSheet}
         />
       </AccessGateProvider>
@@ -196,6 +200,7 @@ export default async function LessonPage({ params }: LessonPageProps) {
 
   const hasContent = validFiles.length > 0
   const hasExercises = exercises.length > 0
+  const showChat = hasExercises || hasLessonContext
 
   // Batch-fetch all media referenced inside exercise content blocks
   const mediaMap = hasExercises ? await queryMediaByIds(extractAllMediaIds(exercises)) : {}
@@ -230,7 +235,7 @@ export default async function LessonPage({ params }: LessonPageProps) {
             lessonSlug={lessonSlug}
             lessonId={lesson.id}
             mediaMap={mediaMap}
-            hasExercises={hasExercises}
+            showChat={showChat}
             formulaSheet={formulaSheet}
           />
         ) : (
@@ -240,7 +245,16 @@ export default async function LessonPage({ params }: LessonPageProps) {
               exerciseTitle={lesson.title}
               backUrl={backUrl}
               primaryContent={<EmptyLessonPlaceholder />}
-              chatContent={null}
+              chatContent={
+                showChat ? (
+                  <ChatInterface
+                    lessonId={chatLessonId}
+                    translationNamespace="courses"
+                    showMathTools={true}
+                    formulaSheet={formulaSheet}
+                  />
+                ) : null
+              }
             />
           </>
         )}
@@ -271,7 +285,7 @@ export default async function LessonPage({ params }: LessonPageProps) {
         lessonSlug={lessonSlug}
         lessonId={lesson.id}
         chatLessonId={chatLessonId}
-        hasExercises={hasExercises}
+        showChat={showChat}
         formulaSheet={formulaSheet}
       />
     </AccessGateProvider>

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1471,6 +1471,10 @@ export interface Lesson {
    */
   contentFiles?: (string | Media)[] | null;
   /**
+   * AI context text for this lesson. Injected into chat prompts at runtime. NOT indexed or searchable.
+   */
+  lessonContextText?: string | null;
+  /**
    * AI system prompt for this lesson (uses default if not set)
    */
   prompt?: (string | null) | Prompt;
@@ -3268,6 +3272,7 @@ export interface LessonsSelect<T extends boolean = true> {
   accessType?: T;
   blocks?: T;
   contentFiles?: T;
+  lessonContextText?: T;
   prompt?: T;
   slug?: T;
   contentStatus?: T;


### PR DESCRIPTION
## Summary
- Chat was gated only on `hasExercises`. It now renders whenever the lesson has exercises **or** `lessonContextText` is non-empty, so context-only lessons expose the chat.
- Fixes the dev-vs-main behavior drift: previously a lesson with `lessonContextText` filled but no exercises showed chat on dev but not on main.

## Changes
- `page.tsx`: derive `hasLessonContext` + `showChat = hasExercises || hasLessonContext`; render `ChatInterface` in the empty-lesson placeholder when `showChat`.
- `LessonPager`, `PdfLessonPager`, `ExercisesPager`: accept `showChat` prop (replaces `hasExercises`) as the chat render gate.
- `payload-types.ts`: regenerated (schema had `lessonContextText` but types were stale).

## Test plan
- [x] Lesson with `lessonContextText` filled, zero exercises → chat visible.
- [ ] Lesson with exercises, empty context → chat visible.
- [ ] Lesson with both empty → chat hidden.
- [ ] Lesson with both → chat visible.
- [ ] `pnpm typecheck` passes (verified locally).
- [ ] `pnpm lint` passes (verified locally).