### PR TITLE
#1090: Intermittent image upload failure with ambiguous error messaging…

### DIFF
--- a/src/app/api/chat-assets/finalize/route.ts
+++ b/src/app/api/chat-assets/finalize/route.ts
@@ -18,26 +18,63 @@ import { head } from '@vercel/blob'
 import { isVercelBlobUrl } from '@/infra/blob/vercel-blob-adapter'
 import sharp from 'sharp'
 
+type DimensionResult =
+  | { width: number; height: number }
+  | { error: 'corrupted' }
+  | { error: 'invalid_format' }
+  | { error: 'network' }
+
 /**
  * Get image dimensions from a URL using sharp
- * Returns null if the file is not an image or cannot be read
+ * Returns dimension info, or a specific error type if the image cannot be read
  */
-async function getImageDimensionsFromUrl(
-  url: string,
-): Promise<{ width: number; height: number } | null> {
+async function getImageDimensionsFromUrl(url: string): Promise<DimensionResult> {
   try {
     const response = await fetch(url)
     if (!response.ok) {
-      return null
+      return { error: 'network' }
     }
+
     const buffer = await response.arrayBuffer()
+    const uint8Array = new Uint8Array(buffer)
+
+    // Validate minimum buffer size for any image format
+    if (uint8Array.length < 12) {
+      return { error: 'invalid_format' }
+    }
+
+    // Check for valid image magic bytes (JPEG, PNG, WebP, GIF)
+    const isJPEG = uint8Array[0] === 0xff && uint8Array[1] === 0xd8 && uint8Array[2] === 0xff
+    const isPNG =
+      uint8Array[0] === 0x89 &&
+      uint8Array[1] === 0x50 &&
+      uint8Array[2] === 0x4e &&
+      uint8Array[3] === 0x47
+    const isWebP =
+      uint8Array[0] === 0x52 &&
+      uint8Array[1] === 0x49 &&
+      uint8Array[2] === 0x46 &&
+      uint8Array[3] === 0x46 &&
+      uint8Array[8] === 0x57 &&
+      uint8Array[9] === 0x45 &&
+      uint8Array[10] === 0x42 &&
+      uint8Array[11] === 0x50
+    const isGIF = uint8Array[0] === 0x47 && uint8Array[1] === 0x49 && uint8Array[2] === 0x46
+
+    if (!isJPEG && !isPNG && !isWebP && !isGIF) {
+      return { error: 'invalid_format' }
+    }
+
+    // Try to read metadata with sharp - this will fail for corrupted images
     const metadata = await sharp(Buffer.from(buffer)).metadata()
     if (!metadata.width || !metadata.height) {
-      return null
+      return { error: 'corrupted' }
     }
+
     return { width: metadata.width, height: metadata.height }
   } catch {
-    return null
+    // Any exception from sharp indicates a corrupted/unreadable image
+    return { error: 'corrupted' }
   }
 }
 
@@ -226,22 +263,44 @@ export async function POST(request: Request): Promise<Response> {
 
     // Server-side image dimension validation for image types
     if (blobContentType?.startsWith('image/')) {
-      const dimensions = await getImageDimensionsFromUrl(resolvedBlobUrl)
-      if (dimensions) {
+      const dimensionResult = await getImageDimensionsFromUrl(resolvedBlobUrl)
+
+      // Handle specific error cases
+      if ('error' in dimensionResult) {
+        if (dimensionResult.error === 'corrupted') {
+          return Response.json(
+            {
+              error:
+                'This image could not be processed. It may be corrupted or in an unsupported format. Please try uploading a different image or resave it in a different format.',
+            },
+            { status: 422 },
+          )
+        }
+        if (dimensionResult.error === 'invalid_format') {
+          return Response.json(
+            {
+              error:
+                'Image format is not supported. Please upload a JPEG, PNG, WebP, or GIF image.',
+            },
+            { status: 415 },
+          )
+        }
+        // For network errors, allow the upload to proceed (blob exists, client validated)
+      } else {
+        // dimensionResult is { width, height }
+        const dimensions = dimensionResult as { width: number; height: number }
         if (
           dimensions.width < CHAT_ASSET_MIN_IMAGE_WIDTH ||
           dimensions.height < CHAT_ASSET_MIN_IMAGE_HEIGHT
         ) {
           return Response.json(
             {
-              error: `Image is too small. Minimum size is ${CHAT_ASSET_MIN_IMAGE_WIDTH}x${CHAT_ASSET_MIN_IMAGE_HEIGHT} pixels, but this image is ${dimensions.width}x${dimensions.height} pixels.`,
+              error: `Image is too small. Minimum size is ${CHAT_ASSET_MIN_IMAGE_WIDTH}x${CHAT_ASSET_MIN_IMAGE_HEIGHT} pixels, but this image is ${dimensions.width}x${dimensions.height} pixels. Please upload a clearer photo.`,
             },
             { status: 422 },
           )
         }
       }
-      // If dimensions cannot be determined, allow the upload to proceed
-      // (the client-side validation should have caught invalid images)
     }
 
     const expiresAt = new Date(Date.now() + CHAT_ASSET_RETENTION_DAYS * 24 * 60 * 60 * 1000)

--- a/src/app/api/chat-assets/finalize/route.ts
+++ b/src/app/api/chat-assets/finalize/route.ts
@@ -270,7 +270,8 @@ export async function POST(request: Request): Promise<Response> {
         if (dimensionResult.error === 'corrupted') {
           return Response.json(
             {
-              error: 'IMAGE_CORRUPTED',
+              error:
+                'This image could not be processed. It may be corrupted or in an unsupported format. Please try uploading a different image or resave it in a different format.',
               code: 'chatImageCorrupted',
             },
             { status: 422 },
@@ -279,7 +280,8 @@ export async function POST(request: Request): Promise<Response> {
         if (dimensionResult.error === 'invalid_format') {
           return Response.json(
             {
-              error: 'IMAGE_INVALID_FORMAT',
+              error:
+                'Image format is not supported. Please upload a JPEG, PNG, WebP, or GIF image.',
               code: 'chatImageInvalidFormat',
             },
             { status: 415 },

--- a/src/app/api/chat-assets/finalize/route.ts
+++ b/src/app/api/chat-assets/finalize/route.ts
@@ -28,7 +28,7 @@ type DimensionResult =
  * Get image dimensions from a URL using sharp
  * Returns dimension info, or a specific error type if the image cannot be read
  */
-async function getImageDimensionsFromUrl(url: string): Promise<DimensionResult> {
+export async function getImageDimensionsFromUrl(url: string): Promise<DimensionResult> {
   try {
     const response = await fetch(url)
     if (!response.ok) {
@@ -270,8 +270,8 @@ export async function POST(request: Request): Promise<Response> {
         if (dimensionResult.error === 'corrupted') {
           return Response.json(
             {
-              error:
-                'This image could not be processed. It may be corrupted or in an unsupported format. Please try uploading a different image or resave it in a different format.',
+              error: 'IMAGE_CORRUPTED',
+              code: 'chatImageCorrupted',
             },
             { status: 422 },
           )
@@ -279,13 +279,16 @@ export async function POST(request: Request): Promise<Response> {
         if (dimensionResult.error === 'invalid_format') {
           return Response.json(
             {
-              error:
-                'Image format is not supported. Please upload a JPEG, PNG, WebP, or GIF image.',
+              error: 'IMAGE_INVALID_FORMAT',
+              code: 'chatImageInvalidFormat',
             },
             { status: 415 },
           )
         }
         // For network errors, allow the upload to proceed (blob exists, client validated)
+        console.warn(
+          `[chat-assets/finalize] Image metadata fetch failed for ${resolvedBlobUrl}, proceeding with upload`,
+        )
       } else {
         // dimensionResult is { width, height }
         const dimensions = dimensionResult as { width: number; height: number }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -295,6 +295,8 @@
     "chatFileTooLarge": "File too large (max 10MB)",
     "chatMaxFiles": "Maximum 5 files allowed",
     "chatUploadFailed": "Failed to upload file",
+    "chatImageCorrupted": "This image could not be processed. It may be corrupted or in an unsupported format. Please try uploading a different image or resave it in a different format.",
+    "chatImageInvalidFormat": "Image format is not supported. Please upload a JPEG, PNG, WebP, or GIF image.",
     "chatQuotaCounter": "{used}/{max} questions used",
     "chatQuotaResetIn": "Resets in {time}",
     "chatQuotaExhausted": "You've reached your question limit. Try again in {time}",

--- a/src/i18n/he.json
+++ b/src/i18n/he.json
@@ -295,6 +295,8 @@
     "chatFileTooLarge": "הקובץ גדול מדי (מקסימום 10MB)",
     "chatMaxFiles": "מותר עד 5 קבצים",
     "chatUploadFailed": "העלאת הקובץ נכשלה",
+    "chatImageCorrupted": "לא ניתן לעבד את התמונה. ייתכן שהיא פגומה או בפורמט שאינו נתמך. נסה להעלות תמונה אחרת או לשמור אותה בפורמט אחר.",
+    "chatImageInvalidFormat": "פורמט התמונה אינו נתמך. נא להעלות תמונה בפורמט JPEG, PNG, WebP או GIF.",
     "chatQuotaCounter": "{used}/{max} שאלות נוצלו",
     "chatQuotaResetIn": "מתאפס בעוד {time}",
     "chatQuotaExhausted": "הגעת למגבלת השאלות שלך. נסה שוב בעוד {time}",

--- a/tests/unit/api/chat-asset-finalize.spec.ts
+++ b/tests/unit/api/chat-asset-finalize.spec.ts
@@ -4,59 +4,14 @@
  */
 
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { getImageDimensionsFromUrl } from '@/app/api/chat-assets/finalize/route'
 
-// Create a test version of the function that mirrors the route's implementation
-type DimensionResult =
-  | { width: number; height: number }
-  | { error: 'corrupted' }
-  | { error: 'invalid_format' }
-  | { error: 'network' }
-
-async function getImageDimensionsFromUrl(url: string): Promise<DimensionResult> {
-  try {
-    const response = await fetch(url)
-    if (!response.ok) {
-      return { error: 'network' }
-    }
-
-    const buffer = await response.arrayBuffer()
-    const uint8Array = new Uint8Array(buffer)
-
-    // Validate minimum buffer size for any image format
-    if (uint8Array.length < 12) {
-      return { error: 'invalid_format' }
-    }
-
-    // Check for valid image magic bytes (JPEG, PNG, WebP, GIF)
-    const isJPEG = uint8Array[0] === 0xff && uint8Array[1] === 0xd8 && uint8Array[2] === 0xff
-    const isPNG =
-      uint8Array[0] === 0x89 &&
-      uint8Array[1] === 0x50 &&
-      uint8Array[2] === 0x4e &&
-      uint8Array[3] === 0x47
-    const isWebP =
-      uint8Array[0] === 0x52 &&
-      uint8Array[1] === 0x49 &&
-      uint8Array[2] === 0x46 &&
-      uint8Array[3] === 0x46 &&
-      uint8Array[8] === 0x57 &&
-      uint8Array[9] === 0x45 &&
-      uint8Array[10] === 0x42 &&
-      uint8Array[11] === 0x50
-    const isGIF = uint8Array[0] === 0x47 && uint8Array[1] === 0x49 && uint8Array[2] === 0x46
-
-    if (!isJPEG && !isPNG && !isWebP && !isGIF) {
-      return { error: 'invalid_format' }
-    }
-
-    // For testing purposes, we'll use a mock implementation
-    // In the real route, sharp is used to read metadata
-    throw new Error('sharp-mock-error')
-  } catch {
-    // Any exception from sharp indicates a corrupted/unreadable image
-    return { error: 'corrupted' }
-  }
-}
+// Mock sharp module
+vi.mock('sharp', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    metadata: vi.fn(),
+  })),
+}))
 
 describe('getImageDimensionsFromUrl', () => {
   // Valid JPEG magic bytes
@@ -84,14 +39,12 @@ describe('getImageDimensionsFromUrl', () => {
     0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
   ])
 
-  // Invalid: too short
-  const tooShort = new Uint8Array([0xff, 0xd8, 0xff])
-
   // Mock fetch globally
   const mockFetch = vi.fn()
 
   beforeEach(() => {
     vi.stubGlobal('fetch', mockFetch)
+    vi.clearAllMocks()
   })
 
   afterEach(() => {
@@ -148,48 +101,108 @@ describe('getImageDimensionsFromUrl', () => {
 
   describe('returns { error: "corrupted" }', () => {
     it('when sharp throws an exception on valid JPEG header', async () => {
-      // Valid JPEG header but sharp will fail (mock throws)
+      // Valid JPEG header but sharp will fail (metadata throws)
       mockFetch.mockResolvedValueOnce({
         ok: true,
         arrayBuffer: vi.fn().mockResolvedValue(validJPEG),
       })
+
+      const sharp = await import('sharp')
+      const mockSharp = sharp.default as unknown as ReturnType<typeof vi.fn>
+      mockSharp.mockImplementationOnce(() => ({
+        metadata: vi.fn().mockRejectedValueOnce(new Error('Sharp error')),
+      }))
 
       const result = await getImageDimensionsFromUrl('https://example.com/corrupt.jpg')
 
       expect(result).toEqual({ error: 'corrupted' })
     })
 
-    it('when sharp throws an exception on valid PNG header', async () => {
+    it('when sharp returns missing dimensions', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: vi.fn().mockResolvedValue(validJPEG),
+      })
+
+      const sharp = await import('sharp')
+      const mockSharp = sharp.default as unknown as ReturnType<typeof vi.fn>
+      mockSharp.mockImplementationOnce(() => ({
+        metadata: vi.fn().mockResolvedValue({ width: undefined, height: undefined }),
+      }))
+
+      const result = await getImageDimensionsFromUrl('https://example.com/nodims.jpg')
+
+      expect(result).toEqual({ error: 'corrupted' })
+    })
+  })
+
+  describe('returns dimensions for valid images', () => {
+    it('returns dimensions for valid JPEG', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: vi.fn().mockResolvedValue(validJPEG),
+      })
+
+      const sharp = await import('sharp')
+      const mockSharp = sharp.default as unknown as ReturnType<typeof vi.fn>
+      mockSharp.mockImplementationOnce(() => ({
+        metadata: vi.fn().mockResolvedValue({ width: 800, height: 600 }),
+      }))
+
+      const result = await getImageDimensionsFromUrl('https://example.com/valid.jpg')
+
+      expect(result).toEqual({ width: 800, height: 600 })
+    })
+
+    it('returns dimensions for valid PNG', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         arrayBuffer: vi.fn().mockResolvedValue(validPNG),
       })
 
-      const result = await getImageDimensionsFromUrl('https://example.com/corrupt.png')
+      const sharp = await import('sharp')
+      const mockSharp = sharp.default as unknown as ReturnType<typeof vi.fn>
+      mockSharp.mockImplementationOnce(() => ({
+        metadata: vi.fn().mockResolvedValue({ width: 1024, height: 768 }),
+      }))
 
-      expect(result).toEqual({ error: 'corrupted' })
+      const result = await getImageDimensionsFromUrl('https://example.com/valid.png')
+
+      expect(result).toEqual({ width: 1024, height: 768 })
     })
 
-    it('when sharp throws an exception on valid WebP header', async () => {
+    it('returns dimensions for valid WebP', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         arrayBuffer: vi.fn().mockResolvedValue(validWebP),
       })
 
-      const result = await getImageDimensionsFromUrl('https://example.com/corrupt.webp')
+      const sharp = await import('sharp')
+      const mockSharp = sharp.default as unknown as ReturnType<typeof vi.fn>
+      mockSharp.mockImplementationOnce(() => ({
+        metadata: vi.fn().mockResolvedValue({ width: 1920, height: 1080 }),
+      }))
 
-      expect(result).toEqual({ error: 'corrupted' })
+      const result = await getImageDimensionsFromUrl('https://example.com/valid.webp')
+
+      expect(result).toEqual({ width: 1920, height: 1080 })
     })
 
-    it('when sharp throws an exception on valid GIF header', async () => {
+    it('returns dimensions for valid GIF', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         arrayBuffer: vi.fn().mockResolvedValue(validGIF),
       })
 
-      const result = await getImageDimensionsFromUrl('https://example.com/corrupt.gif')
+      const sharp = await import('sharp')
+      const mockSharp = sharp.default as unknown as ReturnType<typeof vi.fn>
+      mockSharp.mockImplementationOnce(() => ({
+        metadata: vi.fn().mockResolvedValue({ width: 640, height: 480 }),
+      }))
 
-      expect(result).toEqual({ error: 'corrupted' })
+      const result = await getImageDimensionsFromUrl('https://example.com/valid.gif')
+
+      expect(result).toEqual({ width: 640, height: 480 })
     })
   })
 
@@ -200,103 +213,34 @@ describe('getImageDimensionsFromUrl', () => {
       { name: 'WebP', bytes: validWebP, expected: true },
       { name: 'GIF', bytes: validGIF, expected: true },
       { name: 'invalid', bytes: invalidBytes, expected: false },
-    ])('correctly identifies $name format', ({ bytes, expected }) => {
-      // Just test the magic byte detection logic
-      const isJPEG = bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff
-      const isPNG = bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47
-      const isWebP =
-        bytes[0] === 0x52 &&
-        bytes[1] === 0x49 &&
-        bytes[2] === 0x46 &&
-        bytes[3] === 0x46 &&
-        bytes[8] === 0x57 &&
-        bytes[9] === 0x45 &&
-        bytes[10] === 0x42 &&
-        bytes[11] === 0x50
-      const isGIF = bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46
+    ])(
+      'correctly identifies $name format',
+      async ({ bytes, expected }) => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          arrayBuffer: vi.fn().mockResolvedValue(bytes),
+        })
 
-      const isValidImage = isJPEG || isPNG || isWebP || isGIF
+        // Mock sharp to return dimensions for valid formats
+        const sharp = await import('sharp')
+        const mockSharp = sharp.default as unknown as ReturnType<typeof vi.fn>
+        if (expected) {
+          mockSharp.mockImplementationOnce(() => ({
+            metadata: vi.fn().mockResolvedValue({ width: 100, height: 100 }),
+          }))
+        } else {
+          // Invalid formats will fail at magic byte check
+        }
 
-      expect(isValidImage).toBe(expected)
-    })
-  })
-})
+        const result = await getImageDimensionsFromUrl(`https://example.com/test.${expected ? 'jpg' : 'txt'}`)
 
-describe('Error response handling', () => {
-  it('should return 422 for corrupted images', async () => {
-    // Simulate the route's error handling logic
-    const dimensionResult = { error: 'corrupted' as const }
-
-    let response: Response
-    if ('error' in dimensionResult) {
-      if (dimensionResult.error === 'corrupted') {
-        response = Response.json(
-          {
-            error:
-              'This image could not be processed. It may be corrupted or in an unsupported format. Please try uploading a different image or resave it in a different format.',
-          },
-          { status: 422 },
-        )
-      } else {
-        response = Response.json({ error: 'Unknown error' }, { status: 500 })
-      }
-    } else {
-      response = Response.json({ success: true })
-    }
-
-    expect(response.status).toBe(422)
-    const body = await response.json()
-    expect(body.error).toContain('could not be processed')
-  })
-
-  it('should return 415 for invalid format', async () => {
-    const dimensionResult = { error: 'invalid_format' as const }
-
-    let response: Response
-    if ('error' in dimensionResult) {
-      if (dimensionResult.error === 'invalid_format') {
-        response = Response.json(
-          {
-            error: 'Image format is not supported. Please upload a JPEG, PNG, WebP, or GIF image.',
-          },
-          { status: 415 },
-        )
-      } else {
-        response = Response.json({ error: 'Unknown error' }, { status: 500 })
-      }
-    } else {
-      response = Response.json({ success: true })
-    }
-
-    expect(response.status).toBe(415)
-    const body = await response.json()
-    expect(body.error).toContain('not supported')
-  })
-
-  it('should return 422 for too small images', async () => {
-    const CHAT_ASSET_MIN_IMAGE_WIDTH = 100
-    const CHAT_ASSET_MIN_IMAGE_HEIGHT = 100
-    const dimensionResult = { width: 50, height: 50 }
-
-    let response: Response
-    if (
-      dimensionResult.width < CHAT_ASSET_MIN_IMAGE_WIDTH ||
-      dimensionResult.height < CHAT_ASSET_MIN_IMAGE_HEIGHT
-    ) {
-      response = Response.json(
-        {
-          error: `Image is too small. Minimum size is ${CHAT_ASSET_MIN_IMAGE_WIDTH}x${CHAT_ASSET_MIN_IMAGE_HEIGHT} pixels, but this image is ${dimensionResult.width}x${dimensionResult.height} pixels. Please upload a clearer photo.`,
-        },
-        { status: 422 },
-      )
-    } else {
-      response = Response.json({ success: true })
-    }
-
-    expect(response.status).toBe(422)
-    const body = await response.json()
-    expect(body.error).toContain('too small')
-    expect(body.error).toContain('50x50')
-    expect(body.error).toContain('100x100')
+        if (expected) {
+          expect(result).toHaveProperty('width')
+          expect(result).toHaveProperty('height')
+        } else {
+          expect(result).toEqual({ error: 'invalid_format' })
+        }
+      },
+    )
   })
 })

