### PR TITLE
feat: Constrain Gemini output with responseSchema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ node_modules
 # Payload default media upload directory
 public/media/
 
+# Local-only testing materials for interactive lesson / schema work
+schema-testing/
+
 public/robots.txt
 public/sitemap*.xml
 

--- a/src/infra/llm/genkit/adapters/unified-adapter.ts
+++ b/src/infra/llm/genkit/adapters/unified-adapter.ts
@@ -73,12 +73,6 @@ interface MultimodalCompletionInput {
   model: AIModel & { modelKey?: AIModelKey }
   attachments: Array<{ data: string; mimeType: string }>
   timeoutMs?: number
-  /**
-   * Optional Zod schema — when provided, the model is constrained to
-   * produce JSON matching this schema via Gemini's responseSchema feature.
-   * Genkit bridges Zod to the provider-specific structured-output contract.
-   */
-  responseSchema?: unknown
 }
 
 /**
@@ -269,16 +263,6 @@ export async function createGenkitUnifiedAdapter(
                     ? { thinkingConfig: { thinkingBudget: input.model.thinkingBudget } }
                     : {}),
                 },
-                // Constrain output to a Zod schema when provided. Genkit
-                // translates this to Gemini's responseSchema/responseMimeType.
-                ...(input.responseSchema
-                  ? {
-                      output: {
-                        schema: input.responseSchema as never,
-                        format: 'json' as const,
-                      },
-                    }
-                  : {}),
               })
 
               return {

--- a/src/infra/llm/genkit/adapters/unified-adapter.ts
+++ b/src/infra/llm/genkit/adapters/unified-adapter.ts
@@ -73,6 +73,12 @@ interface MultimodalCompletionInput {
   model: AIModel & { modelKey?: AIModelKey }
   attachments: Array<{ data: string; mimeType: string }>
   timeoutMs?: number
+  /**
+   * Optional Zod schema — when provided, the model is constrained to
+   * produce JSON matching this schema via Gemini's responseSchema feature.
+   * Genkit bridges Zod to the provider-specific structured-output contract.
+   */
+  responseSchema?: unknown
 }
 
 /**
@@ -263,6 +269,16 @@ export async function createGenkitUnifiedAdapter(
                     ? { thinkingConfig: { thinkingBudget: input.model.thinkingBudget } }
                     : {}),
                 },
+                // Constrain output to a Zod schema when provided. Genkit
+                // translates this to Gemini's responseSchema/responseMimeType.
+                ...(input.responseSchema
+                  ? {
+                      output: {
+                        schema: input.responseSchema as never,
+                        format: 'json' as const,
+                      },
+                    }
+                  : {}),
               })
 
               return {

--- a/src/infra/llm/providers/factory.ts
+++ b/src/infra/llm/providers/factory.ts
@@ -164,8 +164,6 @@ export interface UnifiedLLMProvider {
       }
       attachments: Array<{ data: string; mimeType: string }>
       timeoutMs?: number
-      /** Optional Zod schema — constrains model output to a specific shape. */
-      responseSchema?: unknown
     },
     payload: Payload,
   ) => Promise<{ text: string; raw?: unknown }>

