### PR TITLE
fix(chat): Source exercises from lesson.blocks — F2 + F3

### DIFF
--- a/src/server/payload/endpoints/agent/chat/prompt-composition.ts
+++ b/src/server/payload/endpoints/agent/chat/prompt-composition.ts
@@ -175,6 +175,101 @@ function buildLessonContextBlock(
 }
 
 /**
+ * Walk a lesson's `blocks[]` (textarea-stored JSON) and return the
+ * exercises in author-curated order. Replaces the previous reverse
+ * `Exercise.lesson` lookup which produced arbitrary order and pulled in
+ * any orphan / draft exercise tagged with the lesson id (audit F2 / F3).
+ *
+ * Notes:
+ *  - Only `exerciseRef` blocks are followed; `contentPage` blocks are
+ *    out of scope for the chat prompt's exercises section.
+ *  - The lesson page itself uses `blocks[]` as its source of truth, so
+ *    matching that ordering keeps the model's view in sync with what
+ *    the student sees.
+ *  - Filters by `status: 'published'` to suppress drafts. Lessons that
+ *    don't store status on exercises will simply not match the filter
+ *    and we fall back to the full set.
+ */
+async function fetchExercisesFromLessonBlocks(
+  payload: Payload,
+  lessonId: string,
+  reqLogger: Logger,
+): Promise<Array<{ id: string; title?: string; content: unknown }> | undefined> {
+  try {
+    const lesson = (await payload.findByID({
+      collection: 'lessons',
+      id: lessonId,
+      depth: 0,
+      select: { blocks: true },
+      overrideAccess: true,
+    })) as unknown as { blocks?: string | unknown[] }
+
+    const rawBlocks = lesson.blocks
+    let parsed: unknown[] = []
+    if (Array.isArray(rawBlocks)) {
+      parsed = rawBlocks
+    } else if (typeof rawBlocks === 'string' && rawBlocks.trim().length > 0) {
+      try {
+        const j = JSON.parse(rawBlocks)
+        if (Array.isArray(j)) parsed = j
+      } catch (err) {
+        reqLogger.warn({ err, lessonId }, 'Failed to parse lesson.blocks as JSON')
+      }
+    }
+    if (parsed.length === 0) return []
+
+    // Collect ordered exerciseRef IDs
+    const orderedIds: string[] = []
+    for (const block of parsed) {
+      if (!block || typeof block !== 'object') continue
+      const b = block as { blockType?: string; exercise?: string | { id?: string } }
+      if (b.blockType !== 'exerciseRef') continue
+      const id = typeof b.exercise === 'string' ? b.exercise : b.exercise?.id
+      if (id) orderedIds.push(id)
+    }
+    if (orderedIds.length === 0) return []
+
+    // Bulk fetch — Mongo $in does not preserve order so we reorder client-side
+    const result = await payload.find({
+      collection: 'exercises',
+      where: { id: { in: orderedIds } },
+      depth: 0,
+      select: { id: true, title: true, content: true, _status: true },
+      limit: 200,
+      overrideAccess: true,
+    })
+
+    const byId = new Map<string, { id: string; title?: string; content: unknown }>()
+    for (const doc of result.docs) {
+      const e = doc as { id: string; title?: string; content?: unknown; _status?: string }
+      // Drop drafts when status is set; documents without _status pass through.
+      if (e._status && e._status !== 'published') continue
+      byId.set(e.id, { id: e.id, title: e.title, content: e.content })
+    }
+    const ordered = orderedIds
+      .map((id) => byId.get(id))
+      .filter((v): v is { id: string; title?: string; content: unknown } => v !== undefined)
+
+    reqLogger.info(
+      {
+        lessonId,
+        blocksCount: parsed.length,
+        exerciseRefCount: orderedIds.length,
+        publishedCount: ordered.length,
+      },
+      'Fetched exercises from lesson blocks',
+    )
+    return ordered
+  } catch (error) {
+    reqLogger.warn(
+      { err: error, lessonId },
+      'Failed to fetch exercises from lesson blocks; falling back to none',
+    )
+    return undefined
+  }
+}
+
+/**
  * Resolve a relationship field that may be a string id or a populated doc.
  */
 async function resolveRel(
@@ -429,34 +524,10 @@ export async function fetchLessonContextForContext(
 
   if (context.relationTo === 'lessons') {
     lessonContext = await fetchLessonContext(payload, context.value, user, reqLogger)
-    // Fetch all exercises for the lesson to inject into context
-    try {
-      const exercisesResult = await payload.find({
-        collection: 'exercises',
-        where: { lesson: { equals: context.value } },
-        depth: 0,
-        select: { id: true, title: true, content: true },
-        limit: 100,
-        overrideAccess: true, // Exercises are public-readable but limit fields
-      })
-      exercises = exercisesResult.docs.map((e) => ({
-        id: e.id as string,
-        title: (e as { title?: string }).title,
-        content: (e as { content: unknown }).content,
-      }))
-      reqLogger.info(
-        { lessonId: context.value, exerciseCount: exercises.length },
-        'Fetched exercises for lesson context',
-      )
-    } catch (error) {
-      reqLogger.warn(
-        { err: error, lessonId: context.value },
-        'Failed to fetch exercises for lesson',
-      )
-    }
+    exercises = await fetchExercisesFromLessonBlocks(payload, context.value, reqLogger)
   } else if (context.relationTo === 'exercises') {
     lessonContext = await fetchExerciseLessonContext(payload, context.value, user, reqLogger)
-    // Also fetch exercises for the parent lesson
+    // Resolve the parent lesson and pull its curated blocks list
     try {
       const exercise = await payload.findByID({
         collection: 'exercises',
@@ -469,23 +540,7 @@ export async function fetchLessonContextForContext(
           ? (exercise as { lesson: string }).lesson
           : (exercise as { lesson: { id: string } }).lesson?.id
       if (lessonId) {
-        const exercisesResult = await payload.find({
-          collection: 'exercises',
-          where: { lesson: { equals: lessonId } },
-          depth: 0,
-          select: { id: true, title: true, content: true },
-          limit: 100,
-          overrideAccess: true,
-        })
-        exercises = exercisesResult.docs.map((e) => ({
-          id: e.id as string,
-          title: (e as { title?: string }).title,
-          content: (e as { content: unknown }).content,
-        }))
-        reqLogger.info(
-          { lessonId, exerciseCount: exercises.length },
-          'Fetched exercises for parent lesson (exercise context)',
-        )
+        exercises = await fetchExercisesFromLessonBlocks(payload, lessonId, reqLogger)
       }
     } catch (error) {
       reqLogger.warn(


### PR DESCRIPTION
## Implements F2 + F3 from the [chat audit](docs/audits/2026-05-07-chat-system-prompt-audit.md)

### Symptom
Live debug-prompt for \`lesson-1\` showed exercises in arbitrary order: \`[14, 12, 29, 28, 27, ..., 1]\`. Includes any orphan / draft exercise tagged with the lesson id.

### Root cause
\`fetchLessonContextForContext\` queries \`Exercise.lesson === lessonId\` — reverse lookup, no sort, no \`status\` filter. The lesson page itself uses \`lesson.blocks[]\` as its source of truth, so the chat's view drifts from what the student sees.

### Fix
New helper \`fetchExercisesFromLessonBlocks\`:
1. Read \`lesson.blocks\` (textarea-stored JSON)
2. Filter \`blockType === 'exerciseRef'\`
3. Collect ids in author-curated order
4. Bulk-fetch with \`select: { id, title, content, _status }\`
5. Drop drafts (\`_status\` set and not \`published\`)
6. Reorder client-side (Mongo \`\$in\` doesn't preserve order)

Used for both the \`lessons\` and \`exercises\` context paths.

### Verification
Local diag for \`lesson-1\` before vs after:

\`\`\`
before: [14, 12, 29, 28, 27, 26, 25, 24, 23, 22, ...]   (arbitrary)
after:  [הסבר-1, הסבר-2, 1, 2, 3, 4, ..., 29]            (curated)
\`\`\`

Order now matches what students see on the lesson page.

### Known follow-up (not blocking)
The 31 entries still include the two explanation pages (\`הסבר 1\`, \`הסבר 2\`) because they're stored as documents in the \`exercises\` collection. Distinguishing them needs a content-modeling change (e.g. a \`kind\` field) and will be a separate audit task.

### Test plan
- [x] \`pnpm typecheck\` clean
- [x] Local diag confirms ordering
- [ ] After merge, live-verify on dev