### PR TITLE
chore(ci): Pre-install pnpm 10 in kody workflow

### DIFF
--- a/.github/workflows/kody.yml
+++ b/.github/workflows/kody.yml
@@ -80,6 +80,13 @@ jobs:
         with:
           node-version: 22
 
+      # Install pnpm 10 BEFORE kody runs, so kody's own
+      # `pnpm not on PATH — installing via npm install -g pnpm` step
+      # is skipped. Otherwise it pulls latest pnpm (currently 11), which
+      # the existing pnpm-lock.yaml format doesn't accept.
+      - name: Install pnpm 10
+        run: npm install -g pnpm@10
+
       - name: Write pip cache key for LiteLLM
         run: echo "litellm[proxy]" > .kody-pip-requirements.txt
 


### PR DESCRIPTION
## Why

Kody auto-installs pnpm via \`npm install -g pnpm\` when it's not on PATH, which currently resolves to 11.x. The repo's pnpm-lock.yaml is formatted for pnpm 9 or 10, and pnpm 11 rejects the \`overrides\` block as mismatched (\`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH\`). Result: every \`@kody resolve\` / \`@kody fix\` preflights fail before any actual work.

## Fix

One step before the kody invocation: \`npm install -g pnpm@10\`. With pnpm 10 already on PATH, kody's \`isOnPath('pnpm')\` short-circuits and skips its own version-agnostic install. Lockfile stays untouched, no contributor disruption.

## Test plan

- [x] \`engines.pnpm\` and lockfile remain compatible with pnpm 10
- [ ] After merge, re-trigger \`@kody resolve\` on #1404; preflight should reach the actual resolve step.