--- a/src/infra/llm/providers/factory.ts
+++ b/src/infra/llm/providers/factory.ts
@@ -155,9 +155,17 @@ export interface UnifiedLLMProvider {
   generateMultimodalCompletion: (
     input: {
       prompt: string
-      model: { name: string; temperature: number; maxOutputTokens: number; modelKey?: AIModelKey }
+      model: {
+        name: string
+        temperature: number
+        maxOutputTokens: number
+        modelKey?: AIModelKey
+        thinkingBudget?: number
+      }
       attachments: Array<{ data: string; mimeType: string }>
       timeoutMs?: number
+      /** Optional Zod schema — constrains model output to a specific shape. */
+      responseSchema?: unknown
     },
     payload: Payload,
   ) => Promise<{ text: string; raw?: unknown }>

--- a/src/infra/llm/services/interactive-lesson/interactive-lesson-generation-service.ts
+++ b/src/infra/llm/services/interactive-lesson/interactive-lesson-generation-service.ts
@@ -6,11 +6,13 @@
  * Two-pass approach: LLM extracts geometry + proof, we render SVG deterministically.
  */
 import type { Payload } from 'payload'
+import { z } from 'zod'
 import type { AIModel, AIModelKey } from '../../models'
 import { getModelRegistryEntry, getProviderModelName } from '../../models'
 import { INTERACTIVE_LESSON_PROMPT } from '../../prompts/interactive-lesson-generation'
 import { LLMProviderType } from '../../providers/types'
 import { optimizeImageForAI } from '../image-optimizer-service'
+import { InteractiveLessonResponseSchema } from './interactive-lesson-schema'
 import type {
   InteractiveLesson,
   InteractiveLessonInput,
@@ -23,24 +25,20 @@ import type {
  */
 export async function generateInteractiveLesson(
   input: InteractiveLessonInput,
-  payload: Payload,
+  _payload: Payload,
 ): Promise<InteractiveLessonResponse> {
   const startTime = Date.now()
   let modelConfig: AIModel | null = null
 
   try {
-    const { createGenkitUnifiedAdapter } = await import('../../genkit/adapters/unified-adapter')
-    const adapter = await createGenkitUnifiedAdapter(payload)
+    const apiKey = process.env.GEMINI_API_KEY
+    if (!apiKey) throw new Error('GEMINI_API_KEY not configured')
+
+    const modelName = 'gemini-2.5-flash'
     modelConfig = {
       ...resolveModelConfig('IMAGE_TO_EXERCISE'),
-      // Use Gemini 2.5 Flash explicitly — 2.0 Flash produces only ~4 steps on
-      // complex multi-part geometry proofs. 2.5 Flash with thinking produces 18-20.
-      // The "googleai/" prefix tells the adapter to skip DB config resolution.
-      name: 'googleai/gemini-2.5-flash',
-      // Temperature 0 for more deterministic structured JSON output.
+      name: `googleai/${modelName}`,
       temperature: 0,
-      // Thinking tokens count against maxOutputTokens — budget for both.
-      // Bumped to 96K to reduce mid-JSON truncation on long outputs.
       maxOutputTokens: 98304,
       thinkingBudget: 24576,
     }
@@ -48,16 +46,18 @@ export async function generateInteractiveLesson(
     const prompt = buildPrompt(input.locale)
     const { attachmentData, sizeBytes } = await prepareImage(input)
 
-    const result = await adapter.generateMultimodalCompletion(
-      {
-        prompt,
-        model: modelConfig,
-        attachments: [{ data: attachmentData, mimeType: input.mimeType }],
-      },
-      payload,
-    )
+    // Direct Gemini call with responseSchema so the model is constrained
+    // to produce exactly the shape we expect. Eliminates most field-name
+    // variations (id vs label, p1 vs from, etc.) at the source.
+    const responseText = await callGeminiWithSchema({
+      apiKey,
+      modelName,
+      prompt,
+      attachmentData,
+      attachmentMimeType: input.mimeType,
+    })
 
-    const parsed = parseResponse(result.text)
+    const parsed = parseResponse(responseText)
 
     if (parsed.error) {
       return buildErrorResponse(
@@ -96,6 +96,85 @@ function buildPrompt(locale: 'he' | 'en'): string {
       ? '\n\nIMPORTANT: Generate ALL narration, claims, reasons, and explanations in Hebrew.'
       : '\n\nIMPORTANT: Generate ALL narration, claims, reasons, and explanations in English.'
   return `${INTERACTIVE_LESSON_PROMPT}${localeInstruction}`
+}
+
+/**
+ * Call Gemini 2.5 Flash directly with a responseSchema constraint.
+ *
+ * Bypasses the Genkit adapter so we can pass responseSchema to Gemini's
+ * v1beta generateContent endpoint — the model is then forced to produce
+ * JSON matching our exact shape, eliminating field-name variations
+ * (id vs label, p1 vs from, etc.) at the source.
+ */
+async function callGeminiWithSchema(args: {
+  apiKey: string
+  modelName: string
+  prompt: string
+  attachmentData: string
+  attachmentMimeType: string
+}): Promise<string> {
+  const schemaForGemini = zodToGeminiSchema(InteractiveLessonResponseSchema)
+
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${args.modelName}:generateContent?key=${args.apiKey}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [
+          {
+            parts: [
+              { inlineData: { mimeType: args.attachmentMimeType, data: args.attachmentData } },
+              { text: args.prompt },
+            ],
+          },
+        ],
+        generationConfig: {
+          temperature: 0,
+          maxOutputTokens: 98304,
+          thinkingConfig: { thinkingBudget: 24576 },
+          responseMimeType: 'application/json',
+          responseSchema: schemaForGemini,
+        },
+      }),
+    },
+  )
+
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`Gemini API error ${res.status}: ${body.slice(0, 200)}`)
+  }
+
+  const json = await res.json()
+  const text =
+    json.candidates?.[0]?.content?.parts
+      ?.filter((p: { text?: string }) => p.text)
+      ?.map((p: { text: string }) => p.text)
+      ?.join('') || ''
+  return text
+}
+
+/**
+ * Convert a Zod schema to the OpenAPI 3.0 subset Gemini's responseSchema
+ * accepts. Strips $schema and additionalProperties recursively — both
+ * are in JSON Schema but rejected by Gemini's endpoint.
+ */
+function zodToGeminiSchema(schema: z.ZodType): Record<string, unknown> {
+  const jsonSchema = z.toJSONSchema(schema) as Record<string, unknown>
+  return stripUnsupportedKeys(jsonSchema) as Record<string, unknown>
+}
+
+function stripUnsupportedKeys(node: unknown): unknown {
+  if (Array.isArray(node)) return node.map(stripUnsupportedKeys)
+  if (node && typeof node === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(node)) {
+      if (k === '$schema' || k === 'additionalProperties') continue
+      out[k] = stripUnsupportedKeys(v)
+    }
+    return out
+  }
+  return node
 }
 
 async function prepareImage(input: InteractiveLessonInput) {

--- a/src/infra/llm/services/interactive-lesson/interactive-lesson-generation-service.ts
+++ b/src/infra/llm/services/interactive-lesson/interactive-lesson-generation-service.ts
@@ -7,10 +7,12 @@
  */
 import type { Payload } from 'payload'
 import { z } from 'zod'
-import type { AIModel, AIModelKey } from '../../models'
-import { getModelRegistryEntry, getProviderModelName } from '../../models'
+import type { AIModel } from '../../models'
 import { INTERACTIVE_LESSON_PROMPT } from '../../prompts/interactive-lesson-generation'
-import { LLMProviderType } from '../../providers/types'
+import { getCircuitBreaker } from '../../providers/shared/circuit-breaker'
+import { withRetry } from '../../providers/shared/retry'
+import { withTimeout } from '../../providers/shared/timeout'
+import { logger } from '@/infra/utils/logger/logger'
 import { optimizeImageForAI } from '../image-optimizer-service'
 import { InteractiveLessonResponseSchema } from './interactive-lesson-schema'
 import type {
@@ -18,6 +20,19 @@ import type {
   InteractiveLessonInput,
   InteractiveLessonResponse,
 } from './interactive-lesson-types'
+
+// Single source of truth for the Gemini call config. Used for both the API
+// request and metadata reporting so they can't diverge.
+const GEMINI_CONFIG = {
+  modelName: 'gemini-2.5-flash',
+  temperature: 0,
+  maxOutputTokens: 98304,
+  thinkingBudget: 24576,
+  timeoutMs: 180_000,
+  maxRetries: 2,
+} as const
+
+const circuitBreaker = getCircuitBreaker('interactive-lesson-gemini')
 
 /**
  * Generate an interactive lesson from an uploaded image.
@@ -34,28 +49,40 @@ export async function generateInteractiveLesson(
     const apiKey = process.env.GEMINI_API_KEY
     if (!apiKey) throw new Error('GEMINI_API_KEY not configured')
 
-    const modelName = 'gemini-2.5-flash'
     modelConfig = {
-      ...resolveModelConfig('IMAGE_TO_EXERCISE'),
-      name: `googleai/${modelName}`,
-      temperature: 0,
-      maxOutputTokens: 98304,
-      thinkingBudget: 24576,
+      name: `googleai/${GEMINI_CONFIG.modelName}`,
+      temperature: GEMINI_CONFIG.temperature,
+      maxOutputTokens: GEMINI_CONFIG.maxOutputTokens,
+      thinkingBudget: GEMINI_CONFIG.thinkingBudget,
     }
 
     const prompt = buildPrompt(input.locale)
     const { attachmentData, sizeBytes } = await prepareImage(input)
 
-    // Direct Gemini call with responseSchema so the model is constrained
-    // to produce exactly the shape we expect. Eliminates most field-name
-    // variations (id vs label, p1 vs from, etc.) at the source.
-    const responseText = await callGeminiWithSchema({
-      apiKey,
-      modelName,
-      prompt,
-      attachmentData,
-      attachmentMimeType: input.mimeType,
-    })
+    // Direct Gemini call with responseSchema so the model is constrained to
+    // produce exactly the shape we expect. Wrapped in the same reliability
+    // primitives the Genkit adapter uses (timeout + retry + circuit breaker)
+    // so a transient 5xx/429 doesn't fail the user's request on first try.
+    const responseText = await circuitBreaker.execute(() =>
+      withRetry(
+        () =>
+          withTimeout(
+            () =>
+              callGeminiWithSchema({
+                apiKey,
+                prompt,
+                attachmentData,
+                attachmentMimeType: input.mimeType,
+              }),
+            { timeoutMs: GEMINI_CONFIG.timeoutMs, message: 'Gemini request timed out' },
+          ),
+        {
+          maxRetries: GEMINI_CONFIG.maxRetries,
+          isRetryable: isRetryableGeminiError,
+          logPrefix: '[InteractiveLesson]',
+        },
+      ),
+    )
 
     const parsed = parseResponse(responseText)
 
@@ -99,16 +126,38 @@ function buildPrompt(locale: 'he' | 'en'): string {
 }
 
 /**
+ * Custom error that carries the HTTP status so withRetry can decide
+ * whether to retry based on the code (5xx/429 yes, 4xx no).
+ */
+class GeminiApiError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'GeminiApiError'
+  }
+}
+
+function isRetryableGeminiError(err: Error): boolean {
+  if (err instanceof GeminiApiError) {
+    return err.status >= 500 || err.status === 429
+  }
+  // Timeouts and network errors are retryable
+  return err.name === 'TimeoutError' || err.message.includes('fetch failed')
+}
+
+/**
  * Call Gemini 2.5 Flash directly with a responseSchema constraint.
  *
- * Bypasses the Genkit adapter so we can pass responseSchema to Gemini's
- * v1beta generateContent endpoint — the model is then forced to produce
- * JSON matching our exact shape, eliminating field-name variations
- * (id vs label, p1 vs from, etc.) at the source.
+ * We bypass the Genkit adapter to pass responseSchema to Gemini's v1beta
+ * generateContent endpoint — the model is then forced to produce JSON
+ * matching our exact shape, eliminating field-name variations (id vs
+ * label, p1 vs from, etc.) at the source. Timeout/retry/circuit-breaker
+ * are applied by the caller.
  */
 async function callGeminiWithSchema(args: {
   apiKey: string
-  modelName: string
   prompt: string
   attachmentData: string
   attachmentMimeType: string
@@ -116,7 +165,7 @@ async function callGeminiWithSchema(args: {
   const schemaForGemini = zodToGeminiSchema(InteractiveLessonResponseSchema)
 
   const res = await fetch(
-    `https://generativelanguage.googleapis.com/v1beta/models/${args.modelName}:generateContent?key=${args.apiKey}`,
+    `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_CONFIG.modelName}:generateContent?key=${args.apiKey}`,
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -130,9 +179,9 @@ async function callGeminiWithSchema(args: {
           },
         ],
         generationConfig: {
-          temperature: 0,
-          maxOutputTokens: 98304,
-          thinkingConfig: { thinkingBudget: 24576 },
+          temperature: GEMINI_CONFIG.temperature,
+          maxOutputTokens: GEMINI_CONFIG.maxOutputTokens,
+          thinkingConfig: { thinkingBudget: GEMINI_CONFIG.thinkingBudget },
           responseMimeType: 'application/json',
           responseSchema: schemaForGemini,
         },
@@ -141,8 +190,11 @@ async function callGeminiWithSchema(args: {
   )
 
   if (!res.ok) {
+    // Log the raw body server-side for debugging, but don't include it in
+    // the thrown error message so nothing leaks upstream.
     const body = await res.text()
-    throw new Error(`Gemini API error ${res.status}: ${body.slice(0, 200)}`)
+    logger.error({ status: res.status, body: body.slice(0, 500) }, 'Gemini API error')
+    throw new GeminiApiError(res.status, `Gemini API returned ${res.status}`)
   }
 
   const json = await res.json()
@@ -300,13 +352,6 @@ function validateLabel(l: Record<string, unknown>) {
     x: Number(l.x || 0),
     y: Number(l.y || 0),
     fontSize: Number(l.fontSize || 12),
-  }
-}
-
-function resolveModelConfig(modelKey: AIModelKey): AIModel {
-  return {
-    name: getProviderModelName(LLMProviderType.GEMINI, modelKey),
-    ...getModelRegistryEntry(modelKey),
   }
 }
 

--- a/src/infra/llm/services/interactive-lesson/interactive-lesson-schema.ts
+++ b/src/infra/llm/services/interactive-lesson/interactive-lesson-schema.ts
@@ -1,15 +1,20 @@
 /**
  * Zod response schema for the Gemini interactive lesson call.
  *
- * Passed to Gemini via Genkit's `output.schema` / Gemini's `responseSchema`
- * so the model is constrained to produce exactly this shape. This eliminates
- * field-name variations (`id` vs `label`, `p1`/`p2` vs `from`/`to`, etc.)
- * at the source instead of normalizing them defensively after the fact.
+ * Passed to Gemini via `responseSchema` + `responseMimeType: application/json`
+ * (direct fetch in interactive-lesson-generation-service.ts) so the model
+ * is constrained to produce exactly this shape. Eliminates field-name
+ * variations (`id` vs `label`, `p1`/`p2` vs `from`/`to`, etc.) at the
+ * source instead of normalizing them defensively after the fact.
  *
- * NOTE: this schema defines what WE ask Gemini to produce. The existing
- * validators/normalizers in interactive-lesson-generation-service.ts still
- * run as a safety net for:
- *   - Old payloads from before responseSchema was wired
+ * Schema complexity constraint: Gemini's responseSchema endpoint accepts
+ * a strict OpenAPI 3.0 subset. Keep this schema flat — avoid `$ref`,
+ * `$defs`, `oneOf` with discriminator, etc. The `stripUnsupportedKeys`
+ * helper only strips `$schema` and `additionalProperties`; other
+ * JSON-Schema-only constructs will pass through and cause API errors.
+ *
+ * NOTE: the existing validators/normalizers in the service still run as
+ * a safety net for:
  *   - Rare cases where Gemini ignores the schema
  *   - Error responses (IMAGE_UNCLEAR, NOT_MATH) that bypass the schema
  */

--- a/src/infra/llm/services/interactive-lesson/interactive-lesson-schema.ts
+++ b/src/infra/llm/services/interactive-lesson/interactive-lesson-schema.ts
@@ -1,0 +1,71 @@
+/**
+ * Zod response schema for the Gemini interactive lesson call.
+ *
+ * Passed to Gemini via Genkit's `output.schema` / Gemini's `responseSchema`
+ * so the model is constrained to produce exactly this shape. This eliminates
+ * field-name variations (`id` vs `label`, `p1`/`p2` vs `from`/`to`, etc.)
+ * at the source instead of normalizing them defensively after the fact.
+ *
+ * NOTE: this schema defines what WE ask Gemini to produce. The existing
+ * validators/normalizers in interactive-lesson-generation-service.ts still
+ * run as a safety net for:
+ *   - Old payloads from before responseSchema was wired
+ *   - Rare cases where Gemini ignores the schema
+ *   - Error responses (IMAGE_UNCLEAR, NOT_MATH) that bypass the schema
+ */
+import { z } from 'zod'
+
+const GeoPointSchema = z.object({
+  label: z.string(),
+  x: z.number(),
+  y: z.number(),
+})
+
+const GeoSegmentSchema = z.object({
+  from: z.string(),
+  to: z.string(),
+  style: z.enum(['solid', 'dashed', 'bold']).optional(),
+  color: z.enum(['blue', 'red', 'green', 'orange', 'purple']).optional(),
+})
+
+const GeoAngleSchema = z.object({
+  points: z.array(z.string()).length(3),
+  rightAngle: z.boolean().optional(),
+})
+
+const GeoLabelSchema = z.object({
+  text: z.string(),
+  x: z.number(),
+  y: z.number(),
+  fontSize: z.number().optional(),
+})
+
+const GeometrySchema = z.object({
+  width: z.number(),
+  height: z.number(),
+  points: z.array(GeoPointSchema),
+  segments: z.array(GeoSegmentSchema),
+  angles: z.array(GeoAngleSchema),
+  labels: z.array(GeoLabelSchema),
+})
+
+const StepSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  claim: z.string(),
+  reason: z.string(),
+  narration: z.string(),
+  explanation: z.string(),
+  durationSeconds: z.number(),
+  /** Array of [from, to] label pairs. */
+  highlightSegments: z.array(z.array(z.string()).length(2)),
+  highlightPoints: z.array(z.string()),
+})
+
+export const InteractiveLessonResponseSchema = z.object({
+  title: z.string(),
+  geometry: GeometrySchema,
+  steps: z.array(StepSchema),
+})
+
+export type InteractiveLessonResponseShape = z.infer<typeof InteractiveLessonResponseSchema>


### PR DESCRIPTION
Gemini was inconsistent about field names (id vs label, p1 vs from, varying highlight formats) across runs, requiring defensive normalizers after the fact.

Now we pass a Zod schema (via Gemini's responseSchema + responseMimeType: application/json) that forces the model to produce exactly the shape we expect. The normalizers stay as a safety net but should rarely be needed.

Tested: vidtest2 rectangle (7 points with labels A-G, was returning undefined), square problem (7 points), inequality (empty geometry, 7 steps). All pass schema validation on first try.