### PR TITLE
#1499: [P2] Implement or redirect /signup route

### DIFF
--- a/src/app/(frontend)/signup/SignupForm.tsx
+++ b/src/app/(frontend)/signup/SignupForm.tsx
@@ -9,6 +9,7 @@ import { GoogleLoginButton } from '@/ui/web/auth/GoogleLoginButton'
 import { Button } from '@/ui/web/components/button'
 import { Card, CardContent, CardFooter, CardHeader } from '@/ui/web/components/card'
 import { useTranslations } from '@/ui/web/providers/I18n'
+import { usePasswordLogin } from '@/ui/web/providers/PasswordLoginProvider'
 import { useSearchParams } from 'next/navigation'
 import React, { Suspense, useState } from 'react'
 import { toast } from 'sonner'
@@ -28,6 +29,7 @@ function SignupFormContent() {
   const router = useRouterWithLoading()
   const searchParams = useSearchParams()
   const returnTo = searchParams?.get('returnTo') || '/'
+  const passwordEnabled = usePasswordLogin()
   const [errors, setErrors] = useState<Record<string, string>>({})
 
   const { execute: executeSignup, isLoading } = useAsyncAction(
@@ -127,29 +129,35 @@ function SignupFormContent() {
       <CardContent className="p-card-padding-lg">
         <div className="space-y-4">
           <GoogleLoginButton returnTo={returnTo} className="w-full" />
-          <div className="relative">
-            <div className="absolute inset-0 flex items-center">
-              <span className="w-full border-t" />
-            </div>
-            <div className="relative flex justify-center text-body-xs uppercase">
-              <span className="bg-card/80 px-2 text-muted-foreground">{tOauth('orDivider')}</span>
-            </div>
-          </div>
-        </div>
-        <form onSubmit={onSubmit} className="space-y-4">
-          <SignupFormFields t={t} isLoading={isLoading} errors={errors} />
+          {passwordEnabled && (
+            <>
+              <div className="relative">
+                <div className="absolute inset-0 flex items-center">
+                  <span className="w-full border-t" />
+                </div>
+                <div className="relative flex justify-center text-body-xs uppercase">
+                  <span className="bg-card/80 px-2 text-muted-foreground">
+                    {tOauth('orDivider')}
+                  </span>
+                </div>
+              </div>
+              <form onSubmit={onSubmit} className="space-y-4">
+                <SignupFormFields t={t} isLoading={isLoading} errors={errors} />
 
-          <Button type="submit" className="w-full" disabled={isLoading}>
-            {isLoading ? (
-              <span className="flex items-center gap-content-gap-xs">
-                <Spinner size="sm" />
-                {t('creatingAccount')}
-              </span>
-            ) : (
-              t('createAccount')
-            )}
-          </Button>
-        </form>
+                <Button type="submit" className="w-full" disabled={isLoading}>
+                  {isLoading ? (
+                    <span className="flex items-center gap-content-gap-xs">
+                      <Spinner size="sm" />
+                      {t('creatingAccount')}
+                    </span>
+                  ) : (
+                    t('createAccount')
+                  )}
+                </Button>
+              </form>
+            </>
+          )}
+        </div>
       </CardContent>
       <CardFooter className="flex justify-center">
         <p className="text-body-sm text-muted-foreground">

--- a/src/app/(frontend)/signup/actions/signup_createUser-action.ts
+++ b/src/app/(frontend)/signup/actions/signup_createUser-action.ts
@@ -17,10 +17,19 @@ import {
 } from '@/server/services/guest-session-upgrade'
 import { clearGuestSessionCookie, GUEST_SESSION_COOKIE_NAME } from '@/server/services/guest-session'
 import { logger } from '@/infra/utils/logger'
+import { isPasswordLoginEnabled } from '@/infra/config/system-params'
 
 export async function signupAction(formData: FormData): Promise<SignupResult> {
   try {
-    // 1. Extract data
+    // 1. Check if password login is enabled (server-side enforcement)
+    if (!(await isPasswordLoginEnabled())) {
+      return {
+        success: false,
+        message: 'Password login is currently disabled.',
+      }
+    }
+
+    // 2. Extract data
     const rawData = {
       name: formData.get('name'),
       email: formData.get('email'),
@@ -29,7 +38,7 @@ export async function signupAction(formData: FormData): Promise<SignupResult> {
       website: formData.get('website'),
     }
 
-    // 2. Honeypot check (anti-spam layer 1)
+    // 3. Honeypot check (anti-spam layer 1)
     if (rawData.website && rawData.website.toString().trim() !== '') {
       return {
         success: false,
@@ -37,7 +46,7 @@ export async function signupAction(formData: FormData): Promise<SignupResult> {
       }
     }
 
-    // 3. Validate with Zod
+    // 4. Validate with Zod
     const parsed = SignupSchema.safeParse(rawData)
 
     if (!parsed.success) {
@@ -52,7 +61,7 @@ export async function signupAction(formData: FormData): Promise<SignupResult> {
 
     const { name, email, password, confirmPassword } = parsed.data
 
-    // 4. Check password match
+    // 5. Check password match
     if (password !== confirmPassword) {
       return {
         success: false,
@@ -60,7 +69,7 @@ export async function signupAction(formData: FormData): Promise<SignupResult> {
       }
     }
 
-    // 5. Rate limiting (anti-spam layer 2)
+    // 6. Rate limiting (anti-spam layer 2)
     const emailHash = Buffer.from(email).toString('base64')
     if (!checkRateLimit(emailHash)) {
       return {
@@ -69,7 +78,7 @@ export async function signupAction(formData: FormData): Promise<SignupResult> {
       }
     }
 
-    // 6. Create user via Payload
+    // 7. Create user via Payload
     const payload = await getPayload({ config })
 
     try {

--- a/src/app/(frontend)/signup/page.tsx
+++ b/src/app/(frontend)/signup/page.tsx
@@ -1,19 +1,7 @@
-import { redirect } from 'next/navigation'
-import { isPasswordLoginEnabled } from '@/infra/config/system-params'
 import { SignupPageContent } from './SignupPageContent'
 
-export default async function SignupPage({
-  searchParams,
-}: {
-  searchParams: Promise<Record<string, string>>
-}) {
-  const passwordEnabled = await isPasswordLoginEnabled()
+export const metadata = { title: 'Sign Up' }
 
-  if (!passwordEnabled) {
-    const params = await searchParams
-    const query = new URLSearchParams(params).toString()
-    redirect(query ? `/login?${query}` : '/login')
-  }
-
+export default async function SignupPage() {
   return <SignupPageContent />
 }

--- a/tests/e2e/signup-redirect.e2e.spec.ts
+++ b/tests/e2e/signup-redirect.e2e.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * E2E test for issue #1499: /signup route should render signup page
+ *
+ * Expected: Navigating to /signup should render the signup page (not redirect to /login)
+ *
+ * The server-side code was incorrectly redirecting to /login when isPasswordLoginEnabled()
+ * returned false. This test verifies the signup page renders correctly.
+ */
+import { expect, test } from '@playwright/test'
+
+// Hardcoded to avoid BOM character in NEXT_PUBLIC_SERVER_URL environment variable
+const BASE_URL = 'http://localhost:3000'
+
+test.describe('Signup Route (Issue #1499)', () => {
+  test('navigating to /signup should render signup page, not redirect to /login', async ({
+    page,
+  }) => {
+    // Navigate to the signup page
+    await page.goto(`${BASE_URL}/signup`)
+
+    // Verify the page loaded successfully by checking for a key element
+    const heading = page.locator('h1', { hasText: /create account|sign up/i })
+    await expect(heading).toBeVisible({ timeout: 10000 })
+
+    // Verify we're on the signup page (not redirected to login)
+    await expect(page).toHaveURL(/\/signup/)
+  })
+
+  test('signup page should display Google OAuth signup option', async ({ page }) => {
+    await page.goto(`${BASE_URL}/signup`)
+
+    // Verify we're on signup page
+    await expect(page).toHaveURL(/\/signup/)
+
+    // Verify Google OAuth button is visible
+    const googleButton = page.locator('button', { hasText: /google|continue with google/i })
+    await expect(googleButton).toBeVisible()
+  })
+
+  test('signup page URL should not contain /login', async ({ page }) => {
+    await page.goto(`${BASE_URL}/signup`)
+
+    // Verify we stayed on signup page
+    await expect(page).toHaveURL(/\/signup/)
+
+    // Also check the URL doesn't contain /login
+    const currentUrl = page.url()
+    expect(currentUrl).not.toContain('/login')
+  })
+})

--- a/tests/e2e/signup-redirect.e2e.spec.ts
+++ b/tests/e2e/signup-redirect.e2e.spec.ts
@@ -8,8 +8,8 @@
  */
 import { expect, test } from '@playwright/test'
 
-// Hardcoded to avoid BOM character in NEXT_PUBLIC_SERVER_URL environment variable
-const BASE_URL = 'http://localhost:3000'
+// Derive BASE_URL from env var (BOM sanitized), matching playwright.config.ts baseURL fallback
+const BASE_URL = (process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:3000').replace(/^﻿/, '')
 
 test.describe('Signup Route (Issue #1499)', () => {
   test('navigating to /signup should render signup page, not redirect to /login', async ({


### PR DESCRIPTION
## Summary

- Added `isPasswordLoginEnabled()` guard as the first step of `signupAction` to prevent direct POST bypass when password login is disabled (server-side enforcement complementing the client-side form hiding).
- Updated E2E test `BASE_URL` to derive from `NEXT_PUBLIC_SERVER_URL` with BOM sanitization, matching the playwright.config.ts fallback.

## Changes

- `src/app/(frontend)/signup/actions/signup_createUser-action.ts`
- `tests/e2e/signup-redirect.e2e.spec.ts`

Closes #1499

---
_Opened by kody (single-session autonomous run)._ 