### PR TITLE
#1344: כאשר תלמיד מסיים, מופיע על הכרטיס בחינה - v שלא ממוקם טוב .

### DIFF
--- a/src/ui/web/components/UnifiedCard/index.tsx
+++ b/src/ui/web/components/UnifiedCard/index.tsx
@@ -150,11 +150,9 @@ export function UnifiedCard({
 
           {/* Progress ring — right side */}
           {showProgress && (
-            <div className="shrink-0 w-14 h-14">
+            <div className="shrink-0 w-14 h-14 relative">
               <ProgressCircle percentage={progress} size={56} strokeWidth={6} strokeColor={color}>
-                {progress >= 100 ? (
-                  <CheckCircle className="w-full h-full text-success" />
-                ) : (
+                {progress >= 100 ? null : (
                   <>
                     {progressLabel && (
                       <span className="text-[9px] font-bold fill-foreground leading-none">
@@ -173,6 +171,10 @@ export function UnifiedCard({
                   </>
                 )}
               </ProgressCircle>
+              {/* Completion checkmark — positioned over the progress circle */}
+              {progress >= 100 && (
+                <CheckCircle className="absolute inset-0 w-full h-full text-success" />
+              )}
             </div>
           )}
         </div>

--- a/tests/unit/ui/web/UnifiedCard.spec.tsx
+++ b/tests/unit/ui/web/UnifiedCard.spec.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import { CheckCircle } from 'lucide-react'
+import type { ComponentProps } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { UnifiedCard } from '@/ui/web/components/UnifiedCard'
+
+// Mock CheckCircle to verify it renders
+vi.mock('lucide-react', async () => {
+  const actual = await vi.importActual('lucide-react')
+  return {
+    ...actual,
+    CheckCircle: ({ className, ...props }: ComponentProps<typeof CheckCircle>) => (
+      <svg data-testid="check-circle" className={className} {...props}>
+        <circle cx="12" cy="12" r="10" />
+        <path d="m9 11 3 3L22 4" />
+      </svg>
+    ),
+  }
+})
+
+describe('UnifiedCard completion state', () => {
+  it('renders CheckCircle when progress is 100', () => {
+    render(<UnifiedCard title="Test Lesson" progress={100} />)
+    expect(screen.getByTestId('check-circle')).toBeTruthy()
+  })
+
+  it('does not render CheckCircle when progress is less than 100', () => {
+    render(<UnifiedCard title="Test Lesson" progress={99} />)
+    expect(screen.queryByTestId('check-circle')).toBeNull()
+  })
+
+  it('does not render CheckCircle when progress is 0', () => {
+    render(<UnifiedCard title="Test Lesson" progress={0} />)
+    expect(screen.queryByTestId('check-circle')).toBeNull()
+  })
+
+  it('renders percentage text when progress is between 0 and 100', () => {
+    render(<UnifiedCard title="Test Lesson" progress={75} />)
+    expect(screen.getByText('75%')).toBeTruthy()
+  })
+
+  it('renders percentage text for 99% progress', () => {
+    render(<UnifiedCard title="Test Lesson" progress={99} />)
+    expect(screen.getByText('99%')).toBeTruthy()
+  })
+
+  it('renders title correctly', () => {
+    render(<UnifiedCard title="My Test Lesson" progress={50} />)
+    expect(screen.getByText('My Test Lesson')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary

- **Modified** `src/ui/web/components/UnifiedCard/index.tsx`: Changed progress ring container to use `relative` positioning and render `CheckCircle` as an absolutely-positioned sibling instead of an SVG child, fixing the misaligned V mark when students complete exams/lessons
- **Added** `tests/unit/ui/web/UnifiedCard.spec.tsx`: Unit tests verifying the completion checkmark renders correctly at 100% progress and doesn't render for incomplete progress levels

## Changes

- `src/ui/web/components/UnifiedCard/index.tsx`
- `tests/unit/ui/web/UnifiedCard.spec.tsx`

Closes #1344

---
_Opened by kody (single-session autonomous run)._ 