### PR TITLE
feat(V1-270): Persist Gemini interactive lesson responses

### DIFF
--- a/src/infra/llm/services/interactive-lesson/interactive-lesson-generation-service.ts
+++ b/src/infra/llm/services/interactive-lesson/interactive-lesson-generation-service.ts
@@ -32,6 +32,13 @@ const GEMINI_CONFIG = {
   maxRetries: 2,
 } as const
 
+/**
+ * Version tag for the prompt + response schema. Bump this when the prompt
+ * text or the response schema changes materially — cache entries with an
+ * older version are ignored on lookup so stale shapes don't get served.
+ */
+export const INTERACTIVE_LESSON_PROMPT_VERSION = 'v1'
+
 const circuitBreaker = getCircuitBreaker('interactive-lesson-gemini')
 
 /**
@@ -40,10 +47,25 @@ const circuitBreaker = getCircuitBreaker('interactive-lesson-gemini')
  */
 export async function generateInteractiveLesson(
   input: InteractiveLessonInput,
-  _payload: Payload,
+  payload: Payload,
 ): Promise<InteractiveLessonResponse> {
   const startTime = Date.now()
   let modelConfig: AIModel | null = null
+
+  // Read-through cache: if this (user, media, locale, promptVersion) was
+  // generated before, return the stored payload instead of re-calling Gemini.
+  const cached = await readCache(payload, input)
+  if (cached) {
+    return {
+      success: true,
+      data: cached.lesson,
+      metadata: {
+        model: `${cached.model} (cached)`,
+        processingTimeMs: Date.now() - startTime,
+        imageSizeBytes: 0,
+      },
+    }
+  }
 
   try {
     const apiKey = process.env.GEMINI_API_KEY
@@ -96,13 +118,18 @@ export async function generateInteractiveLesson(
     }
 
     const lesson = validateLesson(parsed, input.locale)
+    const processingTimeMs = Date.now() - startTime
+
+    // Write-through cache. Fire-and-forget — if this fails (e.g. DB
+    // unavailable), we still return the lesson we just generated.
+    void writeCache(payload, input, lesson, modelConfig.name, processingTimeMs)
 
     return {
       success: true,
       data: lesson,
       metadata: {
         model: modelConfig.name,
-        processingTimeMs: Date.now() - startTime,
+        processingTimeMs,
         imageSizeBytes: sizeBytes,
       },
     }
@@ -114,6 +141,73 @@ export async function generateInteractiveLesson(
       startTime,
       0,
     )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Read-through cache (interactive-lessons collection)
+// ---------------------------------------------------------------------------
+
+interface CachedEntry {
+  lesson: InteractiveLesson
+  model: string
+}
+
+async function readCache(
+  payload: Payload,
+  input: InteractiveLessonInput,
+): Promise<CachedEntry | null> {
+  try {
+    const result = await payload.find({
+      collection: 'interactive-lessons',
+      where: {
+        and: [
+          { user: { equals: input.userId } },
+          { media: { equals: input.mediaId } },
+          { locale: { equals: input.locale } },
+          { promptVersion: { equals: INTERACTIVE_LESSON_PROMPT_VERSION } },
+        ],
+      },
+      limit: 1,
+      sort: '-createdAt',
+      overrideAccess: true,
+    })
+    if (result.docs.length === 0) return null
+    const doc = result.docs[0]
+    return {
+      lesson: doc.lesson as unknown as InteractiveLesson,
+      model: (doc.model as string) ?? 'unknown',
+    }
+  } catch (err) {
+    // Never fail generation just because the cache lookup failed.
+    logger.warn({ err }, 'Interactive lesson cache read failed')
+    return null
+  }
+}
+
+async function writeCache(
+  payload: Payload,
+  input: InteractiveLessonInput,
+  lesson: InteractiveLesson,
+  model: string,
+  processingTimeMs: number,
+): Promise<void> {
+  try {
+    await payload.create({
+      collection: 'interactive-lessons',
+      data: {
+        user: String(input.userId),
+        media: String(input.mediaId),
+        locale: input.locale,
+        promptVersion: INTERACTIVE_LESSON_PROMPT_VERSION,
+        lesson: lesson as unknown as Record<string, unknown>,
+        model,
+        processingTimeMs,
+      },
+      overrideAccess: true,
+    })
+  } catch (err) {
+    logger.warn({ err }, 'Interactive lesson cache write failed')
   }
 }
 

--- a/src/infra/llm/services/interactive-lesson/interactive-lesson-types.ts
+++ b/src/infra/llm/services/interactive-lesson/interactive-lesson-types.ts
@@ -106,6 +106,10 @@ export interface InteractiveLessonInput {
   imageBuffer: Buffer
   mimeType: string
   locale: 'he' | 'en'
+  /** For the cache lookup: identifies who owns this lesson. */
+  userId: string | number
+  /** For the cache lookup: identifies which uploaded image. */
+  mediaId: string | number
 }
 
 /** Playback state shared between player and chat */

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -82,6 +82,7 @@ export interface Config {
     lessons: Lesson;
     'content-pages': ContentPage;
     'context-extractions': ContextExtraction;
+    'interactive-lessons': InteractiveLesson;
     exercises: Exercise;
     'extraction-logs': ExtractionLog;
     'formula-sheets': FormulaSheet;
@@ -126,6 +127,7 @@ export interface Config {
     lessons: LessonsSelect<false> | LessonsSelect<true>;
     'content-pages': ContentPagesSelect<false> | ContentPagesSelect<true>;
     'context-extractions': ContextExtractionsSelect<false> | ContextExtractionsSelect<true>;
+    'interactive-lessons': InteractiveLessonsSelect<false> | InteractiveLessonsSelect<true>;
     exercises: ExercisesSelect<false> | ExercisesSelect<true>;
     'extraction-logs': ExtractionLogsSelect<false> | ExtractionLogsSelect<true>;
     'formula-sheets': FormulaSheetsSelect<false> | FormulaSheetsSelect<true>;
@@ -1860,6 +1862,44 @@ export interface ContextExtraction {
   createdAt: string;
 }
 /**
+ * Cached Gemini responses for the Ask page interactive lesson player
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "interactive-lessons".
+ */
+export interface InteractiveLesson {
+  id: string;
+  user: string | User;
+  media: string | Media;
+  locale: 'he' | 'en';
+  /**
+   * Version tag for the prompt + schema used to generate this lesson. Bump when the prompt or response schema changes; old rows are ignored by cache lookups but kept for audit.
+   */
+  promptVersion: string;
+  /**
+   * Full InteractiveLesson payload as returned by the validator.
+   */
+  lesson:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  /**
+   * Model name used for generation (e.g. googleai/gemini-2.5-flash).
+   */
+  model?: string | null;
+  /**
+   * Time taken by the Gemini call, in milliseconds.
+   */
+  processingTimeMs?: number | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "extraction-logs".
  */
@@ -2757,6 +2797,10 @@ export interface PayloadLockedDocument {
         value: string | ContextExtraction;
       } | null)
     | ({
+        relationTo: 'interactive-lessons';
+        value: string | InteractiveLesson;
+      } | null)
+    | ({
         relationTo: 'exercises';
         value: string | Exercise;
       } | null)
@@ -3362,6 +3406,21 @@ export interface ContextExtractionsSelect<T extends boolean = true> {
   lesson?: T;
   sourceMedia?: T;
   text?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "interactive-lessons_select".
+ */
+export interface InteractiveLessonsSelect<T extends boolean = true> {
+  user?: T;
+  media?: T;
+  locale?: T;
+  promptVersion?: T;
+  lesson?: T;
+  model?: T;
+  processingTimeMs?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -14,6 +14,7 @@ import { ConfigSecrets } from '@/server/payload/collections/ConfigSecrets'
 import { ConfigValues } from '@/server/payload/collections/ConfigValues'
 import { ContentPages } from '@/server/payload/collections/ContentPages'
 import { ContextExtractions } from '@/server/payload/collections/ContextExtractions'
+import { InteractiveLessons } from '@/server/payload/collections/InteractiveLessons'
 import { Conversations } from '@/server/payload/collections/Conversations'
 import { Courses } from '@/server/payload/collections/Courses'
 import { ExerciseAssets } from '@/server/payload/collections/ExerciseAssets'
@@ -171,6 +172,7 @@ export default buildConfig({
     Lessons,
     ContentPages,
     ContextExtractions,
+    InteractiveLessons,
     Exercises,
     ExtractionLogs,
     FormulaSheets,

--- a/src/server/payload/collections/InteractiveLessons.ts
+++ b/src/server/payload/collections/InteractiveLessons.ts
@@ -1,0 +1,107 @@
+/**
+ * InteractiveLessons Collection
+ *
+ * Read-through cache for Gemini-generated interactive lesson payloads.
+ * Keyed by (user, media, locale) — if a user re-opens the same uploaded
+ * image, we serve the stored lesson instead of spending Gemini tokens
+ * (~$0.01 + 60-90s per generation) to reproduce it.
+ *
+ * Invalidation: `promptVersion` is stamped at save time. When the prompt
+ * or schema changes materially, bump the INTERACTIVE_LESSON_PROMPT_VERSION
+ * constant and lookups against older versions fall through to a fresh
+ * generation (the old row is left untouched for audit).
+ *
+ * Access:
+ * - Admin-only read/write via the UI (hidden from navigation).
+ * - The generation service uses `overrideAccess: true` server-side for
+ *   both lookup and write, since the flow is bound to the authenticated
+ *   caller via the required `user` + `media` relations.
+ */
+import type { CollectionConfig } from 'payload'
+
+export const InteractiveLessons: CollectionConfig = {
+  slug: 'interactive-lessons',
+  admin: {
+    hidden: true,
+    group: 'System',
+    description: 'Cached Gemini responses for the Ask page interactive lesson player',
+    useAsTitle: 'id',
+  },
+  access: {
+    read: ({ req }) => {
+      if (!req.user) return false
+      return req.user.collection === 'users' && req.user.role === 'admin'
+    },
+    create: ({ req }) => {
+      if (!req.user) return false
+      return req.user.collection === 'users' && req.user.role === 'admin'
+    },
+    update: ({ req }) => {
+      if (!req.user) return false
+      return req.user.collection === 'users' && req.user.role === 'admin'
+    },
+    delete: ({ req }) => {
+      if (!req.user) return false
+      return req.user.collection === 'users' && req.user.role === 'admin'
+    },
+  },
+  fields: [
+    {
+      name: 'user',
+      type: 'relationship',
+      relationTo: 'users',
+      required: true,
+      index: true,
+    },
+    {
+      name: 'media',
+      type: 'relationship',
+      relationTo: 'media',
+      required: true,
+      index: true,
+    },
+    {
+      name: 'locale',
+      type: 'select',
+      required: true,
+      options: [
+        { label: 'Hebrew', value: 'he' },
+        { label: 'English', value: 'en' },
+      ],
+      index: true,
+    },
+    {
+      name: 'promptVersion',
+      type: 'text',
+      required: true,
+      index: true,
+      admin: {
+        description:
+          'Version tag for the prompt + schema used to generate this lesson. Bump when the prompt or response schema changes; old rows are ignored by cache lookups but kept for audit.',
+      },
+    },
+    {
+      name: 'lesson',
+      type: 'json',
+      required: true,
+      admin: {
+        description: 'Full InteractiveLesson payload as returned by the validator.',
+      },
+    },
+    {
+      name: 'model',
+      type: 'text',
+      admin: {
+        description: 'Model name used for generation (e.g. googleai/gemini-2.5-flash).',
+      },
+    },
+    {
+      name: 'processingTimeMs',
+      type: 'number',
+      admin: {
+        description: 'Time taken by the Gemini call, in milliseconds.',
+      },
+    },
+  ],
+  timestamps: true,
+}

--- a/src/server/payload/endpoints/agent/generate-interactive-lesson.ts
+++ b/src/server/payload/endpoints/agent/generate-interactive-lesson.ts
@@ -35,7 +35,10 @@ export async function agentGenerateInteractiveLesson(
     // Fetch the uploaded media file
     const { imageBuffer, mimeType } = await fetchMediaImage(req, mediaId)
 
-    const result = await generateInteractiveLesson({ imageBuffer, mimeType, locale }, req.payload)
+    const result = await generateInteractiveLesson(
+      { imageBuffer, mimeType, locale, userId: req.user.id, mediaId },
+      req.payload,
+    )
 
     if (!result.success) {
       reqLogger.warn({ error: result.error, mediaId }, 'Generation failed')


### PR DESCRIPTION
Add InteractiveLessons collection as a read-through cache keyed by (user, media, locale, promptVersion). On generation: look up first, return cached if found, otherwise call Gemini and write-through save on success.

Re-opening the same uploaded image no longer re-spends Gemini tokens (~$0.01 + 60-90s). The Resume video button also survives page reloads now since lessons are persisted per (user, media).

Invalidation via INTERACTIVE_LESSON_PROMPT_VERSION constant — bump it when the prompt or schema changes materially; older rows are ignored by lookup but kept for audit. Both read and write are fire-and-forget — cache failures never break generation.