### PR TITLE
fix(chat): Mark active exercise in lesson context block

### DIFF
--- a/scripts/diag-debug-prompt.ts
+++ b/scripts/diag-debug-prompt.ts
@@ -57,6 +57,7 @@ async function main() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     logger as any,
     undefined,
+    exerciseId,
   )
 
   const composed = await composeFullSystemInstructions(

--- a/src/server/payload/endpoints/agent/chat-debug-prompt.ts
+++ b/src/server/payload/endpoints/agent/chat-debug-prompt.ts
@@ -95,6 +95,7 @@ export async function agentChatDebugPrompt(
     { id: ownerId },
     reqLogger as Logger,
     validated.courseId,
+    validated.exerciseId,
   )
 
   // 5) Compose the full system instructions exactly as the chat pipeline does

--- a/src/server/payload/endpoints/agent/chat.ts
+++ b/src/server/payload/endpoints/agent/chat.ts
@@ -729,12 +729,14 @@ async function handleContextScopedChat(
   )
 
   // Fetch lesson context and compose system instructions
+  // (see pipeline.ts for the activeExerciseId rationale)
   const lessonContext = await fetchLessonContextForContext(
     req.payload,
     context,
     { id: ownerId },
     logger as Logger,
     validated.courseId,
+    validated.exerciseId,
   )
 
   // Only inject IMAGE_HANDLING_INSTRUCTIONS when the request actually

--- a/src/server/payload/endpoints/agent/chat/pipeline.ts
+++ b/src/server/payload/endpoints/agent/chat/pipeline.ts
@@ -223,13 +223,18 @@ export async function runChatPipeline(
     reqLogger as Logger,
   )
 
-  // Fetch lesson context and compose system instructions
+  // Fetch lesson context and compose system instructions.
+  // Pass exerciseId as activeExerciseId so the model gets a clear
+  // "currently active exercise" marker even when the conversation is
+  // lesson-scoped (which is the case any time the page sends both
+  // lessonId and exerciseId — extractContextCandidate prefers lesson).
   const lessonContext = await fetchLessonContextForContext(
     req.payload,
     context,
     { id: ownerId },
     reqLogger as Logger,
     validated.courseId,
+    validated.exerciseId,
   )
 
   // Only inject IMAGE_HANDLING_INSTRUCTIONS when the request actually

--- a/src/server/payload/endpoints/agent/chat/prompt-composition.ts
+++ b/src/server/payload/endpoints/agent/chat/prompt-composition.ts
@@ -518,6 +518,7 @@ export async function fetchLessonContextForContext(
   user: { id: string },
   reqLogger: Logger,
   courseId?: string,
+  activeExerciseId?: string,
 ): Promise<LessonContext> {
   let lessonContext: LessonContext
   let exercises: LessonContext['exercises'] = undefined
@@ -525,6 +526,50 @@ export async function fetchLessonContextForContext(
   if (context.relationTo === 'lessons') {
     lessonContext = await fetchLessonContext(payload, context.value, user, reqLogger)
     exercises = await fetchExercisesFromLessonBlocks(payload, context.value, reqLogger)
+
+    // The lesson page sends BOTH lessonId and exerciseId — extractContextCandidate
+    // picks the lesson, so the conversation stays lesson-scoped (one conversation
+    // per lesson, exercises share it). But we still need to tell the model which
+    // exercise the student is *currently* viewing or it anchors on the most-recent
+    // hidden injection (often the previous exercise). Augment the lessonContextBlock
+    // with a "Currently active exercise" section.
+    if (activeExerciseId) {
+      try {
+        const activeExercise = (await payload.findByID({
+          collection: 'exercises',
+          id: activeExerciseId,
+          depth: 0,
+          overrideAccess: true,
+        })) as unknown as Record<string, unknown>
+        const activeBlock = buildLessonContextBlock(null, null, null, activeExercise)
+        if (activeBlock && lessonContext.lessonContextBlock) {
+          // Replace the helper's intro line with a more directive header so the model
+          // treats this as authoritative even when the conversation history mentions
+          // earlier exercises.
+          const cleaned = activeBlock
+            .replace(
+              /^.*do not refuse to discuss it\.\n+/,
+              '## Currently Active Exercise (authoritative — ignore earlier exercise context in chat history)\n',
+            )
+            .replace(/^## Current Exercise/m, '### Active Exercise Details')
+          lessonContext = {
+            ...lessonContext,
+            lessonContextBlock: lessonContext.lessonContextBlock + '\n\n' + cleaned,
+          }
+        } else if (activeBlock) {
+          lessonContext = { ...lessonContext, lessonContextBlock: activeBlock }
+        }
+        reqLogger.info(
+          { activeExerciseId, hasActiveBlock: !!activeBlock },
+          'Augmented lesson context with active exercise marker',
+        )
+      } catch (error) {
+        reqLogger.warn(
+          { err: error, activeExerciseId },
+          'Failed to fetch active exercise; lesson context block left unchanged',
+        )
+      }
+    }
   } else if (context.relationTo === 'exercises') {
     lessonContext = await fetchExerciseLessonContext(payload, context.value, user, reqLogger)
     // Resolve the parent lesson and pull its curated blocks list


### PR DESCRIPTION
## User report
> "Chat addresses the previous exercise. I click next to exercise number 4 and the chat is getting a context for Exercise three."

## Root cause

\`extractContextCandidate\` prefers \`lessonId\` over \`exerciseId\` so when the page sends both (which it always does), the request goes through the lesson path. The system prompt got the lesson title + full unordered exercises list, but **no marker for which exercise is currently active**. With no clear pointer, the model anchored on the most recent hidden context-injection in chat history — which is the *previous* exercise the student just chatted about.

## Fix

Thread \`validated.exerciseId\` through \`fetchLessonContextForContext\` as \`activeExerciseId\`. When set on the lesson path, fetch that exercise and append it to \`lessonContextBlock\` under:

\`\`\`
## Currently Active Exercise (authoritative — ignore earlier exercise context in chat history)
### Active Exercise Details
Title: …
Body: …
### Sub-question 1 …
### Sub-question 2 …
\`\`\`

The "authoritative" header tells the model to treat this section as ground truth even when chat history mentions earlier exercises.

## Verification

Local diag for \`lesson-1 + exercise 14\`:

\`\`\`
before:  lessonContextBlock length:   222   (lesson info only)
after:   lessonContextBlock length: 1,111   (lesson + active-exercise marker + body)
\`\`\`

Without \`exerciseId\`, behavior is unchanged (block stays at 222).

## Touched files

- \`prompt-composition.ts\` — new \`activeExerciseId\` parameter, augments lessonContextBlock
- \`pipeline.ts\`, \`chat.ts\`, \`chat-debug-prompt.ts\` — pass \`validated.exerciseId\` through
- \`scripts/diag-debug-prompt.ts\` — same plumbing for local audits

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] Local diag confirms marker appears for lesson+exercise, absent for lesson-only
- [ ] After merge, navigate 3→4 on dev and confirm chat addresses exercise 4