### PR TITLE
chore: release v0.25.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5997,6 +5997,9 @@ Note: Database values unchanged, backward compatibility exports added
 
 # Changelog
 
+## v0.25.3 — 2026-04-26
+
+_No notable commits since the last release._
 ## v0.25.2 — 2026-04-24
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "a-guy",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "Website template for Payload",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Automated release PR opened by kody.

## v0.25.3 — 2026-04-26

_No notable commits since the last release._

The release orchestrator will merge this into `dev` and continue to publish + deploy.

Tracking-Issue: #1352

