### PR TITLE
#1497: [P2] Add client-side validation for empty email/password fields

### DIFF
--- a/src/app/(frontend)/login/LoginForm.tsx
+++ b/src/app/(frontend)/login/LoginForm.tsx
@@ -25,10 +25,23 @@ function LoginFormContent() {
   const returnTo = sanitizeReturnTo(searchParams?.get('returnTo'))
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
     setError(null)
+    setFieldErrors({})
+
+    const email = (e.currentTarget.elements.namedItem('email') as HTMLInputElement)?.value
+    const password = (e.currentTarget.elements.namedItem('password') as HTMLInputElement)?.value
+    const errors: Record<string, string> = {}
+    if (!email?.trim()) errors.email = t('errors.emailRequired')
+    if (!password?.trim()) errors.password = t('errors.passwordRequired')
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors)
+      return
+    }
+
     setIsLoading(true)
     try {
       const formData = new FormData(e.currentTarget)
@@ -40,6 +53,20 @@ function LoginFormContent() {
       }
     } finally {
       setIsLoading(false)
+    }
+  }
+
+  function validateForm(e: React.MouseEvent<HTMLButtonElement>) {
+    const form = e.currentTarget.form
+    if (!form) return
+    const email = (form.elements.namedItem('email') as HTMLInputElement)?.value
+    const password = (form.elements.namedItem('password') as HTMLInputElement)?.value
+    const errors: Record<string, string> = {}
+    if (!email?.trim()) errors.email = t('errors.emailRequired')
+    if (!password?.trim()) errors.password = t('errors.passwordRequired')
+    if (Object.keys(errors).length > 0) {
+      e.preventDefault()
+      setFieldErrors(errors)
     }
   }
 
@@ -101,7 +128,11 @@ function LoginFormContent() {
                   type="email"
                   placeholder={t('emailPlaceholder')}
                   required
+                  className={fieldErrors.email ? 'border-destructive' : ''}
                 />
+                {fieldErrors.email && (
+                  <p className="text-body-sm text-destructive">{fieldErrors.email}</p>
+                )}
               </div>
               <div className="space-y-1">
                 <Label htmlFor="password">{t('password')}</Label>
@@ -111,10 +142,14 @@ function LoginFormContent() {
                   type="password"
                   placeholder={t('passwordPlaceholder')}
                   required
+                  className={fieldErrors.password ? 'border-destructive' : ''}
                 />
+                {fieldErrors.password && (
+                  <p className="text-body-sm text-destructive">{fieldErrors.password}</p>
+                )}
               </div>
               {error && <p className="text-body-sm text-destructive">{error}</p>}
-              <Button type="submit" className="w-full" disabled={isLoading}>
+              <Button type="submit" className="w-full" disabled={isLoading} onClick={validateForm}>
                 {isLoading ? t('loggingIn') : t('loginButton')}
               </Button>
             </form>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -129,6 +129,8 @@
       "noAccount": "Don't have an account?",
       "signupLink": "Sign up",
       "errors": {
+        "emailRequired": "Email is required",
+        "passwordRequired": "Password is required",
         "invalidCredentials": "Invalid email or password"
       }
     },

--- a/src/i18n/he.json
+++ b/src/i18n/he.json
@@ -152,6 +152,8 @@
       "noAccount": "אין לך חשבון?",
       "signupLink": "הירשם",
       "errors": {
+        "emailRequired": "אימייל נדרש",
+        "passwordRequired": "סיסמה נדרשת",
         "invalidCredentials": "אימייל או סיסמה שגויים"
       }
     },

--- a/tests/unit/login-page-client-validation.int.spec.tsx
+++ b/tests/unit/login-page-client-validation.int.spec.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 
+import '@testing-library/jest-dom'
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 

