### PR TITLE
#1382: [test] kody v0.3.50 smoke — state-comment size regression

### DIFF
--- a/docs/SMOKE_CHECKS.md
+++ b/docs/SMOKE_CHECKS.md
@@ -40,3 +40,4 @@ After any migration stage, verify these critical paths:
 # Individual checks
 curl -s http://localhost:3000/api/health
 ```
+


### PR DESCRIPTION
## Summary

- Added trailing newline to `docs/SMOKE_CHECKS.md` — a no-op style change to exercise the kody-engine v0.3.50 smoke test flow (classify → bug → plan → run → review), verifying state-comment size stays under ~15KB and the flow advances past planning without regression loops.

## Changes

- `docs/SMOKE_CHECKS.md`

Closes #1382

---
_Opened by kody (single-session autonomous run)._ 