### PR TITLE
test: CI baseline diagnostic — empty branch off dev

### DIFF
--- a/CI-BASELINE-CHECK.md
+++ b/CI-BASELINE-CHECK.md
@@ -1,0 +1,8 @@
+# CI baseline check
+
+This branch adds nothing but this file. It exists to verify that dev's CI
+coverage failure reproduces on a fresh branch — i.e. that the failure is
+independent of any feature changes elsewhere.
+
+If this branch fails `Integration Tests` with the same `50/45` coverage error
+dev is hitting, the root cause is in dev itself and needs a dev-level fix.


### PR DESCRIPTION
Adds only a marker file. Purpose is to see whether Integration Tests

on a fresh branch off dev also fail — confirming (or ruling out) that

dev's coverage baseline is the blocker rather than anything on the

v1-272 feature branch.