### PR TITLE
fix(chat): Cap exercises section size — F4

### DIFF
--- a/src/infra/llm/prompt-composer.server.ts
+++ b/src/infra/llm/prompt-composer.server.ts
@@ -135,20 +135,15 @@ export function composeSystemInstructions(
       ? withCourseContext + '\n\n## Lesson Content\n' + lessonContextText.trim()
       : withCourseContext
 
-  // Step 7: Append lesson exercises (if provided)
+  // Step 7: Append lesson exercises (if provided), with size budget.
+  // Audit F4: previously emitted full content of every exercise — for a
+  // 31-exercise lesson that produced a ~14 KB system prompt that diluted
+  // the model's attention. Now: per-exercise content is truncated to
+  // EXERCISE_CONTENT_BUDGET, and the section as a whole stops after
+  // EXERCISES_SECTION_BUDGET with a tail noting how many exercises remain.
   let withExercises = withLessonContext
   if (exercises && exercises.length > 0) {
-    const exercisesSection =
-      '\n\n## Lesson Exercises\nThe following exercises are available in this lesson. You can answer questions about them:\n\n' +
-      exercises
-        .map((exercise, idx) => {
-          const title = exercise.title ? `**${exercise.title}**` : `Exercise ${idx + 1}`
-          const content = formatExerciseContent(exercise.content)
-          return `${idx + 1}. ${title}\n${content}`
-        })
-        .join('\n\n')
-
-    withExercises = withLessonContext + exercisesSection
+    withExercises = withLessonContext + buildExercisesSection(exercises)
   }
 
   // Step 8: Append mandatory math formatting instructions
@@ -160,6 +155,70 @@ export function composeSystemInstructions(
   return hasImageAttached
     ? withMathFormatting + '\n\n' + IMAGE_HANDLING_INSTRUCTIONS
     : withMathFormatting
+}
+
+/**
+ * Per-exercise body is truncated to this many characters to keep the
+ * "## Lesson Exercises" section bounded for lessons with many exercises
+ * or long bodies. Title is always shown — only the body is truncated.
+ */
+const EXERCISE_CONTENT_BUDGET = 400
+
+/**
+ * Total budget for the exercises section. Once exceeded, remaining
+ * exercises are listed by title only and a "...and N more" tail is added.
+ */
+const EXERCISES_SECTION_BUDGET = 4000
+
+/**
+ * Build the exercises section of the system prompt with size budgeting.
+ * Title is always included; per-exercise body is truncated to
+ * EXERCISE_CONTENT_BUDGET; total emitted text is capped at
+ * EXERCISES_SECTION_BUDGET with a tail noting how many remain.
+ */
+function buildExercisesSection(
+  exercises: Array<{ id: string; title?: string; content: unknown }>,
+): string {
+  const header =
+    '\n\n## Lesson Exercises\nThe following exercises are available in this lesson. You can answer questions about them:\n\n'
+
+  const lines: string[] = []
+  let used = 0
+  let remaining = exercises.length
+
+  for (let idx = 0; idx < exercises.length; idx++) {
+    const exercise = exercises[idx]
+    const title = exercise.title ? `**${exercise.title}**` : `Exercise ${idx + 1}`
+    const fullContent = formatExerciseContent(exercise.content)
+    const truncatedContent =
+      fullContent.length > EXERCISE_CONTENT_BUDGET
+        ? fullContent.slice(0, EXERCISE_CONTENT_BUDGET) + '…(truncated)'
+        : fullContent
+
+    const candidate = `${idx + 1}. ${title}\n${truncatedContent}`
+
+    // If adding this entry would blow the budget, switch to title-only mode
+    // for the rest and break.
+    if (used + candidate.length > EXERCISES_SECTION_BUDGET) {
+      const remainingTitles = exercises.slice(idx).map((e, i) => {
+        const t = e.title ? `**${e.title}**` : `Exercise ${idx + i + 1}`
+        return `${idx + i + 1}. ${t}`
+      })
+      lines.push(...remainingTitles)
+      remaining = 0
+      break
+    }
+
+    lines.push(candidate)
+    used += candidate.length + 2 // +2 for the joining \n\n
+    remaining--
+  }
+
+  let body = lines.join('\n\n')
+  if (remaining > 0) {
+    body += `\n\n…and ${remaining} more exercise${remaining === 1 ? '' : 's'} in this lesson (titles only above to fit the prompt budget).`
+  }
+  return header + body
 }
 
 /**

--- a/tests/unit/lib/ai/prompt-composer-size-cap.test.ts
+++ b/tests/unit/lib/ai/prompt-composer-size-cap.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Verifies the exercises section in composeSystemInstructions stays
+ * within budget — implements audit F4. Without this cap a 31-exercise
+ * lesson with multi-part question_geometry blocks pushed the system
+ * prompt past 14 KB, diluting the model's attention.
+ */
+import { composeSystemInstructions } from '@/infra/llm/prompt-composer.server'
+import { describe, expect, it } from 'vitest'
+
+function makeExercise(idx: number, opts?: { longBody?: boolean }) {
+  const body = opts?.longBody ? 'x'.repeat(2000) : 'short body'
+  return {
+    id: `ex-${idx}`,
+    title: `Exercise ${idx}`,
+    content: {
+      blocks: [{ id: 'b1', type: 'rich_text', format: 'md-math-v1', value: body, mediaIds: [] }],
+    },
+  }
+}
+
+describe('composeSystemInstructions — exercises section size cap (audit F4)', () => {
+  it('truncates oversized per-exercise content', () => {
+    const exercises = [makeExercise(1, { longBody: true })]
+    const out = composeSystemInstructions(
+      [],
+      'You are a tutor.',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      exercises,
+      false,
+    )
+    // Content was 2000 chars, cap is 400 → must contain truncation marker
+    expect(out).toContain('…(truncated)')
+    // Title still present
+    expect(out).toContain('**Exercise 1**')
+  })
+
+  it('lists later exercises by title only when section budget is reached', () => {
+    // 30 exercises, each with a 1000-char body → far exceeds 4 KB section budget
+    const exercises = Array.from({ length: 30 }, (_, i) => makeExercise(i + 1, { longBody: true }))
+    const out = composeSystemInstructions(
+      [],
+      'You are a tutor.',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      exercises,
+      false,
+    )
+
+    // Every title should still appear (titles-only mode for the tail)
+    for (let i = 1; i <= 30; i++) {
+      expect(out).toContain(`**Exercise ${i}**`)
+    }
+
+    // The exercises section length should be bounded — measured between
+    // its header and the next mandatory block.
+    const sectionStart = out.indexOf('## Lesson Exercises')
+    const sectionEnd = out.indexOf('## Math Formatting (CRITICAL)')
+    const sectionLength = sectionEnd - sectionStart
+    expect(sectionLength).toBeLessThan(8000) // generous upper bound; would be 30 KB without the cap
+  })
+
+  it('emits all content when section fits the budget', () => {
+    const exercises = [makeExercise(1), makeExercise(2)]
+    const out = composeSystemInstructions(
+      [],
+      'You are a tutor.',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      exercises,
+      false,
+    )
+    // Both bodies fit inside the budget, no truncation
+    expect(out).not.toContain('…(truncated)')
+    expect(out).toContain('short body')
+  })
+})


### PR DESCRIPTION
## Implements F4 from the [chat audit](docs/audits/2026-05-07-chat-system-prompt-audit.md)

### Symptom
Live debug-prompt for \`lesson-1\`: \`composedSystemMessageLength: 14751\`. The exercises section emitted full content of all 31 exercises with multi-part question bodies. That much text dilutes Gemini's attention and correlates with the wrong-count and lost-context bugs we kept seeing.

### Fix
Two budgets in \`buildExercisesSection\`:
- \`EXERCISE_CONTENT_BUDGET\` (400 chars) — per-exercise body truncation with \`…(truncated)\` marker.
- \`EXERCISES_SECTION_BUDGET\` (4000 chars) — total content. Once exceeded, remaining exercises are listed by **title only**.

Title is always present so meta-questions like "what exercises are in this lesson" still answer correctly even when bodies are truncated.

### Verification
Local diag for \`lesson-1\`:

\`\`\`
before:  composedSystemMessageLength: 14,751
after:   composedSystemMessageLength:  7,611   (-48%)
\`\`\`

First 22 exercises keep truncated bodies; 23-31 are title-only — student-visible titles still appear in the prompt without "...N more" cryptic tail.

### Tests

\`tests/unit/lib/ai/prompt-composer-size-cap.test.ts\` — 3 tests:
1. Per-exercise truncation when body exceeds 400 chars.
2. Section-budget enforcement: 30 long-body exercises → all titles still present, total section < 8 KB.
3. No-op when section already fits.