### PR TITLE
feat: Add Media tab for three-tab lesson view

### DIFF
--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/DualModeLessonView/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/DualModeLessonView/index.tsx
@@ -2,11 +2,12 @@
  * @fileType component
  * @domain lessons
  * @pattern dual-view
- * @ai-summary Two-tab lesson view that lets the student toggle between a paper-style
- *             "PDF" document built from the same exercise blocks the Interactive tab
- *             renders, and the interactive exercise pager. Tab choice is persisted
- *             per lesson in localStorage. Both tabs read from `exercise.content.blocks`
- *             so admin edits flow to both.
+ * @ai-summary Tab-based lesson view supporting up to three tabs: Media (attached
+ *             files), PDF (worksheet from exercise blocks), and Interactive (exercise
+ *             pager with answer UI). Media tab only appears when the lesson has
+ *             attached files. Tab choice is persisted per lesson in localStorage.
+ *             Both PDF and Interactive tabs read from `exercise.content.blocks` so
+ *             admin edits flow to both.
  */
 
 'use client'
@@ -19,6 +20,7 @@ import { useTranslations } from '@/ui/web/providers/I18n'
 import { BlocksDocumentLessonView } from '../BlocksDocumentLessonView'
 import { ExercisesPager } from '../ExercisesPager'
 import { LessonPager } from '../LessonPager'
+import { MediaTabContent } from '../MediaTabContent'
 import { TabButton } from './TabButton'
 import { useLessonViewMode } from './useLessonViewMode'
 
