### PR TITLE
feat: Schema-mode Gemini extraction for lesson context PDFs

### DIFF
--- a/.kody/missions/auto-fix-ci.state.json
+++ b/.kody/missions/auto-fix-ci.state.json
@@ -1,12 +1,17 @@
 {
   "version": 1,
-  "rev": 37,
+  "rev": 30,
   "cursor": "fix-ci-action-taken-2026-04-29",
   "data": {
     "perPr": {
+      "1227": {
+        "lastSha": "01da2421b50b6bc8f82bd907b22fd2a524314b40",
+        "attempts": 2,
+        "stuck": true
+      },
       "1266": {
-        "lastSha": "b0e0e4ef1ee2d3b908e285e741a2cfa0d9747fae",
-        "attempts": 1,
+        "lastSha": "7f64a26f993738887c6d6cd9d660c9b736a9de65",
+        "attempts": 2,
         "stuck": false
       }
     }

--- a/.kody/missions/auto-resolve.state.json
+++ b/.kody/missions/auto-resolve.state.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "rev": 9,
+  "rev": 5,
   "cursor": "checked",
   "data": {
     "perPr": {}

--- a/.kody/missions/auto-sync.state.json
+++ b/.kody/missions/auto-sync.state.json
@@ -1,104 +1,98 @@
 {
   "version": 1,
-  "rev": 32,
-  "cursor": "tick-37",
+  "rev": 24,
+  "cursor": "tick",
   "data": {
     "perPr": {
       "1217": {
-        "lastSha": "3257733d198a573003a65ebcbacc55432e100892",
-        "attempts": 0,
-        "stuck": false,
-        "lastActionAt": null
-      },
-      "1227": {
-        "lastSha": "742776244b41def217bcf4a99351aaa8cd5bde71",
+        "lastSha": "c14d3f3bd8f4c4d78b9cbccf83c218374654ab4b",
         "attempts": 1,
         "stuck": false,
-        "lastActionAt": "2026-04-29T19:44:41Z"
-      },
-      "1266": {
-        "lastSha": "b0e0e4ef1ee2d3b908e285e741a2cfa0d9747fae",
-        "attempts": 0,
-        "stuck": false,
-        "lastActionAt": null
+        "lastActionAt": "2026-04-29T12:00:00Z"
       },
       "1272": {
-        "lastSha": "8183610c426343ece531eeaffbc62be249e14899",
+        "lastSha": "57b5ea91fbed0df2ffce670a516900935e7b8846",
         "attempts": 0,
         "stuck": false,
         "lastActionAt": null
       },
       "1355": {
-        "lastSha": "969f3e256728230bc2e97b8a6ed3ce1713b45a39",
+        "lastSha": "176f76c6a360d894aaeab797b20c9bc00a9295b6",
         "attempts": 0,
         "stuck": false,
         "lastActionAt": null
       },
       "1364": {
-        "lastSha": "422c42c2a348f07771490d1b791422377511387d",
+        "lastSha": "93c28e5ee13906a1afd1f4b007c475c4cadbec90",
         "attempts": 0,
         "stuck": false,
         "lastActionAt": null
       },
       "1366": {
-        "lastSha": "94caf103fdca6f7973f7a3021567362fee7ffd33",
+        "lastSha": "85dce98025a968e3204c892e3b64602c259039f0",
+        "attempts": 0,
+        "stuck": false,
+        "lastActionAt": null
+      },
+      "1369": {
+        "lastSha": "8704f71b5cdce7a703380a24dedd2a2d14cec49d",
         "attempts": 0,
         "stuck": false,
         "lastActionAt": null
       },
       "1374": {
-        "lastSha": "1acbc8d06ff5753fe7179db4e066c81478aa3b89",
+        "lastSha": "7c8422f58d6605ff0d882b9d705d4ea77f49f675",
         "attempts": 0,
         "stuck": false,
         "lastActionAt": null
       },
       "1375": {
-        "lastSha": "5e4bb96b67ba64ec5a947bf581bc10efb5eef079",
+        "lastSha": "f31284efc564a7ec9e0b5de6d83bccbaa7eb7dd2",
         "attempts": 0,
         "stuck": false,
         "lastActionAt": null
       },
       "1376": {
-        "lastSha": "9597a296e1eca7e31a507a6adb851afb3cc8c6d2",
+        "lastSha": "5727ebf5112a8b3d68e4823748985dee5c061d97",
         "attempts": 0,
         "stuck": false,
         "lastActionAt": null
       },
       "1377": {
-        "lastSha": "179b97fa66d30ae1ebaeb09415188cac7c43192d",
+        "lastSha": "b8152a75f4cf55c82efbe1296c6ab553186e0271",
         "attempts": 0,
         "stuck": false,
         "lastActionAt": null
       },
       "1379": {
-        "lastSha": "add45ac681fb90aaec095679a7d2e8f411546c08",
+        "lastSha": "6c190cad4b09f989532f56680eb5f4a2db22f129",
         "attempts": 0,
         "stuck": false,
         "lastActionAt": null
       },
       "1381": {
-        "lastSha": "41113e1e790d18721a8af44841d323c5dc302106",
+        "lastSha": "29340900adf97845af2ac56f5db9424f14e86941",
         "attempts": 0,
         "stuck": false,
         "lastActionAt": null
       },
       "1383": {
-        "lastSha": "335351c6b7fe07dd0d08c630121218acea7bf7d1",
-        "attempts": 0,
-        "stuck": false,
-        "lastActionAt": null
-      },
-      "1384": {
-        "lastSha": "31f1ee29c3f70a36fae36d324bd15249aa76e10a",
-        "attempts": 0,
-        "stuck": false,
-        "lastActionAt": null
-      },
-      "1386": {
-        "lastSha": "862bd5685115048c7ab94e2f58c002ee50c91523",
+        "lastSha": "142ca9b6217ecbe90fa351d2f2838bed11105035",
         "attempts": 1,
         "stuck": false,
-        "lastActionAt": "2026-04-29T19:44:41Z"
+        "lastActionAt": "2026-04-29T07:16:00Z"
+      },
+      "1384": {
+        "lastSha": "10a4f7f2eb1ffe1110f9ab4fb18573bb241453d6",
+        "attempts": 1,
+        "stuck": false,
+        "lastActionAt": "2026-04-29T08:22:53Z"
+      },
+      "1386": {
+        "lastSha": "39df47f912c9a771b64413100e564b5b0e861f0d",
+        "attempts": 0,
+        "stuck": false,
+        "lastActionAt": null
       }
     }
   },

--- a/src/app/api/lessons/context-extraction/route.ts
+++ b/src/app/api/lessons/context-extraction/route.ts
@@ -62,10 +62,14 @@ export const PUT = withApiHandler<PutBody>(
   async ({ payload, body, user }) => {
     const { extractionId, text } = body
 
+    // Invalidate the structured `exercises` snapshot so Stage 2
+    // (create-context-exercises) falls back to re-parsing the edited text.
+    // Without this, schema-mode extractions would silently ignore inline
+    // viewer edits because Stage 2 prefers the unchanged exercises array.
     await payload.update({
       collection: 'context-extractions',
       id: extractionId,
-      data: { text },
+      data: { text, exercises: null },
       user: user!,
       overrideAccess: false,
     })

--- a/src/app/api/lessons/create-context-exercises/route.ts
+++ b/src/app/api/lessons/create-context-exercises/route.ts
@@ -2,8 +2,10 @@
  * Create Exercises from Context API
  *
  * POST /api/lessons/create-context-exercises
- * Reads the latest ContextExtraction for the lesson, parses its LaTeX text
- * into individual exercises, and creates Exercise documents with LaTeX blocks.
+ * Reads the latest ContextExtraction for the lesson and creates Exercise
+ * documents with LaTeX blocks. Prefers the structured `exercises` array
+ * produced by schema-mode extraction; falls back to regex-parsing the
+ * `text` field for legacy extractions that have no structured payload.
  *
  * Idempotent: deletes previous context_extraction exercises before creating new ones,
  * and reconciles lesson.blocks (drops stale refs, appends new exerciseRef entries).
@@ -19,6 +21,49 @@ const createContextExercisesSchema = z.object({
 })
 
 type CreateContextExercisesBody = z.infer<typeof createContextExercisesSchema>
+
+interface CreatableExercise {
+  number: number
+  title?: string
+  latexContent: string
+  solution: string | null
+}
+
+function isStructuredExercise(value: unknown): value is {
+  number: number
+  latex: string
+  solution?: string | null
+} {
+  if (!value || typeof value !== 'object') return false
+  const v = value as Record<string, unknown>
+  if (typeof v.number !== 'number') return false
+  if (typeof v.latex !== 'string') return false
+  return true
+}
+
+interface StructuredReadResult {
+  exercises: CreatableExercise[]
+  skipped: number
+}
+
+function readStructuredExercises(extraction: unknown): StructuredReadResult | null {
+  const value = (extraction as { exercises?: unknown })?.exercises
+  if (!Array.isArray(value)) return null
+  const valid: CreatableExercise[] = []
+  let skipped = 0
+  for (const entry of value) {
+    if (!isStructuredExercise(entry) || !entry.latex.trim()) {
+      skipped++
+      continue
+    }
+    valid.push({
+      number: entry.number,
+      latexContent: entry.latex,
+      solution: typeof entry.solution === 'string' && entry.solution.trim() ? entry.solution : null,
+    })
+  }
+  return valid.length > 0 ? { exercises: valid, skipped } : null
+}
 
 type LessonBlock = {
   id: string
@@ -55,7 +100,7 @@ export const POST = withApiHandler<CreateContextExercisesBody, unknown>(
     auth: 'admin',
     bodySchema: createContextExercisesSchema,
   },
-  async ({ payload, body }) => {
+  async ({ payload, body, user }) => {
     const { lessonId } = body
 
     // Fetch the latest context extraction for this lesson
@@ -75,22 +120,51 @@ export const POST = withApiHandler<CreateContextExercisesBody, unknown>(
       )
     }
 
-    const extractionText = (extractionResult.docs[0] as unknown as { text: string }).text
+    const extractionDoc = extractionResult.docs[0] as unknown as {
+      text: string
+      exercises?: unknown
+    }
 
-    if (!extractionText?.trim()) {
-      return apiError(
-        'VALIDATION_ERROR',
-        'Context extraction is empty. Run "Convert Context" again.',
-        400,
+    // Prefer the structured exercises array from schema-mode extraction.
+    // Fall back to regex-parsing the rendered text for legacy extractions.
+    const structured = readStructuredExercises(extractionDoc)
+    let allExercises: CreatableExercise[] | null = structured?.exercises ?? null
+    let source: 'structured' | 'legacy_text' = 'structured'
+    const warnings: string[] = []
+
+    if (structured && structured.skipped > 0) {
+      // Surface partial corruption so admins don't silently lose exercises
+      // when Gemini occasionally emits malformed entries inside an otherwise-
+      // valid response.
+      warnings.push(
+        `Skipped ${structured.skipped} malformed entr${structured.skipped === 1 ? 'y' : 'ies'} in structured exercises — review the extraction in the viewer before publishing.`,
       )
     }
 
-    // Parse into exercises
-    const segments = parseContextText(extractionText)
-    const allExercises = segments.flatMap((seg) => seg.exercises)
+    if (!allExercises) {
+      source = 'legacy_text'
+      const extractionText = extractionDoc.text
+      if (!extractionText?.trim()) {
+        return apiError(
+          'VALIDATION_ERROR',
+          'Context extraction is empty. Run "Convert Context" again.',
+          400,
+        )
+      }
 
-    if (allExercises.length === 0) {
-      return apiError('VALIDATION_ERROR', 'No exercises found in context text', 400)
+      const segments = parseContextText(extractionText)
+      const legacy = segments.flatMap((seg) =>
+        seg.exercises.map((ex) => ({
+          number: ex.number,
+          title: ex.title,
+          latexContent: ex.latexContent,
+          solution: ex.solution,
+        })),
+      )
+      if (legacy.length === 0) {
+        return apiError('VALIDATION_ERROR', 'No exercises found in context text', 400)
+      }
+      allExercises = legacy
     }
 
     // Capture IDs of existing context_extraction exercises so we can drop their
@@ -125,7 +199,6 @@ export const POST = withApiHandler<CreateContextExercisesBody, unknown>(
 
     // Create exercises with LaTeX blocks
     const createdIds: string[] = []
-    const warnings: string[] = []
 
     for (let i = 0; i < allExercises.length; i++) {
       const exercise = allExercises[i]
@@ -188,7 +261,8 @@ export const POST = withApiHandler<CreateContextExercisesBody, unknown>(
           collection: 'lessons',
           id: lessonId,
           data: { blocks: JSON.stringify(nextBlocks) } as Record<string, unknown>,
-          overrideAccess: true,
+          user: user!,
+          overrideAccess: false,
         })
         lessonBlocksUpdated = true
       } catch (err) {
@@ -200,6 +274,7 @@ export const POST = withApiHandler<CreateContextExercisesBody, unknown>(
     return apiSuccess({
       exerciseIds: createdIds,
       exerciseCount: createdIds.length,
+      source,
       lessonBlocksUpdated,
       warnings: warnings.length > 0 ? warnings : undefined,
     })

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1855,9 +1855,21 @@ export interface ContextExtraction {
    */
   sourceMedia: string | Media;
   /**
-   * Raw LaTeX text extracted from the source media
+   * LaTeX rendering of the structured exercises. Generated for the viewer; the structured `exercises` field is the source of truth.
    */
   text: string;
+  /**
+   * Structured exercises returned by schema-mode extraction: [{ number, latex, solution }]. Stage 2 (create-context-exercises) reads this directly when present.
+   */
+  exercises?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -3425,6 +3437,7 @@ export interface ContextExtractionsSelect<T extends boolean = true> {
   lesson?: T;
   sourceMedia?: T;
   text?: T;
+  exercises?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/src/server/payload/collections/ContextExtractions.ts
+++ b/src/server/payload/collections/ContextExtractions.ts
@@ -67,7 +67,16 @@ export const ContextExtractions: CollectionConfig = {
       required: true,
       maxLength: 200_000,
       admin: {
-        description: 'Raw LaTeX text extracted from the source media',
+        description:
+          'LaTeX rendering of the structured exercises. Generated for the viewer; the structured `exercises` field is the source of truth.',
+      },
+    },
+    {
+      name: 'exercises',
+      type: 'json',
+      admin: {
+        description:
+          'Structured exercises returned by schema-mode extraction: [{ number, latex, solution }]. Stage 2 (create-context-exercises) reads this directly when present.',
       },
     },
   ],

--- a/src/server/services/lesson-context-conversion/extract-context.ts
+++ b/src/server/services/lesson-context-conversion/extract-context.ts
@@ -11,12 +11,17 @@
  */
 import { isVercelBlobUrl } from '@/infra/blob/vercel-blob-adapter'
 import { fetchBuffer } from '@/infra/utils/http'
-import type { Lesson, Media, Prompt } from '@/payload-types'
-import type { UnifiedLLMProvider } from '@/infra/llm/providers/factory'
-import type { AIModel } from '@/infra/llm/models'
+import type { ContextExtraction, Lesson, Media, Prompt } from '@/payload-types'
 import { getPdfBufferFromBlob, normalizeToAbsoluteUrl } from '@/server/services/pdf-fetcher'
 import { splitPdfIntoPages } from '@/server/utils/pdf-page-splitter'
 import { validateExtractedLatex } from './validate-latex'
+import {
+  extractStructuredExercisesFromPage,
+  mergeExercisesAcrossPages,
+  renderExercisesAsLatexText,
+  type ExtractPageResult,
+} from './structured-extraction'
+import type { ExtractedExercise } from './structured-extraction-schema'
 import type { Payload, User } from 'payload'
 
 // Controlled concurrency for page-by-page PDF processing
@@ -36,6 +41,7 @@ export interface ExtractContextResult {
   success: boolean
   updatedContextText?: string
   extractedChunkLength?: number
+  exercisesExtracted?: number
   error?: string
   warnings?: string[]
 }
@@ -176,115 +182,86 @@ export async function extractLessonContext(
     const metadataText = `Lesson: ${lessonTitle}\nDescription: ${lessonDescription}`
     const fullPrompt = `${promptTyped.template}\n\n${metadataText}`
 
-    // ========== Step 6: Create LLM adapter and model config ==========
-    const { createGenkitUnifiedAdapter } =
-      await import('@/infra/llm/genkit/adapters/unified-adapter')
-    const adapter = await createGenkitUnifiedAdapter(payload)
-
-    const { getModelRegistryEntry, getProviderModelName } = await import('@/infra/llm/models')
-    const { LLMProviderType } = await import('@/infra/llm/providers/types')
-    const modelEntry = getModelRegistryEntry('PDF_TO_EXERCISE')
-    const modelConfig = {
-      name: getProviderModelName(LLMProviderType.GEMINI, 'PDF_TO_EXERCISE'),
-      ...modelEntry,
-      modelKey: 'PDF_TO_EXERCISE' as const,
+    const apiKey = process.env.GEMINI_API_KEY
+    if (!apiKey) {
+      return {
+        success: false,
+        error: 'GEMINI_API_KEY is not configured on the server',
+        warnings,
+      }
     }
 
-    // ========== Step 7: Process based on media type ==========
-    let extractedText: string
-
+    // ========== Step 6: Schema-mode extraction per page ==========
+    // Each page returns a structured { exercises: [...] } payload that we
+    // merge across pages, then render to a parser-compatible LaTeX `text`
+    // for the existing viewer. The structured array is what Stage 2 reads.
+    let pageBuffers: Buffer[]
     if (isPdf) {
-      // ========== PDF: Process page-by-page with controlled concurrency ==========
-      const pages = await splitPdfIntoPages(fileBuffer)
-      const totalPages = pages.length
-
-      warnings.push(`Processing ${totalPages} pages with concurrency ${PAGE_CONCURRENCY}`)
-
-      // Process pages in batches
-      const results: Array<{ pageIndex: number; latex: string | null; warning?: string }> = []
-
-      for (let i = 0; i < pages.length; i += PAGE_CONCURRENCY) {
-        const batch = pages.slice(i, i + PAGE_CONCURRENCY)
-        const batchResults = await Promise.allSettled(
-          batch.map((pageBuffer) =>
-            extractSinglePage(adapter, modelConfig, fullPrompt, pageBuffer, payload),
-          ),
-        )
-
-        for (let j = 0; j < batchResults.length; j++) {
-          const result = batchResults[j]
-          const pageIndex = i + j
-
-          if (result.status === 'fulfilled') {
-            results.push({ pageIndex, latex: result.value.latex, warning: result.value.warning })
-            warnings.push(
-              `Page ${pageIndex + 1}/${totalPages}: extracted successfully (${result.value.latex.length} chars)`,
-            )
-          } else {
-            const errorMsg =
-              result.reason instanceof Error ? result.reason.message : 'Unknown error'
-            warnings.push(
-              `Page ${pageIndex + 1}/${totalPages}: extraction failed — ${errorMsg}. Skipped.`,
-            )
-            results.push({ pageIndex, latex: null })
-          }
-        }
-      }
-
-      // Sort by page index to ensure correct order
-      results.sort((a, b) => a.pageIndex - b.pageIndex)
-
-      // Check if all pages failed
-      const successfulResults = results.filter((r) => r.latex !== null)
-      if (successfulResults.length === 0) {
-        return {
-          success: false,
-          error: 'All pages failed extraction',
-          warnings,
-        }
-      }
-
-      // Report summary
-      const skippedCount = results.filter((r) => r.latex === null).length
-      if (skippedCount > 0) {
-        warnings.push(
-          `Successfully extracted ${successfulResults.length}/${totalPages} pages. ${skippedCount} pages skipped.`,
-        )
-      } else {
-        warnings.push(`Successfully extracted all ${totalPages} pages.`)
-      }
-
-      // Stitch results together
-      extractedText = stitchLatexPages(successfulResults.map((r) => r.latex!))
-
-      // Add size warning if needed
-      if (extractedText.length > LATEX_SIZE_WARNING_THRESHOLD) {
-        warnings.push(
-          `Combined LaTeX is ${extractedText.length} chars (threshold: ${LATEX_SIZE_WARNING_THRESHOLD}). May approach size limit.`,
-        )
-      }
+      pageBuffers = await splitPdfIntoPages(fileBuffer)
+      warnings.push(`Processing ${pageBuffers.length} pages with concurrency ${PAGE_CONCURRENCY}`)
     } else {
-      // ========== Non-PDF (image): Single call, existing behavior ==========
-      const mimeType = mediaTyped.mimeType || 'image/png'
-      const base64Data = fileBuffer.toString('base64')
+      // Treat the entire image as a single "page" for the schema call.
+      pageBuffers = [fileBuffer]
+    }
 
-      const response = await adapter.generateMultimodalCompletion(
-        {
-          prompt: fullPrompt,
-          model: modelConfig,
-          attachments: [{ data: base64Data, mimeType }],
-        },
-        payload,
+    const totalPages = pageBuffers.length
+    const pageResults: ExtractPageResult[] = []
+
+    for (let i = 0; i < pageBuffers.length; i += PAGE_CONCURRENCY) {
+      const batch = pageBuffers.slice(i, i + PAGE_CONCURRENCY)
+      const settled = await Promise.allSettled(
+        batch.map((buf, j) =>
+          extractStructuredExercisesFromPage({
+            apiKey,
+            promptTemplate: fullPrompt,
+            pageBuffer: buf,
+            pageIndex: i + j,
+          }),
+        ),
       )
 
-      const responseText = response.text?.trim()
-      if (!responseText) {
-        return { success: false, error: 'AI returned empty response', warnings }
+      for (let j = 0; j < settled.length; j++) {
+        const pageIndex = i + j
+        const result = settled[j]
+        if (result.status === 'fulfilled') {
+          pageResults.push(result.value)
+          warnings.push(
+            `Page ${pageIndex + 1}/${totalPages}: extracted ${result.value.exercises.length} exercise(s)${result.value.warning ? ' — ' + result.value.warning : ''}`,
+          )
+        } else {
+          const errorMsg = result.reason instanceof Error ? result.reason.message : 'Unknown error'
+          warnings.push(
+            `Page ${pageIndex + 1}/${totalPages}: extraction failed — ${errorMsg}. Skipped.`,
+          )
+          pageResults.push({ pageIndex, exercises: [] })
+        }
       }
+    }
 
-      const validation = validateExtractedLatex(responseText)
-      warnings.push(...validation.warnings)
-      extractedText = validation.sanitizedText
+    const successfulPages = pageResults.filter((p) => p.exercises.length > 0).length
+    if (successfulPages === 0 && totalPages > 0) {
+      return {
+        success: false,
+        error: 'No exercises extracted from any page',
+        warnings,
+      }
+    }
+
+    const mergedExercises: ExtractedExercise[] = mergeExercisesAcrossPages(pageResults)
+    warnings.push(`Merged ${mergedExercises.length} exercise(s) across ${totalPages} page(s).`)
+
+    // Render structured exercises into a parser-compatible LaTeX text view
+    // so the existing ContextExerciseViewer keeps working unchanged. Run it
+    // through the same sanitizer/validator we've always used.
+    const renderedText = renderExercisesAsLatexText(mergedExercises)
+    const validation = validateExtractedLatex(renderedText || ' ')
+    warnings.push(...validation.warnings)
+    let extractedText = validation.sanitizedText
+
+    if (extractedText.length > LATEX_SIZE_WARNING_THRESHOLD) {
+      warnings.push(
+        `Combined LaTeX is ${extractedText.length} chars (threshold: ${LATEX_SIZE_WARNING_THRESHOLD}). May approach size limit.`,
+      )
     }
 
     // ========== Step 8: Build final text based on mode ==========
@@ -322,11 +299,19 @@ export async function extractLessonContext(
       depth: 0,
     })
 
+    // Persist both the structured exercises array AND the rendered text view.
+    // Stage 2 prefers `exercises` when present; the viewer reads `text` and
+    // remains backward compatible.
+    const extractionUpdate: Pick<ContextExtraction, 'text' | 'exercises'> = {
+      text: updatedContextText,
+      exercises: mergedExercises,
+    }
+
     if (existingExtraction.docs.length > 0) {
       await payload.update({
         collection: 'context-extractions',
         id: existingExtraction.docs[0].id,
-        data: { text: updatedContextText },
+        data: extractionUpdate,
         user,
         overrideAccess: false,
       })
@@ -336,7 +321,7 @@ export async function extractLessonContext(
         data: {
           lesson: lessonId,
           sourceMedia: mediaId,
-          text: updatedContextText,
+          ...extractionUpdate,
         },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         user: user as any,
@@ -348,6 +333,7 @@ export async function extractLessonContext(
       success: true,
       updatedContextText,
       extractedChunkLength: extractedText.length,
+      exercisesExtracted: mergedExercises.length,
       warnings: warnings.length > 0 ? warnings : undefined,
     }
   } catch (error) {
@@ -386,184 +372,4 @@ export async function extractLessonContext(
       warnings: warnings.length > 0 ? warnings : undefined,
     }
   }
-}
-
-/**
- * Extract LaTeX content from a single PDF page.
- * Uses validateExtractedLatex for full validation (braces, environments, fonts, sanitization).
- */
-async function extractSinglePage(
-  adapter: UnifiedLLMProvider,
-  modelConfig: AIModel,
-  prompt: string,
-  pageBuffer: Buffer,
-  payload: Payload,
-): Promise<{ latex: string; warning?: string }> {
-  const base64Data = pageBuffer.toString('base64')
-
-  const response = await adapter.generateMultimodalCompletion(
-    {
-      prompt,
-      model: modelConfig,
-      attachments: [{ data: base64Data, mimeType: 'application/pdf' }],
-    },
-    payload,
-  )
-
-  const extractedText = response.text?.trim()
-
-  if (!extractedText) {
-    throw new Error('AI returned empty response')
-  }
-
-  const validation = validateExtractedLatex(extractedText)
-  const allWarnings = [...validation.warnings, ...validation.errors]
-  const warning = allWarnings.length > 0 ? allWarnings.join('; ') : undefined
-
-  return { latex: validation.sanitizedText, warning }
-}
-
-/**
- * Stitch multiple LaTeX page results into a single valid LaTeX document.
- *
- * Strategy:
- * 1. Take the preamble (\documentclass through \begin{document}) from page 1
- * 2. Extract content between \begin{document} and \end{document} from ALL pages
- * 3. Strip per-page artifacts: outline comments, page headers, \begin{hebrew}/\end{hebrew}
- * 4. Separate exercise content from solution content
- * 5. Combine: preamble + all exercises + all solutions + \end{document}
- */
-function stitchLatexPages(pages: string[]): string {
-  if (pages.length === 0) return ''
-  if (pages.length === 1) return pages[0]
-
-  const preamble = extractPreamble(pages[0])
-  const allContent = pages.map(extractDocumentContent)
-
-  // Separate exercises from solutions across all pages
-  const exerciseParts: string[] = []
-  const solutionParts: string[] = []
-
-  for (const content of allContent) {
-    const { exercises, solutions } = splitExercisesAndSolutions(content)
-    if (exercises.trim()) exerciseParts.push(exercises.trim())
-    if (solutions.trim()) solutionParts.push(solutions.trim())
-  }
-
-  // Build final document
-  const parts: string[] = []
-
-  if (exerciseParts.length > 0) {
-    parts.push(exerciseParts.join('\n\n'))
-  }
-
-  if (solutionParts.length > 0) {
-    parts.push('\\newpage\n\\section*{פתרונות}\n\n' + solutionParts.join('\n\n'))
-  }
-
-  const body = parts.join('\n\n')
-
-  if (preamble) {
-    return `${preamble}\n\n${body}\n\n\\end{document}`
-  }
-
-  return body
-}
-
-/**
- * Extract the preamble (everything up to and including \begin{document}).
- */
-function extractPreamble(page: string): string {
-  const beginDoc = page.indexOf('\\begin{document}')
-  if (beginDoc !== -1) {
-    return page.slice(0, beginDoc + '\\begin{document}'.length)
-  }
-  return ''
-}
-
-/**
- * Extract content between \begin{document} and \end{document},
- * then clean up per-page artifacts.
- */
-function extractDocumentContent(page: string): string {
-  let content = page
-
-  // Extract between \begin{document} and \end{document} if present
-  const beginDoc = content.indexOf('\\begin{document}')
-  const endDoc = content.indexOf('\\end{document}')
-  if (beginDoc !== -1 && endDoc !== -1 && beginDoc < endDoc) {
-    content = content.slice(beginDoc + '\\begin{document}'.length, endDoc)
-  }
-
-  // Strip preamble fragments that might appear without \begin{document}
-  content = content.replace(/\\documentclass[\s\S]*?(?=\\begin\{|\\section|\\noindent|$)/m, '')
-
-  // Strip \begin{hebrew} and \end{hebrew} — we'll handle language wrapping at document level
-  content = content.replace(/\\begin\{hebrew\}/g, '')
-  content = content.replace(/\\end\{hebrew\}/g, '')
-
-  // Strip outline comment blocks (% OUTLINE: ... through next non-comment line)
-  content = content.replace(/^%\s*(?:OUTLINE|\\begin\{comment\})[\s\S]*?(?=\n[^%\n])/gm, '')
-  // Strip individual % comment lines at the start
-  content = content.replace(/^%[^\n]*\n/gm, '')
-
-  // Strip repeated page headers like "מתמטיקה, חורף תשפ"ה, מס' 35471 + נספח"
-  content = content.replace(/^\\noindent\s*\n*מתמטיקה,.*$/gm, '')
-
-  // Strip page number lines like "-3-", "- 5 -", "05"
-  content = content.replace(/^\\noindent\s*\n*-\s*\d+\s*-\s*$/gm, '')
-  content = content.replace(/^\s*0\d\s*$/gm, '')
-
-  // Strip "המשך מעבר לדף" / "המשך בעמוד N" continuation lines
-  content = content.replace(/^\\noindent\s*\n*\/המשך.*\/\s*$/gm, '')
-
-  // Strip bare \section*{} with empty braces (stitching artifacts)
-  content = content.replace(/\\section\*\{\s*\}/g, '')
-
-  // Clean up excessive blank lines
-  content = content.replace(/\n{4,}/g, '\n\n\n')
-
-  return content.trim()
-}
-
-/**
- * Split page content into exercises part and solutions part.
- * Solutions are identified by \section*{פתרונות} or \subsection*{פתרון שאלה N} headers.
- */
-function splitExercisesAndSolutions(content: string): {
-  exercises: string
-  solutions: string
-} {
-  // Find the first solutions section marker
-  const solutionsMarkers = [/\\newpage\s*\\section\*\{פתרונות\}/, /\\section\*\{פתרונות\}/]
-
-  let splitIndex = -1
-  for (const marker of solutionsMarkers) {
-    const match = content.match(marker)
-    if (match && match.index !== undefined) {
-      splitIndex = match.index
-      break
-    }
-  }
-
-  if (splitIndex === -1) {
-    // No solutions section found — check for individual solution headers
-    const solMatch = content.match(/\\subsection\*\{פתרון שאלה/)
-    if (solMatch && solMatch.index !== undefined) {
-      splitIndex = solMatch.index
-    }
-  }
-
-  if (splitIndex === -1) {
-    return { exercises: content, solutions: '' }
-  }
-
-  const exercises = content.slice(0, splitIndex).trim()
-  let solutions = content.slice(splitIndex).trim()
-
-  // Strip the \section*{פתרונות} header itself — we'll add one unified header during stitching
-  solutions = solutions.replace(/^\\newpage\s*/, '')
-  solutions = solutions.replace(/^\\section\*\{פתרונות\}\s*/, '')
-
-  return { exercises, solutions }
 }

--- a/src/server/services/lesson-context-conversion/structured-extraction-schema.ts
+++ b/src/server/services/lesson-context-conversion/structured-extraction-schema.ts
@@ -1,0 +1,40 @@
+/**
+ * Schema for structured context extraction.
+ *
+ * Gemini is called with responseMimeType='application/json' + responseSchema
+ * so each page returns an exercises array directly, instead of free-form
+ * LaTeX that must be re-split with regex. The latex/solution fields still
+ * carry compile-ready LaTeX content per the existing prompt rules.
+ */
+import { z } from 'zod'
+
+export const ExtractedExerciseSchema = z.object({
+  number: z
+    .number()
+    .int()
+    .min(1)
+    .describe('The exercise number as displayed in the source document.'),
+  latex: z
+    .string()
+    .min(1)
+    .describe(
+      'Compile-ready LaTeX body for this single exercise. Do NOT include preamble, \\begin{document}, or wrapper environments — only the body of this exercise.',
+    ),
+  solution: z
+    .string()
+    .nullable()
+    .describe(
+      'Worked solution for this exercise as compile-ready LaTeX, or null if the source contains no solution for it.',
+    ),
+})
+
+export const ExtractedPageSchema = z.object({
+  exercises: z
+    .array(ExtractedExerciseSchema)
+    .describe(
+      'Every exercise visible on this page. Empty array if the page contains no exercises (cover, formula sheet, instructions).',
+    ),
+})
+
+export type ExtractedExercise = z.infer<typeof ExtractedExerciseSchema>
+export type ExtractedPage = z.infer<typeof ExtractedPageSchema>

--- a/src/server/services/lesson-context-conversion/structured-extraction.ts
+++ b/src/server/services/lesson-context-conversion/structured-extraction.ts
@@ -1,0 +1,345 @@
+/**
+ * Structured (schema-mode) context extraction.
+ *
+ * Calls Gemini directly with responseMimeType='application/json' +
+ * responseSchema so each PDF page returns a clean { exercises: [...] }
+ * payload. Bypasses the unified Genkit adapter only because that adapter
+ * does not surface responseSchema today; the same retry/timeout/circuit-
+ * breaker primitives are applied here as in the rest of the LLM layer.
+ */
+import { z } from 'zod'
+import { logger } from '@/infra/utils/logger/logger'
+import { getCircuitBreaker } from '@/infra/llm/providers/shared/circuit-breaker'
+import { withRetry } from '@/infra/llm/providers/shared/retry'
+import { withTimeout } from '@/infra/llm/providers/shared/timeout'
+import { ExtractedPageSchema, type ExtractedExercise } from './structured-extraction-schema'
+
+const GEMINI_CONFIG = {
+  modelName: 'gemini-2.5-flash',
+  temperature: 0.1,
+  maxOutputTokens: 32768,
+  timeoutMs: 180_000,
+  maxRetries: 2,
+} as const
+
+const circuitBreaker = getCircuitBreaker('context-extraction-gemini')
+
+const SCHEMA_INSTRUCTION = [
+  '',
+  '═══════════════════════════════════════════════',
+  'OUTPUT FORMAT — JSON SCHEMA MODE',
+  '═══════════════════════════════════════════════',
+  '',
+  'IGNORE any earlier instruction telling you to output LaTeX as a complete document.',
+  'You MUST return JSON matching the responseSchema. Specifically:',
+  '',
+  '- Return an object with a single key: "exercises" (an array).',
+  '- Each item in the array represents ONE exercise visible on this page.',
+  '- "number": the exercise number exactly as displayed in the source (preserve original numbering — if the source says 7, return 7).',
+  '- "latex": the body of THAT exercise as compile-ready LaTeX. Do NOT include the document preamble, \\begin{document}, \\end{document}, outline comments, or any wrapper environment. Just the exercise body.',
+  '- "solution": the worked solution for THAT exercise as compile-ready LaTeX (Hebrew explanations) if the source contains one. Otherwise null.',
+  '- Apply ALL the math-mode, hierarchy, blank-preservation, and diagram rules from the earlier instructions to the LaTeX you place inside "latex" and "solution".',
+  '- If the page is a cover/instructions/formula-sheet/blank page, return { "exercises": [] }.',
+  '',
+].join('\n')
+
+export class GeminiSchemaApiError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'GeminiSchemaApiError'
+  }
+}
+
+function isRetryableGeminiError(err: Error): boolean {
+  if (err instanceof GeminiSchemaApiError) {
+    return err.status >= 500 || err.status === 429
+  }
+  return err.name === 'TimeoutError' || err.message.includes('fetch failed')
+}
+
+/**
+ * Convert a Zod schema to the OpenAPI 3.0 subset Gemini's responseSchema
+ * accepts. Strips $schema and additionalProperties recursively.
+ */
+function zodToGeminiSchema(schema: z.ZodType): Record<string, unknown> {
+  const jsonSchema = z.toJSONSchema(schema) as Record<string, unknown>
+  return stripUnsupportedKeys(jsonSchema) as Record<string, unknown>
+}
+
+function stripUnsupportedKeys(node: unknown): unknown {
+  if (Array.isArray(node)) return node.map(stripUnsupportedKeys)
+  if (node && typeof node === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(node)) {
+      if (k === '$schema' || k === 'additionalProperties') continue
+      out[k] = stripUnsupportedKeys(v)
+    }
+    return out
+  }
+  return node
+}
+
+/**
+ * Re-escape unescaped LaTeX backslashes that appear inside JSON string
+ * literals. Gemini occasionally emits raw \frac, \sqrt, \implies inside the
+ * latex/solution fields without doubling the backslash, which breaks
+ * JSON.parse. Crucially, we only rewrite content INSIDE quoted strings —
+ * not the surrounding JSON structure — so unrelated backslash sequences
+ * (e.g. inside a future numeric / boolean position) cannot be over-escaped.
+ *
+ * The matcher walks string-literal regions delimited by unescaped quotes,
+ * tracking escape state so an embedded \" doesn't end the string. Within a
+ * region, any backslash NOT followed by one of "\\/bfnrtu (the JSON-valid
+ * escape leads, including the unicode escape u — its 4 hex digits are
+ * already valid characters and need no rewriting) gets doubled.
+ */
+export function fixLatexEscapes(text: string): string {
+  let out = ''
+  let inString = false
+  let i = 0
+  while (i < text.length) {
+    const ch = text[i]
+    if (!inString) {
+      out += ch
+      if (ch === '"') inString = true
+      i++
+      continue
+    }
+    // Inside a JSON string literal.
+    if (ch === '"') {
+      out += ch
+      inString = false
+      i++
+      continue
+    }
+    if (ch === '\\') {
+      const next = text[i + 1] ?? ''
+      if (next === '' || /[^"\\/bfnrtu]/.test(next)) {
+        // Lone backslash before a non-escape char → double it.
+        out += '\\\\'
+        i++
+      } else {
+        // Valid JSON escape sequence — copy both chars verbatim.
+        out += ch + next
+        i += 2
+      }
+      continue
+    }
+    out += ch
+    i++
+  }
+  return out
+}
+
+export function parseSchemaResponse(responseText: string): unknown {
+  const cleaned = responseText
+    .trim()
+    .replace(/^```json\s*/i, '')
+    .replace(/^```\s*/, '')
+    .replace(/```\s*$/, '')
+    .trim()
+  try {
+    return JSON.parse(cleaned)
+  } catch {
+    return JSON.parse(fixLatexEscapes(cleaned))
+  }
+}
+
+async function callGeminiWithSchema(args: {
+  apiKey: string
+  prompt: string
+  pdfBase64: string
+}): Promise<string> {
+  const schemaForGemini = zodToGeminiSchema(ExtractedPageSchema)
+
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_CONFIG.modelName}:generateContent?key=${args.apiKey}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [
+          {
+            parts: [
+              { inlineData: { mimeType: 'application/pdf', data: args.pdfBase64 } },
+              { text: args.prompt },
+            ],
+          },
+        ],
+        generationConfig: {
+          temperature: GEMINI_CONFIG.temperature,
+          maxOutputTokens: GEMINI_CONFIG.maxOutputTokens,
+          responseMimeType: 'application/json',
+          responseSchema: schemaForGemini,
+        },
+      }),
+    },
+  )
+
+  if (!res.ok) {
+    const body = await res.text()
+    logger.error(
+      { status: res.status, body: body.slice(0, 500) },
+      'Context-extraction Gemini API error',
+    )
+    throw new GeminiSchemaApiError(res.status, `Gemini API returned ${res.status}`)
+  }
+
+  const json = await res.json()
+  const text =
+    json.candidates?.[0]?.content?.parts
+      ?.filter((p: { text?: string }) => p.text)
+      ?.map((p: { text: string }) => p.text)
+      ?.join('') || ''
+  return text
+}
+
+export interface ExtractPageResult {
+  pageIndex: number
+  exercises: ExtractedExercise[]
+  warning?: string
+}
+
+/**
+ * Extract structured exercises from a single PDF page.
+ * The provided prompt is concatenated with a JSON-schema instruction so the
+ * existing admin-managed context_extractor prompts continue to work — they
+ * supply the LaTeX content rules; we override only the output container.
+ */
+export async function extractStructuredExercisesFromPage(args: {
+  apiKey: string
+  promptTemplate: string
+  pageBuffer: Buffer
+  pageIndex: number
+}): Promise<ExtractPageResult> {
+  const fullPrompt = `${args.promptTemplate}\n${SCHEMA_INSTRUCTION}`
+
+  const responseText = await circuitBreaker.execute(() =>
+    withRetry(
+      () =>
+        withTimeout(
+          () =>
+            callGeminiWithSchema({
+              apiKey: args.apiKey,
+              prompt: fullPrompt,
+              pdfBase64: args.pageBuffer.toString('base64'),
+            }),
+          { timeoutMs: GEMINI_CONFIG.timeoutMs, message: 'Gemini context-extraction timed out' },
+        ),
+      {
+        maxRetries: GEMINI_CONFIG.maxRetries,
+        isRetryable: isRetryableGeminiError,
+        logPrefix: '[ContextExtractionSchema]',
+      },
+    ),
+  )
+
+  if (!responseText.trim()) {
+    return { pageIndex: args.pageIndex, exercises: [], warning: 'Empty response' }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = parseSchemaResponse(responseText)
+  } catch (err) {
+    return {
+      pageIndex: args.pageIndex,
+      exercises: [],
+      warning: `Failed to parse JSON: ${err instanceof Error ? err.message : 'unknown'}`,
+    }
+  }
+
+  const validated = ExtractedPageSchema.safeParse(parsed)
+  if (!validated.success) {
+    return {
+      pageIndex: args.pageIndex,
+      exercises: [],
+      warning: `Schema validation failed: ${validated.error.message.slice(0, 200)}`,
+    }
+  }
+
+  return { pageIndex: args.pageIndex, exercises: validated.data.exercises }
+}
+
+/**
+ * Merge per-page exercise arrays into a single ordered list.
+ *
+ * Page-by-page extraction has no shared numbering context — page 2 may
+ * label its first exercise "1" because, viewed in isolation, it looks
+ * like the start of a document. We:
+ *
+ *   1. Concatenate exercises in page order.
+ *   2. Detect duplicate numbers across pages.
+ *   3. If duplicates exist, renumber sequentially from 1 by overall position.
+ *      Otherwise keep the LLM-supplied numbers — they are usually correct
+ *      when source pages carry their own \setcounter context.
+ */
+export function mergeExercisesAcrossPages(pageResults: ExtractPageResult[]): ExtractedExercise[] {
+  const ordered = [...pageResults].sort((a, b) => a.pageIndex - b.pageIndex)
+  const flat: ExtractedExercise[] = []
+  for (const page of ordered) {
+    for (const ex of page.exercises) {
+      flat.push(ex)
+    }
+  }
+
+  if (flat.length === 0) return []
+
+  const numbers = new Set<number>()
+  let hasConflict = false
+  for (const ex of flat) {
+    if (numbers.has(ex.number)) {
+      hasConflict = true
+      break
+    }
+    numbers.add(ex.number)
+  }
+
+  if (!hasConflict) return flat
+
+  return flat.map((ex, idx) => ({ ...ex, number: idx + 1 }))
+}
+
+/**
+ * Render a structured exercise list back into the same kind of LaTeX text
+ * the legacy context-exercise-parser already understands. This lets the
+ * existing ContextExerciseViewer keep working unchanged in this PR — it
+ * fetches `text` from ContextExtractions and parses with parseContextText,
+ * which matches the \textbf{תרגיל N} / \section*{פתרון תרגיל N} markers
+ * we emit here. The structured `exercises` array is what create-context-
+ * exercises actually consumes; this rendered text is a compatibility view.
+ */
+/** Placeholder used in the rendered text when an exercise has no solution.
+ * Non-empty so the legacy parser's "phantom exercise" filter (which drops
+ * exercises with no matching solution when others do have one) keeps every
+ * exercise visible in the admin preview. */
+const NO_SOLUTION_PLACEHOLDER = 'הפתרון לא נכלל בחומר המקור.'
+
+export function renderExercisesAsLatexText(exercises: ExtractedExercise[]): string {
+  if (exercises.length === 0) return ''
+
+  const parts: string[] = []
+
+  for (const ex of exercises) {
+    parts.push(`\\textbf{תרגיל ${ex.number}}`)
+    parts.push('')
+    parts.push(ex.latex.trim())
+    parts.push('')
+  }
+
+  parts.push('')
+  parts.push('\\section*{פתרונות}')
+  parts.push('')
+  for (const ex of exercises) {
+    parts.push(`\\section*{פתרון תרגיל ${ex.number}}`)
+    parts.push('')
+    const solution = ex.solution !== null && ex.solution.trim() ? ex.solution.trim() : null
+    parts.push(solution ?? NO_SOLUTION_PLACEHOLDER)
+    parts.push('')
+  }
+
+  return parts.join('\n').trim() + '\n'
+}

--- a/tests/unit/server/services/lesson-context-conversion/structured-extraction.spec.ts
+++ b/tests/unit/server/services/lesson-context-conversion/structured-extraction.spec.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest'
+import {
+  fixLatexEscapes,
+  mergeExercisesAcrossPages,
+  parseSchemaResponse,
+  renderExercisesAsLatexText,
+} from '@/server/services/lesson-context-conversion/structured-extraction'
+import { parseContextText } from '@/lib/context-exercise-parser'
+
+describe('mergeExercisesAcrossPages', () => {
+  it('keeps original numbers when they are unique across pages', () => {
+    const merged = mergeExercisesAcrossPages([
+      {
+        pageIndex: 0,
+        exercises: [
+          { number: 3, latex: 'x_1', solution: null },
+          { number: 4, latex: 'x_2', solution: null },
+        ],
+      },
+      {
+        pageIndex: 1,
+        exercises: [
+          { number: 5, latex: 'x_3', solution: null },
+          { number: 6, latex: 'x_4', solution: null },
+        ],
+      },
+    ])
+
+    expect(merged.map((e) => e.number)).toEqual([3, 4, 5, 6])
+  })
+
+  it('renumbers sequentially when pages collide on numbering', () => {
+    // Each page processed independently can label its first exercise "1" —
+    // when that produces duplicates we lose meaning, so renumber globally.
+    const merged = mergeExercisesAcrossPages([
+      {
+        pageIndex: 0,
+        exercises: [{ number: 1, latex: 'a', solution: null }],
+      },
+      {
+        pageIndex: 1,
+        exercises: [
+          { number: 1, latex: 'b', solution: null },
+          { number: 2, latex: 'c', solution: null },
+        ],
+      },
+    ])
+
+    expect(merged.map((e) => e.number)).toEqual([1, 2, 3])
+    expect(merged.map((e) => e.latex)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('respects page order when concatenating', () => {
+    const merged = mergeExercisesAcrossPages([
+      { pageIndex: 1, exercises: [{ number: 7, latex: 'late', solution: null }] },
+      { pageIndex: 0, exercises: [{ number: 3, latex: 'early', solution: null }] },
+    ])
+
+    expect(merged.map((e) => e.latex)).toEqual(['early', 'late'])
+  })
+
+  it('returns empty array when no exercises were extracted', () => {
+    const merged = mergeExercisesAcrossPages([
+      { pageIndex: 0, exercises: [] },
+      { pageIndex: 1, exercises: [] },
+    ])
+    expect(merged).toEqual([])
+  })
+})
+
+describe('renderExercisesAsLatexText', () => {
+  it('emits markers parseContextText recognises so the legacy viewer keeps working', () => {
+    const text = renderExercisesAsLatexText([
+      { number: 3, latex: 'התרגיל הראשון', solution: 'פתרון ראשון' },
+      { number: 4, latex: 'התרגיל השני', solution: null },
+    ])
+
+    expect(text).toContain('\\textbf{תרגיל 3}')
+    expect(text).toContain('\\textbf{תרגיל 4}')
+    expect(text).toContain('\\section*{פתרונות}')
+    expect(text).toContain('\\section*{פתרון תרגיל 3}')
+    // Exercise 4 has no solution: a placeholder solution is emitted so the
+    // legacy parser's phantom filter keeps the exercise in the preview.
+    expect(text).toContain('\\section*{פתרון תרגיל 4}')
+
+    // Round-trip: the legacy parser should split this into two exercises.
+    const parsed = parseContextText(text)
+    const exercises = parsed.flatMap((seg) => seg.exercises)
+    expect(exercises).toHaveLength(2)
+    expect(exercises[0].number).toBe(3)
+    expect(exercises[1].number).toBe(4)
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(renderExercisesAsLatexText([])).toBe('')
+  })
+
+  it('emits placeholder solutions when none are provided so every exercise survives the legacy phantom filter', () => {
+    const text = renderExercisesAsLatexText([
+      { number: 1, latex: 'a', solution: null },
+      { number: 2, latex: 'b', solution: null },
+    ])
+    // The legacy parser drops exercises lacking a matched solution when any
+    // exercise has one. Emitting placeholder solutions keeps both visible.
+    expect(text).toContain('\\section*{פתרון תרגיל 1}')
+    expect(text).toContain('\\section*{פתרון תרגיל 2}')
+
+    const exercises = parseContextText(text).flatMap((s) => s.exercises)
+    expect(exercises).toHaveLength(2)
+  })
+})
+
+describe('fixLatexEscapes', () => {
+  it('rewrites lone LaTeX backslashes inside JSON string literals so JSON.parse succeeds', () => {
+    // \i is not a valid JSON escape — JSON.parse fails on this literally.
+    // After repair, the backslash becomes \\i which decodes to a single \i.
+    const broken = '{"latex": "\\implies"}'
+    expect(() => JSON.parse(broken)).toThrow()
+    const fixed = fixLatexEscapes(broken)
+    expect(JSON.parse(fixed)).toEqual({ latex: '\\implies' })
+  })
+
+  it('preserves valid JSON escape sequences inside strings', () => {
+    // \" \\ \/ \b \f \n \r \t — all must pass through untouched.
+    const valid = '{"a": "line\\nbreak", "b": "quote\\"end", "c": "slash\\\\path"}'
+    expect(fixLatexEscapes(valid)).toBe(valid)
+    expect(JSON.parse(fixLatexEscapes(valid))).toEqual({
+      a: 'line\nbreak',
+      b: 'quote"end',
+      c: 'slash\\path',
+    })
+  })
+
+  it('leaves structural JSON characters alone', () => {
+    // The previous regex-based version applied the fix to the entire JSON
+    // including structural positions. Confirm braces/commas/colons/numbers
+    // are untouched and the rewriter is no-op on already-valid JSON.
+    const json = '{"n": 42, "arr": [1, 2, 3]}'
+    expect(fixLatexEscapes(json)).toBe(json)
+  })
+
+  it('does not exit a string region on an embedded escaped quote', () => {
+    // The walker tracks escape state — a \" inside a string must not be
+    // treated as the closing quote, otherwise the fix would start applying
+    // to the surrounding structure. Use \i (invalid JSON escape) to trigger
+    // the rewrite specifically inside the string region.
+    const broken = '{"latex": "\\implies \\"yes\\""}'
+    expect(() => JSON.parse(broken)).toThrow()
+    expect(JSON.parse(fixLatexEscapes(broken))).toEqual({ latex: '\\implies "yes"' })
+  })
+
+  it('parseSchemaResponse falls back to fixLatexEscapes when first parse fails', () => {
+    // Round-trip: code-fence stripping + escape repair on a Gemini-style
+    // response with a raw \implies inside the latex field.
+    const response =
+      '```json\n{"exercises": [{"number": 1, "latex": "\\implies a", "solution": null}]}\n```'
+    const parsed = parseSchemaResponse(response) as {
+      exercises: Array<{ number: number; latex: string; solution: null }>
+    }
+    expect(parsed.exercises).toEqual([{ number: 1, latex: '\\implies a', solution: null }])
+  })
+})


### PR DESCRIPTION
## Summary

- Resolved conflict in src/app/api/lessons/create-context-exercises/route.ts
- Both sides added different but complementary code:
  - HEAD (PR #1386): `CreatableExercise` interface and `readStructuredExercises()` for schema-mode extraction
  - dev: `LessonBlock` type and `parseLessonBlocks()`/`extractRefId()`/`generateBlockId()` for block reconciliation
  - Kept both — the POST handler uses all of them
- Response object includes both `source` (from HEAD) and `lessonBlocksUpdated` (from dev)
- TypeScript, lint, and format checks all pass

Closes #1386

---
_Opened by kody (single-session autonomous run)._ 