### PR TITLE
#1101: Bug: Open redirect on login form via unsanitized returnTo parame…

### DIFF
--- a/src/app/(frontend)/login/LoginForm.tsx
+++ b/src/app/(frontend)/login/LoginForm.tsx
@@ -13,6 +13,7 @@ import { Label } from '@/ui/web/components/label'
 import { SystemLink } from '@/infra/loading/components/SystemLink'
 import { usePasswordLogin } from '@/ui/web/providers/PasswordLoginProvider'
 import { useTranslations } from '@/ui/web/providers/I18n'
+import { sanitizeReturnTo } from '@/infra/auth/oauth_sanitize'
 import { loginAction } from './login_authenticate-action'
 import telescopeSvg from '@/ui/web/TelescopeLogo/telescope.svg'
 
@@ -21,7 +22,7 @@ function LoginFormContent() {
   const tOauth = useTranslations('auth.oauth')
   const passwordEnabled = usePasswordLogin()
   const searchParams = useSearchParams()
-  const returnTo = searchParams?.get('returnTo') || '/'
+  const returnTo = sanitizeReturnTo(searchParams?.get('returnTo'))
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
 

--- a/tests/unit/infra/auth/oauth_sanitize.spec.ts
+++ b/tests/unit/infra/auth/oauth_sanitize.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeReturnTo } from '@/infra/auth/oauth_sanitize'
+
+describe('sanitizeReturnTo', () => {
+  it('returns / for undefined input', () => {
+    expect(sanitizeReturnTo(undefined)).toBe('/')
+  })
+
+  it('returns / for null input', () => {
+    expect(sanitizeReturnTo(null)).toBe('/')
+  })
+
+  it('returns / for empty string', () => {
+    expect(sanitizeReturnTo('')).toBe('/')
+  })
+
+  it('returns / for absolute HTTPS URL', () => {
+    expect(sanitizeReturnTo('https://evil.com/steal-cookies')).toBe('/')
+  })
+
+  it('returns / for absolute HTTP URL', () => {
+    expect(sanitizeReturnTo('http://evil.com/steal-cookies')).toBe('/')
+  })
+
+  it('returns / for data: URL', () => {
+    expect(sanitizeReturnTo('data:text/html,<script>alert(1)</script>')).toBe('/')
+  })
+
+  it('returns / for javascript: URL', () => {
+    expect(sanitizeReturnTo('javascript:alert(1)')).toBe('/')
+  })
+
+  it('returns / for mailto: URL', () => {
+    expect(sanitizeReturnTo('mailto:attacker@evil.com')).toBe('/')
+  })
+
+  it('returns / for double-slash URL', () => {
+    expect(sanitizeReturnTo('//evil.com')).toBe('/')
+  })
+
+  it('returns / for relative path without leading slash', () => {
+    expect(sanitizeReturnTo('dashboard')).toBe('/')
+  })
+
+  it('returns the path for a valid path starting with /', () => {
+    expect(sanitizeReturnTo('/courses')).toBe('/courses')
+  })
+
+  it('returns / for root path', () => {
+    expect(sanitizeReturnTo('/')).toBe('/')
+  })
+
+  it('trims whitespace from valid paths', () => {
+    expect(sanitizeReturnTo('  /courses  ')).toBe('/courses')
+  })
+
+  it('trims whitespace from dangerous URLs', () => {
+    expect(sanitizeReturnTo('  https://evil.com  ')).toBe('/')
+  })
+
+  it('allows nested paths', () => {
+    expect(sanitizeReturnTo('/courses/intro-to-cs/unit-1')).toBe('/courses/intro-to-cs/unit-1')
+  })
+
+  it('allows paths with query strings', () => {
+    expect(sanitizeReturnTo('/courses?ref=header')).toBe('/courses?ref=header')
+  })
+
+  it('allows paths with hash fragments', () => {
+    expect(sanitizeReturnTo('/courses#section')).toBe('/courses#section')
+  })
+
+  it('allows paths with both query strings and hash fragments', () => {
+    expect(sanitizeReturnTo('/courses?ref=header#section')).toBe('/courses?ref=header#section')
+  })
+})


### PR DESCRIPTION
## Summary

- **Modified `src/app/(frontend)/login/LoginForm.tsx`**: Added `sanitizeReturnTo` import and applied it to the `returnTo` query param (line 25), replacing the unsanitized fallback. This closes the open redirect where `/login?returnTo=https://evil.com/` would redirect authenticated users to an attacker-controlled domain after email/password login.
- **Created `tests/unit/infra/auth/oauth_sanitize.spec.ts`**: Added 18 unit tests covering all current `sanitizeReturnTo` cases — undefined/null/empty inputs, absolute URLs (http/https), dangerous protocols (data:, javascript:, mailto:), double-slash prefixes, relative paths with/without leading slash, and whitespace trimming.

## Changes

- `src/app/(frontend)/login/LoginForm.tsx`
- `tests/unit/infra/auth/oauth_sanitize.spec.ts`

Closes #1101

---
_Opened by kody (single-session autonomous run)._ 