@@ -44,6 +46,8 @@ interface DualModeLessonViewProps {
   /** Exercises whose blocks feed both the PDF document and the Interactive pager. */
   exercises: Exercise[]
   interactive: InteractiveSource
+  /** Attached media files — when present, a "Media" tab is shown as the first tab. */
+  validFiles?: MediaType[]
   mediaMap?: Record<string, MediaType>
   chatLessonId?: string
   showChat?: boolean
@@ -61,6 +65,7 @@ export function DualModeLessonView(props: DualModeLessonViewProps) {
     gradeLevel,
     exercises,
     interactive,
+    validFiles = [],
     mediaMap,
     chatLessonId,
     showChat,
@@ -68,14 +73,17 @@ export function DualModeLessonView(props: DualModeLessonViewProps) {
   } = props
 
   const t = useTranslations('courses')
+  const hasMedia = validFiles.length > 0
   const [mode, select] = useLessonViewMode(lessonId)
 
-  // Stable ids per lesson so tabs and panels can be wired with aria-controls /
-  // aria-labelledby without risk of collision when multiple DualModeLessonView
-  // instances coexist on a page.
+  // If stored mode is 'media' but this lesson has no files, fall back to 'pdf'.
+  const activeMode = mode === 'media' && !hasMedia ? 'pdf' : mode
+
   const tabIds = {
+    mediaTab: `lesson-${lessonId}-tab-media`,
     pdfTab: `lesson-${lessonId}-tab-pdf`,
     interactiveTab: `lesson-${lessonId}-tab-interactive`,
+    mediaPanel: `lesson-${lessonId}-panel-media`,
     pdfPanel: `lesson-${lessonId}-panel-pdf`,
     interactivePanel: `lesson-${lessonId}-panel-interactive`,
   }
@@ -86,24 +94,51 @@ export function DualModeLessonView(props: DualModeLessonViewProps) {
       aria-label={t('lessonViewMode')}
       className="flex items-center gap-1 border-b border-border bg-card px-4 py-2 print:hidden"
     >
+      {hasMedia && (
+        <TabButton
+          id={tabIds.mediaTab}
+          controlsId={tabIds.mediaPanel}
+          label={t('lessonViewModeMedia')}
+          active={activeMode === 'media'}
+          onClick={() => select('media')}
+        />
+      )}
       <TabButton
         id={tabIds.pdfTab}
         controlsId={tabIds.pdfPanel}
         label={t('lessonViewModePdf')}
-        active={mode === 'pdf'}
+        active={activeMode === 'pdf'}
         onClick={() => select('pdf')}
       />
       <TabButton
         id={tabIds.interactiveTab}
         controlsId={tabIds.interactivePanel}
         label={t('lessonViewModeInteractive')}
-        active={mode === 'interactive'}
+        active={activeMode === 'interactive'}
         onClick={() => select('interactive')}
       />
     </div>
   )
 
-  if (mode === 'pdf') {
+  if (activeMode === 'media' && hasMedia) {
+    return (
+      <section role="tabpanel" id={tabIds.mediaPanel} aria-labelledby={tabIds.mediaTab}>
+        <MediaTabContent
+          lessonTitle={lessonTitle}
+          backUrl={backUrl}
+          lessonId={lessonId}
+          validFiles={validFiles}
+          courseSlug={courseSlug}
+          headerSlot={tabBar}
+          showChat={showChat}
+          chatLessonId={chatLessonId}
+          formulaSheet={formulaSheet}
+        />
+      </section>
+    )
+  }
+
+  if (activeMode === 'pdf') {
     return (
       <section role="tabpanel" id={tabIds.pdfPanel} aria-labelledby={tabIds.pdfTab}>
         <BlocksDocumentLessonView

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/DualModeLessonView/useLessonViewMode.ts
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/DualModeLessonView/useLessonViewMode.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react'
 
-export type LessonMode = 'pdf' | 'interactive'
+export type LessonMode = 'media' | 'pdf' | 'interactive'
 
 const STORAGE_PREFIX = 'lesson-view-mode:'
 
@@ -10,7 +10,7 @@ function readStoredMode(lessonId: string): LessonMode | null {
   if (typeof window === 'undefined') return null
   try {
     const raw = window.localStorage.getItem(`${STORAGE_PREFIX}${lessonId}`)
-    return raw === 'pdf' || raw === 'interactive' ? raw : null
+    return raw === 'media' || raw === 'pdf' || raw === 'interactive' ? raw : null
   } catch {
     return null
   }

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/MediaTabContent/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/MediaTabContent/index.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+/**
+ * MediaTabContent
+ *
+ * Renders the lesson's attached media files (PDFs, videos, etc.) as the
+ * "Media" tab inside the three-tab lesson view. Keeps the same ExerciseWorkspace
+ * chrome (back button, title, optional chat panel) but shows the raw media
+ * directly without the paging intro/outro of PdfLessonPager.
+ */
+
+import React from 'react'
+import type { FormulaSheet, Media } from '@/payload-types'
+import { ChatInterface } from '@/ui/web/chat'
+import { Media as MediaComponent } from '@/ui/web/media'
+import { ExerciseWorkspace } from '@/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/exercises/[exerciseSlug]/_components/ExerciseWorkspace'
+
+interface MediaTabContentProps {
+  lessonTitle: string
+  backUrl: string
+  lessonId: string
+  validFiles: Media[]
+  courseSlug: string
+  headerSlot?: React.ReactNode
+  showChat?: boolean
+  chatLessonId?: string
+  formulaSheet?: FormulaSheet | null
+}
+
+export function MediaTabContent({
+  lessonTitle,
+  backUrl,
+  lessonId,
+  validFiles,
+  courseSlug,
+  headerSlot,
+  showChat,
+  chatLessonId,
+  formulaSheet,
+}: MediaTabContentProps) {
+  return (
+    <ExerciseWorkspace
+      exerciseTitle={lessonTitle}
+      backUrl={backUrl}
+      primaryContent={
+        <div className="flex h-full flex-col min-h-0">
+          {headerSlot}
+          <div className="flex-1 overflow-y-auto min-h-0">
+            <div className="w-full p-card-padding-sm md:p-card-padding flex flex-col gap-content-gap">
+              {validFiles.map((file) => (
+                <div key={file.id} className="w-full h-[calc(100vh-120px)]">
+                  <div className="border rounded-lg overflow-hidden bg-card shadow-card h-full">
+                    <MediaComponent
+                      resource={file}
+                      className="w-full h-full"
+                      htmlElement={null}
+                      lessonId={lessonId}
+                      courseId={courseSlug}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      }
+      chatContent={
+        showChat ? (
+          <ChatInterface
+            lessonId={chatLessonId ?? lessonId}
+            translationNamespace="courses"
+            showMathTools={true}
+            formulaSheet={formulaSheet}
+          />
+        ) : null
+      }
+    />
+  )
+}

--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/page.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/page.tsx
@@ -57,6 +57,8 @@ function renderDualMode(args: {
   /** Exercises whose blocks feed both PDF and Interactive tabs. */
   exercises: React.ComponentProps<typeof DualModeLessonView>['exercises']
   interactive: React.ComponentProps<typeof DualModeLessonView>['interactive']
+  /** Attached media files — when present, a Media tab is shown. */
+  validFiles?: Media[]
   mediaMap?: Record<string, Media>
   chatLessonId: string
   showChat: boolean
@@ -85,6 +87,7 @@ function renderDualMode(args: {
         gradeLevel={args.gradeLevel}
         exercises={args.exercises}
         interactive={args.interactive}
+        validFiles={args.validFiles}
         mediaMap={args.mediaMap}
         chatLessonId={args.chatLessonId}
         showChat={args.showChat}
@@ -225,12 +228,11 @@ export default async function LessonPage({ params }: LessonPageProps) {
       }
     }
 
-    // Dual-mode view: when no media is attached AND the lesson has at least one
-    // exercise carrying renderable content blocks, offer a PDF / Interactive
-    // tab toggle. Both tabs read from the same `exercise.content.blocks`.
+    // Multi-tab view: show up to 3 tabs (Media / PDF / Interactive) whenever
+    // the lesson has at least one exercise with renderable blocks. Media tab
+    // only appears when validFiles is non-empty.
     const dualModeExercises = blockExercises.filter(hasRenderableBlocks)
-    const hasAttachedMedia = validFiles.length > 0
-    if (!hasAttachedMedia && dualModeExercises.length > 0) {
+    if (dualModeExercises.length > 0) {
       return renderDualMode({
         accessType: effectiveAccessType,
         courseSlug,
@@ -245,6 +247,7 @@ export default async function LessonPage({ params }: LessonPageProps) {
         backUrl: '/study',
         exercises: dualModeExercises,
         interactive: { kind: 'blocks', blocks: resolvedBlocks, contentPageBodies, validFiles },
+        validFiles,
         mediaMap,
         chatLessonId: lesson.id,
         showChat,
@@ -298,10 +301,9 @@ export default async function LessonPage({ params }: LessonPageProps) {
   // Batch-fetch all media referenced inside exercise content blocks
   const mediaMap = hasExercises ? await queryMediaByIds(extractAllMediaIds(exercises)) : {}
 
-  // Dual-mode view: when no media is attached AND any exercise has renderable
-  // content blocks. Media-attached lessons still route to PdfLessonPager
-  // below (media trumps).
-  if (hasExercises && !hasContent) {
+  // Multi-tab view: show up to 3 tabs (Media / PDF / Interactive) whenever
+  // the lesson has at least one exercise with renderable blocks.
+  if (hasExercises) {
     const dualModeExercises = exercises.filter(hasRenderableBlocks)
     if (dualModeExercises.length > 0) {
       return renderDualMode({
@@ -318,6 +320,7 @@ export default async function LessonPage({ params }: LessonPageProps) {
         backUrl,
         exercises: dualModeExercises,
         interactive: { kind: 'exercises', exercises },
+        validFiles,
         mediaMap,
         chatLessonId,
         showChat,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -219,6 +219,7 @@
     "noExercises": "No exercises available for this lesson.",
     "noPDF": "PDF content is not available for this lesson.",
     "lessonViewMode": "Lesson view mode",
+    "lessonViewModeMedia": "Media",
     "lessonViewModePdf": "PDF",
     "lessonViewModeInteractive": "Interactive",
     "pdfBadge": "PDF",

--- a/src/i18n/he.json
+++ b/src/i18n/he.json
@@ -219,6 +219,7 @@
     "noExercises": "אין תרגילים זמינים לשיעור זה.",
     "noPDF": "תוכן PDF אינו זמין לשיעור זה.",
     "lessonViewMode": "מצב תצוגת שיעור",
+    "lessonViewModeMedia": "מדיה",
     "lessonViewModePdf": "PDF",
     "lessonViewModeInteractive": "אינטראקטיבי",
     "pdfBadge": "PDF",


### PR DESCRIPTION
Lessons with attached media now show a Media tab alongside PDF and Interactive. MediaTabContent renders the files directly in the tab chrome. DualModeLessonView extended to support the optional third tab. Both page.tsx paths now always show the multi-tab view when exercises have renderable blocks.