### PR TITLE
#1498: [P2] Add client-side email format validation

### DIFF
--- a/src/app/(frontend)/login/LoginForm.tsx
+++ b/src/app/(frontend)/login/LoginForm.tsx
@@ -15,6 +15,7 @@ import { usePasswordLogin } from '@/ui/web/providers/PasswordLoginProvider'
 import { useTranslations } from '@/ui/web/providers/I18n'
 import { sanitizeReturnTo } from '@/infra/auth/oauth_sanitize'
 import { loginAction } from './login_authenticate-action'
+import { safeValidate, emailSchema } from '@/infra/utils/validation'
 import telescopeSvg from '@/ui/web/TelescopeLogo/telescope.svg'
 
 function LoginFormContent() {
@@ -35,7 +36,11 @@ function LoginFormContent() {
     const email = (e.currentTarget.elements.namedItem('email') as HTMLInputElement)?.value
     const password = (e.currentTarget.elements.namedItem('password') as HTMLInputElement)?.value
     const errors: Record<string, string> = {}
-    if (!email?.trim()) errors.email = t('errors.emailRequired')
+    if (!email?.trim()) {
+      errors.email = t('errors.emailRequired')
+    } else if (email?.trim() && safeValidate(emailSchema, email).success === false) {
+      errors.email = t('errors.invalidEmail')
+    }
     if (!password?.trim()) errors.password = t('errors.passwordRequired')
     if (Object.keys(errors).length > 0) {
       setFieldErrors(errors)
@@ -62,7 +67,11 @@ function LoginFormContent() {
     const email = (form.elements.namedItem('email') as HTMLInputElement)?.value
     const password = (form.elements.namedItem('password') as HTMLInputElement)?.value
     const errors: Record<string, string> = {}
-    if (!email?.trim()) errors.email = t('errors.emailRequired')
+    if (!email?.trim()) {
+      errors.email = t('errors.emailRequired')
+    } else if (email?.trim() && safeValidate(emailSchema, email).success === false) {
+      errors.email = t('errors.invalidEmail')
+    }
     if (!password?.trim()) errors.password = t('errors.passwordRequired')
     if (Object.keys(errors).length > 0) {
       e.preventDefault()

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -131,7 +131,8 @@
       "errors": {
         "emailRequired": "Email is required",
         "passwordRequired": "Password is required",
-        "invalidCredentials": "Invalid email or password"
+        "invalidCredentials": "Invalid email or password",
+        "invalidEmail": "Valid email is required"
       }
     },
     "account": {

--- a/src/i18n/he.json
+++ b/src/i18n/he.json
@@ -154,7 +154,8 @@
       "errors": {
         "emailRequired": "אימייל נדרש",
         "passwordRequired": "סיסמה נדרשת",
-        "invalidCredentials": "אימייל או סיסמה שגויים"
+        "invalidCredentials": "אימייל או סיסמה שגויים",
+        "invalidEmail": "נדרש אימייל תקין"
       }
     },
     "account": {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -64,7 +64,6 @@ export type SupportedTimezones =
 export interface Config {
   auth: {
     users: UserAuthOperations;
-    'payload-mcp-api-keys': PayloadMcpApiKeyAuthOperations;
   };
   blocks: {};
   collections: {
@@ -105,7 +104,6 @@ export interface Config {
     forms: Form;
     'form-submissions': FormSubmission;
     search: Search;
-    'payload-mcp-api-keys': PayloadMcpApiKey;
     'payload-kv': PayloadKv;
     'payload-jobs': PayloadJob;
     'payload-locked-documents': PayloadLockedDocument;
@@ -151,7 +149,6 @@ export interface Config {
     forms: FormsSelect<false> | FormsSelect<true>;
     'form-submissions': FormSubmissionsSelect<false> | FormSubmissionsSelect<true>;
     search: SearchSelect<false> | SearchSelect<true>;
-    'payload-mcp-api-keys': PayloadMcpApiKeysSelect<false> | PayloadMcpApiKeysSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-jobs': PayloadJobsSelect<false> | PayloadJobsSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -171,13 +168,9 @@ export interface Config {
     footer: FooterSelect<false> | FooterSelect<true>;
   };
   locale: null;
-  user:
-    | (User & {
-        collection: 'users';
-      })
-    | (PayloadMcpApiKey & {
-        collection: 'payload-mcp-api-keys';
-      });
+  user: User & {
+    collection: 'users';
+  };
   jobs: {
     tasks: {
       pdf_to_exercises: TaskPdfToExercises;
@@ -192,24 +185,6 @@ export interface Config {
   };
 }
 export interface UserAuthOperations {
-  forgotPassword: {
-    email: string;
-    password: string;
-  };
-  login: {
-    email: string;
-    password: string;
-  };
-  registerFirstUser: {
-    email: string;
-    password: string;
-  };
-  unlock: {
-    email: string;
-    password: string;
-  };
-}
-export interface PayloadMcpApiKeyAuthOperations {
   forgotPassword: {
     email: string;
     password: string;
@@ -2638,74 +2613,6 @@ export interface Search {
   createdAt: string;
 }
 /**
- * API keys control which collections, resources, tools, and prompts MCP clients can access
- *
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "payload-mcp-api-keys".
- */
-export interface PayloadMcpApiKey {
-  id: string;
-  /**
-   * The user that the API key is associated with.
-   */
-  user: string | User;
-  /**
-   * A useful label for the API key.
-   */
-  label?: string | null;
-  /**
-   * The purpose of the API key.
-   */
-  description?: string | null;
-  courses?: {
-    /**
-     * Allow clients to find courses.
-     */
-    find?: boolean | null;
-    /**
-     * Allow clients to create courses.
-     */
-    create?: boolean | null;
-  };
-  chapters?: {
-    /**
-     * Allow clients to find chapters.
-     */
-    find?: boolean | null;
-    /**
-     * Allow clients to create chapters.
-     */
-    create?: boolean | null;
-  };
-  lessons?: {
-    /**
-     * Allow clients to find lessons.
-     */
-    find?: boolean | null;
-    /**
-     * Allow clients to create lessons.
-     */
-    create?: boolean | null;
-  };
-  exercises?: {
-    /**
-     * Allow clients to find exercises.
-     */
-    find?: boolean | null;
-  };
-  media?: {
-    /**
-     * Allow clients to find media.
-     */
-    find?: boolean | null;
-  };
-  updatedAt: string;
-  createdAt: string;
-  enableAPIKey?: boolean | null;
-  apiKey?: string | null;
-  apiKeyIndex?: string | null;
-}
-/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
@@ -2968,21 +2875,12 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'search';
         value: string | Search;
-      } | null)
-    | ({
-        relationTo: 'payload-mcp-api-keys';
-        value: string | PayloadMcpApiKey;
       } | null);
   globalSlug?: string | null;
-  user:
-    | {
-        relationTo: 'users';
-        value: string | User;
-      }
-    | {
-        relationTo: 'payload-mcp-api-keys';
-        value: string | PayloadMcpApiKey;
-      };
+  user: {
+    relationTo: 'users';
+    value: string | User;
+  };
   updatedAt: string;
   createdAt: string;
 }
@@ -2992,15 +2890,10 @@ export interface PayloadLockedDocument {
  */
 export interface PayloadPreference {
   id: string;
-  user:
-    | {
-        relationTo: 'users';
-        value: string | User;
-      }
-    | {
-        relationTo: 'payload-mcp-api-keys';
-        value: string | PayloadMcpApiKey;
-      };
+  user: {
+    relationTo: 'users';
+    value: string | User;
+  };
   key?: string | null;
   value?:
     | {
@@ -4138,48 +4031,6 @@ export interface SearchSelect<T extends boolean = true> {
       };
   updatedAt?: T;
   createdAt?: T;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "payload-mcp-api-keys_select".
- */
-export interface PayloadMcpApiKeysSelect<T extends boolean = true> {
-  user?: T;
-  label?: T;
-  description?: T;
-  courses?:
-    | T
-    | {
-        find?: T;
-        create?: T;
-      };
-  chapters?:
-    | T
-    | {
-        find?: T;
-        create?: T;
-      };
-  lessons?:
-    | T
-    | {
-        find?: T;
-        create?: T;
-      };
-  exercises?:
-    | T
-    | {
-        find?: T;
-      };
-  media?:
-    | T
-    | {
-        find?: T;
-      };
-  updatedAt?: T;
-  createdAt?: T;
-  enableAPIKey?: T;
-  apiKey?: T;
-  apiKeyIndex?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -64,6 +64,7 @@ export type SupportedTimezones =
 export interface Config {
   auth: {
     users: UserAuthOperations;
+    'payload-mcp-api-keys': PayloadMcpApiKeyAuthOperations;
   };
   blocks: {};
   collections: {
@@ -104,6 +105,7 @@ export interface Config {
     forms: Form;
     'form-submissions': FormSubmission;
     search: Search;
+    'payload-mcp-api-keys': PayloadMcpApiKey;
     'payload-kv': PayloadKv;
     'payload-jobs': PayloadJob;
     'payload-locked-documents': PayloadLockedDocument;
@@ -149,6 +151,7 @@ export interface Config {
     forms: FormsSelect<false> | FormsSelect<true>;
     'form-submissions': FormSubmissionsSelect<false> | FormSubmissionsSelect<true>;
     search: SearchSelect<false> | SearchSelect<true>;
+    'payload-mcp-api-keys': PayloadMcpApiKeysSelect<false> | PayloadMcpApiKeysSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-jobs': PayloadJobsSelect<false> | PayloadJobsSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -168,9 +171,13 @@ export interface Config {
     footer: FooterSelect<false> | FooterSelect<true>;
   };
   locale: null;
-  user: User & {
-    collection: 'users';
-  };
+  user:
+    | (User & {
+        collection: 'users';
+      })
+    | (PayloadMcpApiKey & {
+        collection: 'payload-mcp-api-keys';
+      });
   jobs: {
     tasks: {
       pdf_to_exercises: TaskPdfToExercises;
@@ -185,6 +192,24 @@ export interface Config {
   };
 }
 export interface UserAuthOperations {
+  forgotPassword: {
+    email: string;
+    password: string;
+  };
+  login: {
+    email: string;
+    password: string;
+  };
+  registerFirstUser: {
+    email: string;
+    password: string;
+  };
+  unlock: {
+    email: string;
+    password: string;
+  };
+}
+export interface PayloadMcpApiKeyAuthOperations {
   forgotPassword: {
     email: string;
     password: string;
@@ -2613,6 +2638,74 @@ export interface Search {
   createdAt: string;
 }
 /**
+ * API keys control which collections, resources, tools, and prompts MCP clients can access
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-mcp-api-keys".
+ */
+export interface PayloadMcpApiKey {
+  id: string;
+  /**
+   * The user that the API key is associated with.
+   */
+  user: string | User;
+  /**
+   * A useful label for the API key.
+   */
+  label?: string | null;
+  /**
+   * The purpose of the API key.
+   */
+  description?: string | null;
+  courses?: {
+    /**
+     * Allow clients to find courses.
+     */
+    find?: boolean | null;
+    /**
+     * Allow clients to create courses.
+     */
+    create?: boolean | null;
+  };
+  chapters?: {
+    /**
+     * Allow clients to find chapters.
+     */
+    find?: boolean | null;
+    /**
+     * Allow clients to create chapters.
+     */
+    create?: boolean | null;
+  };
+  lessons?: {
+    /**
+     * Allow clients to find lessons.
+     */
+    find?: boolean | null;
+    /**
+     * Allow clients to create lessons.
+     */
+    create?: boolean | null;
+  };
+  exercises?: {
+    /**
+     * Allow clients to find exercises.
+     */
+    find?: boolean | null;
+  };
+  media?: {
+    /**
+     * Allow clients to find media.
+     */
+    find?: boolean | null;
+  };
+  updatedAt: string;
+  createdAt: string;
+  enableAPIKey?: boolean | null;
+  apiKey?: string | null;
+  apiKeyIndex?: string | null;
+}
+/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
@@ -2875,12 +2968,21 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'search';
         value: string | Search;
+      } | null)
+    | ({
+        relationTo: 'payload-mcp-api-keys';
+        value: string | PayloadMcpApiKey;
       } | null);
   globalSlug?: string | null;
-  user: {
-    relationTo: 'users';
-    value: string | User;
-  };
+  user:
+    | {
+        relationTo: 'users';
+        value: string | User;
+      }
+    | {
+        relationTo: 'payload-mcp-api-keys';
+        value: string | PayloadMcpApiKey;
+      };
   updatedAt: string;
   createdAt: string;
 }
@@ -2890,10 +2992,15 @@ export interface PayloadLockedDocument {
  */
 export interface PayloadPreference {
   id: string;
-  user: {
-    relationTo: 'users';
-    value: string | User;
-  };
+  user:
+    | {
+        relationTo: 'users';
+        value: string | User;
+      }
+    | {
+        relationTo: 'payload-mcp-api-keys';
+        value: string | PayloadMcpApiKey;
+      };
   key?: string | null;
   value?:
     | {
@@ -4031,6 +4138,48 @@ export interface SearchSelect<T extends boolean = true> {
       };
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-mcp-api-keys_select".
+ */
+export interface PayloadMcpApiKeysSelect<T extends boolean = true> {
+  user?: T;
+  label?: T;
+  description?: T;
+  courses?:
+    | T
+    | {
+        find?: T;
+        create?: T;
+      };
+  chapters?:
+    | T
+    | {
+        find?: T;
+        create?: T;
+      };
+  lessons?:
+    | T
+    | {
+        find?: T;
+        create?: T;
+      };
+  exercises?:
+    | T
+    | {
+        find?: T;
+      };
+  media?:
+    | T
+    | {
+        find?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+  enableAPIKey?: T;
+  apiKey?: T;
+  apiKeyIndex?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/tests/unit/login-page-client-validation.int.spec.tsx
+++ b/tests/unit/login-page-client-validation.int.spec.tsx
@@ -126,4 +126,52 @@ describe('Login Form Client-Side Validation - Issue #1497', () => {
       expect(screen.getByText(/password.*required/i)).toBeInTheDocument()
     })
   })
+
+  describe('Invalid email format validation - Issue #1498', () => {
+    it('shows error message when email format is invalid (no @ symbol)', async () => {
+      renderWithPasswordEnabled(<LoginForm />)
+
+      // Fill in an invalid email format (no @ symbol, no domain)
+      const emailInput = screen.getByRole('textbox', { name: /email/i })
+      fireEvent.change(emailInput, { target: { value: 'notanemail' } })
+
+      // Fill in password
+      const passwordInput = screen.getByLabelText(/password/i)
+      fireEvent.change(passwordInput, { target: { value: 'anypassword123' } })
+
+      // Submit the form
+      const submitButton = screen.getByRole('button', { name: /log in/i })
+      fireEvent.click(submitButton)
+
+      await waitFor(() => {})
+
+      // The form should show a validation error for invalid email format
+      // Expected: "Valid email is required" or similar validation message
+      // This will FAIL because the current implementation does NOT validate email format
+      const emailError = screen.getByText(/valid.*email/i)
+      expect(emailError).toBeInTheDocument()
+    })
+
+    it('shows error message when email has no domain (missing @domain.com)', async () => {
+      renderWithPasswordEnabled(<LoginForm />)
+
+      // Fill in an invalid email format (has @ but no domain)
+      const emailInput = screen.getByRole('textbox', { name: /email/i })
+      fireEvent.change(emailInput, { target: { value: 'user@' } })
+
+      // Fill in password
+      const passwordInput = screen.getByLabelText(/password/i)
+      fireEvent.change(passwordInput, { target: { value: 'anypassword123' } })
+
+      // Submit the form
+      const submitButton = screen.getByRole('button', { name: /log in/i })
+      fireEvent.click(submitButton)
+
+      await waitFor(() => {})
+
+      // The form should show a validation error for invalid email format
+      const emailError = screen.getByText(/valid.*email/i)
+      expect(emailError).toBeInTheDocument()
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Restored `src/payload-types.ts` to match base branch `origin/goal-qa-login-page-2026-05-08` — re-added ~150 lines of `PayloadMcpApiKey` interface and related types that were unintentionally removed
- Email validation implementation (LoginForm.tsx, en.json, he.json) remains unchanged and all 7 tests pass
- Quality gates verified: TypeScript compiles clean, lint passes (pre-existing warnings only)

## Changes

- `src/payload-types.ts`

Closes #1498

---
_Opened by kody (single-session autonomous run)._ 