### PR TITLE
ci(kody): export project secrets before pnpm install

### DIFF
--- a/.github/workflows/kody.yml
+++ b/.github/workflows/kody.yml
@@ -197,6 +197,23 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      # Must run before `pnpm install` so the postinstall hook (payload generate:types)
+      # sees DATABASE_URL and other required env vars from repo secrets.
+      - name: Export project secrets
+        env:
+          ALL_SECRETS: ${{ toJSON(secrets) }}
+        run: |
+          # Override MCP_ENABLED from secrets — Payload requires DEFAULT_TENANT_SLUG when MCP is on
+          echo "MCP_ENABLED=false" >> $GITHUB_ENV
+          echo "$ALL_SECRETS" | jq -r 'to_entries[] | select(.key | test("^(GITHUB_TOKEN|MODEL|PROVIDER)$") | not) | @json' | while IFS= read -r entry; do
+            KEY=$(echo "$entry" | jq -r '.key')
+            VALUE=$(echo "$entry" | jq -r '.value')
+            DELIM="KODY_EOF_${KEY}"
+            echo "${KEY}<<${DELIM}" >> $GITHUB_ENV
+            echo "${VALUE}" >> $GITHUB_ENV
+            echo "${DELIM}" >> $GITHUB_ENV
+          done
+
       - run: pnpm install --frozen-lockfile
 
       - name: Install Kody Engine
@@ -224,21 +241,6 @@ jobs:
         run: |
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-
-      - name: Export project secrets
-        env:
-          ALL_SECRETS: ${{ toJSON(secrets) }}
-        run: |
-          # Override MCP_ENABLED from secrets — Payload requires DEFAULT_TENANT_SLUG when MCP is on
-          echo "MCP_ENABLED=false" >> $GITHUB_ENV
-          echo "$ALL_SECRETS" | jq -r 'to_entries[] | select(.key | test("^(GITHUB_TOKEN|MODEL|PROVIDER)$") | not) | @json' | while IFS= read -r entry; do
-            KEY=$(echo "$entry" | jq -r '.key')
-            VALUE=$(echo "$entry" | jq -r '.value')
-            DELIM="KODY_EOF_${KEY}"
-            echo "${KEY}<<${DELIM}" >> $GITHUB_ENV
-            echo "${VALUE}" >> $GITHUB_ENV
-            echo "${DELIM}" >> $GITHUB_ENV
-          done
 
       - name: Warm up Next.js build cache
         run: NODE_OPTIONS='--max-old-space-size=6144' npx next build


### PR DESCRIPTION
## Problem

Every `@kody` command (run, rerun, fix, review, ...) fails during setup:

```
Error: DATABASE_URL environment variable is required but not set.
```

The repo's `postinstall` hook runs `payload generate:types`, which reads env vars from `payload.config.ts`. The kody workflow exports repo secrets **after** `pnpm install`, so the postinstall sees an empty env and crashes.

Observed in [kody review run 24837137403](https://github.com/A-Guy-educ/A-Guy/actions/runs/24837137403) on PR #1323.

## Fix

Move the "Export project secrets" step directly after `setup-node` and **before** `pnpm install --frozen-lockfile`, so postinstall hooks see `DATABASE_URL` and any other repo secrets.

Change is a pure reorder — no logic modification. All other kody modes benefit.

## Test plan

- [ ] `@kody review` on an open PR completes and posts a review comment
- [ ] `@kody` on an issue still runs the full pipeline