### PR TITLE
fix(ci): Lower coverage thresholds to match current baseline

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -46,9 +46,19 @@ export default defineConfig({
         'src/lib/ai/prompts/**',
         'src/lib/ai/services/**',
       ],
+      /**
+       * Thresholds are set just below the current integration-test coverage
+       * baseline so the gate catches regressions without blocking every PR.
+       *
+       * Current baseline (as measured by CI on dev): 30.27% statements,
+       * 23.9% branches, 31.54% functions. The previous aspirational targets
+       * (50/45) were above reality and turned CI red for every branch. Raise
+       * these numbers incrementally as real coverage grows — treat each bump
+       * as a ratchet, not a leap.
+       */
       thresholds: {
-        statements: 50,
-        branches: 45,
+        statements: 28,
+        branches: 22,
         functions: 30,
         autoUpdate: false,
       },

--- a/vitest.config.unit.mts
+++ b/vitest.config.unit.mts
@@ -49,10 +49,23 @@ export default defineConfig({
         'src/lib/ai/prompts/**',
         'src/lib/ai/services/**',
       ],
+      /**
+       * Thresholds are set just below the current unit-test coverage baseline
+       * so the gate catches regressions without blocking every PR.
+       *
+       * Current baseline (measured locally): ~23.8% statements, ~20.2% branches,
+       * ~27.2% functions. The previous aspirational targets (50/45) were above
+       * reality. Raise these numbers incrementally as real coverage grows.
+       *
+       * Note: CI currently runs `pnpm test:unit -- --coverage`, which vitest
+       * parses as a file filter after `--`, so unit coverage is NOT actually
+       * enforced on CI today. These thresholds still apply to local
+       * `pnpm test:unit:coverage` runs.
+       */
       thresholds: {
-        statements: 50,
-        branches: 45,
-        functions: 30,
+        statements: 22,
+        branches: 18,
+        functions: 25,
         autoUpdate: false,
       },
     },


### PR DESCRIPTION
Commit 4e59b010 raised coverage thresholds to 50/45 on both vitest configs

as a 'merge gate', but current coverage on dev is statements 30.27% /

branches 23.9% / functions 31.54% for the int suite and roughly 23/20/27

for unit. That gap turned every PR (and dev itself) red for 2+ days since

there was no way to close ~20 percentage points in a single PR.

Setting thresholds to current-baseline + small buffer so the gate still

catches regressions without blocking normal work:

  - int:  statements 28, branches 22, functions 30

  - unit: statements 22, branches 18, functions 25

Both configs include a comment documenting the rollback and the intent

to ratchet these numbers up as real coverage improves.