### PR TITLE
fix(chat): Restore lessonContextBlock — implements audit F1

### DIFF
--- a/src/server/payload/endpoints/agent/chat/prompt-composition.ts
+++ b/src/server/payload/endpoints/agent/chat/prompt-composition.ts
@@ -211,11 +211,22 @@ async function fetchLessonContext(
   user: { id: string },
   reqLogger: Logger,
 ): Promise<LessonContext> {
+  // The select clause must include title, type, and chapter — without them
+  // buildLessonContextBlock returns undefined and the chat loses any
+  // grounding context (audit F1). Keep the lessonContextText/description/
+  // prompt fields too since they're consumed below.
   const lesson = (await payload.findByID({
     collection: 'lessons',
     id: lessonId,
     depth: 0,
-    select: { lessonContextText: true, description: true, prompt: true },
+    select: {
+      title: true,
+      type: true,
+      chapter: true,
+      lessonContextText: true,
+      description: true,
+      prompt: true,
+    },
     user,
     overrideAccess: false,
   })) as unknown as Record<string, unknown>


### PR DESCRIPTION
## Implements F1 from the [chat audit doc](docs/audits/2026-05-07-chat-system-prompt-audit.md)

### Symptom
Live debug-prompt for \`lesson-1\` returned \`lessonContextBlock: null\` — the lesson context block (PR #1450) was silently empty for every text-only chat opened on a lesson page.

### Root cause
The select clause on the lesson findByID was restricting fields to \`lessonContextText\`, \`description\`, \`prompt\`. \`title\` and \`chapter\` were excluded → \`buildLessonContextBlock(lesson, chapter, course)\` had nothing to render → returned \`undefined\`. The exercise path didn't hit the bug because \`fetchExerciseLessonContext\` does its own findByID without a select clause.

### Fix
Add \`title\`, \`type\`, \`chapter\` to the select clause.

### Verification
Local diag against the dev DB:

\`\`\`
before: lessonContextBlock length: 0
after:  lessonContextBlock length: 222
        ## Current Lesson
        Course: כיתה ט
        Chapter: משולשים דומים
        Lesson: דימיון משולשים
        Type: practice
\`\`\`

After merge, will live-verify on dev via \`/api/agent/chat/debug-prompt\` and the chat itself.