### PR TITLE
fix(chat): Pass lessonContextText and exercises through streaming pipeline

### DIFF
--- a/src/server/payload/endpoints/agent/chat/pipeline.ts
+++ b/src/server/payload/endpoints/agent/chat/pipeline.ts
@@ -248,8 +248,8 @@ export async function runChatPipeline(
       lessonContext.courseContextText,
       req.user?.id,
       lessonContext.lessonContextBlock,
-      undefined,
-      undefined,
+      lessonContext.lessonContextText,
+      lessonContext.exercises,
       hasImageAttached,
     )
   } catch (error) {


### PR DESCRIPTION
## Why

User reported: \`dev.aguy.co.il/courses/grade-9/chapters/chapter-1/lessons/lesson-1\` has 15 exercises but chat answers \"4\". Cause: the streaming pipeline (\`pipeline.ts\`, used by student chats) was calling \`composeFullSystemInstructions\` with \`undefined\` for both \`lessonContextText\` and \`exercises\`, even though \`fetchLessonContextForContext\` populates them with the full lesson content and up to 100 exercises. The non-streaming path in \`chat.ts\` already passes both. Net effect: text-only chats saw only lesson metadata + the active exercise body, so the model counted sub-questions (4 in exercise 14) instead of exercises in the lesson.

## Fix

Pass \`lessonContext.lessonContextText\` and \`lessonContext.exercises\` through the existing \`composeFullSystemInstructions\` call. One-line change, keeps streaming path consistent with the non-streaming path.

## Test plan

- [x] \`pnpm typecheck\` clean
- [ ] After merge, ask \"how many exercises does this lesson have\" on the same lesson — should report the actual count (15+), not 4.