### PR TITLE
fix: Stop Interactive tab from opening on PDF page

### DIFF
--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/DualModeLessonView/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/DualModeLessonView/index.tsx
@@ -175,7 +175,10 @@ export function DualModeLessonView(props: DualModeLessonViewProps) {
           lessonId={lessonId}
           mediaMap={mediaMap}
           contentPageBodies={interactive.contentPageBodies}
-          validFiles={interactive.validFiles}
+          /* Don't pass validFiles here — when running inside the multi-tab
+             view, the dedicated Media tab handles attached files. Forwarding
+             them would also insert a PDF page into LessonPager's internal
+             flow, making the Interactive tab open on the PDF. */
           chatLessonId={chatLessonId}
           showChat={showChat}
           formulaSheet={formulaSheet}


### PR DESCRIPTION
When DualModeLessonView wraps LessonPager, don't forward validFiles. The dedicated Media tab already renders the attached files; forwarding them also inserted a PDF page into LessonPager's internal flow, making the Interactive tab open on the PDF instead of the first exercise.