### PR TITLE
feat: 3-button lesson conversion (Full Media / Full LaTeX / Steps)

### DIFF
--- a/src/app/api/lessons/convert-full-latex/route.ts
+++ b/src/app/api/lessons/convert-full-latex/route.ts
@@ -24,12 +24,13 @@ export const POST = withApiHandler<Body, unknown>(
     auth: 'admin',
     bodySchema,
   },
-  async ({ payload, body, user }) => {
+  async ({ payload, body, user, request }) => {
     const result = await runFullLatexPipeline({
       payload,
       user: user!,
       lessonId: body.lessonId,
       mediaId: body.mediaId,
+      request,
     })
 
     if (!result.success) {

--- a/src/app/api/lessons/convert-full-latex/route.ts
+++ b/src/app/api/lessons/convert-full-latex/route.ts
@@ -1,0 +1,47 @@
+/**
+ * POST /api/lessons/convert-full-latex
+ *
+ * One-button "Full Convert (LaTeX)" path: reads a .tex file attached to
+ * the lesson, splits it into exercises with the deterministic parser
+ * (no Gemini), creates Exercise documents, and runs the LaTeX → typed
+ * block conversion on each. The Gemini AI fallback inside Stage 3 is
+ * still available for blocks the deterministic parser can't handle.
+ */
+import { apiError, apiSuccess } from '@/server/api/responses'
+import { withApiHandler } from '@/server/api/with-api-handler'
+import { runFullLatexPipeline } from '@/server/services/lesson-context-conversion/full-pipeline'
+import { z } from 'zod'
+
+const bodySchema = z.object({
+  lessonId: z.string().min(1),
+  mediaId: z.string().min(1),
+})
+
+type Body = z.infer<typeof bodySchema>
+
+export const POST = withApiHandler<Body, unknown>(
+  {
+    auth: 'admin',
+    bodySchema,
+  },
+  async ({ payload, body, user }) => {
+    const result = await runFullLatexPipeline({
+      payload,
+      user: user!,
+      lessonId: body.lessonId,
+      mediaId: body.mediaId,
+    })
+
+    if (!result.success) {
+      return apiError('UPSTREAM_ERROR', result.error || 'Full LaTeX conversion failed', 400)
+    }
+
+    return apiSuccess({
+      exerciseCount: result.exerciseCount,
+      exerciseIds: result.exerciseIds,
+      latexBlocksConverted: result.latexBlocksConverted,
+      latexBlocksFailed: result.latexBlocksFailed,
+      warnings: result.warnings.length > 0 ? result.warnings : undefined,
+    })
+  },
+)

--- a/src/app/api/lessons/convert-full-media/route.ts
+++ b/src/app/api/lessons/convert-full-media/route.ts
@@ -1,0 +1,48 @@
+/**
+ * POST /api/lessons/convert-full-media
+ *
+ * One-button "Full Convert (Media)" path: runs Stage 1 (Gemini schema-mode
+ * extraction) + Stage 2 (create exercises) + Stage 3 (convert each LaTeX
+ * block to typed blocks) sequentially. Returns counts so the UI can show
+ * a single status line instead of three.
+ */
+import { apiError, apiSuccess } from '@/server/api/responses'
+import { withApiHandler } from '@/server/api/with-api-handler'
+import { runFullMediaPipeline } from '@/server/services/lesson-context-conversion/full-pipeline'
+import { z } from 'zod'
+
+const bodySchema = z.object({
+  lessonId: z.string().min(1),
+  mediaId: z.string().min(1),
+  promptId: z.string().min(1),
+})
+
+type Body = z.infer<typeof bodySchema>
+
+export const POST = withApiHandler<Body, unknown>(
+  {
+    auth: 'admin',
+    bodySchema,
+  },
+  async ({ payload, body, user }) => {
+    const result = await runFullMediaPipeline({
+      payload,
+      user: user!,
+      lessonId: body.lessonId,
+      mediaId: body.mediaId,
+      promptId: body.promptId,
+    })
+
+    if (!result.success) {
+      return apiError('UPSTREAM_ERROR', result.error || 'Full media conversion failed', 400)
+    }
+
+    return apiSuccess({
+      exerciseCount: result.exerciseCount,
+      exerciseIds: result.exerciseIds,
+      latexBlocksConverted: result.latexBlocksConverted,
+      latexBlocksFailed: result.latexBlocksFailed,
+      warnings: result.warnings.length > 0 ? result.warnings : undefined,
+    })
+  },
+)

--- a/src/app/api/lessons/convert-full-media/route.ts
+++ b/src/app/api/lessons/convert-full-media/route.ts
@@ -24,13 +24,14 @@ export const POST = withApiHandler<Body, unknown>(
     auth: 'admin',
     bodySchema,
   },
-  async ({ payload, body, user }) => {
+  async ({ payload, body, user, request }) => {
     const result = await runFullMediaPipeline({
       payload,
       user: user!,
       lessonId: body.lessonId,
       mediaId: body.mediaId,
       promptId: body.promptId,
+      request,
     })
 
     if (!result.success) {

--- a/src/app/api/lessons/create-context-exercises/route.ts
+++ b/src/app/api/lessons/create-context-exercises/route.ts
@@ -2,18 +2,14 @@
  * Create Exercises from Context API
  *
  * POST /api/lessons/create-context-exercises
- * Reads the latest ContextExtraction for the lesson and creates Exercise
- * documents with LaTeX blocks. Prefers the structured `exercises` array
- * produced by schema-mode extraction; falls back to regex-parsing the
- * `text` field for legacy extractions that have no structured payload.
- *
- * Idempotent: deletes previous context_extraction exercises before creating new ones,
- * and reconciles lesson.blocks (drops stale refs, appends new exerciseRef entries).
+ * Thin wrapper over createExercisesFromExtraction. Used by the Steps
+ * Convert flow (admin manually clicks "Create Exercises" in the viewer).
+ * The two full-pipeline endpoints (convert-full-media, convert-full-latex)
+ * call the service directly.
  */
 import { apiError, apiSuccess } from '@/server/api/responses'
 import { withApiHandler } from '@/server/api/with-api-handler'
-import { parseContextText } from '@/lib/context-exercise-parser'
-import { makeLatexBlock } from '@/lib/latex-parser/block-generators'
+import { createExercisesFromExtraction } from '@/server/services/lesson-context-conversion/create-exercises-from-extraction'
 import { z } from 'zod'
 
 const createContextExercisesSchema = z.object({
@@ -21,79 +17,6 @@ const createContextExercisesSchema = z.object({
 })
 
 type CreateContextExercisesBody = z.infer<typeof createContextExercisesSchema>
-
-interface CreatableExercise {
-  number: number
-  title?: string
-  latexContent: string
-  solution: string | null
-}
-
-function isStructuredExercise(value: unknown): value is {
-  number: number
-  latex: string
-  solution?: string | null
-} {
-  if (!value || typeof value !== 'object') return false
-  const v = value as Record<string, unknown>
-  if (typeof v.number !== 'number') return false
-  if (typeof v.latex !== 'string') return false
-  return true
-}
-
-interface StructuredReadResult {
-  exercises: CreatableExercise[]
-  skipped: number
-}
-
-function readStructuredExercises(extraction: unknown): StructuredReadResult | null {
-  const value = (extraction as { exercises?: unknown })?.exercises
-  if (!Array.isArray(value)) return null
-  const valid: CreatableExercise[] = []
-  let skipped = 0
-  for (const entry of value) {
-    if (!isStructuredExercise(entry) || !entry.latex.trim()) {
-      skipped++
-      continue
-    }
-    valid.push({
-      number: entry.number,
-      latexContent: entry.latex,
-      solution: typeof entry.solution === 'string' && entry.solution.trim() ? entry.solution : null,
-    })
-  }
-  return valid.length > 0 ? { exercises: valid, skipped } : null
-}
-
-type LessonBlock = {
-  id: string
-  blockType: 'exerciseRef' | 'contentPageRef'
-  exercise?: string | { id: string }
-  contentPage?: string | { id: string }
-}
-
-function generateBlockId(): string {
-  return Math.random().toString(36).slice(2, 14)
-}
-
-function parseLessonBlocks(value: unknown): LessonBlock[] {
-  if (Array.isArray(value)) return value as LessonBlock[]
-  if (typeof value === 'string' && value.trim()) {
-    try {
-      const parsed = JSON.parse(value)
-      if (Array.isArray(parsed)) return parsed as LessonBlock[]
-    } catch {
-      // ignore
-    }
-  }
-  return []
-}
-
-function extractRefId(val: unknown): string | null {
-  if (typeof val === 'string' && val.length > 0) return val
-  if (val && typeof val === 'object' && 'id' in val) return String((val as { id: unknown }).id)
-  return null
-}
 
 export const POST = withApiHandler<CreateContextExercisesBody, unknown>(
   {
@@ -103,180 +26,22 @@ export const POST = withApiHandler<CreateContextExercisesBody, unknown>(
   async ({ payload, body, user }) => {
     const { lessonId } = body
 
-    // Fetch the latest context extraction for this lesson
-    const extractionResult = await payload.find({
-      collection: 'context-extractions',
-      where: { lesson: { equals: lessonId } },
-      sort: '-updatedAt',
-      limit: 1,
-      depth: 0,
+    const result = await createExercisesFromExtraction({
+      payload,
+      user: user!,
+      lessonId,
     })
 
-    if (extractionResult.docs.length === 0) {
-      return apiError(
-        'VALIDATION_ERROR',
-        'No context extraction found for this lesson. Run "Convert Context" first.',
-        400,
-      )
-    }
-
-    const extractionDoc = extractionResult.docs[0] as unknown as {
-      text: string
-      exercises?: unknown
-    }
-
-    // Prefer the structured exercises array from schema-mode extraction.
-    // Fall back to regex-parsing the rendered text for legacy extractions.
-    const structured = readStructuredExercises(extractionDoc)
-    let allExercises: CreatableExercise[] | null = structured?.exercises ?? null
-    let source: 'structured' | 'legacy_text' = 'structured'
-    const warnings: string[] = []
-
-    if (structured && structured.skipped > 0) {
-      // Surface partial corruption so admins don't silently lose exercises
-      // when Gemini occasionally emits malformed entries inside an otherwise-
-      // valid response.
-      warnings.push(
-        `Skipped ${structured.skipped} malformed entr${structured.skipped === 1 ? 'y' : 'ies'} in structured exercises — review the extraction in the viewer before publishing.`,
-      )
-    }
-
-    if (!allExercises) {
-      source = 'legacy_text'
-      const extractionText = extractionDoc.text
-      if (!extractionText?.trim()) {
-        return apiError(
-          'VALIDATION_ERROR',
-          'Context extraction is empty. Run "Convert Context" again.',
-          400,
-        )
-      }
-
-      const segments = parseContextText(extractionText)
-      const legacy = segments.flatMap((seg) =>
-        seg.exercises.map((ex) => ({
-          number: ex.number,
-          title: ex.title,
-          latexContent: ex.latexContent,
-          solution: ex.solution,
-        })),
-      )
-      if (legacy.length === 0) {
-        return apiError('VALIDATION_ERROR', 'No exercises found in context text', 400)
-      }
-      allExercises = legacy
-    }
-
-    // Capture IDs of existing context_extraction exercises so we can drop their
-    // stale references from lesson.blocks before re-appending the new ones.
-    const staleResult = await payload.find({
-      collection: 'exercises',
-      where: {
-        lesson: { equals: lessonId },
-        origin: { equals: 'context_extraction' },
-      },
-      limit: 0,
-      depth: 0,
-    })
-    const staleIds = new Set(staleResult.docs.map((doc) => String(doc.id)))
-
-    // Delete existing context_extraction exercises for this lesson (idempotent)
-    await payload.delete({
-      collection: 'exercises',
-      where: {
-        lesson: { equals: lessonId },
-        origin: { equals: 'context_extraction' },
-      },
-    })
-
-    // Get current exercise count for ordering
-    const currentExercises = await payload.find({
-      collection: 'exercises',
-      where: { lesson: { equals: lessonId } },
-      limit: 0,
-    })
-    const startOrder = currentExercises.totalDocs
-
-    // Create exercises with LaTeX blocks
-    const createdIds: string[] = []
-
-    for (let i = 0; i < allExercises.length; i++) {
-      const exercise = allExercises[i]
-      const blocks = [makeLatexBlock(exercise.latexContent)]
-
-      // If exercise has a solution, add it as a second LaTeX block
-      if (exercise.solution) {
-        blocks.push(makeLatexBlock(exercise.solution))
-      }
-
-      try {
-        const created = await payload.create({
-          collection: 'exercises',
-          data: {
-            lesson: lessonId,
-            title: exercise.title || `תרגיל ${exercise.number}`,
-            content: { blocks },
-            origin: 'context_extraction',
-            order: startOrder + i,
-          },
-          draft: true,
-          context: { _skipBlockSync: true },
-        })
-        createdIds.push(created.id)
-      } catch (err) {
-        const message = err instanceof Error ? err.message : 'Unknown error'
-        warnings.push(`Failed to create exercise ${exercise.number}: ${message}`)
-      }
-    }
-
-    // Reconcile lesson.blocks: strip stale exerciseRef entries pointing at the
-    // exercises we just deleted, then append exerciseRefs for the newly-created
-    // exercises so they show up in the Lesson admin's playlist.
-    let lessonBlocksUpdated = false
-    if (createdIds.length > 0 || staleIds.size > 0) {
-      try {
-        const lesson = await payload.findByID({
-          collection: 'lessons',
-          id: lessonId,
-          depth: 0,
-        })
-
-        const existingBlocks = parseLessonBlocks((lesson as { blocks?: unknown }).blocks)
-
-        const filteredBlocks = existingBlocks.filter((block) => {
-          if (block.blockType !== 'exerciseRef') return true
-          const refId = extractRefId(block.exercise)
-          return refId === null || !staleIds.has(refId)
-        })
-
-        const appendedBlocks: LessonBlock[] = createdIds.map((exerciseId) => ({
-          id: generateBlockId(),
-          blockType: 'exerciseRef',
-          exercise: exerciseId,
-        }))
-
-        const nextBlocks = [...filteredBlocks, ...appendedBlocks]
-
-        await payload.update({
-          collection: 'lessons',
-          id: lessonId,
-          data: { blocks: JSON.stringify(nextBlocks) } as Record<string, unknown>,
-          user: user!,
-          overrideAccess: false,
-        })
-        lessonBlocksUpdated = true
-      } catch (err) {
-        const message = err instanceof Error ? err.message : 'Unknown error'
-        warnings.push(`Failed to update lesson blocks: ${message}`)
-      }
+    if ('error' in result) {
+      return apiError('VALIDATION_ERROR', result.error.message, 400)
     }
 
     return apiSuccess({
-      exerciseIds: createdIds,
-      exerciseCount: createdIds.length,
-      source,
-      lessonBlocksUpdated,
-      warnings: warnings.length > 0 ? warnings : undefined,
+      exerciseIds: result.exerciseIds,
+      exerciseCount: result.exerciseCount,
+      source: result.source,
+      lessonBlocksUpdated: result.lessonBlocksUpdated,
+      warnings: result.warnings.length > 0 ? result.warnings : undefined,
     })
   },
 )

--- a/src/server/services/lesson-context-conversion/create-exercises-from-extraction.ts
+++ b/src/server/services/lesson-context-conversion/create-exercises-from-extraction.ts
@@ -1,0 +1,285 @@
+/**
+ * Stage 2 of the conversion pipeline as a reusable service.
+ *
+ * Reads the latest ContextExtraction for a lesson and creates Exercise
+ * documents with LaTeX blocks. Prefers the structured `exercises` array
+ * (schema-mode extraction) and falls back to regex-parsing the rendered
+ * `text` for legacy or text-mode extractions.
+ *
+ * Idempotent: deletes prior origin='context_extraction' exercises before
+ * recreating, and reconciles lesson.blocks (drops stale refs, appends
+ * fresh exerciseRef entries).
+ *
+ * Used by:
+ *   - POST /api/lessons/create-context-exercises (Steps Convert)
+ *   - runFullMediaPipeline (Full Convert (Media))
+ *   - runFullLatexPipeline (Full Convert (LaTeX))
+ */
+import type { Payload, User } from 'payload'
+import { parseContextText } from '@/lib/context-exercise-parser'
+import { makeLatexBlock } from '@/lib/latex-parser/block-generators'
+
+export interface CreateExercisesInput {
+  payload: Payload
+  user: User
+  lessonId: string
+}
+
+export interface CreateExercisesResult {
+  exerciseIds: string[]
+  exerciseCount: number
+  source: 'structured' | 'legacy_text'
+  lessonBlocksUpdated: boolean
+  warnings: string[]
+}
+
+export type CreateExercisesError = {
+  code: 'NO_EXTRACTION' | 'EMPTY_EXTRACTION' | 'NO_EXERCISES'
+  message: string
+}
+
+interface CreatableExercise {
+  number: number
+  title?: string
+  latexContent: string
+  solution: string | null
+}
+
+function isStructuredExercise(value: unknown): value is {
+  number: number
+  latex: string
+  solution?: string | null
+} {
+  if (!value || typeof value !== 'object') return false
+  const v = value as Record<string, unknown>
+  if (typeof v.number !== 'number') return false
+  if (typeof v.latex !== 'string') return false
+  return true
+}
+
+function readStructuredExercises(
+  extraction: unknown,
+): { exercises: CreatableExercise[]; skipped: number } | null {
+  const value = (extraction as { exercises?: unknown })?.exercises
+  if (!Array.isArray(value)) return null
+  const valid: CreatableExercise[] = []
+  let skipped = 0
+  for (const entry of value) {
+    if (!isStructuredExercise(entry) || !entry.latex.trim()) {
+      skipped++
+      continue
+    }
+    valid.push({
+      number: entry.number,
+      latexContent: entry.latex,
+      solution: typeof entry.solution === 'string' && entry.solution.trim() ? entry.solution : null,
+    })
+  }
+  return valid.length > 0 ? { exercises: valid, skipped } : null
+}
+
+type LessonBlock = {
+  id: string
+  blockType: 'exerciseRef' | 'contentPageRef'
+  exercise?: string | { id: string }
+  contentPage?: string | { id: string }
+}
+
+function generateBlockId(): string {
+  return Math.random().toString(36).slice(2, 14)
+}
+
+function parseLessonBlocks(value: unknown): LessonBlock[] {
+  if (Array.isArray(value)) return value as LessonBlock[]
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      const parsed = JSON.parse(value)
+      if (Array.isArray(parsed)) return parsed as LessonBlock[]
+    } catch {
+      // ignore
+    }
+  }
+  return []
+}
+
+function extractRefId(val: unknown): string | null {
+  if (typeof val === 'string' && val.length > 0) return val
+  if (val && typeof val === 'object' && 'id' in val) return String((val as { id: unknown }).id)
+  return null
+}
+
+export async function createExercisesFromExtraction(
+  input: CreateExercisesInput,
+): Promise<CreateExercisesResult | { error: CreateExercisesError }> {
+  const { payload, user, lessonId } = input
+
+  const extractionResult = await payload.find({
+    collection: 'context-extractions',
+    where: { lesson: { equals: lessonId } },
+    sort: '-updatedAt',
+    limit: 1,
+    depth: 0,
+  })
+
+  if (extractionResult.docs.length === 0) {
+    return {
+      error: {
+        code: 'NO_EXTRACTION',
+        message: 'No context extraction found for this lesson. Run "Convert Context" first.',
+      },
+    }
+  }
+
+  const extractionDoc = extractionResult.docs[0] as unknown as {
+    text: string
+    exercises?: unknown
+  }
+
+  const structured = readStructuredExercises(extractionDoc)
+  let allExercises: CreatableExercise[] | null = structured?.exercises ?? null
+  let source: 'structured' | 'legacy_text' = 'structured'
+  const warnings: string[] = []
+
+  if (structured && structured.skipped > 0) {
+    warnings.push(
+      `Skipped ${structured.skipped} malformed entr${structured.skipped === 1 ? 'y' : 'ies'} in structured exercises — review the extraction in the viewer before publishing.`,
+    )
+  }
+
+  if (!allExercises) {
+    source = 'legacy_text'
+    const extractionText = extractionDoc.text
+    if (!extractionText?.trim()) {
+      return {
+        error: {
+          code: 'EMPTY_EXTRACTION',
+          message: 'Context extraction is empty. Run "Convert Context" again.',
+        },
+      }
+    }
+
+    const segments = parseContextText(extractionText)
+    const legacy = segments.flatMap((seg) =>
+      seg.exercises.map((ex) => ({
+        number: ex.number,
+        title: ex.title,
+        latexContent: ex.latexContent,
+        solution: ex.solution,
+      })),
+    )
+    if (legacy.length === 0) {
+      return {
+        error: {
+          code: 'NO_EXERCISES',
+          message: 'No exercises found in context text',
+        },
+      }
+    }
+    allExercises = legacy
+  }
+
+  // Capture stale ids before deletion so we can drop their lesson.blocks
+  // references after recreating.
+  const staleResult = await payload.find({
+    collection: 'exercises',
+    where: {
+      lesson: { equals: lessonId },
+      origin: { equals: 'context_extraction' },
+    },
+    limit: 0,
+    depth: 0,
+  })
+  const staleIds = new Set(staleResult.docs.map((doc) => String(doc.id)))
+
+  await payload.delete({
+    collection: 'exercises',
+    where: {
+      lesson: { equals: lessonId },
+      origin: { equals: 'context_extraction' },
+    },
+  })
+
+  const currentExercises = await payload.find({
+    collection: 'exercises',
+    where: { lesson: { equals: lessonId } },
+    limit: 0,
+  })
+  const startOrder = currentExercises.totalDocs
+
+  const createdIds: string[] = []
+
+  for (let i = 0; i < allExercises.length; i++) {
+    const exercise = allExercises[i]
+    const blocks = [makeLatexBlock(exercise.latexContent)]
+
+    if (exercise.solution) {
+      blocks.push(makeLatexBlock(exercise.solution))
+    }
+
+    try {
+      const created = await payload.create({
+        collection: 'exercises',
+        data: {
+          lesson: lessonId,
+          title: exercise.title || `תרגיל ${exercise.number}`,
+          content: { blocks },
+          origin: 'context_extraction',
+          order: startOrder + i,
+        },
+        draft: true,
+        context: { _skipBlockSync: true },
+      })
+      createdIds.push(created.id)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      warnings.push(`Failed to create exercise ${exercise.number}: ${message}`)
+    }
+  }
+
+  let lessonBlocksUpdated = false
+  if (createdIds.length > 0 || staleIds.size > 0) {
+    try {
+      const lesson = await payload.findByID({
+        collection: 'lessons',
+        id: lessonId,
+        depth: 0,
+      })
+
+      const existingBlocks = parseLessonBlocks((lesson as { blocks?: unknown }).blocks)
+
+      const filteredBlocks = existingBlocks.filter((block) => {
+        if (block.blockType !== 'exerciseRef') return true
+        const refId = extractRefId(block.exercise)
+        return refId === null || !staleIds.has(refId)
+      })
+
+      const appendedBlocks: LessonBlock[] = createdIds.map((exerciseId) => ({
+        id: generateBlockId(),
+        blockType: 'exerciseRef',
+        exercise: exerciseId,
+      }))
+
+      const nextBlocks = [...filteredBlocks, ...appendedBlocks]
+
+      await payload.update({
+        collection: 'lessons',
+        id: lessonId,
+        data: { blocks: JSON.stringify(nextBlocks) } as Record<string, unknown>,
+        user,
+        overrideAccess: false,
+      })
+      lessonBlocksUpdated = true
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      warnings.push(`Failed to update lesson blocks: ${message}`)
+    }
+  }
+
+  return {
+    exerciseIds: createdIds,
+    exerciseCount: createdIds.length,
+    source,
+    lessonBlocksUpdated,
+    warnings,
+  }
+}

--- a/src/server/services/lesson-context-conversion/full-pipeline.ts
+++ b/src/server/services/lesson-context-conversion/full-pipeline.ts
@@ -48,6 +48,10 @@ async function convertLatexBlocksOnExercises(
   user: User,
   exerciseIds: string[],
   warnings: string[],
+  /** Real request — required so Stage 3's AI fallback can derive a working
+   *  origin for its internal /api/exercises/import-latex-ai fetch and forward
+   *  the admin's auth cookie. Without these, every fallback call fails. */
+  request: { url: string; headers: Headers },
 ): Promise<{ converted: number; failed: number }> {
   let converted = 0
   let failed = 0
@@ -57,8 +61,8 @@ async function convertLatexBlocksOnExercises(
       const fakeReq = {
         payload,
         user,
-        url: 'http://internal/full-pipeline',
-        headers: new Headers(),
+        url: request.url,
+        headers: request.headers,
         routeParams: {},
         context: {},
       } as unknown as PayloadRequest
@@ -91,10 +95,13 @@ export interface RunFullMediaInput {
   lessonId: string
   mediaId: string
   promptId: string
+  /** Original NextRequest. Required so Stage 3's AI fallback inherits the
+   *  admin's auth cookie and a reachable origin for its internal HTTP call. */
+  request: { url: string; headers: Headers }
 }
 
 export async function runFullMediaPipeline(input: RunFullMediaInput): Promise<FullPipelineResult> {
-  const { payload, user, lessonId, mediaId, promptId } = input
+  const { payload, user, lessonId, mediaId, promptId, request } = input
   const warnings: string[] = []
 
   // Stage 1 — schema-mode Gemini extraction.
@@ -135,7 +142,13 @@ export async function runFullMediaPipeline(input: RunFullMediaInput): Promise<Fu
   warnings.push(...stage2.warnings)
 
   // Stage 3 — convert LaTeX block on each created exercise.
-  const stage3 = await convertLatexBlocksOnExercises(payload, user, stage2.exerciseIds, warnings)
+  const stage3 = await convertLatexBlocksOnExercises(
+    payload,
+    user,
+    stage2.exerciseIds,
+    warnings,
+    request,
+  )
 
   return {
     success: true,
@@ -152,6 +165,9 @@ export interface RunFullLatexInput {
   user: User
   lessonId: string
   mediaId: string
+  /** Original NextRequest. Required so Stage 3's AI fallback inherits the
+   *  admin's auth cookie and a reachable origin for its internal HTTP call. */
+  request: { url: string; headers: Headers }
 }
 
 /**
@@ -197,7 +213,7 @@ async function readLatexFileContent(
 }
 
 export async function runFullLatexPipeline(input: RunFullLatexInput): Promise<FullPipelineResult> {
-  const { payload, user, lessonId, mediaId } = input
+  const { payload, user, lessonId, mediaId, request } = input
   const warnings: string[] = []
 
   // Read the .tex file content.
@@ -315,7 +331,13 @@ export async function runFullLatexPipeline(input: RunFullLatexInput): Promise<Fu
   warnings.push(...stage2.warnings)
 
   // Stage 3 — convert LaTeX block on each created exercise.
-  const stage3 = await convertLatexBlocksOnExercises(payload, user, stage2.exerciseIds, warnings)
+  const stage3 = await convertLatexBlocksOnExercises(
+    payload,
+    user,
+    stage2.exerciseIds,
+    warnings,
+    request,
+  )
 
   return {
     success: true,

--- a/src/server/services/lesson-context-conversion/full-pipeline.ts
+++ b/src/server/services/lesson-context-conversion/full-pipeline.ts
@@ -1,0 +1,328 @@
+/**
+ * Full conversion pipelines for lesson media and LaTeX attachments.
+ *
+ * Each pipeline runs Stage 1 + Stage 2 + Stage 3 in sequence so admins
+ * can click one button and end up with typed exercise blocks attached
+ * to the lesson playlist:
+ *
+ *   - runFullMediaPipeline: PDF/image → Gemini schema-mode extraction →
+ *     create exercises → convert each LaTeX block to typed blocks.
+ *
+ *   - runFullLatexPipeline: .tex file → write the file content directly
+ *     into ContextExtractions.text → split into exercises via the
+ *     deterministic context-exercise parser → convert each LaTeX block
+ *     to typed blocks. No Gemini call for splitting; the per-exercise
+ *     LaTeX conversion still uses the existing AI fallback when the
+ *     deterministic parser can't handle a block.
+ */
+import type { Payload, PayloadRequest, User } from 'payload'
+import { fetchBuffer } from '@/infra/utils/http'
+import { isVercelBlobUrl } from '@/infra/blob/vercel-blob-adapter'
+import { logger } from '@/infra/utils/logger'
+import type { Lesson, Media } from '@/payload-types'
+import { convertLatexBlockOnExercise } from '@/server/payload/endpoints/exercises/convert-latex-block'
+import { getPdfBufferFromBlob, normalizeToAbsoluteUrl } from '@/server/services/pdf-fetcher'
+import { extractLessonContext } from './extract-context'
+import { createExercisesFromExtraction } from './create-exercises-from-extraction'
+
+export interface FullPipelineResult {
+  success: boolean
+  exerciseCount: number
+  exerciseIds: string[]
+  /** Number of exercises whose LaTeX block was successfully converted to typed blocks. */
+  latexBlocksConverted: number
+  /** Number of exercises where the LaTeX-block conversion was attempted but produced no structured output. */
+  latexBlocksFailed: number
+  warnings: string[]
+  error?: string
+}
+
+/**
+ * Stage 3 invocation per exercise. Reuses the existing endpoint handler
+ * (which already has retry/fallback logic) by synthesizing a minimal
+ * PayloadRequest. Failures are surfaced as warnings rather than aborting
+ * the pipeline — the exercise still exists with its raw LaTeX block.
+ */
+async function convertLatexBlocksOnExercises(
+  payload: Payload,
+  user: User,
+  exerciseIds: string[],
+  warnings: string[],
+): Promise<{ converted: number; failed: number }> {
+  let converted = 0
+  let failed = 0
+
+  for (const exerciseId of exerciseIds) {
+    try {
+      const fakeReq = {
+        payload,
+        user,
+        url: 'http://internal/full-pipeline',
+        headers: new Headers(),
+        routeParams: {},
+        context: {},
+      } as unknown as PayloadRequest
+
+      const response = await convertLatexBlockOnExercise(fakeReq, exerciseId)
+      const data = (await response.json()) as { success?: boolean; error?: string }
+
+      if (data.success) {
+        converted++
+      } else {
+        failed++
+        warnings.push(
+          `Exercise ${exerciseId}: LaTeX block conversion did not succeed${data.error ? ' — ' + data.error : ''}`,
+        )
+      }
+    } catch (err) {
+      failed++
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      warnings.push(`Exercise ${exerciseId}: LaTeX block conversion threw — ${message}`)
+      logger.error({ err, exerciseId }, '[full-pipeline] convertLatexBlock failed')
+    }
+  }
+
+  return { converted, failed }
+}
+
+export interface RunFullMediaInput {
+  payload: Payload
+  user: User
+  lessonId: string
+  mediaId: string
+  promptId: string
+}
+
+export async function runFullMediaPipeline(input: RunFullMediaInput): Promise<FullPipelineResult> {
+  const { payload, user, lessonId, mediaId, promptId } = input
+  const warnings: string[] = []
+
+  // Stage 1 — schema-mode Gemini extraction.
+  const stage1 = await extractLessonContext(payload, user, {
+    lessonId,
+    promptId,
+    mediaId,
+    mode: 'replace',
+  })
+
+  if (!stage1.success) {
+    if (stage1.warnings) warnings.push(...stage1.warnings)
+    return {
+      success: false,
+      exerciseCount: 0,
+      exerciseIds: [],
+      latexBlocksConverted: 0,
+      latexBlocksFailed: 0,
+      warnings,
+      error: stage1.error || 'Stage 1 (extraction) failed',
+    }
+  }
+  if (stage1.warnings) warnings.push(...stage1.warnings)
+
+  // Stage 2 — create exercises from the extraction.
+  const stage2 = await createExercisesFromExtraction({ payload, user, lessonId })
+  if ('error' in stage2) {
+    return {
+      success: false,
+      exerciseCount: 0,
+      exerciseIds: [],
+      latexBlocksConverted: 0,
+      latexBlocksFailed: 0,
+      warnings,
+      error: stage2.error.message,
+    }
+  }
+  warnings.push(...stage2.warnings)
+
+  // Stage 3 — convert LaTeX block on each created exercise.
+  const stage3 = await convertLatexBlocksOnExercises(payload, user, stage2.exerciseIds, warnings)
+
+  return {
+    success: true,
+    exerciseCount: stage2.exerciseCount,
+    exerciseIds: stage2.exerciseIds,
+    latexBlocksConverted: stage3.converted,
+    latexBlocksFailed: stage3.failed,
+    warnings,
+  }
+}
+
+export interface RunFullLatexInput {
+  payload: Payload
+  user: User
+  lessonId: string
+  mediaId: string
+}
+
+/**
+ * Pull the file bytes for the attached .tex media. The Media collection
+ * stores files in Vercel Blob in production; locally it falls through to
+ * a normalized URL fetch.
+ */
+async function readLatexFileContent(
+  payload: Payload,
+  user: User,
+  mediaId: string,
+): Promise<string> {
+  const media = (await payload.findByID({
+    collection: 'media',
+    id: mediaId,
+    depth: 0,
+    user,
+    overrideAccess: false,
+  })) as unknown as Media
+
+  if (!media?.url) {
+    throw new Error('Media file has no URL')
+  }
+
+  let fetchUrl = media.url
+  if (!fetchUrl.startsWith('http://') && !fetchUrl.startsWith('https://')) {
+    fetchUrl = await normalizeToAbsoluteUrl(fetchUrl)
+  }
+
+  let buffer: Buffer
+  if (isVercelBlobUrl(fetchUrl)) {
+    const { getPdfBufferFromUrl } = await import('@/infra/blob/vercel-blob-adapter')
+    buffer = await getPdfBufferFromUrl(fetchUrl)
+  } else {
+    try {
+      buffer = await getPdfBufferFromBlob(mediaId, payload)
+    } catch {
+      buffer = await fetchBuffer(fetchUrl, 30000)
+    }
+  }
+
+  return buffer.toString('utf-8')
+}
+
+export async function runFullLatexPipeline(input: RunFullLatexInput): Promise<FullPipelineResult> {
+  const { payload, user, lessonId, mediaId } = input
+  const warnings: string[] = []
+
+  // Read the .tex file content.
+  let latexContent: string
+  try {
+    latexContent = await readLatexFileContent(payload, user, mediaId)
+  } catch (err) {
+    return {
+      success: false,
+      exerciseCount: 0,
+      exerciseIds: [],
+      latexBlocksConverted: 0,
+      latexBlocksFailed: 0,
+      warnings,
+      error: `Failed to read .tex file: ${err instanceof Error ? err.message : 'Unknown error'}`,
+    }
+  }
+
+  if (!latexContent.trim()) {
+    return {
+      success: false,
+      exerciseCount: 0,
+      exerciseIds: [],
+      latexBlocksConverted: 0,
+      latexBlocksFailed: 0,
+      warnings,
+      error: 'The .tex file is empty.',
+    }
+  }
+
+  // Validate the lesson + media association upfront so we don't write a
+  // ContextExtraction for a lesson that wouldn't otherwise allow it.
+  const lesson = (await payload.findByID({
+    collection: 'lessons',
+    id: lessonId,
+    depth: 1,
+    user,
+    overrideAccess: false,
+  })) as unknown as Lesson
+
+  if (!lesson) {
+    return {
+      success: false,
+      exerciseCount: 0,
+      exerciseIds: [],
+      latexBlocksConverted: 0,
+      latexBlocksFailed: 0,
+      warnings,
+      error: 'Lesson not found',
+    }
+  }
+
+  const contentFileIds = (lesson.contentFiles || []).map((cf) =>
+    typeof cf === 'string' ? cf : (cf as unknown as { id: string }).id,
+  )
+  if (!contentFileIds.includes(mediaId)) {
+    return {
+      success: false,
+      exerciseCount: 0,
+      exerciseIds: [],
+      latexBlocksConverted: 0,
+      latexBlocksFailed: 0,
+      warnings,
+      error: 'Media file is not attached to this lesson',
+    }
+  }
+
+  // Upsert ContextExtraction with the raw LaTeX. exercises is null so
+  // Stage 2 falls back to the deterministic parseContextText path.
+  const existing = await payload.find({
+    collection: 'context-extractions',
+    where: {
+      lesson: { equals: lessonId },
+      sourceMedia: { equals: mediaId },
+    },
+    limit: 1,
+    depth: 0,
+  })
+
+  const data = { text: latexContent, exercises: null } as Record<string, unknown>
+
+  if (existing.docs.length > 0) {
+    await payload.update({
+      collection: 'context-extractions',
+      id: existing.docs[0].id,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      data: data as any,
+      user,
+      overrideAccess: false,
+    })
+  } else {
+    await payload.create({
+      collection: 'context-extractions',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      data: { lesson: lessonId, sourceMedia: mediaId, ...data } as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      user: user as any,
+      overrideAccess: false,
+    })
+  }
+
+  // Stage 2 — split text into exercises via the deterministic parser.
+  const stage2 = await createExercisesFromExtraction({ payload, user, lessonId })
+  if ('error' in stage2) {
+    return {
+      success: false,
+      exerciseCount: 0,
+      exerciseIds: [],
+      latexBlocksConverted: 0,
+      latexBlocksFailed: 0,
+      warnings,
+      error: stage2.error.message,
+    }
+  }
+  warnings.push(...stage2.warnings)
+
+  // Stage 3 — convert LaTeX block on each created exercise.
+  const stage3 = await convertLatexBlocksOnExercises(payload, user, stage2.exerciseIds, warnings)
+
+  return {
+    success: true,
+    exerciseCount: stage2.exerciseCount,
+    exerciseIds: stage2.exerciseIds,
+    latexBlocksConverted: stage3.converted,
+    latexBlocksFailed: stage3.failed,
+    warnings,
+  }
+}

--- a/src/ui/admin/exercise-conversion/ConvertContextButton/index.tsx
+++ b/src/ui/admin/exercise-conversion/ConvertContextButton/index.tsx
@@ -7,6 +7,8 @@ interface ConvertContextButtonProps {
   lessonId: string
   mediaId: string
   filename: string
+  /** Override the button label. Defaults to "Convert Context". */
+  label?: string
 }
 
 /**
@@ -15,7 +17,12 @@ interface ConvertContextButtonProps {
  * Triggers the context extraction modal for a specific content file.
  * Shows a button styled identically to existing V1/V2/V3 conversion buttons.
  */
-export function ConvertContextButton({ lessonId, mediaId, filename }: ConvertContextButtonProps) {
+export function ConvertContextButton({
+  lessonId,
+  mediaId,
+  filename,
+  label = 'Convert Context',
+}: ConvertContextButtonProps) {
   const [isModalOpen, setIsModalOpen] = useState(false)
 
   return (
@@ -33,7 +40,7 @@ export function ConvertContextButton({ lessonId, mediaId, filename }: ConvertCon
           cursor: 'pointer',
         }}
       >
-        Convert Context
+        {label}
       </button>
 
       <Suspense

--- a/src/ui/admin/exercise-conversion/FullConvertLatexButton/index.tsx
+++ b/src/ui/admin/exercise-conversion/FullConvertLatexButton/index.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import { useState } from 'react'
+
+interface FullConvertLatexButtonProps {
+  lessonId: string
+  mediaId: string
+  filename: string
+}
+
+/**
+ * One-click "Full Convert (LaTeX)" button. No prompt selection — the
+ * LaTeX path uses the deterministic context-exercise parser to split
+ * the .tex file into exercises and the LaTeX-block parser (with AI
+ * fallback) to convert each exercise into typed blocks.
+ */
+export function FullConvertLatexButton({
+  lessonId,
+  mediaId,
+  filename,
+}: FullConvertLatexButtonProps) {
+  const [isRunning, setIsRunning] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+  const [warnings, setWarnings] = useState<string[]>([])
+
+  async function handleRun() {
+    if (
+      !confirm(
+        `Run Full Convert on ${filename}? This will recreate all context-extraction exercises for this lesson.`,
+      )
+    ) {
+      return
+    }
+    setIsRunning(true)
+    setError(null)
+    setSuccess(null)
+    setWarnings([])
+    try {
+      const response = await fetch('/api/lessons/convert-full-latex', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ lessonId, mediaId }),
+        credentials: 'include',
+      })
+      const data = await response.json()
+      if (!response.ok) {
+        throw new Error(data.error?.message || 'Conversion failed')
+      }
+      const d = data.data
+      setSuccess(
+        `Created ${d.exerciseCount} exercises. Converted ${d.latexBlocksConverted}/${d.exerciseCount} LaTeX blocks.`,
+      )
+      if (Array.isArray(d.warnings)) setWarnings(d.warnings)
+      window.dispatchEvent(new Event('context-extraction-updated'))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Conversion failed')
+    } finally {
+      setIsRunning(false)
+    }
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      <button
+        onClick={handleRun}
+        disabled={isRunning}
+        style={{
+          padding: '4px 12px',
+          fontSize: 11,
+          fontWeight: 500,
+          border: 'none',
+          borderRadius: 3,
+          backgroundColor: isRunning ? 'var(--theme-elevation-400)' : 'var(--theme-success)',
+          color: 'var(--theme-elevation-0)',
+          cursor: isRunning ? 'not-allowed' : 'pointer',
+        }}
+      >
+        {isRunning ? 'Running...' : 'Full Convert (LaTeX)'}
+      </button>
+
+      {error && (
+        <div
+          style={{
+            fontSize: 11,
+            color: 'var(--theme-error)',
+            padding: '4px 8px',
+            backgroundColor: 'var(--theme-error-100)',
+            borderRadius: 3,
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {success && (
+        <div
+          style={{
+            fontSize: 11,
+            color: 'var(--theme-success)',
+            padding: '4px 8px',
+            backgroundColor: 'var(--theme-success-100)',
+            borderRadius: 3,
+          }}
+        >
+          {success}
+        </div>
+      )}
+
+      {warnings.length > 0 && (
+        <details style={{ fontSize: 11, color: 'var(--theme-elevation-700)' }}>
+          <summary style={{ cursor: 'pointer' }}>{warnings.length} warning(s)</summary>
+          <ul style={{ marginTop: 4, paddingLeft: 16 }}>
+            {warnings.map((w, i) => (
+              <li key={i}>{w}</li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  )
+}
+
+export default FullConvertLatexButton

--- a/src/ui/admin/exercise-conversion/FullConvertLatexButton/index.tsx
+++ b/src/ui/admin/exercise-conversion/FullConvertLatexButton/index.tsx
@@ -71,7 +71,7 @@ export function FullConvertLatexButton({
           fontWeight: 500,
           border: 'none',
           borderRadius: 3,
-          backgroundColor: isRunning ? 'var(--theme-elevation-400)' : 'var(--theme-success)',
+          backgroundColor: isRunning ? 'var(--theme-elevation-400)' : 'var(--theme-elevation-900)',
           color: 'var(--theme-elevation-0)',
           cursor: isRunning ? 'not-allowed' : 'pointer',
         }}

--- a/src/ui/admin/exercise-conversion/FullConvertMediaButton/index.tsx
+++ b/src/ui/admin/exercise-conversion/FullConvertMediaButton/index.tsx
@@ -1,0 +1,299 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface PromptOption {
+  id: string
+  title: string
+}
+
+interface FullConvertMediaButtonProps {
+  lessonId: string
+  mediaId: string
+  filename: string
+}
+
+/**
+ * One-click "Full Convert (Media)" button. Opens a small modal so the
+ * admin can pick which context_extractor prompt drives Stage 1, then
+ * runs the full pipeline (Stage 1 → 2 → 3) on the server in one call.
+ */
+export function FullConvertMediaButton({
+  lessonId,
+  mediaId,
+  filename,
+}: FullConvertMediaButtonProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [prompts, setPrompts] = useState<PromptOption[]>([])
+  const [selectedPromptId, setSelectedPromptId] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [isRunning, setIsRunning] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+  const [warnings, setWarnings] = useState<string[]>([])
+
+  useEffect(() => {
+    if (!isOpen) return
+    setIsLoading(true)
+    setError(null)
+    setSuccess(null)
+    setWarnings([])
+    fetch('/api/prompts/for-conversion', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ lessonId }),
+      credentials: 'include',
+    })
+      .then((r) => r.json())
+      .then((data) => setPrompts(data.contextExtractors || []))
+      .catch(() => setError('Failed to load prompts'))
+      .finally(() => setIsLoading(false))
+  }, [isOpen, lessonId])
+
+  useEffect(() => {
+    if (!isOpen) {
+      setSelectedPromptId('')
+      setError(null)
+      setSuccess(null)
+      setWarnings([])
+    }
+  }, [isOpen])
+
+  async function handleRun() {
+    if (!selectedPromptId) {
+      setError('Please select a prompt')
+      return
+    }
+    setIsRunning(true)
+    setError(null)
+    setSuccess(null)
+    setWarnings([])
+    try {
+      const response = await fetch('/api/lessons/convert-full-media', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ lessonId, mediaId, promptId: selectedPromptId }),
+        credentials: 'include',
+      })
+      const data = await response.json()
+      if (!response.ok) {
+        throw new Error(data.error?.message || 'Conversion failed')
+      }
+      const d = data.data
+      setSuccess(
+        `Created ${d.exerciseCount} exercises. Converted ${d.latexBlocksConverted}/${d.exerciseCount} LaTeX blocks.`,
+      )
+      if (Array.isArray(d.warnings)) setWarnings(d.warnings)
+      window.dispatchEvent(new Event('context-extraction-updated'))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Conversion failed')
+    } finally {
+      setIsRunning(false)
+    }
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setIsOpen(true)}
+        style={{
+          padding: '4px 12px',
+          fontSize: 11,
+          fontWeight: 500,
+          border: 'none',
+          borderRadius: 3,
+          backgroundColor: 'var(--theme-success)',
+          color: 'var(--theme-elevation-0)',
+          cursor: 'pointer',
+        }}
+      >
+        Full Convert (Media)
+      </button>
+
+      {isOpen && (
+        <div
+          style={{
+            position: 'fixed',
+            inset: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 1000,
+          }}
+          onClick={(e) => {
+            if (e.target === e.currentTarget && !isRunning) setIsOpen(false)
+          }}
+        >
+          <div
+            style={{
+              backgroundColor: 'var(--theme-elevation-0)',
+              borderRadius: 8,
+              padding: 20,
+              width: '90%',
+              maxWidth: 450,
+              boxShadow: '0 10px 40px rgba(0, 0, 0, 0.2)',
+            }}
+          >
+            <h3
+              style={{
+                fontSize: 16,
+                fontWeight: 600,
+                marginBottom: 4,
+                color: 'var(--theme-elevation-1000)',
+              }}
+            >
+              Full Convert (Media)
+            </h3>
+            <p style={{ fontSize: 12, color: 'var(--theme-elevation-500)', marginBottom: 16 }}>
+              Run extraction → create exercises → convert LaTeX blocks for {filename} in one shot.
+            </p>
+
+            {isLoading && (
+              <div style={{ fontSize: 12, color: 'var(--theme-elevation-500)', padding: 20 }}>
+                Loading prompts...
+              </div>
+            )}
+
+            {!isLoading && prompts.length === 0 && !error && (
+              <div style={{ fontSize: 12, color: 'var(--theme-elevation-500)', padding: 20 }}>
+                No context extractor prompts available for this lesson.
+              </div>
+            )}
+
+            {!isLoading && prompts.length > 0 && (
+              <div style={{ marginBottom: 16 }}>
+                <label
+                  style={{
+                    display: 'block',
+                    fontSize: 12,
+                    fontWeight: 500,
+                    marginBottom: 6,
+                    color: 'var(--theme-elevation-700)',
+                  }}
+                >
+                  Extractor prompt
+                </label>
+                <select
+                  value={selectedPromptId}
+                  onChange={(e) => setSelectedPromptId(e.target.value)}
+                  disabled={isRunning}
+                  style={{
+                    width: '100%',
+                    padding: '8px 12px',
+                    fontSize: 13,
+                    border: '1px solid var(--theme-elevation-200)',
+                    borderRadius: 4,
+                    backgroundColor: 'var(--theme-elevation-0)',
+                    color: 'var(--theme-elevation-1000)',
+                  }}
+                >
+                  <option value="">-- Select a prompt --</option>
+                  {prompts.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.title}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {error && (
+              <div
+                style={{
+                  fontSize: 12,
+                  color: 'var(--theme-error)',
+                  padding: '8px 12px',
+                  backgroundColor: 'var(--theme-error-100)',
+                  borderRadius: 4,
+                  marginBottom: 16,
+                }}
+              >
+                {error}
+              </div>
+            )}
+
+            {success && (
+              <div
+                style={{
+                  fontSize: 12,
+                  color: 'var(--theme-success)',
+                  padding: '8px 12px',
+                  backgroundColor: 'var(--theme-success-100)',
+                  borderRadius: 4,
+                  marginBottom: 16,
+                }}
+              >
+                {success}
+              </div>
+            )}
+
+            {warnings.length > 0 && (
+              <div
+                style={{
+                  fontSize: 12,
+                  color: 'var(--theme-elevation-800)',
+                  padding: '8px 12px',
+                  backgroundColor: 'var(--theme-elevation-100)',
+                  borderRadius: 4,
+                  borderLeft: '3px solid orange',
+                  marginBottom: 16,
+                  maxHeight: 200,
+                  overflowY: 'auto',
+                }}
+              >
+                {warnings.map((w, i) => (
+                  <div key={i} style={{ marginBottom: i < warnings.length - 1 ? 4 : 0 }}>
+                    {w}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+              <button
+                onClick={() => setIsOpen(false)}
+                disabled={isRunning}
+                style={{
+                  padding: '8px 16px',
+                  fontSize: 13,
+                  fontWeight: 500,
+                  border: '1px solid var(--theme-elevation-200)',
+                  borderRadius: 4,
+                  backgroundColor: 'var(--theme-elevation-0)',
+                  color: 'var(--theme-elevation-700)',
+                  cursor: isRunning ? 'not-allowed' : 'pointer',
+                }}
+              >
+                Close
+              </button>
+              <button
+                onClick={handleRun}
+                disabled={isRunning || isLoading || prompts.length === 0 || !!success}
+                style={{
+                  padding: '8px 16px',
+                  fontSize: 13,
+                  fontWeight: 500,
+                  border: '1px solid var(--theme-elevation-200)',
+                  borderRadius: 4,
+                  backgroundColor: success
+                    ? 'var(--theme-success)'
+                    : isRunning
+                      ? 'var(--theme-elevation-400)'
+                      : 'var(--theme-elevation-1000)',
+                  color: 'var(--theme-elevation-0)',
+                  cursor: isRunning || success ? 'not-allowed' : 'pointer',
+                  opacity: isRunning ? 0.6 : 1,
+                }}
+              >
+                {isRunning ? 'Running full pipeline...' : success ? 'Done' : 'Run Full Convert'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+
+export default FullConvertMediaButton

--- a/src/ui/admin/exercise-conversion/FullConvertMediaButton/index.tsx
+++ b/src/ui/admin/exercise-conversion/FullConvertMediaButton/index.tsx
@@ -102,7 +102,7 @@ export function FullConvertMediaButton({
           fontWeight: 500,
           border: 'none',
           borderRadius: 3,
-          backgroundColor: 'var(--theme-success)',
+          backgroundColor: 'var(--theme-elevation-900)',
           color: 'var(--theme-elevation-0)',
           cursor: 'pointer',
         }}

--- a/src/ui/admin/exercise-conversion/LessonConversionPanel/index.tsx
+++ b/src/ui/admin/exercise-conversion/LessonConversionPanel/index.tsx
@@ -3,11 +3,24 @@
 import { useDocumentInfo, useFormFields } from '@payloadcms/ui'
 import { useEffect, useState } from 'react'
 import { ConvertContextButton } from '../ConvertContextButton'
+import { FullConvertLatexButton } from '../FullConvertLatexButton'
+import { FullConvertMediaButton } from '../FullConvertMediaButton'
 
 interface MediaItem {
   id: string
   filename?: string
   mimeType?: string
+}
+
+type FileKind = 'media' | 'latex' | 'unsupported'
+
+function classifyFile(file: MediaItem): FileKind {
+  const mime = file.mimeType ?? ''
+  const name = file.filename ?? ''
+  if (mime === 'application/pdf' || mime.startsWith('image/')) return 'media'
+  if (mime.startsWith('application/x-tex') || mime.startsWith('text/x-tex')) return 'latex'
+  if (name.toLowerCase().endsWith('.tex')) return 'latex'
+  return 'unsupported'
 }
 
 export const LessonConversionPanel = () => {
@@ -100,10 +113,9 @@ export const LessonConversionPanel = () => {
     resolveMedia()
   }, [contentFilesValue, lessonId, lastUpdateTime])
 
-  // PDFs and images are the only types Convert Context handles today.
-  const supportedFiles = mediaItems.filter(
-    (m) => m.mimeType === 'application/pdf' || m.mimeType?.startsWith('image/'),
-  )
+  const supportedFiles = mediaItems
+    .map((m) => ({ ...m, kind: classifyFile(m) }))
+    .filter((m) => m.kind !== 'unsupported')
 
   if (!lessonId) {
     return null // Don't show on create form
@@ -135,7 +147,7 @@ export const LessonConversionPanel = () => {
   }
 
   if (supportedFiles.length === 0) {
-    return null // No PDFs or images — nothing to show
+    return null // No PDFs/images/.tex — nothing to show
   }
 
   return (
@@ -164,56 +176,74 @@ export const LessonConversionPanel = () => {
         </p>
       )}
 
-      {supportedFiles.map((file) => (
-        <div
-          key={file.id}
-          style={{
-            marginBottom: 8,
-            padding: 8,
-            border: '1px solid var(--theme-elevation-200)',
-            borderRadius: 4,
-            backgroundColor: 'var(--theme-elevation-0)',
-          }}
-        >
+      {supportedFiles.map((file) => {
+        const filename = String(file.filename || file.id)
+        const lessonIdStr = String(lessonId)
+        const tag =
+          file.kind === 'latex' ? 'TEX' : file.mimeType?.startsWith('image/') ? 'IMG' : 'PDF'
+
+        return (
           <div
+            key={file.id}
             style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 8,
+              marginBottom: 8,
+              padding: 8,
+              border: '1px solid var(--theme-elevation-200)',
+              borderRadius: 4,
+              backgroundColor: 'var(--theme-elevation-0)',
             }}
           >
-            <span
-              style={{
-                fontSize: 11,
-                fontWeight: 600,
-                color: 'var(--theme-elevation-600)',
-              }}
-            >
-              {file.mimeType?.startsWith('image/') ? 'IMG' : 'PDF'}
-            </span>
-            <span
-              style={{
-                flex: 1,
-                fontSize: 12,
-                fontWeight: 500,
-                color: 'var(--theme-elevation-1000)',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {file.filename || file.id}
-            </span>
-            <div style={{ display: 'flex', gap: 4 }}>
-              <ConvertContextButton
-                lessonId={String(lessonId)}
-                mediaId={file.id}
-                filename={String(file.filename || file.id)}
-              />
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span
+                style={{
+                  fontSize: 11,
+                  fontWeight: 600,
+                  color: 'var(--theme-elevation-600)',
+                }}
+              >
+                {tag}
+              </span>
+              <span
+                style={{
+                  flex: 1,
+                  fontSize: 12,
+                  fontWeight: 500,
+                  color: 'var(--theme-elevation-1000)',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {filename}
+              </span>
+              <div style={{ display: 'flex', gap: 4, alignItems: 'flex-start' }}>
+                {file.kind === 'media' && (
+                  <>
+                    <FullConvertMediaButton
+                      lessonId={lessonIdStr}
+                      mediaId={file.id}
+                      filename={filename}
+                    />
+                    <ConvertContextButton
+                      lessonId={lessonIdStr}
+                      mediaId={file.id}
+                      filename={filename}
+                      label="Steps Convert"
+                    />
+                  </>
+                )}
+                {file.kind === 'latex' && (
+                  <FullConvertLatexButton
+                    lessonId={lessonIdStr}
+                    mediaId={file.id}
+                    filename={filename}
+                  />
+                )}
+              </div>
             </div>
           </div>
-        </div>
-      ))}
+        )
+      })}
     </div>
   )
 }

--- a/src/ui/admin/exercise-conversion/LessonConversionPanel/index.tsx
+++ b/src/ui/admin/exercise-conversion/LessonConversionPanel/index.tsx
@@ -1,14 +1,8 @@
 'use client'
 
 import { useDocumentInfo, useFormFields } from '@payloadcms/ui'
-import { Suspense, useEffect, useState } from 'react'
-import { ConversionStatusPanel } from '../ConversionStatusPanel'
+import { useEffect, useState } from 'react'
 import { ConvertContextButton } from '../ConvertContextButton'
-import { ConvertForm } from '../ConvertForm'
-import { ConvertV2Button } from '../ConvertV2Button'
-import { ConvertV3Button } from '../ConvertV3Button'
-import { DraftExercisesList } from '../DraftExercisesList'
-import { V2StatusPanel } from '../V2StatusPanel'
 
 interface MediaItem {
   id: string
@@ -24,8 +18,6 @@ export const LessonConversionPanel = () => {
 
   const [mediaItems, setMediaItems] = useState<MediaItem[]>([])
   const [isLoading, setIsLoading] = useState(true)
-  const [activeForm, setActiveForm] = useState<string | null>(null)
-  const [expandedPdf, setExpandedPdf] = useState<string | null>(null)
   const [needsSaveNotice, setNeedsSaveNotice] = useState(false)
 
   // Resolve media from persisted lesson data so conversion options always
@@ -108,7 +100,7 @@ export const LessonConversionPanel = () => {
     resolveMedia()
   }, [contentFilesValue, lessonId, lastUpdateTime])
 
-  // Filter for PDFs and images (V3 supports both)
+  // PDFs and images are the only types Convert Context handles today.
   const supportedFiles = mediaItems.filter(
     (m) => m.mimeType === 'application/pdf' || m.mimeType?.startsWith('image/'),
   )
@@ -213,29 +205,6 @@ export const LessonConversionPanel = () => {
               {file.filename || file.id}
             </span>
             <div style={{ display: 'flex', gap: 4 }}>
-              <button
-                onClick={() => setActiveForm(activeForm === file.id ? null : file.id)}
-                style={{
-                  padding: '4px 12px',
-                  fontSize: 11,
-                  fontWeight: 500,
-                  border: activeForm === file.id ? '1px solid var(--theme-elevation-200)' : 'none',
-                  borderRadius: 3,
-                  backgroundColor:
-                    activeForm === file.id
-                      ? 'var(--theme-elevation-100)'
-                      : 'var(--theme-elevation-900)',
-                  color:
-                    activeForm === file.id
-                      ? 'var(--theme-elevation-700)'
-                      : 'var(--theme-elevation-0)',
-                  cursor: 'pointer',
-                }}
-              >
-                {activeForm === file.id ? 'Cancel' : 'Convert (V1)'}
-              </button>
-              <ConvertV2Button lessonId={String(lessonId)} mediaId={file.id} />
-              <ConvertV3Button lessonId={String(lessonId)} mediaId={file.id} />
               <ConvertContextButton
                 lessonId={String(lessonId)}
                 mediaId={file.id}
@@ -243,45 +212,6 @@ export const LessonConversionPanel = () => {
               />
             </div>
           </div>
-
-          {/* Status Panel */}
-          <div style={{ marginTop: 4 }}>
-            <ConversionStatusPanel
-              lessonId={String(lessonId)}
-              mediaId={file.id}
-              onViewExercises={() => setExpandedPdf(expandedPdf === file.id ? null : file.id)}
-            />
-          </div>
-
-          {/* V2 Status Panel */}
-          <div style={{ marginTop: 4 }}>
-            <V2StatusPanel lessonId={String(lessonId)} mediaId={file.id} />
-          </div>
-
-          {/* Inline Convert Form */}
-          {activeForm === file.id && (
-            <Suspense
-              fallback={
-                <div style={{ marginTop: 8, fontSize: 11, color: 'var(--theme-elevation-500)' }}>
-                  Loading...
-                </div>
-              }
-            >
-              <ConvertForm
-                lessonId={String(lessonId)}
-                mediaId={file.id}
-                filename={String(file.filename || file.id)}
-                onClose={() => setActiveForm(null)}
-              />
-            </Suspense>
-          )}
-
-          {/* Draft Exercises */}
-          {expandedPdf === file.id && (
-            <div style={{ marginTop: 4 }}>
-              <DraftExercisesList lessonId={String(lessonId)} sourceDocId={file.id} />
-            </div>
-          )}
         </div>
       ))}
     </div>

--- a/tests/int/create-exercises-from-extraction.int.spec.ts
+++ b/tests/int/create-exercises-from-extraction.int.spec.ts
@@ -1,0 +1,391 @@
+/**
+ * Integration tests for createExercisesFromExtraction (Stage 2 service).
+ *
+ * Covers the structured-vs-text source preference, lesson.blocks
+ * reconciliation (drops stale exerciseRefs, appends new ones, preserves
+ * unrelated entries), and the malformed-entry warnings path.
+ *
+ * @fileType integration-test
+ * @domain content-pipeline
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { AccountRole } from '@/server/payload/collections/Users/roles'
+import { createExercisesFromExtraction } from '@/server/services/lesson-context-conversion/create-exercises-from-extraction'
+import config from '@payload-config'
+import type { Payload, User } from 'payload'
+import { getPayload } from 'payload'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+
+const hasDatabaseUrl = !!process.env.DATABASE_URL
+
+let payload: Payload
+let adminUser: User
+let tenantId: string
+let categoryId: string
+let courseId: string
+let chapterId: string
+const createdLessonIds: string[] = []
+const createdExtractionIds: string[] = []
+const createdExerciseIds: string[] = []
+
+beforeAll(async () => {
+  if (!hasDatabaseUrl) return
+
+  payload = await getPayload({ config })
+
+  const admin = await payload.create({
+    collection: 'users',
+    data: {
+      email: `cefe-admin-${Date.now()}@example.com`,
+      password: 'test123456',
+    } as any,
+  })
+  await payload.update({
+    collection: 'users',
+    id: admin.id,
+    data: { role: AccountRole.Admin },
+    overrideAccess: true,
+  })
+  adminUser = (await payload.findByID({
+    collection: 'users',
+    id: admin.id,
+    overrideAccess: true,
+  })) as unknown as User
+
+  const existingTenants = await payload.find({ collection: 'tenants', limit: 1 })
+  if (existingTenants.docs.length > 0) {
+    tenantId = existingTenants.docs[0].id
+  } else {
+    const tenant = await payload.create({
+      collection: 'tenants',
+      data: { name: 'CEFE Tenant', slug: `cefe-tenant-${Date.now()}` } as any,
+      overrideAccess: true,
+    })
+    tenantId = tenant.id
+  }
+
+  const existingCategories = await payload.find({ collection: 'categories', limit: 1 })
+  categoryId =
+    existingCategories.docs[0]?.id ??
+    (
+      await payload.create({
+        collection: 'categories',
+        data: { title: 'CEFE Category', slug: `cefe-cat-${Date.now()}` } as any,
+        overrideAccess: true,
+      })
+    ).id
+
+  const course = await payload.create({
+    collection: 'courses',
+    data: {
+      courseLabel: 'CE',
+      title: 'CEFE Course',
+      slug: `cefe-course-${Date.now()}`,
+      order: 0,
+      status: 'published',
+      isActive: true,
+      categories: [categoryId],
+      tenant: tenantId,
+    } as any,
+    overrideAccess: true,
+  })
+  courseId = course.id
+
+  const chapter = await payload.create({
+    collection: 'chapters',
+    data: {
+      title: 'CEFE Chapter',
+      slug: `cefe-chap-${Date.now()}`,
+      order: 0,
+      isActive: true,
+      course: courseId,
+      tenant: tenantId,
+    } as any,
+    overrideAccess: true,
+  })
+  chapterId = chapter.id
+}, 60_000)
+
+beforeEach(async () => {
+  if (!payload) return
+  for (const id of createdExerciseIds) {
+    try {
+      await payload.delete({ collection: 'exercises', id, overrideAccess: true })
+    } catch {
+      // already gone
+    }
+  }
+  createdExerciseIds.length = 0
+  for (const id of createdExtractionIds) {
+    try {
+      await payload.delete({ collection: 'context-extractions', id, overrideAccess: true })
+    } catch {
+      // already gone
+    }
+  }
+  createdExtractionIds.length = 0
+  for (const id of createdLessonIds) {
+    try {
+      await payload.delete({ collection: 'lessons', id, overrideAccess: true })
+    } catch {
+      // already gone
+    }
+  }
+  createdLessonIds.length = 0
+})
+
+afterAll(async () => {
+  if (!payload) return
+  if (chapterId) {
+    try {
+      await payload.delete({ collection: 'chapters', id: chapterId, overrideAccess: true })
+    } catch {
+      // ignore
+    }
+  }
+  if (courseId) {
+    try {
+      await payload.delete({ collection: 'courses', id: courseId, overrideAccess: true })
+    } catch {
+      // ignore
+    }
+  }
+  if (adminUser?.id) {
+    try {
+      await payload.delete({ collection: 'users', id: adminUser.id, overrideAccess: true })
+    } catch {
+      // ignore
+    }
+  }
+})
+
+async function createLesson(): Promise<string> {
+  const lesson = await payload.create({
+    collection: 'lessons',
+    data: {
+      title: `CEFE Lesson ${Date.now()}`,
+      slug: `cefe-lesson-${Date.now()}`,
+      order: 0,
+      type: 'practice',
+      status: 'draft',
+      isActive: true,
+      chapter: chapterId,
+      tenant: tenantId,
+    } as any,
+    overrideAccess: true,
+  })
+  createdLessonIds.push(lesson.id)
+  return lesson.id
+}
+
+async function seedExtraction(
+  lessonId: string,
+  data: { text: string; exercises?: unknown },
+): Promise<void> {
+  // sourceMedia is required, so create a tiny media row to point at.
+  const media = await payload.create({
+    collection: 'media',
+    data: {
+      filename: `cefe-${Date.now()}.tex`,
+      mimeType: 'application/x-tex',
+      filesize: 1,
+      alt: 'cefe',
+    } as any,
+    file: {
+      data: Buffer.from('% empty'),
+      mimetype: 'application/x-tex',
+      name: `cefe-${Date.now()}.tex`,
+      size: 8,
+    } as any,
+    overrideAccess: true,
+  })
+  const extraction = await payload.create({
+    collection: 'context-extractions',
+    data: {
+      lesson: lessonId,
+      sourceMedia: media.id,
+      ...data,
+    } as any,
+    overrideAccess: true,
+  })
+  createdExtractionIds.push(extraction.id)
+}
+
+describe('createExercisesFromExtraction', () => {
+  it.skipIf(!hasDatabaseUrl)(
+    'returns NO_EXTRACTION when the lesson has no extraction yet',
+    async () => {
+      const lessonId = await createLesson()
+      const result = await createExercisesFromExtraction({
+        payload,
+        user: adminUser,
+        lessonId,
+      })
+      expect('error' in result).toBe(true)
+      if ('error' in result) {
+        expect(result.error.code).toBe('NO_EXTRACTION')
+      }
+    },
+    30_000,
+  )
+
+  it.skipIf(!hasDatabaseUrl)(
+    'prefers the structured exercises array and creates Exercise documents',
+    async () => {
+      const lessonId = await createLesson()
+      await seedExtraction(lessonId, {
+        text: 'fallback should not run',
+        exercises: [
+          { number: 1, latex: '$x + 1$', solution: null },
+          { number: 2, latex: '$y + 2$', solution: 'נימוק' },
+        ],
+      })
+
+      const result = await createExercisesFromExtraction({
+        payload,
+        user: adminUser,
+        lessonId,
+      })
+
+      expect('error' in result).toBe(false)
+      if ('error' in result) return
+      expect(result.source).toBe('structured')
+      expect(result.exerciseCount).toBe(2)
+      expect(result.lessonBlocksUpdated).toBe(true)
+      createdExerciseIds.push(...result.exerciseIds)
+    },
+    30_000,
+  )
+
+  it.skipIf(!hasDatabaseUrl)(
+    'falls back to text parsing when no structured exercises are present',
+    async () => {
+      const lessonId = await createLesson()
+      const text = `\\begin{document}
+\\textbf{תרגיל 1}
+תוכן ראשון
+\\section*{פתרון תרגיל 1}
+פתרון
+\\end{document}`
+      await seedExtraction(lessonId, { text })
+
+      const result = await createExercisesFromExtraction({
+        payload,
+        user: adminUser,
+        lessonId,
+      })
+
+      expect('error' in result).toBe(false)
+      if ('error' in result) return
+      expect(result.source).toBe('legacy_text')
+      expect(result.exerciseCount).toBe(1)
+      createdExerciseIds.push(...result.exerciseIds)
+    },
+    30_000,
+  )
+
+  it.skipIf(!hasDatabaseUrl)(
+    'reconciles lesson.blocks: drops stale context_extraction refs, preserves unrelated entries, appends new ones',
+    async () => {
+      const lessonId = await createLesson()
+
+      // Pre-existing playlist with one unrelated exerciseRef + one
+      // contentPageRef. Both should survive the reconcile.
+      const unrelatedExercise = await payload.create({
+        collection: 'exercises',
+        data: {
+          lesson: lessonId,
+          title: 'Unrelated',
+          content: { blocks: [] },
+          origin: 'manual',
+          order: 0,
+        } as any,
+        draft: true,
+        overrideAccess: true,
+      })
+      createdExerciseIds.push(unrelatedExercise.id)
+
+      const initialBlocks = [
+        { id: 'a1b2c3', blockType: 'contentPageRef', contentPage: 'page-1' },
+        { id: 'd4e5f6', blockType: 'exerciseRef', exercise: unrelatedExercise.id },
+      ]
+
+      await payload.update({
+        collection: 'lessons',
+        id: lessonId,
+        data: { blocks: JSON.stringify(initialBlocks) } as any,
+        overrideAccess: true,
+      })
+
+      // Run once to create context exercises and append their refs.
+      await seedExtraction(lessonId, {
+        text: '',
+        exercises: [{ number: 1, latex: '$a$', solution: null }],
+      })
+      const first = await createExercisesFromExtraction({
+        payload,
+        user: adminUser,
+        lessonId,
+      })
+      expect('error' in first).toBe(false)
+      if ('error' in first) return
+      createdExerciseIds.push(...first.exerciseIds)
+
+      // Re-run: stale context refs should be dropped, new ones appended,
+      // and the unrelated exerciseRef + contentPageRef must still be there.
+      const second = await createExercisesFromExtraction({
+        payload,
+        user: adminUser,
+        lessonId,
+      })
+      expect('error' in second).toBe(false)
+      if ('error' in second) return
+      createdExerciseIds.push(...second.exerciseIds)
+
+      const lesson = (await payload.findByID({
+        collection: 'lessons',
+        id: lessonId,
+        overrideAccess: true,
+        depth: 0,
+      })) as { blocks?: unknown }
+
+      const blocks = JSON.parse(String(lesson.blocks ?? '[]'))
+      const exerciseRefs = blocks.filter((b: any) => b.blockType === 'exerciseRef')
+      const contentRefs = blocks.filter((b: any) => b.blockType === 'contentPageRef')
+
+      expect(contentRefs).toHaveLength(1)
+      expect(exerciseRefs.map((b: any) => b.exercise)).toContain(unrelatedExercise.id)
+      // The first run's exercise must be gone; second run's exercise must be present.
+      expect(exerciseRefs.map((b: any) => b.exercise)).not.toContain(first.exerciseIds[0])
+      expect(exerciseRefs.map((b: any) => b.exercise)).toContain(second.exerciseIds[0])
+    },
+    60_000,
+  )
+
+  it.skipIf(!hasDatabaseUrl)(
+    'surfaces a warning when malformed entries are skipped from the structured array',
+    async () => {
+      const lessonId = await createLesson()
+      await seedExtraction(lessonId, {
+        text: '',
+        exercises: [
+          { number: 1, latex: '$valid$', solution: null },
+          { latex: 'missing-number' }, // no number — skipped
+          { number: 3, latex: '' }, // empty latex — skipped
+        ],
+      })
+
+      const result = await createExercisesFromExtraction({
+        payload,
+        user: adminUser,
+        lessonId,
+      })
+      expect('error' in result).toBe(false)
+      if ('error' in result) return
+      expect(result.exerciseCount).toBe(1)
+      expect(result.warnings.some((w) => w.includes('Skipped 2 malformed'))).toBe(true)
+      createdExerciseIds.push(...result.exerciseIds)
+    },
+    30_000,
+  )
+})

--- a/tests/int/create-exercises-from-extraction.int.spec.ts
+++ b/tests/int/create-exercises-from-extraction.int.spec.ts
@@ -207,7 +207,7 @@ async function seedExtraction(
       // text is required by the collection schema even when the structured
       // exercises array is the source of truth; pass a placeholder if the
       // caller only cares about the structured field.
-      text: data.text ?? '% structured-only',
+      text: data.text && data.text.trim() ? data.text : '% structured-only',
       exercises: data.exercises,
     } as any,
     overrideAccess: true,

--- a/tests/int/create-exercises-from-extraction.int.spec.ts
+++ b/tests/int/create-exercises-from-extraction.int.spec.ts
@@ -180,7 +180,7 @@ async function createLesson(): Promise<string> {
 
 async function seedExtraction(
   lessonId: string,
-  data: { text: string; exercises?: unknown },
+  data: { text?: string; exercises?: unknown },
 ): Promise<void> {
   // sourceMedia is required, so create a tiny media row to point at.
   const media = await payload.create({
@@ -204,7 +204,11 @@ async function seedExtraction(
     data: {
       lesson: lessonId,
       sourceMedia: media.id,
-      ...data,
+      // text is required by the collection schema even when the structured
+      // exercises array is the source of truth; pass a placeholder if the
+      // caller only cares about the structured field.
+      text: data.text ?? '% structured-only',
+      exercises: data.exercises,
     } as any,
     overrideAccess: true,
   })
@@ -290,17 +294,21 @@ describe('createExercisesFromExtraction', () => {
       const lessonId = await createLesson()
 
       // Pre-existing playlist with one unrelated exerciseRef + one
-      // contentPageRef. Both should survive the reconcile.
+      // contentPageRef. Both should survive the reconcile. Exercise.content
+      // requires at least one block, so seed with a trivial LaTeX block.
       const unrelatedExercise = await payload.create({
         collection: 'exercises',
         data: {
           lesson: lessonId,
           title: 'Unrelated',
-          content: { blocks: [] },
+          content: {
+            blocks: [{ id: 'unrel0', type: 'latex', latex: '$1$' }],
+          },
           origin: 'manual',
           order: 0,
         } as any,
         draft: true,
+        context: { _skipBlockSync: true } as any,
         overrideAccess: true,
       })
       createdExerciseIds.push(unrelatedExercise.id)


### PR DESCRIPTION
## Summary

Convert Context (with the schema-mode Gemini extraction merged earlier) is the only conversion path admins use. The earlier V1/V2/V3 pipelines are dead surface — separate buttons, separate endpoints, separate jobs, separate prompts — that nobody clicks anymore.

This PR deletes all three.

## What's removed

**Admin UI**
- `ConvertForm` (V1), `ConvertV2Button` + `V2StatusPanel`, `ConvertV3Button` + `V3PreviewPanel`
- `ConversionStatusPanel`, `DraftExercisesList`, `LessonMediaActions`
- The entire `src/ui/admin/PdfConversion/` standalone admin page

**API routes**
- `/api/exercises/convert/{queue,queue-v2,single,single/create,runner,status}`
- `/api/jobs/run-immediate`

**Jobs and services**
- `pdfToExercisesTask`, `pdfToExercisesV2Task`
- The whole `src/server/services/exercise-conversion/` tree (extractor/verifier helpers, idempotency, V2 vision detection, V3 transform)
- `task-registry`, `job-service`, `exercise-conversion-service`, the `JobDocument` types module

**Other**
- `.github/workflows/exercise-conversion-runner.yml`
- All V1/V2/V3-specific unit, integration, and e2e tests

**Slimmed**
- `src/server/payload/jobs/constants.ts` — keeps only `PDF_MAX_BYTES` (used by `pdf-fetcher`)
- `src/server/config/constants.ts` — re-exports the same plus the `ENV` map
- `src/payload.config.ts` — drops the two task registrations and inlines a 5-field `JobDocLite` shape for the jobs admin afterRead hook so we don't keep the deleted types module alive

## What's kept

- `LessonConversionPanel` now renders a single **Convert Context** button per attached PDF/image
- `ConvertContextButton`, `ContextExerciseViewer`, `create-context-exercises` route, `convert-latex-block` endpoint (Stage 3) — all unchanged
- Prompts collection still has `extractor` / `verifier` usage values; existing rows are left intact and can be cleaned up in a follow-up migration

## Numbers

80 files changed, ~17.7k lines removed.

## Test plan

- [ ] Open a lesson with a PDF attached — confirm only the **Convert Context** button is visible (no V1/V2/V3 buttons or status panels).
- [ ] Run **Convert Context** end-to-end — extraction, viewer preview, **Create Exercises**, lesson playlist auto-populate. All paths still work.
- [ ] Open the Stage 3 **Convert LaTeX Block** button on a created exercise — still works.
- [ ] Confirm `/admin/pdf-conversion` route 404s (page deleted) and the jobs collection in admin is empty (no V1/V2/V3 jobs queued).
- [ ] CI: typecheck, lint, unit tests, integration tests all pass without the deleted suites.