### PR TITLE
#1349: צ'אט נעלם לאחר רענון עמוד תרגיל בשיעור

### DIFF
--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/page.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound, redirect } from 'next/navigation'
+import type { FormulaSheet } from '@/payload-types'
 import { getSystemLocale } from '@/i18n/server-locale'
 import { isValidContentLocale } from '@/server/payload/fields/contentLocale'
 import { queryCourseBySlug } from '@/server/repos/queries/courses'
@@ -9,6 +10,7 @@ import {
   queryExercisesByLesson,
 } from '@/server/repos/queries/exercises'
 import { queryMediaByIds } from '@/server/repos/queries/media'
+import { resolveFormulaSheet } from '@/server/repos/queries/formula-sheets'
 import { extractAllMediaIds } from '@/ui/web/exerciserenderer/utils/extractMediaIds'
 import { ExercisesPager } from '../../_components/ExercisesPager'
 
@@ -100,6 +102,27 @@ export default async function ExercisePage({ params }: ExercisePageProps) {
 
   const backUrl = '/study'
 
+  // Determine if chat should be shown (lesson has exercises or lesson context)
+  const hasLessonContext = Boolean(lesson.lessonContextText?.trim())
+  const hasExercises = exercises.length > 0
+  const showChat = hasExercises || hasLessonContext
+
+  // Resolve formula sheet for chat (with course fallback)
+  // JSON.parse(JSON.stringify()) strips non-serializable data for Next.js server→client props
+  let formulaSheet: FormulaSheet | null = null
+  if (contentLocale && lessonCourseId) {
+    try {
+      const result = await resolveFormulaSheet({
+        lessonId: lesson.id,
+        courseId: lessonCourseId,
+        locale: contentLocale,
+      })
+      formulaSheet = result?.sheet ? JSON.parse(JSON.stringify(result.sheet)) : null
+    } catch {
+      // Formula sheet resolution failed — continue without it
+    }
+  }
+
   const mediaMap = await queryMediaByIds(extractAllMediaIds(exercises))
 
   return (
@@ -113,6 +136,8 @@ export default async function ExercisePage({ params }: ExercisePageProps) {
       lessonId={lesson.id}
       gradeLevel={course.courseLabel}
       mediaMap={mediaMap}
+      showChat={showChat}
+      formulaSheet={formulaSheet}
     />
   )
 }


### PR DESCRIPTION
> ⚠️ Draft: Environmental issue - not a code defect
> The failures below may be **pre-existing in the repo** — verify before treating as PR-blocking.

## Summary

Implementation of issue #1349 — #1349: צ'אט נעלם לאחר רענון עמוד תרגיל בשיעור

_(agent did not supply PR_SUMMARY)_

Closes #1349

<details>
<summary>Verify output (click to expand)</summary>

```
Environmental issue - not a code defect

The 500 error is not caused by the code changes in PR #1356. The diff only modifies the exercise page (`src/app/(frontend)/courses/.../exercises/[exerciseSlug]/page.tsx`) to pass `showChat` and `formulaSheet` props to `ExercisesPager`. The homepage (`/`) does not use this code path.

Evidence:
- ✅ Build passes locally (`pnpm build` exit 0)
- ✅ TypeScript passes (`pnpm typecheck`)
- ✅ Lint passes (pre-existing warnings only)

Likely causes (check Vercel preview settings):
1. Missing/invalid DATABASE_URL environment variable
2. MongoDB not reachable from preview environment  
3. Stale deployment cache or transient infrastructure issue

The `payload.config.ts` has module-level validation that throws if DATABASE_URL is missing, causing runtime 500s. This is an infrastructure configuration issue, not a code bug in this PR.
```
```

</details>

---
_Opened by kody (single-session autonomous run)._ 