### PR TITLE
fix: Resolve /posts QueryError by using _status field for draft-enabled collections

### DIFF
--- a/src/server/repos/queries/pages.ts
+++ b/src/server/repos/queries/pages.ts
@@ -26,7 +26,7 @@ export const queryPublishedPages = cache(async () => {
   const result = await payload.find({
     collection: 'pages',
     where: {
-      status: {
+      _status: {
         equals: 'published',
       },
     },
@@ -71,7 +71,7 @@ export const queryAllPagesForSitemap = cache(async () => {
   const result = await payload.find({
     collection: 'pages',
     where: {
-      status: {
+      _status: {
         equals: 'published',
       },
     },

--- a/src/server/repos/queries/posts.ts
+++ b/src/server/repos/queries/posts.ts
@@ -27,7 +27,7 @@ export const queryPublishedPosts = cache(
     const result = await payload.find({
       collection: 'posts',
       where: {
-        status: {
+        _status: {
           equals: 'published',
         },
       },
@@ -91,7 +91,7 @@ export const queryAllPostsForSitemap = cache(async () => {
   const result = await payload.find({
     collection: 'posts',
     where: {
-      status: {
+      _status: {
         equals: 'published',
       },
     },

--- a/tests/unit/queries/pages.test.ts
+++ b/tests/unit/queries/pages.test.ts
@@ -106,7 +106,7 @@ describe('Page Queries', () => {
       expect(result).toEqual(mockPages)
       expect(mockPayload.find).toHaveBeenCalledWith({
         collection: 'pages',
-        where: { status: { equals: 'published' } },
+        where: { _status: { equals: 'published' } },
         sort: 'publishedAt',
         limit: 1000,
         pagination: false,
@@ -192,7 +192,7 @@ describe('Page Queries', () => {
       expect(result).toEqual(mockPages)
       expect(mockPayload.find).toHaveBeenCalledWith({
         collection: 'pages',
-        where: { status: { equals: 'published' } },
+        where: { _status: { equals: 'published' } },
         select: { slug: true, updatedAt: true },
         limit: 1000,
         pagination: false,

--- a/tests/unit/queries/posts.test.ts
+++ b/tests/unit/queries/posts.test.ts
@@ -93,7 +93,7 @@ describe('Post Queries', () => {
       expect(result).toEqual(mockResult)
       expect(mockPayload.find).toHaveBeenCalledWith({
         collection: 'posts',
-        where: { status: { equals: 'published' } },
+        where: { _status: { equals: 'published' } },
         sort: '-createdAt',
         page: 1,
         limit: 10,
@@ -112,7 +112,7 @@ describe('Post Queries', () => {
 
       expect(mockPayload.find).toHaveBeenCalledWith({
         collection: 'posts',
-        where: { status: { equals: 'published' } },
+        where: { _status: { equals: 'published' } },
         sort: '-createdAt',
         page: 1,
         limit: 12,
@@ -271,7 +271,7 @@ describe('Post Queries', () => {
       expect(result).toEqual(mockPosts)
       expect(mockPayload.find).toHaveBeenCalledWith({
         collection: 'posts',
-        where: { status: { equals: 'published' } },
+        where: { _status: { equals: 'published' } },
         select: { slug: true, updatedAt: true },
         limit: 1000,
         pagination: false,


### PR DESCRIPTION
## Summary

- Fixes `/posts` returning HTTP 500 with the "Something went wrong!" error fallback. Root cause: `posts` and `pages` collections enable Payload drafts, which exposes the publish state as `_status`, not `status`. Querying with `where: { status: ... }` raised `QueryError: The following path cannot be queried: status` and bubbled to the route-level error boundary.
- Updated the affected unit tests to assert the new field name (5 tests across `tests/unit/queries/{posts,pages}.test.ts` were aligned with the buggy shape).

## Affected files

- `src/server/repos/queries/posts.ts` — L30 (active code path: `/posts` page) and L94 (sitemap, dead code)
- `src/server/repos/queries/pages.ts` — L29 and L74 (both currently dead code, no callers)
- `tests/unit/queries/posts.test.ts`, `tests/unit/queries/pages.test.ts` — assertions updated

## Other `status` query sites left untouched

Other queries (`lesson-blocks.ts`, `study-page.ts`, `course-search.ts`, `api/course-search/route.ts`) target `lessons`, `courses`, `chapters`, `content-pages` — these collections define a real `status` select field rather than using draft state, so `where: { status: ... }` is correct there.

## Test plan

- [x] Local: `/posts` returns 200 (was 500) on dev server
- [x] Local: `pnpm exec vitest run tests/unit/queries/posts.test.ts tests/unit/queries/pages.test.ts` — 19/19 pass
- [x] Pre-push gates: prettier, lint, typecheck — green
- [ ] Full Fast Gate green on this PR
- [ ] No regressions in Build / Integration / E2E