--- a/tests/unit/api/chat-asset-finalize.spec.ts
+++ b/tests/unit/api/chat-asset-finalize.spec.ts
@@ -213,34 +213,33 @@ describe('getImageDimensionsFromUrl', () => {
       { name: 'WebP', bytes: validWebP, expected: true },
       { name: 'GIF', bytes: validGIF, expected: true },
       { name: 'invalid', bytes: invalidBytes, expected: false },
-    ])(
-      'correctly identifies $name format',
-      async ({ bytes, expected }) => {
-        mockFetch.mockResolvedValueOnce({
-          ok: true,
-          arrayBuffer: vi.fn().mockResolvedValue(bytes),
-        })
+    ])('correctly identifies $name format', async ({ bytes, expected }) => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: vi.fn().mockResolvedValue(bytes),
+      })
 
-        // Mock sharp to return dimensions for valid formats
-        const sharp = await import('sharp')
-        const mockSharp = sharp.default as unknown as ReturnType<typeof vi.fn>
-        if (expected) {
-          mockSharp.mockImplementationOnce(() => ({
-            metadata: vi.fn().mockResolvedValue({ width: 100, height: 100 }),
-          }))
-        } else {
-          // Invalid formats will fail at magic byte check
-        }
+      // Mock sharp to return dimensions for valid formats
+      const sharp = await import('sharp')
+      const mockSharp = sharp.default as unknown as ReturnType<typeof vi.fn>
+      if (expected) {
+        mockSharp.mockImplementationOnce(() => ({
+          metadata: vi.fn().mockResolvedValue({ width: 100, height: 100 }),
+        }))
+      } else {
+        // Invalid formats will fail at magic byte check
+      }
 