--- a/tests/unit/login-page-client-validation.int.spec.tsx
+++ b/tests/unit/login-page-client-validation.int.spec.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { LoginForm } from '@/app/(frontend)/login/LoginForm'
+import { I18nProvider } from '@/ui/web/providers/I18n'
+import { PasswordLoginProvider } from '@/ui/web/providers/PasswordLoginProvider'
+import enMessages from '../../src/i18n/en.json'
+import heMessages from '../../src/i18n/he.json'
+
+// Mock the login action to prevent actual API calls
+vi.mock('@/app/(frontend)/login/login_authenticate-action', () => ({
+  loginAction: vi.fn().mockResolvedValue({ success: false, error: 'invalidCredentials' }),
+}))
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  useSearchParams: vi.fn().mockReturnValue({
+    get: vi.fn().mockReturnValue(null),
+  }),
+  usePathname: vi.fn().mockReturnValue('/login'),
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+const renderWithPasswordEnabled = (children: React.ReactNode) => {
+  return render(
+    <I18nProvider locale="en" messages={enMessages}>
+      <PasswordLoginProvider enabled={true}>{children}</PasswordLoginProvider>
+    </I18nProvider>,
+  )
+}
+
+const renderWithPasswordEnabledHebrew = (children: React.ReactNode) => {
+  return render(
+    <I18nProvider locale="he" messages={heMessages}>
+      <PasswordLoginProvider enabled={true}>{children}</PasswordLoginProvider>
+    </I18nProvider>,
+  )
+}
+
+describe('Login Form Client-Side Validation - Issue #1497', () => {
+  describe('Empty email field validation', () => {
+    it('shows error message when email field is empty on submit (English)', async () => {
+      renderWithPasswordEnabled(<LoginForm />)
+
+      // Submit the form without entering email by clicking the submit button
+      const submitButton = screen.getByRole('button', { name: /log in/i })
+      fireEvent.click(submitButton)
+
+      // Wait for any validation to complete
+      await waitFor(() => {})
+
+      // The form should show a validation error for the empty email field
+      // Expected: "Email is required" or similar validation message
+      // This will fail because the current implementation doesn't show custom error messages
+      const emailError = screen.getByText(/email.*required/i)
+      expect(emailError).toBeInTheDocument()
+    })
+
+    it('shows error message when email field is empty on submit (Hebrew)', async () => {
+      renderWithPasswordEnabledHebrew(<LoginForm />)
+
+      // Submit the form without entering email
+      const submitButton = screen.getByRole('button', { name: /התחבר/i })
+      fireEvent.click(submitButton)
+
+      await waitFor(() => {})
+
+      // The form should show a validation error for the empty email field
+      // Expected: Hebrew validation message for required email
+      const emailError = screen.getByText(/אימייל.*נדרש|דוא"ל.*נדרש/i)
+      expect(emailError).toBeInTheDocument()
+    })
+  })
+
+  describe('Empty password field validation', () => {
+    it('shows error message when password field is empty on submit (English)', async () => {
+      renderWithPasswordEnabled(<LoginForm />)
+
+      // Submit the form without entering password
+      const submitButton = screen.getByRole('button', { name: /log in/i })
+      fireEvent.click(submitButton)
+
+      await waitFor(() => {})
+
+      // The form should show a validation error for the empty password field
+      // Expected: "Password is required" or similar validation message
+      const passwordError = screen.getByText(/password.*required/i)
+      expect(passwordError).toBeInTheDocument()
+    })
+
+    it('shows error message when password field is empty on submit (Hebrew)', async () => {
+      renderWithPasswordEnabledHebrew(<LoginForm />)
+
+      // Submit the form without entering password
+      const submitButton = screen.getByRole('button', { name: /התחבר/i })
+      fireEvent.click(submitButton)
+
+      await waitFor(() => {})
+
+      // The form should show a validation error for the empty password field
+      // Expected: Hebrew validation message for required password
+      const passwordError = screen.getByText(/סיסמה.*נדרשת/i)
+      expect(passwordError).toBeInTheDocument()
+    })
+  })
+
+  describe('Both fields empty validation', () => {
+    it('shows error messages for both email and password when both are empty (English)', async () => {
+      renderWithPasswordEnabled(<LoginForm />)
+
+      // Submit the form without entering anything
+      const submitButton = screen.getByRole('button', { name: /log in/i })
+      fireEvent.click(submitButton)
+
+      await waitFor(() => {})
+
+      // Both validation errors should be visible
+      expect(screen.getByText(/email.*required/i)).toBeInTheDocument()
+      expect(screen.getByText(/password.*required/i)).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- **src/app/(frontend)/login/LoginForm.tsx**: Added `fieldErrors` state, client-side validation in `handleSubmit` (prevents server call when fields empty), `validateForm` onClick handler for test compatibility, `border-destructive` class + inline error `<p>` elements for email and password fields — mirrors the existing `SignupFormFields` pattern
- **src/i18n/en.json**: Added `auth.login.errors.emailRequired: "Email is required"` and `auth.login.errors.passwordRequired: "Password is required"`
- **src/i18n/he.json**: Added Hebrew equivalents `"אימייל נדרש"` and `"סיסמה נדרשת"` (using "נדרש" to match the pre-committed Hebrew test regex)
- **tests/unit/login-page-client-validation.int.spec.tsx**: Added missing `import '@testing-library/jest-dom'` (required for `toBeInTheDocument()` matcher in unit environment); this is a test infrastructure fix, not a weakening of assertions

## Changes

- `src/app/(frontend)/login/LoginForm.tsx`
- `src/i18n/en.json`
- `src/i18n/he.json`
- `tests/unit/login-page-client-validation.int.spec.tsx`

Closes #1497

---
_Opened by kody (single-session autonomous run)._ 