### PR TITLE
fix(chat): Correctly parse multi-event SSE batches in chatStream

### DIFF
--- a/src/server/services/api/api-service.ts
+++ b/src/server/services/api/api-service.ts
@@ -6,6 +6,7 @@
  */
 import { ChatRole } from '@/infra/llm/chat-message-role'
 import { logger } from '@/infra/utils/logger'
+import { parseSSEData } from '@/server/payload/endpoints/agent/chat/sse-helpers'
 
 export interface ChatApiResponse {
   success: boolean
@@ -324,30 +325,30 @@ export const apiService = {
         if (done) break
 
         buffer += decoder.decode(value, { stream: true })
-        const lines = buffer.split('\n')
-        buffer = lines.pop() || ''
 
-        for (const line of lines) {
-          const trimmedLine = line.trim()
-          if (trimmedLine.startsWith('event: ')) {
-            const eventType = trimmedLine.slice(7).trim() as 'chunk' | 'done' | 'error'
+        // SSE messages are terminated by a blank line ("\n\n"). Split off all
+        // completed messages and keep any trailing partial in the buffer so
+        // events whose event/data pair straddles two reads are still parsed.
+        const lastBoundary = buffer.lastIndexOf('\n\n')
+        if (lastBoundary === -1) continue
 
-            // Find the corresponding data line (next line that starts with 'data: ')
-            const dataIndex = lines.indexOf(line) + 1
-            if (dataIndex < lines.length && lines[dataIndex].trim().startsWith('data: ')) {
-              try {
-                const eventData = JSON.parse(lines[dataIndex].trim().slice(6))
-                yield {
-                  type: eventType,
-                  ...(eventData.text !== undefined && { text: eventData.text }),
-                  ...(eventData.conversationId && { conversationId: eventData.conversationId }),
-                  ...(eventData.contextKey && { contextKey: eventData.contextKey }),
-                  ...(eventData.error && { error: eventData.error }),
-                }
-              } catch {
-                // Ignore JSON parse errors
-              }
-            }
+        const completed = buffer.slice(0, lastBoundary + 2)
+        buffer = buffer.slice(lastBoundary + 2)
+
+        for (const parsed of parseSSEData(completed)) {
+          if (!parsed.event) continue
+          const eventData = (parsed.data ?? {}) as {
+            text?: string
+            conversationId?: string
+            contextKey?: string
+            error?: string
+          }
+          yield {
+            type: parsed.event,
+            ...(eventData.text !== undefined && { text: eventData.text }),
+            ...(eventData.conversationId && { conversationId: eventData.conversationId }),
+            ...(eventData.contextKey && { contextKey: eventData.contextKey }),
+            ...(eventData.error && { error: eventData.error }),
           }
         }
       }

--- a/tests/unit/server/services/api-service.test.ts
+++ b/tests/unit/server/services/api-service.test.ts
@@ -81,4 +81,69 @@ describe('apiService', () => {
       expect(result).toEqual({ success: false, error: 'Network error' })
     })
   })
+
+  describe('chatStream SSE parsing', () => {
+    function makeSSEResponse(payload: string): Response {
+      const encoder = new TextEncoder()
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode(payload))
+          controller.close()
+        },
+      })
+      return new Response(stream, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      })
+    }
+
+    async function collectChunks(generator: ReturnType<typeof apiService.chatStream>) {
+      const events: Array<{ type: string; text?: string }> = []
+      for await (const evt of generator) {
+        events.push(evt)
+      }
+      return events
+    }
+
+    it('emits every chunk when multiple chunk events arrive in one buffer flush', async () => {
+      // Regression for #1452: lines.indexOf(line) returned the FIRST 'event: chunk'
+      // index for every chunk in the same flush, so all chunks yielded the first
+      // chunk's text. Symptom: user saw only the first token repeated (e.g. "אאא…").
+      const payload =
+        'event: chunk\ndata: {"text":"אני "}\n\n' +
+        'event: chunk\ndata: {"text":"כאן "}\n\n' +
+        'event: chunk\ndata: {"text":"כדי "}\n\n' +
+        'event: done\ndata: {"conversationId":"c1","contextKey":"k1"}\n\n'
+
+      vi.mocked(fetch).mockResolvedValue(makeSSEResponse(payload))
+
+      const events = await collectChunks(apiService.chatStream('hi', 'ack', { exerciseId: 'ex-1' }))
+
+      const chunkTexts = events.filter((e) => e.type === 'chunk').map((e) => e.text)
+      expect(chunkTexts).toEqual(['אני ', 'כאן ', 'כדי '])
+      expect(events.some((e) => e.type === 'done')).toBe(true)
+    })
+
+    it('handles SSE messages split across reads (event line and data line in different flushes)', async () => {
+      const encoder = new TextEncoder()
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode('event: chunk\n'))
+          controller.enqueue(encoder.encode('data: {"text":"hello"}\n\n'))
+          controller.enqueue(
+            encoder.encode('event: done\ndata: {"conversationId":"c1","contextKey":"k1"}\n\n'),
+          )
+          controller.close()
+        },
+      })
+      vi.mocked(fetch).mockResolvedValue(
+        new Response(stream, { status: 200, headers: { 'Content-Type': 'text/event-stream' } }),
+      )
+
+      const events = await collectChunks(apiService.chatStream('hi', 'ack', { exerciseId: 'ex-1' }))
+
+      const chunkTexts = events.filter((e) => e.type === 'chunk').map((e) => e.text)
+      expect(chunkTexts).toEqual(['hello'])
+    })
+  })
 })


### PR DESCRIPTION
Closes #1452

## Summary

- Student chat showed the first streamed token repeated (e.g. `"אאא…"`) instead of the full reply; admin chat was unaffected because it doesn't use streaming.
- Root cause in `apiService.chatStream`: the SSE parser used `lines.indexOf(line) + 1` to find each event's data line, which always returns the first occurrence. When multiple `event: chunk` messages arrived in one `reader.read()` flush (the normal case for fast token streaming), every iteration read back the first chunk's data — so the user saw the first token N times. The same loop also silently dropped events whose `event:` and `data:` lines arrived in different flushes.
- Fix: split the buffer on the SSE `"\n\n"` message terminator and delegate parsing to the existing, tested `parseSSEData` helper in `sse-helpers.ts`. Trailing partials stay in the buffer until the next read.

## Test plan

- [x] `pnpm exec vitest run tests/unit/server/services/api-service.test.ts --config ./vitest.config.unit.mts` — 5/5 passing, including 2 new regression tests
- [x] `pnpm typecheck` clean
- [ ] Manual: open a Hebrew student chat, confirm the streamed reply renders the full text (no `"אאא"` repetition)

## Regression tests added

1. **Multi-event single flush** — three `event: chunk` messages in one buffer must yield three distinct texts. RED on the old code yields the first text three times.
2. **Event/data split across reads** — `event:` and `data:` lines arriving in separate flushes must still produce the chunk. RED on the old code drops it.