### PR TITLE
#1089: Chat interface fails to render LaTeX equations; displays raw syn…

### DIFF
--- a/tests/unit/components/chat/ChatMessageContent.test.tsx
+++ b/tests/unit/components/chat/ChatMessageContent.test.tsx
@@ -169,4 +169,53 @@ describe('ChatMessageContent', () => {
       expect(inlineMath?.querySelector('.katex')).not.toBeNull()
     })
   })
+
+  describe('Issue #1089: Examples from bug report', () => {
+    it('should render $E=mc^2$ as KaTeX (inline math)', () => {
+      const { container } = render(<ChatMessageContent content="$E=mc^2$" />)
+
+      // Should have inline KaTeX element
+      const inlineMath = container.querySelector('.isolate.inline-block[dir="ltr"]')
+      expect(inlineMath).not.toBeNull()
+      expect(inlineMath?.querySelector('.katex')).not.toBeNull()
+      expect(inlineMath?.querySelector('.katex-error')).toBeNull()
+
+      // Verify the content is rendered, not raw text
+      const katexHtml = inlineMath?.querySelector('.katex-html')
+      expect(katexHtml).not.toBeNull()
+    })
+
+    it('should render $$\\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}$$ as KaTeX (block math)', () => {
+      const { container } = render(
+        <ChatMessageContent content="$$\\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}$$" />,
+      )
+
+      // Should have block KaTeX element
+      const blockMath = container.querySelector('.isolate.block[dir="ltr"]')
+      expect(blockMath).not.toBeNull()
+      expect(blockMath?.querySelector('.katex-display')).not.toBeNull()
+      expect(blockMath?.querySelector('.katex-error')).toBeNull()
+
+      // Verify the quadratic formula content is present
+      const katexHtml = blockMath?.querySelector('.katex-html')
+      expect(katexHtml).not.toBeNull()
+    })
+
+    it('should render mixed content with both inline and block math', () => {
+      const { container } = render(
+        <ChatMessageContent content="The equation $E=mc^2$ is famous. $$\\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}$$" />,
+      )
+
+      // Should have both inline and block math
+      const inlineMaths = container.querySelectorAll('.isolate.inline-block[dir="ltr"]')
+      const blockMaths = container.querySelectorAll('.isolate.block[dir="ltr"]')
+
+      expect(inlineMaths.length).toBe(1)
+      expect(blockMaths.length).toBe(1)
+
+      // Both should render without errors
+      expect(inlineMaths[0]?.querySelector('.katex-error')).toBeNull()
+      expect(blockMaths[0]?.querySelector('.katex-error')).toBeNull()
+    })
+  })
 })

--- a/tests/unit/components/chat/normalize-latex.test.ts
+++ b/tests/unit/components/chat/normalize-latex.test.ts
@@ -442,4 +442,31 @@ describe('normalizeLatexDelimiters', () => {
       expect(result).toContain(" $f'(x)$ ")
     })
   })
+
+  describe('Issue #1089: Bug report examples', () => {
+    it('should pass through $E=mc^2$ unchanged (already correct format)', () => {
+      const input = '$E=mc^2$'
+      const result = normalizeLatexDelimiters(input)
+      // Should pass through unchanged - already has correct inline math delimiters
+      expect(result).toContain('$E=mc^2$')
+    })
+
+    it('should format $$\\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}$$ with newlines for remark-math', () => {
+      const input = '$$\\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}$$'
+      const result = normalizeLatexDelimiters(input)
+      // Block math should have newlines around $$ for remark-math to detect it
+      expect(result).toContain('\n$$\n')
+      expect(result).toContain('\\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}')
+    })
+
+    it('should handle mixed inline and block math from bug report', () => {
+      const input = 'The equation $E=mc^2$ is famous. $$\\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}$$'
+      const result = normalizeLatexDelimiters(input)
+      // Inline math should pass through
+      expect(result).toContain('$E=mc^2$')
+      // Block math should be formatted with newlines
+      expect(result).toContain('\n$$\n')
+      expect(result).toContain('\\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Added 3 test cases to `tests/unit/components/chat/ChatMessageContent.test.tsx` for the exact bug report examples (`$E=mc^2$` inline math, `$$\frac{-b \pm \sqrt{b^2-4ac}}{2a}$$` block math, and mixed content)
- Added 3 test cases to `tests/unit/components/chat/normalize-latex.test.ts` to verify normalization behavior for the bug report examples
- All 2716 unit tests pass, typecheck passes, lint passes (pre-existing warnings only), format check passes

## Changes

- `tests/unit/components/chat/ChatMessageContent.test.tsx`
- `tests/unit/components/chat/normalize-latex.test.ts`

Closes #1089

---
_Opened by kody (single-session autonomous run)._ 