-        const result = await getImageDimensionsFromUrl(`https://example.com/test.${expected ? 'jpg' : 'txt'}`)
+      const result = await getImageDimensionsFromUrl(
+        `https://example.com/test.${expected ? 'jpg' : 'txt'}`,
+      )
 
-        if (expected) {
-          expect(result).toHaveProperty('width')
-          expect(result).toHaveProperty('height')
-        } else {
-          expect(result).toEqual({ error: 'invalid_format' })
-        }
-      },
-    )
+      if (expected) {
+        expect(result).toHaveProperty('width')
+        expect(result).toHaveProperty('height')
+      } else {
+        expect(result).toEqual({ error: 'invalid_format' })
+      }
+    })
   })
 })

--- a/tests/unit/api/chat-asset-finalize.spec.ts
+++ b/tests/unit/api/chat-asset-finalize.spec.ts
@@ -64,7 +64,7 @@ describe('getImageDimensionsFromUrl', () => {
       expect(result).toEqual({ error: 'network' })
     })
 
-    it('when fetch throws network error - returns corrupted (catch-all for fetch errors)', async () => {
+    it('when fetch promise rejects - returns corrupted (catch-all for promise rejections)', async () => {
       mockFetch.mockRejectedValueOnce(new Error('Network error'))
 
       const result = await getImageDimensionsFromUrl('https://example.com/image.jpg')

--- a/tests/unit/api/chat-asset-finalize.spec.ts
+++ b/tests/unit/api/chat-asset-finalize.spec.ts
@@ -1,0 +1,302 @@
+/**
+ * Unit tests for Chat Asset Finalize Route
+ * Tests the getImageDimensionsFromUrl function and error handling
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+// Create a test version of the function that mirrors the route's implementation
+type DimensionResult =
+  | { width: number; height: number }
+  | { error: 'corrupted' }
+  | { error: 'invalid_format' }
+  | { error: 'network' }
+
+async function getImageDimensionsFromUrl(url: string): Promise<DimensionResult> {
+  try {
+    const response = await fetch(url)
+    if (!response.ok) {
+      return { error: 'network' }
+    }
+
+    const buffer = await response.arrayBuffer()
+    const uint8Array = new Uint8Array(buffer)
+
+    // Validate minimum buffer size for any image format
+    if (uint8Array.length < 12) {
+      return { error: 'invalid_format' }
+    }
+
+    // Check for valid image magic bytes (JPEG, PNG, WebP, GIF)
+    const isJPEG = uint8Array[0] === 0xff && uint8Array[1] === 0xd8 && uint8Array[2] === 0xff
+    const isPNG =
+      uint8Array[0] === 0x89 &&
+      uint8Array[1] === 0x50 &&
+      uint8Array[2] === 0x4e &&
+      uint8Array[3] === 0x47
+    const isWebP =
+      uint8Array[0] === 0x52 &&
+      uint8Array[1] === 0x49 &&
+      uint8Array[2] === 0x46 &&
+      uint8Array[3] === 0x46 &&
+      uint8Array[8] === 0x57 &&
+      uint8Array[9] === 0x45 &&
+      uint8Array[10] === 0x42 &&
+      uint8Array[11] === 0x50
+    const isGIF = uint8Array[0] === 0x47 && uint8Array[1] === 0x49 && uint8Array[2] === 0x46
+
+    if (!isJPEG && !isPNG && !isWebP && !isGIF) {
+      return { error: 'invalid_format' }
+    }
+
+    // For testing purposes, we'll use a mock implementation
+    // In the real route, sharp is used to read metadata
+    throw new Error('sharp-mock-error')
+  } catch {
+    // Any exception from sharp indicates a corrupted/unreadable image
+    return { error: 'corrupted' }
+  }
+}
+
+describe('getImageDimensionsFromUrl', () => {
+  // Valid JPEG magic bytes
+  const validJPEG = new Uint8Array([
+    0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
+  ])
+
+  // Valid PNG magic bytes
+  const validPNG = new Uint8Array([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+  ])
+
+  // Valid WebP magic bytes (RIFF...WEBP)
+  const validWebP = new Uint8Array([
+    0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+  ])
+
+  // Valid GIF magic bytes
+  const validGIF = new Uint8Array([
+    0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  ])
+
+  // Invalid: not an image (random bytes)
+  const invalidBytes = new Uint8Array([
+    0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
+  ])
+
+  // Invalid: too short
+  const tooShort = new Uint8Array([0xff, 0xd8, 0xff])
+
+  // Mock fetch globally
+  const mockFetch = vi.fn()
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('returns { error: "network" }', () => {
+    it('when fetch returns non-ok status', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(0)),
+      })
+
+      const result = await getImageDimensionsFromUrl('https://example.com/image.jpg')
+
+      expect(result).toEqual({ error: 'network' })
+    })
+
+    it('when fetch throws network error - returns corrupted (catch-all for fetch errors)', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'))
+
+      const result = await getImageDimensionsFromUrl('https://example.com/image.jpg')
+
+      // Note: fetch exceptions are caught in the outer catch and treated as 'corrupted'
+      // since we can't differentiate between network errors and image processing errors
+      expect(result).toEqual({ error: 'corrupted' })
+    })
+  })
+
+  describe('returns { error: "invalid_format" }', () => {
+    it('when buffer is too short', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: vi.fn().mockResolvedValue(new Uint8Array([0xff, 0xd8])),
+      })
+
+      const result = await getImageDimensionsFromUrl('https://example.com/image.jpg')
+
+      expect(result).toEqual({ error: 'invalid_format' })
+    })
+
+    it('when buffer has invalid magic bytes', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: vi.fn().mockResolvedValue(invalidBytes),
+      })
+
+      const result = await getImageDimensionsFromUrl('https://example.com/file.txt')
+
+      expect(result).toEqual({ error: 'invalid_format' })
+    })
+  })
+
+  describe('returns { error: "corrupted" }', () => {
+    it('when sharp throws an exception on valid JPEG header', async () => {
+      // Valid JPEG header but sharp will fail (mock throws)
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: vi.fn().mockResolvedValue(validJPEG),
+      })
+
+      const result = await getImageDimensionsFromUrl('https://example.com/corrupt.jpg')
+
+      expect(result).toEqual({ error: 'corrupted' })
+    })
+
+    it('when sharp throws an exception on valid PNG header', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: vi.fn().mockResolvedValue(validPNG),
+      })
+
+      const result = await getImageDimensionsFromUrl('https://example.com/corrupt.png')
+
+      expect(result).toEqual({ error: 'corrupted' })
+    })
+
+    it('when sharp throws an exception on valid WebP header', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: vi.fn().mockResolvedValue(validWebP),
+      })
+
+      const result = await getImageDimensionsFromUrl('https://example.com/corrupt.webp')
+
+      expect(result).toEqual({ error: 'corrupted' })
+    })
+
+    it('when sharp throws an exception on valid GIF header', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: vi.fn().mockResolvedValue(validGIF),
+      })
+
+      const result = await getImageDimensionsFromUrl('https://example.com/corrupt.gif')
+
+      expect(result).toEqual({ error: 'corrupted' })
+    })
+  })
+
+  describe('image format detection', () => {
+    it.each([
+      { name: 'JPEG', bytes: validJPEG, expected: true },
+      { name: 'PNG', bytes: validPNG, expected: true },
+      { name: 'WebP', bytes: validWebP, expected: true },
+      { name: 'GIF', bytes: validGIF, expected: true },
+      { name: 'invalid', bytes: invalidBytes, expected: false },
+    ])('correctly identifies $name format', ({ bytes, expected }) => {
+      // Just test the magic byte detection logic
+      const isJPEG = bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff
+      const isPNG = bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47
+      const isWebP =
+        bytes[0] === 0x52 &&
+        bytes[1] === 0x49 &&
+        bytes[2] === 0x46 &&
+        bytes[3] === 0x46 &&
+        bytes[8] === 0x57 &&
+        bytes[9] === 0x45 &&
+        bytes[10] === 0x42 &&
+        bytes[11] === 0x50
+      const isGIF = bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46
+
+      const isValidImage = isJPEG || isPNG || isWebP || isGIF
+
+      expect(isValidImage).toBe(expected)
+    })
+  })
+})
+
+describe('Error response handling', () => {
+  it('should return 422 for corrupted images', async () => {
+    // Simulate the route's error handling logic
+    const dimensionResult = { error: 'corrupted' as const }
+
+    let response: Response
+    if ('error' in dimensionResult) {
+      if (dimensionResult.error === 'corrupted') {
+        response = Response.json(
+          {
+            error:
+              'This image could not be processed. It may be corrupted or in an unsupported format. Please try uploading a different image or resave it in a different format.',
+          },
+          { status: 422 },
+        )
+      } else {
+        response = Response.json({ error: 'Unknown error' }, { status: 500 })
+      }
+    } else {
+      response = Response.json({ success: true })
+    }
+
+    expect(response.status).toBe(422)
+    const body = await response.json()
+    expect(body.error).toContain('could not be processed')
+  })
+
+  it('should return 415 for invalid format', async () => {
+    const dimensionResult = { error: 'invalid_format' as const }
+
+    let response: Response
+    if ('error' in dimensionResult) {
+      if (dimensionResult.error === 'invalid_format') {
+        response = Response.json(
+          {
+            error: 'Image format is not supported. Please upload a JPEG, PNG, WebP, or GIF image.',
+          },
+          { status: 415 },
+        )
+      } else {
+        response = Response.json({ error: 'Unknown error' }, { status: 500 })
+      }
+    } else {
+      response = Response.json({ success: true })
+    }
+
+    expect(response.status).toBe(415)
+    const body = await response.json()
+    expect(body.error).toContain('not supported')
+  })
+
+  it('should return 422 for too small images', async () => {
+    const CHAT_ASSET_MIN_IMAGE_WIDTH = 100
+    const CHAT_ASSET_MIN_IMAGE_HEIGHT = 100
+    const dimensionResult = { width: 50, height: 50 }
+
+    let response: Response
+    if (
+      dimensionResult.width < CHAT_ASSET_MIN_IMAGE_WIDTH ||
+      dimensionResult.height < CHAT_ASSET_MIN_IMAGE_HEIGHT
+    ) {
+      response = Response.json(
+        {
+          error: `Image is too small. Minimum size is ${CHAT_ASSET_MIN_IMAGE_WIDTH}x${CHAT_ASSET_MIN_IMAGE_HEIGHT} pixels, but this image is ${dimensionResult.width}x${dimensionResult.height} pixels. Please upload a clearer photo.`,
+        },
+        { status: 422 },
+      )
+    } else {
+      response = Response.json({ success: true })
+    }
+
+    expect(response.status).toBe(422)
+    const body = await response.json()
+    expect(body.error).toContain('too small')
+    expect(body.error).toContain('50x50')
+    expect(body.error).toContain('100x100')
+  })
+})

--- a/tests/unit/api/chat-asset-finalize.spec.ts
+++ b/tests/unit/api/chat-asset-finalize.spec.ts
@@ -64,7 +64,7 @@ describe('getImageDimensionsFromUrl', () => {
       expect(result).toEqual({ error: 'network' })
     })
 
-    it('when fetch promise rejects - returns corrupted (catch-all for promise rejections)', async () => {
+    it('when fetch rejects (promise rejected)', async () => {
       mockFetch.mockRejectedValueOnce(new Error('Network error'))
 
       const result = await getImageDimensionsFromUrl('https://example.com/image.jpg')


### PR DESCRIPTION
## Summary

- Confirmed route.ts returns user-friendly error messages instead of opaque code strings
- Confirmed test name "when fetch rejects (promise rejected)" at line 67 matches suggestion
- All quality gates pass (TypeScript ✓, Lint ✓, Unit tests 2725 ✓)

Closes #1090

---
_Opened by kody (single-session autonomous run)._ 