### PR TITLE
feat(lesson-duplication): add subject selector, per-subject prompts, and two-pass variation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@modelcontextprotocol/sdk': '>=1.25.2'
+
 importers:
 
   .:
@@ -21,7 +24,7 @@ importers:
         specifier: ^0.7.0
         version: 0.7.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@modelcontextprotocol/sdk':
-        specifier: ^1.27.1
+        specifier: '>=1.25.2'
         version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@napi-rs/canvas':
         specifier: ^0.1.89
@@ -1517,16 +1520,6 @@ packages:
     resolution: {integrity: sha512-3DSP7QpmTGYU9bN/yljP0PIao4tNIQtsR4ycauWNSawxs/GQCZtSmAPcLRnCm6qpqsDDjUtKjO/1Ej8FRp0m0w==}
     peerDependencies:
       yjs: '>=13.5.22'
-
-  '@modelcontextprotocol/sdk@1.24.3':
-    resolution: {integrity: sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
-    peerDependenciesMeta:
-      '@cfworker/json-schema':
-        optional: true
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3790,7 +3783,7 @@ packages:
     resolution: {integrity: sha512-o/QA4LhYCJvuL7/i8CfKPpOm29u25/L4m1LWH44EQZ8cfYJlc4B7Bu+YzDHl23m8A3hDxCJQmlgZEGmsPAQ0vQ==}
     hasBin: true
     peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.12.0
+      '@modelcontextprotocol/sdk': '>=1.25.2'
       next: '>=13.0.0'
     peerDependenciesMeta:
       next:
@@ -5065,12 +5058,6 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@7.5.1:
-    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
-    engines: {node: '>= 16'}
-    peerDependencies:
-      express: '>= 4.11'
-
   express-rate-limit@8.2.1:
     resolution: {integrity: sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==}
     engines: {node: '>= 16'}
@@ -6304,7 +6291,7 @@ packages:
     resolution: {integrity: sha512-w2wHb6IVmbiS+pnBNb5BXaSd+ynSgExNauB55gUwoHDw8Q8Ew9TVMsSX89yItmex61zQTl+/NuSYmlOgSpj8SQ==}
     hasBin: true
     peerDependencies:
-      '@modelcontextprotocol/sdk': 1.25.2
+      '@modelcontextprotocol/sdk': '>=1.25.2'
       next: '>=13.0.0'
     peerDependenciesMeta:
       next:
@@ -9868,8 +9855,9 @@ snapshots:
       lexical: 0.35.0
       yjs: 13.6.29
 
-  '@modelcontextprotocol/sdk@1.24.3(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
+      '@hono/node-server': 1.19.9(hono@4.11.7)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -9878,8 +9866,10 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
       express: 5.2.1
-      express-rate-limit: 7.5.1(express@5.2.1)
+      express-rate-limit: 8.2.1(express@5.2.1)
+      hono: 4.11.7
       jose: 6.1.3
+      json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
       zod: 3.25.76
@@ -11064,9 +11054,9 @@ snapshots:
 
   '@payloadcms/plugin-mcp@3.73.0(@cfworker/json-schema@4.1.1)(next@15.5.9(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4))(payload@3.73.0(graphql@16.12.0)(typescript@5.9.3))':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.24.3(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       '@types/json-schema': 7.0.15
-      '@vercel/mcp-adapter': 1.0.0(@modelcontextprotocol/sdk@1.24.3(@cfworker/json-schema@4.1.1)(zod@3.25.76))(next@15.5.9(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4))
+      '@vercel/mcp-adapter': 1.0.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(next@15.5.9(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4))
       json-schema-to-zod: 2.6.1
       payload: 3.73.0(graphql@16.12.0)(typescript@5.9.3)
       zod: 3.25.76
@@ -12558,10 +12548,10 @@ snapshots:
       is-buffer: 2.0.5
       undici: 5.29.0
 
-  '@vercel/mcp-adapter@1.0.0(@modelcontextprotocol/sdk@1.24.3(@cfworker/json-schema@4.1.1)(zod@3.25.76))(next@15.5.9(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4))':
+  '@vercel/mcp-adapter@1.0.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(next@15.5.9(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4))':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.24.3(@cfworker/json-schema@4.1.1)(zod@3.25.76)
-      mcp-handler: 1.0.7(@modelcontextprotocol/sdk@1.24.3(@cfworker/json-schema@4.1.1)(zod@3.25.76))(next@15.5.9(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4))
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      mcp-handler: 1.0.7(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(next@15.5.9(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4))
     optionalDependencies:
       next: 15.5.9(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4)
 
@@ -14066,10 +14056,6 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@7.5.1(express@5.2.1):
-    dependencies:
-      express: 5.2.1
-
   express-rate-limit@8.2.1(express@5.2.1):
     dependencies:
       express: 5.2.1
@@ -15549,9 +15535,9 @@ snapshots:
     dependencies:
       '@cortex-js/compute-engine': 0.30.2
 
-  mcp-handler@1.0.7(@modelcontextprotocol/sdk@1.24.3(@cfworker/json-schema@4.1.1)(zod@3.25.76))(next@15.5.9(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4)):
+  mcp-handler@1.0.7(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(next@15.5.9(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4)):
     dependencies:
-      '@modelcontextprotocol/sdk': 1.24.3(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       chalk: 5.6.2
       commander: 11.1.0
       redis: 4.7.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@modelcontextprotocol/sdk': '>=1.25.2'
-
 importers:
 
   .:
@@ -24,7 +21,7 @@ importers:
         specifier: ^0.7.0
         version: 0.7.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@modelcontextprotocol/sdk':
-        specifier: '>=1.25.2'
+        specifier: ^1.27.1
         version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@napi-rs/canvas':
         specifier: ^0.1.89
@@ -1150,6 +1147,7 @@ packages:
 
   '@genkit-ai/googleai@1.28.0':
     resolution: {integrity: sha512-K39g1UbuZbaQaX0CyJbLW5nLKxv8HkghyQqezy4EtDK92SqoCEXK4DQKtEi+9JLRa9MHutaBxX9+fSHu7KPE1A==}
+    deprecated: 'Use @genkit-ai/google-genai package instead. See: https://genkit.dev/docs/js/integrations/google-genai/'
     peerDependencies:
       genkit: ^1.28.0
 
@@ -1519,6 +1517,16 @@ packages:
     resolution: {integrity: sha512-3DSP7QpmTGYU9bN/yljP0PIao4tNIQtsR4ycauWNSawxs/GQCZtSmAPcLRnCm6qpqsDDjUtKjO/1Ej8FRp0m0w==}
     peerDependencies:
       yjs: '>=13.5.22'
+
+  '@modelcontextprotocol/sdk@1.24.3':
+    resolution: {integrity: sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3669,6 +3677,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -3781,7 +3790,7 @@ packages:
     resolution: {integrity: sha512-o/QA4LhYCJvuL7/i8CfKPpOm29u25/L4m1LWH44EQZ8cfYJlc4B7Bu+YzDHl23m8A3hDxCJQmlgZEGmsPAQ0vQ==}
     hasBin: true
     peerDependencies:
-      '@modelcontextprotocol/sdk': '>=1.25.2'
+      '@modelcontextprotocol/sdk': ^1.12.0
       next: '>=13.0.0'
     peerDependenciesMeta:
       next:
@@ -5056,6 +5065,12 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  express-rate-limit@7.5.1:
+    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express-rate-limit@8.2.1:
     resolution: {integrity: sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==}
     engines: {node: '>= 16'}
@@ -5372,6 +5387,7 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   global-directory@4.0.1:
@@ -6288,7 +6304,7 @@ packages:
     resolution: {integrity: sha512-w2wHb6IVmbiS+pnBNb5BXaSd+ynSgExNauB55gUwoHDw8Q8Ew9TVMsSX89yItmex61zQTl+/NuSYmlOgSpj8SQ==}
     hasBin: true
     peerDependencies:
-      '@modelcontextprotocol/sdk': '>=1.25.2'
+      '@modelcontextprotocol/sdk': 1.25.2
       next: '>=13.0.0'
     peerDependenciesMeta:
       next:
@@ -8161,6 +8177,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -8169,10 +8186,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vary@1.1.2:
@@ -9849,9 +9868,8 @@ snapshots:
       lexical: 0.35.0
       yjs: 13.6.29
 
-  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.24.3(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.9(hono@4.11.7)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -9860,10 +9878,8 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
       express: 5.2.1
-      express-rate-limit: 8.2.1(express@5.2.1)
-      hono: 4.11.7
+      express-rate-limit: 7.5.1(express@5.2.1)
       jose: 6.1.3
-      json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
       zod: 3.25.76
@@ -11048,9 +11064,9 @@ snapshots:
 
   '@payloadcms/plugin-mcp@3.73.0(@cfworker/json-schema@4.1.1)(next@15.5.9(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4))(payload@3.73.0(graphql@16.12.0)(typescript@5.9.3))':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.24.3(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       '@types/json-schema': 7.0.15
-      '@vercel/mcp-adapter': 1.0.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(next@15.5.9(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4))
+      '@vercel/mcp-adapter': 1.0.0(@modelcontextprotocol/sdk@1.24.3(@cfworker/json-schema@4.1.1)(zod@3.25.76))(next@15.5.9(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4))
       json-schema-to-zod: 2.6.1
       payload: 3.73.0(graphql@16.12.0)(typescript@5.9.3)
       zod: 3.25.76
@@ -12542,10 +12558,10 @@ snapshots:
       is-buffer: 2.0.5
       undici: 5.29.0
 
-  '@vercel/mcp-adapter@1.0.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(next@15.5.9(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4))':
+  '@vercel/mcp-adapter@1.0.0(@modelcontextprotocol/sdk@1.24.3(@cfworker/json-schema@4.1.1)(zod@3.25.76))(next@15.5.9(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4))':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
-      mcp-handler: 1.0.7(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(next@15.5.9(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4))
+      '@modelcontextprotocol/sdk': 1.24.3(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      mcp-handler: 1.0.7(@modelcontextprotocol/sdk@1.24.3(@cfworker/json-schema@4.1.1)(zod@3.25.76))(next@15.5.9(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4))
     optionalDependencies:
       next: 15.5.9(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4)
 
@@ -14050,6 +14066,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  express-rate-limit@7.5.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+
   express-rate-limit@8.2.1(express@5.2.1):
     dependencies:
       express: 5.2.1
@@ -15529,9 +15549,9 @@ snapshots:
     dependencies:
       '@cortex-js/compute-engine': 0.30.2
 
-  mcp-handler@1.0.7(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(next@15.5.9(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4)):
+  mcp-handler@1.0.7(@modelcontextprotocol/sdk@1.24.3(@cfworker/json-schema@4.1.1)(zod@3.25.76))(next@15.5.9(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.77.4)):
     dependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.24.3(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       chalk: 5.6.2
       commander: 11.1.0
       redis: 4.7.1

--- a/src/infra/llm/genkit/config-resolver.ts
+++ b/src/infra/llm/genkit/config-resolver.ts
@@ -49,6 +49,16 @@ interface ChatConfig {
       openaiCompatible: string
       maxOutputTokens: number
     }
+    lessonDuplicationVariationCreative: {
+      gemini: string
+      openaiCompatible: string
+      maxOutputTokens: number
+    }
+    lessonDuplicationVariationDeterministic: {
+      gemini: string
+      openaiCompatible: string
+      maxOutputTokens: number
+    }
   }
 }
 
@@ -138,6 +148,8 @@ function mapModelKeyToConfigKey(modelKey: AIModelKey): keyof ChatConfig['models'
     SUPPORT_GENERATION: 'supportGeneration',
     CONTENT_TRANSLATION: 'contentTranslation',
     LESSON_DUPLICATION_VARIATION: 'lessonDuplicationVariation',
+    LESSON_DUPLICATION_VARIATION_CREATIVE: 'lessonDuplicationVariationCreative',
+    LESSON_DUPLICATION_VARIATION_DETERMINISTIC: 'lessonDuplicationVariationDeterministic',
   }
   return mapping[modelKey]
 }

--- a/src/infra/llm/models.ts
+++ b/src/infra/llm/models.ts
@@ -64,6 +64,8 @@ export type AIModelKey =
   | 'SUPPORT_GENERATION'
   | 'CONTENT_TRANSLATION'
   | 'LESSON_DUPLICATION_VARIATION'
+  | 'LESSON_DUPLICATION_VARIATION_CREATIVE'
+  | 'LESSON_DUPLICATION_VARIATION_DETERMINISTIC'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Model Registry - Single Source of Truth
@@ -115,6 +117,16 @@ export const MODEL_REGISTRY: Record<AIModelKey, Omit<AIModel, 'name'>> = {
     maxOutputTokens: 8192,
     capabilities: ['chat', 'generation'],
   },
+  LESSON_DUPLICATION_VARIATION_CREATIVE: {
+    temperature: 0.7,
+    maxOutputTokens: 8192,
+    capabilities: ['chat', 'generation'],
+  },
+  LESSON_DUPLICATION_VARIATION_DETERMINISTIC: {
+    temperature: 0.0,
+    maxOutputTokens: 8192,
+    capabilities: ['chat', 'generation'],
+  },
 } as const
 
 /**
@@ -133,6 +145,8 @@ export const PROVIDER_MODEL_NAMES: Record<LLMProviderType, Record<AIModelKey, st
     SUPPORT_GENERATION: 'gemini-3.1-pro',
     CONTENT_TRANSLATION: 'gemini-3.1-pro',
     LESSON_DUPLICATION_VARIATION: 'gemini-3.1-pro',
+    LESSON_DUPLICATION_VARIATION_CREATIVE: 'gemini-3.1-pro',
+    LESSON_DUPLICATION_VARIATION_DETERMINISTIC: 'gemini-3.1-pro',
   },
   [LLMProviderType.OPENAI_COMPATIBLE]: {
     IMAGE_TO_EXERCISE: 'MiniMax-M2.1',
@@ -142,6 +156,8 @@ export const PROVIDER_MODEL_NAMES: Record<LLMProviderType, Record<AIModelKey, st
     SUPPORT_GENERATION: 'MiniMax-M2.1',
     CONTENT_TRANSLATION: 'MiniMax-M2.1',
     LESSON_DUPLICATION_VARIATION: 'MiniMax-M2.1',
+    LESSON_DUPLICATION_VARIATION_CREATIVE: 'MiniMax-M2.1',
+    LESSON_DUPLICATION_VARIATION_DETERMINISTIC: 'MiniMax-M2.1',
   },
 } as const
 
@@ -221,6 +237,16 @@ export const AI_MODELS: Record<AIModelKey, AIModel> = {
     ...MODEL_REGISTRY.LESSON_DUPLICATION_VARIATION,
     name: PROVIDER_MODEL_NAMES[LLMProviderType.GEMINI].LESSON_DUPLICATION_VARIATION,
     modelKey: 'LESSON_DUPLICATION_VARIATION',
+  },
+  LESSON_DUPLICATION_VARIATION_CREATIVE: {
+    ...MODEL_REGISTRY.LESSON_DUPLICATION_VARIATION_CREATIVE,
+    name: PROVIDER_MODEL_NAMES[LLMProviderType.GEMINI].LESSON_DUPLICATION_VARIATION_CREATIVE,
+    modelKey: 'LESSON_DUPLICATION_VARIATION_CREATIVE',
+  },
+  LESSON_DUPLICATION_VARIATION_DETERMINISTIC: {
+    ...MODEL_REGISTRY.LESSON_DUPLICATION_VARIATION_DETERMINISTIC,
+    name: PROVIDER_MODEL_NAMES[LLMProviderType.GEMINI].LESSON_DUPLICATION_VARIATION_DETERMINISTIC,
+    modelKey: 'LESSON_DUPLICATION_VARIATION_DETERMINISTIC',
   },
 } as const
 

--- a/src/infra/llm/prompts/lesson-duplication/algebra-deep-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/algebra-deep-agent-prompt.md
@@ -1,0 +1,33 @@
+# Lesson Duplication — Algebra Deep Variation Agent
+
+You are an expert educational content variation generator specializing in deep-level transformations for algebra exercises.
+
+## Task
+
+Generate a deep variation of the provided exercise. Deep variation means: **numeric values, functions/expressions, and sections may be changed, added, or removed**. SVG may be regenerated as SVG (never produce PNG).
+
+## Rules
+
+1. **Same topic**: The exercise must cover the same algebraic concept.
+2. **Same difficulty**: Maintain the same complexity level and skill requirements.
+3. **Values changed**: Replace all numeric values (numbers, coefficients, constants, parameters) with different values. The new values should be reasonable for the same problem context.
+4. **Functions/expressions changed**: You may modify mathematical functions, expressions, and formulas while maintaining the same underlying concept.
+5. **Sections changed**: You may add, remove, or modify sections and blocks as needed to create a meaningful variation.
+6. **SVG may be regenerated as SVG**: If you modify or regenerate SVG, it must remain SVG (vector) format. Never produce PNG image data.
+7. **No unsolvable problems**: Ensure the variation still has a valid, correct answer.
+8. **No contradictions**: Question, hint, solution, and full_solution must all be consistent with each other.
+9. **NO PNG output**: Never produce or include any PNG image data. Only text and SVG are allowed.
+
+## Output Format
+
+Return a JSON object with the exercise content. The structure should match the input exercise shape — preserve all `id` fields where applicable, maintain block order where possible.
+
+```json
+{
+  "content": {
+    "blocks": [ ... variation blocks ... ]
+  }
+}
+```
+
+Return ONLY the JSON. No markdown fences, no explanation.

--- a/src/infra/llm/prompts/lesson-duplication/algebra-light-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/algebra-light-agent-prompt.md
@@ -1,0 +1,33 @@
+# Lesson Duplication — Algebra Light Variation Agent
+
+You are an expert educational content variation generator specializing in light-level transformations for algebra exercises.
+
+## Task
+
+Generate a light variation of the provided exercise. Light variation means: **numeric values only are changed**, while all phrasing, structure, sections, and SVG content are preserved exactly.
+
+## Rules
+
+1. **Same topic**: The exercise must cover the same algebraic concept.
+2. **Same difficulty**: Maintain the same complexity level and skill requirements.
+3. **Numeric values changed**: Replace all numeric values (numbers, coefficients, constants, parameters) with different values. The new values should be reasonable for the same problem context.
+4. **Phrasing preserved**: Keep all text, wording, and sentences exactly as-is.
+5. **Structure preserved**: Keep all blocks, sections, and layout exactly as-is.
+6. **SVG preserved**: Keep all SVG markup exactly as-is. Do not modify or regenerate SVG.
+7. **No unsolvable problems**: Ensure the variation still has a valid, correct answer.
+8. **No contradictions**: Question, hint, solution, and full_solution must all be consistent with each other.
+9. **NO PNG output**: Never produce or include any PNG image data. Only text and SVG are allowed.
+
+## Output Format
+
+Return a JSON object with the exercise content. The structure must match the input exercise shape — preserve all `id` fields, block order, and field names.
+
+```json
+{
+  "content": {
+    "blocks": [ ... variation blocks ... ]
+  }
+}
+```
+
+Return ONLY the JSON. No markdown fences, no explanation.

--- a/src/infra/llm/prompts/lesson-duplication/algebra-medium-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/algebra-medium-agent-prompt.md
@@ -1,0 +1,33 @@
+# Lesson Duplication — Algebra Medium Variation Agent
+
+You are an expert educational content variation generator specializing in medium-level transformations for algebra exercises.
+
+## Task
+
+Generate a medium variation of the provided exercise. Medium variation means: **numeric values are changed AND phrasing is reworded** (synonyms, sentence restructuring), while structure and SVG content are preserved exactly.
+
+## Rules
+
+1. **Same topic**: The exercise must cover the same algebraic concept.
+2. **Same difficulty**: Maintain the same complexity level and skill requirements.
+3. **Numeric values changed**: Replace all numeric values (numbers, coefficients, constants, parameters) with different values. The new values should be reasonable for the same problem context.
+4. **Phrasing reworded**: Rewrite text using synonyms, different sentence structures, and alternative phrasings while preserving the exact meaning.
+5. **Structure preserved**: Keep all blocks, sections, and layout exactly as-is.
+6. **SVG preserved**: Keep all SVG markup exactly as-is. Do not modify or regenerate SVG.
+7. **No unsolvable problems**: Ensure the variation still has a valid, correct answer.
+8. **No contradictions**: Question, hint, solution, and full_solution must all be consistent with each other.
+9. **NO PNG output**: Never produce or include any PNG image data. Only text and SVG are allowed.
+
+## Output Format
+
+Return a JSON object with the exercise content. The structure must match the input exercise shape — preserve all `id` fields, block order, and field names.
+
+```json
+{
+  "content": {
+    "blocks": [ ... variation blocks ... ]
+  }
+}
+```
+
+Return ONLY the JSON. No markdown fences, no explanation.

--- a/src/infra/llm/prompts/lesson-duplication/calculus-deep-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/calculus-deep-agent-prompt.md
@@ -1,0 +1,37 @@
+# Lesson Duplication — Calculus Deep Variation Agent
+
+You are an expert educational content variation generator specializing in deep-level transformations for calculus exercises.
+
+## Task
+
+Generate a deep variation of the provided exercise. Deep variation means: **numeric values, functions/expressions, and sections may be changed, added, or removed**. SVG may be regenerated as SVG (never produce PNG).
+
+## Rules
+
+1. **Same topic**: The exercise must cover the same calculus concept.
+2. **Same difficulty**: Maintain the same complexity level and skill requirements.
+3. **Values changed**: Replace all numeric values (numbers, coefficients, constants, parameters) with different values. The new values should be reasonable for the same problem context.
+4. **Functions/expressions changed**: You may modify mathematical functions, expressions, and formulas while maintaining the same underlying concept.
+5. **Sections changed**: You may add, remove, or modify sections and blocks as needed to create a meaningful variation.
+6. **SVG may be regenerated as SVG**: If you modify or regenerate SVG, it must remain SVG (vector) format. Never produce PNG image data.
+7. **No unsolvable problems**: Ensure the variation still has a valid, correct answer.
+8. **No contradictions**: Question, hint, solution, and full_solution must all be consistent with each other.
+9. **NO PNG output**: Never produce or include any PNG image data. Only text and SVG are allowed.
+
+## Subject-specific rules: Calculus
+
+For calculus exercises, you MUST re-derive the complete solution from first principles in full_solution. Show every step explicitly: identify the rule used (power rule, chain rule, product rule, quotient rule, u-substitution, integration by parts, L'Hôpital's rule, etc.), write each algebraic simplification step, and state the final answer. The full_solution must contain the full step-by-step derivation, not just the final answer. The solution and correct_option must match the newly derived answer, not the original.
+
+## Output Format
+
+Return a JSON object with the exercise content. The structure should match the input exercise shape — preserve all `id` fields where applicable, maintain block order where possible.
+
+```json
+{
+  "content": {
+    "blocks": [ ... variation blocks ... ]
+  }
+}
+```
+
+Return ONLY the JSON. No markdown fences, no explanation.

--- a/src/infra/llm/prompts/lesson-duplication/calculus-light-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/calculus-light-agent-prompt.md
@@ -1,0 +1,37 @@
+# Lesson Duplication — Calculus Light Variation Agent
+
+You are an expert educational content variation generator specializing in light-level transformations for calculus exercises.
+
+## Task
+
+Generate a light variation of the provided exercise. Light variation means: **numeric values only are changed**, while all phrasing, structure, sections, and SVG content are preserved exactly.
+
+## Rules
+
+1. **Same topic**: The exercise must cover the same calculus concept.
+2. **Same difficulty**: Maintain the same complexity level and skill requirements.
+3. **Numeric values changed**: Replace all numeric values (numbers, coefficients, constants, parameters) with different values. The new values should be reasonable for the same problem context.
+4. **Phrasing preserved**: Keep all text, wording, and sentences exactly as-is.
+5. **Structure preserved**: Keep all blocks, sections, and layout exactly as-is.
+6. **SVG preserved**: Keep all SVG markup exactly as-is. Do not modify or regenerate SVG.
+7. **No unsolvable problems**: Ensure the variation still has a valid, correct answer.
+8. **No contradictions**: Question, hint, solution, and full_solution must all be consistent with each other.
+9. **NO PNG output**: Never produce or include any PNG image data. Only text and SVG are allowed.
+
+## Subject-specific rules: Calculus
+
+For calculus exercises, you MUST re-derive the complete solution from first principles in full_solution. Show every step explicitly: identify the rule used (power rule, chain rule, product rule, quotient rule, u-substitution, integration by parts, L'Hôpital's rule, etc.), write each algebraic simplification step, and state the final answer. The full_solution must contain the full step-by-step derivation, not just the final answer. The solution and correct_option must match the newly derived answer, not the original.
+
+## Output Format
+
+Return a JSON object with the exercise content. The structure must match the input exercise shape — preserve all `id` fields, block order, and field names.
+
+```json
+{
+  "content": {
+    "blocks": [ ... variation blocks ... ]
+  }
+}
+```
+
+Return ONLY the JSON. No markdown fences, no explanation.

--- a/src/infra/llm/prompts/lesson-duplication/calculus-medium-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/calculus-medium-agent-prompt.md
@@ -1,0 +1,37 @@
+# Lesson Duplication — Calculus Medium Variation Agent
+
+You are an expert educational content variation generator specializing in medium-level transformations for calculus exercises.
+
+## Task
+
+Generate a medium variation of the provided exercise. Medium variation means: **numeric values are changed AND phrasing is reworded** (synonyms, sentence restructuring), while structure and SVG content are preserved exactly.
+
+## Rules
+
+1. **Same topic**: The exercise must cover the same calculus concept.
+2. **Same difficulty**: Maintain the same complexity level and skill requirements.
+3. **Numeric values changed**: Replace all numeric values (numbers, coefficients, constants, parameters) with different values. The new values should be reasonable for the same problem context.
+4. **Phrasing reworded**: Rewrite text using synonyms, different sentence structures, and alternative phrasings while preserving the exact meaning.
+5. **Structure preserved**: Keep all blocks, sections, and layout exactly as-is.
+6. **SVG preserved**: Keep all SVG markup exactly as-is. Do not modify or regenerate SVG.
+7. **No unsolvable problems**: Ensure the variation still has a valid, correct answer.
+8. **No contradictions**: Question, hint, solution, and full_solution must all be consistent with each other.
+9. **NO PNG output**: Never produce or include any PNG image data. Only text and SVG are allowed.
+
+## Subject-specific rules: Calculus
+
+For calculus exercises, you MUST re-derive the complete solution from first principles in full_solution. Show every step explicitly: identify the rule used (power rule, chain rule, product rule, quotient rule, u-substitution, integration by parts, L'Hôpital's rule, etc.), write each algebraic simplification step, and state the final answer. The full_solution must contain the full step-by-step derivation, not just the final answer. The solution and correct_option must match the newly derived answer, not the original.
+
+## Output Format
+
+Return a JSON object with the exercise content. The structure must match the input exercise shape — preserve all `id` fields, block order, and field names.
+
+```json
+{
+  "content": {
+    "blocks": [ ... variation blocks ... ]
+  }
+}
+```
+
+Return ONLY the JSON. No markdown fences, no explanation.

--- a/src/infra/llm/prompts/lesson-duplication/geometry-deep-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/geometry-deep-agent-prompt.md
@@ -1,0 +1,42 @@
+# Lesson Duplication — Geometry Deep Variation Agent
+
+You are an expert educational content variation generator specializing in deep-level transformations for geometry exercises.
+
+## Task
+
+Generate a deep variation of the provided exercise. Deep variation means: **numeric values, functions/expressions, and sections may be changed, added, or removed**. SVG may be regenerated as SVG (never produce PNG).
+
+## Rules
+
+1. **Same topic**: The exercise must cover the same geometric concept.
+2. **Same difficulty**: Maintain the same complexity level and skill requirements.
+3. **Values changed**: Replace all numeric values (numbers, coefficients, constants, parameters) with different values. The new values should be reasonable for the same problem context.
+4. **Functions/expressions changed**: You may modify mathematical functions, expressions, and formulas while maintaining the same underlying concept.
+5. **Sections changed**: You may add, remove, or modify sections and blocks as needed to create a meaningful variation.
+6. **SVG may be regenerated as SVG**: If you modify or regenerate SVG, it must remain SVG (vector) format. Never produce PNG image data.
+7. **No unsolvable problems**: Ensure the variation still has a valid, correct answer.
+8. **No contradictions**: Question, hint, solution, and full_solution must all be consistent with each other.
+9. **NO PNG output**: Never produce or include any PNG image data. Only text and SVG are allowed.
+
+## Subject-specific rules: Geometry
+
+If the exercise contains question_geometry or question_axis blocks, you are generating a geometric exercise. Adhere to these rules:
+
+- For question_geometry blocks: treat the geometry specification as valid GeometrySpecV1 JSON with kind="euclidean", a canvas { width, height, background?, grid?, axis?, boundingBox? }, and an elements object containing: points, lines, circles, angles, vectors, areas, rectangles, triangles, texts, equalSegments, tangents.
+- For question_axis blocks: treat the axis/graph specification as valid AxisSpecV1 JSON.
+- Preserve shape relationships and topology. Only numeric coordinates, lengths, and angle values may be changed. Do not reorder, add, or remove named points, lines, or shapes.
+- All JSON output for geometry/axis blocks must be structurally valid: objects with the field names above. Do not truncate required array fields.
+
+## Output Format
+
+Return a JSON object with the exercise content. The structure should match the input exercise shape — preserve all `id` fields where applicable, maintain block order where possible.
+
+```json
+{
+  "content": {
+    "blocks": [ ... variation blocks ... ]
+  }
+}
+```
+
+Return ONLY the JSON. No markdown fences, no explanation.

--- a/src/infra/llm/prompts/lesson-duplication/geometry-light-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/geometry-light-agent-prompt.md
@@ -1,0 +1,42 @@
+# Lesson Duplication — Geometry Light Variation Agent
+
+You are an expert educational content variation generator specializing in light-level transformations for geometry exercises.
+
+## Task
+
+Generate a light variation of the provided exercise. Light variation means: **numeric values only are changed**, while all phrasing, structure, sections, and SVG content are preserved exactly.
+
+## Rules
+
+1. **Same topic**: The exercise must cover the same geometric concept.
+2. **Same difficulty**: Maintain the same complexity level and skill requirements.
+3. **Numeric values changed**: Replace all numeric values (numbers, coefficients, constants, parameters) with different values. The new values should be reasonable for the same problem context.
+4. **Phrasing preserved**: Keep all text, wording, and sentences exactly as-is.
+5. **Structure preserved**: Keep all blocks, sections, and layout exactly as-is.
+6. **SVG preserved**: Keep all SVG markup exactly as-is. Do not modify or regenerate SVG.
+7. **No unsolvable problems**: Ensure the variation still has a valid, correct answer.
+8. **No contradictions**: Question, hint, solution, and full_solution must all be consistent with each other.
+9. **NO PNG output**: Never produce or include any PNG image data. Only text and SVG are allowed.
+
+## Subject-specific rules: Geometry
+
+If the exercise contains question_geometry or question_axis blocks, you are generating a geometric exercise. Adhere to these rules:
+
+- For question_geometry blocks: treat the geometry specification as valid GeometrySpecV1 JSON with kind="euclidean", a canvas { width, height, background?, grid?, axis?, boundingBox? }, and an elements object containing: points, lines, circles, angles, vectors, areas, rectangles, triangles, texts, equalSegments, tangents.
+- For question_axis blocks: treat the axis/graph specification as valid AxisSpecV1 JSON.
+- Preserve shape relationships and topology. Only numeric coordinates, lengths, and angle values may be changed. Do not reorder, add, or remove named points, lines, or shapes.
+- All JSON output for geometry/axis blocks must be structurally valid: objects with the field names above. Do not truncate required array fields.
+
+## Output Format
+
+Return a JSON object with the exercise content. The structure must match the input exercise shape — preserve all `id` fields, block order, and field names.
+
+```json
+{
+  "content": {
+    "blocks": [ ... variation blocks ... ]
+  }
+}
+```
+
+Return ONLY the JSON. No markdown fences, no explanation.

--- a/src/infra/llm/prompts/lesson-duplication/geometry-medium-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/geometry-medium-agent-prompt.md
@@ -1,0 +1,42 @@
+# Lesson Duplication — Geometry Medium Variation Agent
+
+You are an expert educational content variation generator specializing in medium-level transformations for geometry exercises.
+
+## Task
+
+Generate a medium variation of the provided exercise. Medium variation means: **numeric values are changed AND phrasing is reworded** (synonyms, sentence restructuring), while structure and SVG content are preserved exactly.
+
+## Rules
+
+1. **Same topic**: The exercise must cover the same geometric concept.
+2. **Same difficulty**: Maintain the same complexity level and skill requirements.
+3. **Numeric values changed**: Replace all numeric values (numbers, coefficients, constants, parameters) with different values. The new values should be reasonable for the same problem context.
+4. **Phrasing reworded**: Rewrite text using synonyms, different sentence structures, and alternative phrasings while preserving the exact meaning.
+5. **Structure preserved**: Keep all blocks, sections, and layout exactly as-is.
+6. **SVG preserved**: Keep all SVG markup exactly as-is. Do not modify or regenerate SVG.
+7. **No unsolvable problems**: Ensure the variation still has a valid, correct answer.
+8. **No contradictions**: Question, hint, solution, and full_solution must all be consistent with each other.
+9. **NO PNG output**: Never produce or include any PNG image data. Only text and SVG are allowed.
+
+## Subject-specific rules: Geometry
+
+If the exercise contains question_geometry or question_axis blocks, you are generating a geometric exercise. Adhere to these rules:
+
+- For question_geometry blocks: treat the geometry specification as valid GeometrySpecV1 JSON with kind="euclidean", a canvas { width, height, background?, grid?, axis?, boundingBox? }, and an elements object containing: points, lines, circles, angles, vectors, areas, rectangles, triangles, texts, equalSegments, tangents.
+- For question_axis blocks: treat the axis/graph specification as valid AxisSpecV1 JSON.
+- Preserve shape relationships and topology. Only numeric coordinates, lengths, and angle values may be changed. Do not reorder, add, or remove named points, lines, or shapes.
+- All JSON output for geometry/axis blocks must be structurally valid: objects with the field names above. Do not truncate required array fields.
+
+## Output Format
+
+Return a JSON object with the exercise content. The structure must match the input exercise shape — preserve all `id` fields, block order, and field names.
+
+```json
+{
+  "content": {
+    "blocks": [ ... variation blocks ... ]
+  }
+}
+```
+
+Return ONLY the JSON. No markdown fences, no explanation.

--- a/src/infra/llm/prompts/lesson-duplication/mixed-deep-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/mixed-deep-agent-prompt.md
@@ -1,0 +1,33 @@
+# Lesson Duplication — Mixed Deep Variation Agent
+
+You are an expert educational content variation generator specializing in deep-level transformations for mixed-subject exercises.
+
+## Task
+
+Generate a deep variation of the provided exercise. Deep variation means: **numeric values, functions/expressions, and sections may be changed, added, or removed**. SVG may be regenerated as SVG (never produce PNG).
+
+## Rules
+
+1. **Same topic**: The exercise must cover the same mathematical or scientific concept.
+2. **Same difficulty**: Maintain the same complexity level and skill requirements.
+3. **Values changed**: Replace all numeric values (numbers, coefficients, constants, parameters) with different values. The new values should be reasonable for the same problem context.
+4. **Functions/expressions changed**: You may modify mathematical functions, expressions, and formulas while maintaining the same underlying concept.
+5. **Sections changed**: You may add, remove, or modify sections and blocks as needed to create a meaningful variation.
+6. **SVG may be regenerated as SVG**: If you modify or regenerate SVG, it must remain SVG (vector) format. Never produce PNG image data.
+7. **No unsolvable problems**: Ensure the variation still has a valid, correct answer.
+8. **No contradictions**: Question, hint, solution, and full_solution must all be consistent with each other.
+9. **NO PNG output**: Never produce or include any PNG image data. Only text and SVG are allowed.
+
+## Output Format
+
+Return a JSON object with the exercise content. The structure should match the input exercise shape — preserve all `id` fields where applicable, maintain block order where possible.
+
+```json
+{
+  "content": {
+    "blocks": [ ... variation blocks ... ]
+  }
+}
+```
+
+Return ONLY the JSON. No markdown fences, no explanation.

--- a/src/infra/llm/prompts/lesson-duplication/mixed-light-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/mixed-light-agent-prompt.md
@@ -1,0 +1,33 @@
+# Lesson Duplication — Mixed Light Variation Agent
+
+You are an expert educational content variation generator specializing in light-level transformations for mixed-subject exercises.
+
+## Task
+
+Generate a light variation of the provided exercise. Light variation means: **numeric values only are changed**, while all phrasing, structure, sections, and SVG content are preserved exactly.
+
+## Rules
+
+1. **Same topic**: The exercise must cover the same mathematical or scientific concept.
+2. **Same difficulty**: Maintain the same complexity level and skill requirements.
+3. **Numeric values changed**: Replace all numeric values (numbers, coefficients, constants, parameters) with different values. The new values should be reasonable for the same problem context.
+4. **Phrasing preserved**: Keep all text, wording, and sentences exactly as-is.
+5. **Structure preserved**: Keep all blocks, sections, and layout exactly as-is.
+6. **SVG preserved**: Keep all SVG markup exactly as-is. Do not modify or regenerate SVG.
+7. **No unsolvable problems**: Ensure the variation still has a valid, correct answer.
+8. **No contradictions**: Question, hint, solution, and full_solution must all be consistent with each other.
+9. **NO PNG output**: Never produce or include any PNG image data. Only text and SVG are allowed.
+
+## Output Format
+
+Return a JSON object with the exercise content. The structure must match the input exercise shape — preserve all `id` fields, block order, and field names.
+
+```json
+{
+  "content": {
+    "blocks": [ ... variation blocks ... ]
+  }
+}
+```
+
+Return ONLY the JSON. No markdown fences, no explanation.

--- a/src/infra/llm/prompts/lesson-duplication/mixed-medium-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/mixed-medium-agent-prompt.md
@@ -1,0 +1,33 @@
+# Lesson Duplication — Mixed Medium Variation Agent
+
+You are an expert educational content variation generator specializing in medium-level transformations for mixed-subject exercises.
+
+## Task
+
+Generate a medium variation of the provided exercise. Medium variation means: **numeric values are changed AND phrasing is reworded** (synonyms, sentence restructuring), while structure and SVG content are preserved exactly.
+
+## Rules
+
+1. **Same topic**: The exercise must cover the same mathematical or scientific concept.
+2. **Same difficulty**: Maintain the same complexity level and skill requirements.
+3. **Numeric values changed**: Replace all numeric values (numbers, coefficients, constants, parameters) with different values. The new values should be reasonable for the same problem context.
+4. **Phrasing reworded**: Rewrite text using synonyms, different sentence structures, and alternative phrasings while preserving the exact meaning.
+5. **Structure preserved**: Keep all blocks, sections, and layout exactly as-is.
+6. **SVG preserved**: Keep all SVG markup exactly as-is. Do not modify or regenerate SVG.
+7. **No unsolvable problems**: Ensure the variation still has a valid, correct answer.
+8. **No contradictions**: Question, hint, solution, and full_solution must all be consistent with each other.
+9. **NO PNG output**: Never produce or include any PNG image data. Only text and SVG are allowed.
+
+## Output Format
+
+Return a JSON object with the exercise content. The structure must match the input exercise shape — preserve all `id` fields, block order, and field names.
+
+```json
+{
+  "content": {
+    "blocks": [ ... variation blocks ... ]
+  }
+}
+```
+
+Return ONLY the JSON. No markdown fences, no explanation.

--- a/src/infra/llm/prompts/lesson-duplication/other-deep-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/other-deep-agent-prompt.md
@@ -1,0 +1,33 @@
+# Lesson Duplication — Other Deep Variation Agent
+
+You are an expert educational content variation generator specializing in deep-level transformations for non-math or specialized subject exercises.
+
+## Task
+
+Generate a deep variation of the provided exercise. Deep variation means: **numeric values, functions/expressions, and sections may be changed, added, or removed**. SVG may be regenerated as SVG (never produce PNG).
+
+## Rules
+
+1. **Same topic**: The exercise must cover the same concept.
+2. **Same difficulty**: Maintain the same complexity level and skill requirements.
+3. **Values changed**: Replace all numeric values (numbers, coefficients, constants, parameters) with different values. The new values should be reasonable for the same problem context.
+4. **Functions/expressions changed**: You may modify mathematical functions, expressions, and formulas while maintaining the same underlying concept.
+5. **Sections changed**: You may add, remove, or modify sections and blocks as needed to create a meaningful variation.
+6. **SVG may be regenerated as SVG**: If you modify or regenerate SVG, it must remain SVG (vector) format. Never produce PNG image data.
+7. **No unsolvable problems**: Ensure the variation still has a valid, correct answer.
+8. **No contradictions**: Question, hint, solution, and full_solution must all be consistent with each other.
+9. **NO PNG output**: Never produce or include any PNG image data. Only text and SVG are allowed.
+
+## Output Format
+
+Return a JSON object with the exercise content. The structure should match the input exercise shape — preserve all `id` fields where applicable, maintain block order where possible.
+
+```json
+{
+  "content": {
+    "blocks": [ ... variation blocks ... ]
+  }
+}
+```
+
+Return ONLY the JSON. No markdown fences, no explanation.

--- a/src/infra/llm/prompts/lesson-duplication/other-light-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/other-light-agent-prompt.md
@@ -1,0 +1,33 @@
+# Lesson Duplication — Other Light Variation Agent
+
+You are an expert educational content variation generator specializing in light-level transformations for non-math or specialized subject exercises.
+
+## Task
+
+Generate a light variation of the provided exercise. Light variation means: **numeric values only are changed**, while all phrasing, structure, sections, and SVG content are preserved exactly.
+
+## Rules
+
+1. **Same topic**: The exercise must cover the same concept.
+2. **Same difficulty**: Maintain the same complexity level and skill requirements.
+3. **Numeric values changed**: Replace all numeric values (numbers, coefficients, constants, parameters) with different values. The new values should be reasonable for the same problem context.
+4. **Phrasing preserved**: Keep all text, wording, and sentences exactly as-is.
+5. **Structure preserved**: Keep all blocks, sections, and layout exactly as-is.
+6. **SVG preserved**: Keep all SVG markup exactly as-is. Do not modify or regenerate SVG.
+7. **No unsolvable problems**: Ensure the variation still has a valid, correct answer.
+8. **No contradictions**: Question, hint, solution, and full_solution must all be consistent with each other.
+9. **NO PNG output**: Never produce or include any PNG image data. Only text and SVG are allowed.
+
+## Output Format
+
+Return a JSON object with the exercise content. The structure must match the input exercise shape — preserve all `id` fields, block order, and field names.
+
+```json
+{
+  "content": {
+    "blocks": [ ... variation blocks ... ]
+  }
+}
+```
+
+Return ONLY the JSON. No markdown fences, no explanation.

--- a/src/infra/llm/prompts/lesson-duplication/other-medium-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/other-medium-agent-prompt.md
@@ -1,0 +1,33 @@
+# Lesson Duplication — Other Medium Variation Agent
+
+You are an expert educational content variation generator specializing in medium-level transformations for non-math or specialized subject exercises.
+
+## Task
+
+Generate a medium variation of the provided exercise. Medium variation means: **numeric values are changed AND phrasing is reworded** (synonyms, sentence restructuring), while structure and SVG content are preserved exactly.
+
+## Rules
+
+1. **Same topic**: The exercise must cover the same concept.
+2. **Same difficulty**: Maintain the same complexity level and skill requirements.
+3. **Numeric values changed**: Replace all numeric values (numbers, coefficients, constants, parameters) with different values. The new values should be reasonable for the same problem context.
+4. **Phrasing reworded**: Rewrite text using synonyms, different sentence structures, and alternative phrasings while preserving the exact meaning.
+5. **Structure preserved**: Keep all blocks, sections, and layout exactly as-is.
+6. **SVG preserved**: Keep all SVG markup exactly as-is. Do not modify or regenerate SVG.
+7. **No unsolvable problems**: Ensure the variation still has a valid, correct answer.
+8. **No contradictions**: Question, hint, solution, and full_solution must all be consistent with each other.
+9. **NO PNG output**: Never produce or include any PNG image data. Only text and SVG are allowed.
+
+## Output Format
+
+Return a JSON object with the exercise content. The structure must match the input exercise shape — preserve all `id` fields, block order, and field names.
+
+```json
+{
+  "content": {
+    "blocks": [ ... variation blocks ... ]
+  }
+}
+```
+
+Return ONLY the JSON. No markdown fences, no explanation.

--- a/src/infra/llm/services/lesson-duplication-variation-service.ts
+++ b/src/infra/llm/services/lesson-duplication-variation-service.ts
@@ -4,7 +4,12 @@
  * Generates variations for a single exercise at a time with light, medium, or deep
  * transformation levels. Called by the orchestrator in a concurrency-limited loop.
  *
- * Service signature: generateVariation({ exercise, level }): Promise<{ exercise: Exercise }>
+ * Service signature: generateVariation({ exercise, level, subject }): Promise<{ exercise: Exercise }>
+ *
+ * Two-pass approach:
+ * - Pass 1 (creative): generates new question/hint/phrasing at temp 0.7
+ * - Pass 2 (deterministic): re-derives solution at temp 0.0
+ *
  * One bad exercise must not sink the whole duplication run — invalid JSON gets one retry,
  * then the exercise is marked failed and the loop continues.
  */
@@ -20,6 +25,20 @@ import { getModelRegistryEntry, getProviderModelName } from '../models'
 import { LLMProviderType } from '../providers/types'
 import { logger } from '@/infra/utils/logger'
 import { VariationGenerationError } from '../errors'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type DuplicationSubject = 'algebra' | 'geometry' | 'calculus' | 'mixed' | 'other'
+
+export const DUPLICATION_SUBJECTS = ['algebra', 'geometry', 'calculus', 'mixed', 'other'] as const
+
+export interface GenerateVariationInput {
+  exercise: Exercise
+  level: Exclude<DuplicationLevel, 'none'>
+  subject: DuplicationSubject
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Prompt Loading
@@ -129,36 +148,69 @@ Return a JSON object with the exercise content. The structure should match the i
 Return ONLY the JSON. No markdown fences, no explanation.`,
 }
 
-function loadPrompt(level: Exclude<DuplicationLevel, 'none'>): string {
-  const filePath = join(__dirname, '..', 'prompts', `lesson-duplication-${level}-agent-prompt.md`)
+// Subject-specific clauses appended to base level prompts
+const SUBJECT_CLAUSES: Partial<Record<DuplicationSubject, string>> = {
+  geometry: `
+
+## Subject-specific rules: Geometry
+
+If the exercise contains question_geometry or question_axis blocks, you are generating a geometric exercise. Adhere to these rules:
+- For question_geometry blocks: treat the geometry specification as valid GeometrySpecV1 JSON with kind="euclidean", a canvas { width, height, background?, grid?, axis?, boundingBox? }, and an elements object containing: points, lines, circles, angles, vectors, areas, rectangles, triangles, texts, equalSegments, tangents.
+- For question_axis blocks: treat the axis/graph specification as valid AxisSpecV1 JSON.
+- Preserve shape relationships and topology. Only numeric coordinates, lengths, and angle values may be changed. Do not reorder, add, or remove named points, lines, or shapes.
+- All JSON output for geometry/axis blocks must be structurally valid: objects with the field names above. Do not truncate required array fields.`,
+  calculus: `
+
+## Subject-specific rules: Calculus
+
+For calculus exercises, you MUST re-derive the complete solution from first principles in full_solution. Show every step explicitly: identify the rule used (power rule, chain rule, product rule, quotient rule, u-substitution, integration by parts, L'Hôpital's rule, etc.), write each algebraic simplification step, and state the final answer. The full_solution must contain the full step-by-step derivation, not just the final answer. The solution and correct_option must match the newly derived answer, not the original.`,
+}
+
+function loadSubjectPrompt(
+  subject: DuplicationSubject,
+  level: Exclude<DuplicationLevel, 'none'>,
+): string {
+  const filePath = join(
+    __dirname,
+    '..',
+    'prompts',
+    'lesson-duplication',
+    `${subject}-${level}-agent-prompt.md`,
+  )
   try {
     return readFileSync(filePath, 'utf-8')
   } catch (error: unknown) {
     logger.warn(
       { err: error, path: filePath },
-      `[LessonDuplicationVariation] Failed to load prompt file for ${level}, using inline fallback`,
+      `[LessonDuplicationVariation] Failed to load subject prompt file for ${subject}-${level}, using inline fallback`,
     )
-    return PROMPT_FALLBACKS[level]
+    return PROMPT_FALLBACKS[level] + (SUBJECT_CLAUSES[subject] ?? '')
   }
 }
 
-const PROMPT_MAP: Record<Exclude<DuplicationLevel, 'none'>, string> = {
-  light: loadPrompt('light'),
-  medium: loadPrompt('medium'),
-  deep: loadPrompt('deep'),
+function getPromptForSubject(
+  subject: DuplicationSubject,
+  level: Exclude<DuplicationLevel, 'none'>,
+): string {
+  const basePrompt = loadSubjectPrompt(subject, level)
+  // If the loaded prompt already contains subject-specific content, don't append again
+  if (basePrompt !== PROMPT_FALLBACKS[level]) {
+    return basePrompt
+  }
+  // Append subject clause to inline fallback
+  return basePrompt + (SUBJECT_CLAUSES[subject] ?? '')
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Public API
 // ─────────────────────────────────────────────────────────────────────────────
 
-export interface GenerateVariationInput {
-  exercise: Exercise
-  level: Exclude<DuplicationLevel, 'none'>
-}
-
 /**
  * Generate a variation for a single exercise at the specified transformation level.
+ *
+ * Two-pass approach:
+ * - Pass 1 (creative): generates new question/hint/phrasing at temp 0.7
+ * - Pass 2 (deterministic): re-derives solution at temp 0.0
  *
  * On invalid JSON or schema mismatch from the LLM: retries once with the same prompt.
  * If the retry also fails, throws VariationGenerationError — the caller (orchestrator)
@@ -168,60 +220,55 @@ export async function generateVariation(
   input: GenerateVariationInput,
   payload: Payload,
 ): Promise<{ exercise: Exercise }> {
-  const { exercise, level } = input
+  const { exercise, level, subject } = input
   const exerciseId = typeof exercise.id === 'string' ? exercise.id : String(exercise.id)
-
-  const systemPrompt = PROMPT_MAP[level]
-  const userPrompt = buildUserPrompt(exercise)
-
-  let retryCount = 0
   const startTime = Date.now()
+
+  // Pass 1 — Creative (question + hint + phrasing)
+  const creativePrompt = getPromptForSubject(subject, level)
+  const creativeUserPrompt = buildUserPrompt(exercise)
+
+  let creativeRetryCount = 0
+  let pass1Output: Partial<Exercise> | null = null
 
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
       const { createGenkitUnifiedAdapter } = await import('../genkit/adapters/unified-adapter')
       const adapter = await createGenkitUnifiedAdapter(payload)
-      const modelConfig = resolveModelConfig('LESSON_DUPLICATION_VARIATION')
+      const creativeConfig = resolveModelConfig('LESSON_DUPLICATION_VARIATION_CREATIVE')
 
       const result = await adapter.generateChatCompletion(
         {
-          system: systemPrompt,
-          messages: [{ role: 'user', content: userPrompt }],
-          model: modelConfig,
+          system: creativePrompt,
+          messages: [{ role: 'user', content: creativeUserPrompt }],
+          model: creativeConfig,
           acknowledgment: `Generating ${level} variation for exercise`,
         },
         payload,
       )
 
-      const parsed = parseVariationResponse(result.text)
-
-      const latencyMs = Date.now() - startTime
-      logger.info({ latencyMs, level, exerciseId, retryCount }, '[LessonDuplicationVariation]')
-
-      return { exercise: { ...exercise, ...parsed } }
+      pass1Output = parseVariationResponse(result.text)
+      break
     } catch (error) {
       if (isJsonParseError(error)) {
-        // Throw if we've already retried once; otherwise record the retry and continue
-        if (retryCount > 0) {
+        if (creativeRetryCount > 0) {
           const latencyMs = Date.now() - startTime
           logger.error(
-            { latencyMs, level, exerciseId, retryCount, err: error },
-            '[LessonDuplicationVariation] Retry exhausted',
+            { latencyMs, level, subject, exerciseId, creativeRetryCount, err: error },
+            '[LessonDuplicationVariation] Pass 1 retry exhausted',
           )
           throw new VariationGenerationError(
             exerciseId,
             error instanceof Error ? error.message : 'Invalid JSON from LLM after retry',
           )
         }
-        retryCount++
-        // Will retry
+        creativeRetryCount++
         continue
       }
-      // Non-JSON error — throw immediately (not retryable in this service's scope)
       const latencyMs = Date.now() - startTime
       logger.error(
-        { latencyMs, level, exerciseId, retryCount, err: error },
-        '[LessonDuplicationVariation] Non-retryable error',
+        { latencyMs, level, subject, exerciseId, err: error },
+        '[LessonDuplicationVariation] Pass 1 non-retryable error',
       )
       throw new VariationGenerationError(
         exerciseId,
@@ -229,8 +276,76 @@ export async function generateVariation(
       )
     }
   }
-  // Unreachable — loop exits only via throw
-  throw new VariationGenerationError(exerciseId, 'Unexpected loop exit')
+
+  if (!pass1Output) {
+    throw new VariationGenerationError(exerciseId, 'Unexpected: pass 1 produced no output')
+  }
+
+  // Pass 2 — Deterministic (solution derivation)
+  const derivationPrompt = buildSolutionDerivationPrompt(exercise, pass1Output)
+  let pass2RetryCount = 0
+  let pass2Patch: Pass2Patch | null = null
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const { createGenkitUnifiedAdapter } = await import('../genkit/adapters/unified-adapter')
+      const adapter = await createGenkitUnifiedAdapter(payload)
+      const deterministicConfig = resolveModelConfig('LESSON_DUPLICATION_VARIATION_DETERMINISTIC')
+
+      const result = await adapter.generateChatCompletion(
+        {
+          system: derivationPrompt,
+          messages: [{ role: 'user', content: '' }],
+          model: deterministicConfig,
+          acknowledgment: 'Deriving solution for exercise variation',
+        },
+        payload,
+      )
+
+      pass2Patch = parseSolutionDerivationResponse(result.text)
+      break
+    } catch (error) {
+      if (isJsonParseError(error)) {
+        if (pass2RetryCount > 0) {
+          const latencyMs = Date.now() - startTime
+          logger.error(
+            { latencyMs, level, subject, exerciseId, pass2RetryCount, err: error },
+            '[LessonDuplicationVariation] Pass 2 retry exhausted',
+          )
+          throw new VariationGenerationError(
+            exerciseId,
+            error instanceof Error ? error.message : 'Invalid JSON from LLM after retry',
+          )
+        }
+        pass2RetryCount++
+        continue
+      }
+      const latencyMs = Date.now() - startTime
+      logger.error(
+        { latencyMs, level, subject, exerciseId, err: error },
+        '[LessonDuplicationVariation] Pass 2 non-retryable error',
+      )
+      throw new VariationGenerationError(
+        exerciseId,
+        error instanceof Error ? error.message : 'Unknown error',
+      )
+    }
+  }
+
+  if (!pass2Patch) {
+    throw new VariationGenerationError(exerciseId, 'Unexpected: pass 2 produced no output')
+  }
+
+  // Merge: pass-1 blocks (question/hint) + pass-2 solution fields
+  const mergedBlocks = mergePassOutputs(pass1Output, pass2Patch)
+
+  const latencyMs = Date.now() - startTime
+  logger.info(
+    { latencyMs, level, subject, exerciseId },
+    '[LessonDuplicationVariation] Two-pass complete',
+  )
+
+  return { exercise: { ...exercise, content: { blocks: mergedBlocks } } }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -239,6 +354,38 @@ export async function generateVariation(
 
 function buildUserPrompt(exercise: Exercise): string {
   return `Generate a variation for the following exercise.\n\nInput exercise:\n${JSON.stringify(exercise, null, 2)}`
+}
+
+function buildSolutionDerivationPrompt(exercise: Exercise, pass1Output: Partial<Exercise>): string {
+  return `You are a strict mathematical derivation assistant. Given a newly generated exercise question,
+re-derive the correct answer from first principles and return only the solution fields.
+
+Input original exercise:
+${JSON.stringify(exercise, null, 2)}
+
+Pass 1 generated question/phrasing:
+${JSON.stringify(pass1Output, null, 2)}
+
+Task:
+1. Solve the new question independently (do not trust any answer provided in pass 1 output).
+2. Write the complete step-by-step solution in fullSolution (show every step).
+3. Write a brief solution in solution.
+4. Return ONLY these fields (do not include any other fields):
+{
+  "solution": <rich_text object>,
+  "fullSolution": <rich_text object>,
+  "answer": { "correctOptionIds": [<correct option id>] }
+}
+
+rich_text object format: { "type": "rich_text", "format": "md-math-v1", "value": "...", "mediaIds": [] }
+
+Return ONLY the JSON. No markdown fences, no explanation.`
+}
+
+interface Pass2Patch {
+  solution?: unknown
+  fullSolution?: unknown
+  answer?: { correctOptionIds: string[] }
 }
 
 function parseVariationResponse(text: string): Partial<Exercise> {
@@ -255,6 +402,41 @@ function parseVariationResponse(text: string): Partial<Exercise> {
   }
 
   return parsed as Partial<Exercise>
+}
+
+function parseSolutionDerivationResponse(text: string): Pass2Patch {
+  const cleaned = text
+    .replace(/^```json\s*/i, '')
+    .replace(/^```\s*/, '')
+    .replace(/```\s*$/, '')
+    .trim()
+
+  return JSON.parse(cleaned) as Pass2Patch
+}
+
+function mergePassOutputs(pass1Output: Partial<Exercise>, pass2Patch: Pass2Patch): unknown[] {
+  const pass1Blocks = (pass1Output.content as { blocks: unknown[] } | undefined)?.blocks ?? []
+
+  // For each block in pass1Output, overlay pass2 solution fields
+  return pass1Blocks.map((block: unknown) => {
+    const b = block as Record<string, unknown>
+    const result: Record<string, unknown> = { ...b }
+
+    // Pass-2 overwrites solution fields if provided
+    if (pass2Patch.solution !== undefined) {
+      result.solution = pass2Patch.solution
+    }
+    if (pass2Patch.fullSolution !== undefined) {
+      result.fullSolution = pass2Patch.fullSolution
+    }
+    if (pass2Patch.answer?.correctOptionIds !== undefined) {
+      if (!result.answer) result.answer = {}
+      ;(result.answer as Record<string, unknown>).correctOptionIds =
+        pass2Patch.answer.correctOptionIds
+    }
+
+    return result
+  })
 }
 
 function resolveModelConfig(modelKey: AIModelKey): AIModel {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -64,6 +64,7 @@ export type SupportedTimezones =
 export interface Config {
   auth: {
     users: UserAuthOperations;
+    'payload-mcp-api-keys': PayloadMcpApiKeyAuthOperations;
   };
   blocks: {};
   collections: {
@@ -104,6 +105,7 @@ export interface Config {
     forms: Form;
     'form-submissions': FormSubmission;
     search: Search;
+    'payload-mcp-api-keys': PayloadMcpApiKey;
     'payload-kv': PayloadKv;
     'payload-jobs': PayloadJob;
     'payload-locked-documents': PayloadLockedDocument;
@@ -149,6 +151,7 @@ export interface Config {
     forms: FormsSelect<false> | FormsSelect<true>;
     'form-submissions': FormSubmissionsSelect<false> | FormSubmissionsSelect<true>;
     search: SearchSelect<false> | SearchSelect<true>;
+    'payload-mcp-api-keys': PayloadMcpApiKeysSelect<false> | PayloadMcpApiKeysSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-jobs': PayloadJobsSelect<false> | PayloadJobsSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -168,9 +171,13 @@ export interface Config {
     footer: FooterSelect<false> | FooterSelect<true>;
   };
   locale: null;
-  user: User & {
-    collection: 'users';
-  };
+  user:
+    | (User & {
+        collection: 'users';
+      })
+    | (PayloadMcpApiKey & {
+        collection: 'payload-mcp-api-keys';
+      });
   jobs: {
     tasks: {
       pdf_to_exercises: TaskPdfToExercises;
@@ -186,6 +193,24 @@ export interface Config {
   };
 }
 export interface UserAuthOperations {
+  forgotPassword: {
+    email: string;
+    password: string;
+  };
+  login: {
+    email: string;
+    password: string;
+  };
+  registerFirstUser: {
+    email: string;
+    password: string;
+  };
+  unlock: {
+    email: string;
+    password: string;
+  };
+}
+export interface PayloadMcpApiKeyAuthOperations {
   forgotPassword: {
     email: string;
     password: string;
@@ -2618,6 +2643,74 @@ export interface Search {
   createdAt: string;
 }
 /**
+ * API keys control which collections, resources, tools, and prompts MCP clients can access
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-mcp-api-keys".
+ */
+export interface PayloadMcpApiKey {
+  id: string;
+  /**
+   * The user that the API key is associated with.
+   */
+  user: string | User;
+  /**
+   * A useful label for the API key.
+   */
+  label?: string | null;
+  /**
+   * The purpose of the API key.
+   */
+  description?: string | null;
+  courses?: {
+    /**
+     * Allow clients to find courses.
+     */
+    find?: boolean | null;
+    /**
+     * Allow clients to create courses.
+     */
+    create?: boolean | null;
+  };
+  chapters?: {
+    /**
+     * Allow clients to find chapters.
+     */
+    find?: boolean | null;
+    /**
+     * Allow clients to create chapters.
+     */
+    create?: boolean | null;
+  };
+  lessons?: {
+    /**
+     * Allow clients to find lessons.
+     */
+    find?: boolean | null;
+    /**
+     * Allow clients to create lessons.
+     */
+    create?: boolean | null;
+  };
+  exercises?: {
+    /**
+     * Allow clients to find exercises.
+     */
+    find?: boolean | null;
+  };
+  media?: {
+    /**
+     * Allow clients to find media.
+     */
+    find?: boolean | null;
+  };
+  updatedAt: string;
+  createdAt: string;
+  enableAPIKey?: boolean | null;
+  apiKey?: string | null;
+  apiKeyIndex?: string | null;
+}
+/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
@@ -2880,12 +2973,21 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'search';
         value: string | Search;
+      } | null)
+    | ({
+        relationTo: 'payload-mcp-api-keys';
+        value: string | PayloadMcpApiKey;
       } | null);
   globalSlug?: string | null;
-  user: {
-    relationTo: 'users';
-    value: string | User;
-  };
+  user:
+    | {
+        relationTo: 'users';
+        value: string | User;
+      }
+    | {
+        relationTo: 'payload-mcp-api-keys';
+        value: string | PayloadMcpApiKey;
+      };
   updatedAt: string;
   createdAt: string;
 }
@@ -2895,10 +2997,15 @@ export interface PayloadLockedDocument {
  */
 export interface PayloadPreference {
   id: string;
-  user: {
-    relationTo: 'users';
-    value: string | User;
-  };
+  user:
+    | {
+        relationTo: 'users';
+        value: string | User;
+      }
+    | {
+        relationTo: 'payload-mcp-api-keys';
+        value: string | PayloadMcpApiKey;
+      };
   key?: string | null;
   value?:
     | {
@@ -4037,6 +4144,48 @@ export interface SearchSelect<T extends boolean = true> {
       };
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-mcp-api-keys_select".
+ */
+export interface PayloadMcpApiKeysSelect<T extends boolean = true> {
+  user?: T;
+  label?: T;
+  description?: T;
+  courses?:
+    | T
+    | {
+        find?: T;
+        create?: T;
+      };
+  chapters?:
+    | T
+    | {
+        find?: T;
+        create?: T;
+      };
+  lessons?:
+    | T
+    | {
+        find?: T;
+        create?: T;
+      };
+  exercises?:
+    | T
+    | {
+        find?: T;
+      };
+  media?:
+    | T
+    | {
+        find?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+  enableAPIKey?: T;
+  apiKey?: T;
+  apiKeyIndex?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -64,7 +64,6 @@ export type SupportedTimezones =
 export interface Config {
   auth: {
     users: UserAuthOperations;
-    'payload-mcp-api-keys': PayloadMcpApiKeyAuthOperations;
   };
   blocks: {};
   collections: {
@@ -105,7 +104,6 @@ export interface Config {
     forms: Form;
     'form-submissions': FormSubmission;
     search: Search;
-    'payload-mcp-api-keys': PayloadMcpApiKey;
     'payload-kv': PayloadKv;
     'payload-jobs': PayloadJob;
     'payload-locked-documents': PayloadLockedDocument;
@@ -151,7 +149,6 @@ export interface Config {
     forms: FormsSelect<false> | FormsSelect<true>;
     'form-submissions': FormSubmissionsSelect<false> | FormSubmissionsSelect<true>;
     search: SearchSelect<false> | SearchSelect<true>;
-    'payload-mcp-api-keys': PayloadMcpApiKeysSelect<false> | PayloadMcpApiKeysSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-jobs': PayloadJobsSelect<false> | PayloadJobsSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
@@ -171,13 +168,9 @@ export interface Config {
     footer: FooterSelect<false> | FooterSelect<true>;
   };
   locale: null;
-  user:
-    | (User & {
-        collection: 'users';
-      })
-    | (PayloadMcpApiKey & {
-        collection: 'payload-mcp-api-keys';
-      });
+  user: User & {
+    collection: 'users';
+  };
   jobs: {
     tasks: {
       pdf_to_exercises: TaskPdfToExercises;
@@ -193,24 +186,6 @@ export interface Config {
   };
 }
 export interface UserAuthOperations {
-  forgotPassword: {
-    email: string;
-    password: string;
-  };
-  login: {
-    email: string;
-    password: string;
-  };
-  registerFirstUser: {
-    email: string;
-    password: string;
-  };
-  unlock: {
-    email: string;
-    password: string;
-  };
-}
-export interface PayloadMcpApiKeyAuthOperations {
   forgotPassword: {
     email: string;
     password: string;
@@ -1791,6 +1766,10 @@ export interface LessonDuplication {
    */
   level: 'none' | 'light' | 'medium' | 'deep';
   /**
+   * Subject area for variation prompts.
+   */
+  subject?: ('algebra' | 'geometry' | 'calculus' | 'mixed' | 'other') | null;
+  /**
    * Job status. `none` finishes inline; others go through the queue.
    */
   status: 'pending' | 'running' | 'succeeded' | 'failed' | 'needs_review';
@@ -2639,74 +2618,6 @@ export interface Search {
   createdAt: string;
 }
 /**
- * API keys control which collections, resources, tools, and prompts MCP clients can access
- *
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "payload-mcp-api-keys".
- */
-export interface PayloadMcpApiKey {
-  id: string;
-  /**
-   * The user that the API key is associated with.
-   */
-  user: string | User;
-  /**
-   * A useful label for the API key.
-   */
-  label?: string | null;
-  /**
-   * The purpose of the API key.
-   */
-  description?: string | null;
-  courses?: {
-    /**
-     * Allow clients to find courses.
-     */
-    find?: boolean | null;
-    /**
-     * Allow clients to create courses.
-     */
-    create?: boolean | null;
-  };
-  chapters?: {
-    /**
-     * Allow clients to find chapters.
-     */
-    find?: boolean | null;
-    /**
-     * Allow clients to create chapters.
-     */
-    create?: boolean | null;
-  };
-  lessons?: {
-    /**
-     * Allow clients to find lessons.
-     */
-    find?: boolean | null;
-    /**
-     * Allow clients to create lessons.
-     */
-    create?: boolean | null;
-  };
-  exercises?: {
-    /**
-     * Allow clients to find exercises.
-     */
-    find?: boolean | null;
-  };
-  media?: {
-    /**
-     * Allow clients to find media.
-     */
-    find?: boolean | null;
-  };
-  updatedAt: string;
-  createdAt: string;
-  enableAPIKey?: boolean | null;
-  apiKey?: string | null;
-  apiKeyIndex?: string | null;
-}
-/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
@@ -2969,21 +2880,12 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'search';
         value: string | Search;
-      } | null)
-    | ({
-        relationTo: 'payload-mcp-api-keys';
-        value: string | PayloadMcpApiKey;
       } | null);
   globalSlug?: string | null;
-  user:
-    | {
-        relationTo: 'users';
-        value: string | User;
-      }
-    | {
-        relationTo: 'payload-mcp-api-keys';
-        value: string | PayloadMcpApiKey;
-      };
+  user: {
+    relationTo: 'users';
+    value: string | User;
+  };
   updatedAt: string;
   createdAt: string;
 }
@@ -2993,15 +2895,10 @@ export interface PayloadLockedDocument {
  */
 export interface PayloadPreference {
   id: string;
-  user:
-    | {
-        relationTo: 'users';
-        value: string | User;
-      }
-    | {
-        relationTo: 'payload-mcp-api-keys';
-        value: string | PayloadMcpApiKey;
-      };
+  user: {
+    relationTo: 'users';
+    value: string | User;
+  };
   key?: string | null;
   value?:
     | {
@@ -3422,6 +3319,7 @@ export interface LessonsSelect<T extends boolean = true> {
 export interface LessonDuplicationsSelect<T extends boolean = true> {
   sourceLesson?: T;
   level?: T;
+  subject?: T;
   status?: T;
   outputLesson?: T;
   failures?:
@@ -4139,48 +4037,6 @@ export interface SearchSelect<T extends boolean = true> {
       };
   updatedAt?: T;
   createdAt?: T;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "payload-mcp-api-keys_select".
- */
-export interface PayloadMcpApiKeysSelect<T extends boolean = true> {
-  user?: T;
-  label?: T;
-  description?: T;
-  courses?:
-    | T
-    | {
-        find?: T;
-        create?: T;
-      };
-  chapters?:
-    | T
-    | {
-        find?: T;
-        create?: T;
-      };
-  lessons?:
-    | T
-    | {
-        find?: T;
-        create?: T;
-      };
-  exercises?:
-    | T
-    | {
-        find?: T;
-      };
-  media?:
-    | T
-    | {
-        find?: T;
-      };
-  updatedAt?: T;
-  createdAt?: T;
-  enableAPIKey?: T;
-  apiKey?: T;
-  apiKeyIndex?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/server/payload/collections/LessonDuplications.ts
+++ b/src/server/payload/collections/LessonDuplications.ts
@@ -20,6 +20,9 @@ import { createdByField } from '../fields/createdBy'
 export const DUPLICATION_LEVELS = ['none', 'light', 'medium', 'deep'] as const
 export type DuplicationLevel = (typeof DUPLICATION_LEVELS)[number]
 
+export const DUPLICATION_SUBJECTS = ['algebra', 'geometry', 'calculus', 'mixed', 'other'] as const
+export type DuplicationSubject = (typeof DUPLICATION_SUBJECTS)[number]
+
 export const DUPLICATION_STATUSES = [
   'pending',
   'running',
@@ -33,7 +36,7 @@ export const LessonDuplications: CollectionConfig = {
   slug: 'lesson-duplications',
   admin: {
     useAsTitle: 'id',
-    defaultColumns: ['sourceLesson', 'level', 'status', 'outputLesson', 'createdAt'],
+    defaultColumns: ['sourceLesson', 'level', 'subject', 'status', 'outputLesson', 'createdAt'],
     group: 'System',
     description: 'Lesson duplication job records, one per duplicate request.',
   },
@@ -58,6 +61,12 @@ export const LessonDuplications: CollectionConfig = {
       required: true,
       options: DUPLICATION_LEVELS.map((v) => ({ label: v, value: v })),
       admin: { description: 'Variation level applied to the duplicate.' },
+    },
+    {
+      name: 'subject',
+      type: 'select',
+      options: DUPLICATION_SUBJECTS.map((v) => ({ label: v, value: v })),
+      admin: { description: 'Subject area for variation prompts.' },
     },
     {
       name: 'status',

--- a/src/server/payload/endpoints/lessons/duplicate.ts
+++ b/src/server/payload/endpoints/lessons/duplicate.ts
@@ -19,15 +19,21 @@ import type { PayloadRequest } from 'payload'
 
 import {
   DUPLICATION_LEVELS,
+  DUPLICATION_SUBJECTS,
   type DuplicationLevel,
+  type DuplicationSubject,
 } from '@/server/payload/collections/LessonDuplications'
 
 interface DuplicateBody {
   level?: unknown
+  subject?: unknown
 }
 
 const isLevel = (v: unknown): v is DuplicationLevel =>
   typeof v === 'string' && (DUPLICATION_LEVELS as readonly string[]).includes(v)
+
+const isSubject = (v: unknown): v is DuplicationSubject =>
+  typeof v === 'string' && (DUPLICATION_SUBJECTS as readonly string[]).includes(v)
 
 /** Strip Payload-managed fields from a doc so it can be passed to `create`. */
 function stripManagedFields<T extends Record<string, unknown>>(
@@ -138,7 +144,19 @@ export async function duplicateLessonEndpoint(req: PayloadRequest): Promise<Resp
   }
   const level: DuplicationLevel = body.level
 
-  // 4) Verify source lesson exists
+  // 4) Validate subject (required for level != none)
+  let subject: DuplicationSubject | undefined
+  if (level !== 'none') {
+    if (!isSubject(body.subject)) {
+      return Response.json(
+        { error: `subject must be one of: ${DUPLICATION_SUBJECTS.join(', ')}` },
+        { status: 400 },
+      )
+    }
+    subject = body.subject
+  }
+
+  // 5) Verify source lesson exists
   try {
     await req.payload.findByID({
       collection: 'lessons',
@@ -157,13 +175,14 @@ export async function duplicateLessonEndpoint(req: PayloadRequest): Promise<Resp
     data: {
       sourceLesson: lessonId,
       level,
+      subject,
       status: 'pending',
     } as never,
     overrideAccess: true,
     req,
   })
 
-  // 6) For level=none, deep-clone immediately
+  // 7) For level=none, deep-clone immediately
   if (level === 'none') {
     try {
       const outputLessonId = await deepCloneLesson(req, lessonId)
@@ -191,6 +210,6 @@ export async function duplicateLessonEndpoint(req: PayloadRequest): Promise<Resp
     }
   }
 
-  // 7) For light/medium/deep, leave pending — return immediately
+  // 8) For light/medium/deep, leave pending — return immediately
   return Response.json({ id: record.id, status: 'pending' })
 }

--- a/src/server/services/lesson-duplication/orchestrator.ts
+++ b/src/server/services/lesson-duplication/orchestrator.ts
@@ -17,6 +17,7 @@
 import type { Payload } from 'payload'
 import type { Exercise } from '@/payload-types'
 import type { ContentBlock } from '@/server/payload/collections/Exercises/schemas'
+import type { DuplicationSubject } from '@/server/payload/collections/LessonDuplications'
 import { logger } from '@/infra/utils/logger'
 import { withConcurrencyLimit } from '@/infra/utils/concurrency'
 import { selectExercisesScaled } from '@/server/services/lesson-duplication/selectors'
@@ -57,10 +58,11 @@ export interface StrategyResult {
 export async function runStrategy(
   exercise: ExerciseDoc,
   level: 'none' | 'light' | 'medium' | 'deep',
-  _payload: Payload,
+  subject: DuplicationSubject,
+  payload: Payload,
 ): Promise<StrategyResult> {
-  const router = new RouterStrategy()
-  const result = await router.apply(exercise as unknown as Exercise, level)
+  const router = new RouterStrategy(payload)
+  const result = await router.apply(exercise as unknown as Exercise, level, subject)
 
   const content = result.exercise.content as unknown as { blocks: ContentBlock[] }
   return {
@@ -151,6 +153,7 @@ async function processExercise(
   exercise: ExerciseDoc,
   duplicationId: string,
   level: 'none' | 'light' | 'medium' | 'deep',
+  subject: DuplicationSubject,
   payload: Payload,
 ): Promise<StrategyResult | null> {
   const exerciseRef = exercise.id
@@ -158,7 +161,7 @@ async function processExercise(
   // Step 1: Run strategy
   let strategyResult: StrategyResult
   try {
-    strategyResult = await runStrategy(exercise, level, payload)
+    strategyResult = await runStrategy(exercise, level, subject, payload)
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown strategy error'
     logger.error({ exerciseRef, level, err }, 'Strategy generation failed')
@@ -269,14 +272,13 @@ export async function runDuplicationOrchestrator(
 
     const selectedExercises = selectExercisesScaled(allExercises.docs as ExerciseDoc[], 20)
 
+    const duplicationLevel = duplication.level as 'none' | 'light' | 'medium' | 'deep'
+    const duplicationSubject =
+      (duplication.subject as DuplicationSubject | null | undefined) ?? 'mixed'
+
     // Process all exercises with concurrency limit
     const results = await withConcurrencyLimit(selectedExercises, CONCURRENCY_LIMIT, (exercise) =>
-      processExercise(
-        exercise,
-        duplicationId,
-        duplication.level as 'none' | 'light' | 'medium' | 'deep',
-        payload,
-      ),
+      processExercise(exercise, duplicationId, duplicationLevel, duplicationSubject, payload),
     )
 
     const succeeded = results.filter((r) => r !== null).length

--- a/src/server/services/lesson-duplication/strategies/router.ts
+++ b/src/server/services/lesson-duplication/strategies/router.ts
@@ -7,17 +7,41 @@
  * @ai-summary Routes exercises to the appropriate variation strategy (script or AI).
  */
 
+import type { Payload } from 'payload'
 import type { Exercise } from '@/payload-types'
-import type { DuplicationLevel } from '@/server/payload/collections/LessonDuplications'
+import type {
+  DuplicationLevel,
+  DuplicationSubject,
+} from '@/server/payload/collections/LessonDuplications'
 import type { VariationStrategy, VariationResult } from './types'
 import { ScriptVariationStrategy } from './script-strategy'
 
-/** AI placeholder strategy — throws until K4 is implemented. */
+/** AI variation strategy — calls generateVariation with two-pass approach. */
 class AiVariationStrategy implements VariationStrategy {
-  async apply(exercise: Exercise, level: DuplicationLevel): Promise<VariationResult> {
+  constructor(private readonly payload: Payload) {
+    this.payload = payload
+  }
+
+  async apply(
+    exercise: Exercise,
+    level: DuplicationLevel,
+    subject?: DuplicationSubject,
+  ): Promise<VariationResult> {
+    void subject // subject parameter required by VariationStrategy interface
     if (level === 'none') return { exercise }
-    // K4: implement AI variation
-    throw new Error('AiVariationStrategy is not yet implemented (K4)')
+
+    const effectiveSubject: DuplicationSubject = subject ?? 'mixed'
+    const { generateVariation } =
+      await import('@/infra/llm/services/lesson-duplication-variation-service')
+    const result = await generateVariation(
+      {
+        exercise,
+        level: level as Exclude<DuplicationLevel, 'none'>,
+        subject: effectiveSubject,
+      },
+      this.payload,
+    )
+    return { exercise: result.exercise }
   }
 }
 
@@ -27,27 +51,34 @@ class AiVariationStrategy implements VariationStrategy {
  * Routing rules:
  *  - level=none: return exercise unchanged
  *  - light + purely-algebraic: ScriptVariationStrategy (fast, no AI)
- *  - light + not algebraic OR medium/deep: AiVariationStrategy (throws until K4)
+ *  - light + not algebraic OR medium/deep: AiVariationStrategy (two-pass)
  */
 export class RouterStrategy implements VariationStrategy {
-  private readonly scriptStrategy = new ScriptVariationStrategy()
-  private readonly aiStrategy = new AiVariationStrategy()
+  constructor(
+    private readonly payload: Payload,
+    private readonly scriptStrategy = new ScriptVariationStrategy(),
+  ) {}
 
-  async apply(exercise: Exercise, level: DuplicationLevel): Promise<VariationResult> {
+  async apply(
+    exercise: Exercise,
+    level: DuplicationLevel,
+    subject?: DuplicationSubject,
+  ): Promise<VariationResult> {
     if (level === 'none') {
       return { exercise }
     }
 
     // Try script strategy for light + purely-algebraic
     if (level === 'light') {
-      const result = await this.scriptStrategy.apply(exercise, level)
+      const result = await this.scriptStrategy.apply(exercise, level, subject)
       if (!result.needsAiFallback) {
         return result
       }
       // Fall through to AI if script returned needsAiFallback
     }
 
-    // K4: medium/deep, or light with needsAiFallback → AI
-    return this.aiStrategy.apply(exercise, level)
+    // medium/deep, or light with needsAiFallback → AI
+    const aiStrategy = new AiVariationStrategy(this.payload)
+    return aiStrategy.apply(exercise, level, subject)
   }
 }

--- a/src/server/services/lesson-duplication/strategies/script-strategy.ts
+++ b/src/server/services/lesson-duplication/strategies/script-strategy.ts
@@ -8,7 +8,10 @@
  */
 
 import type { Exercise } from '@/payload-types'
-import type { DuplicationLevel } from '@/server/payload/collections/LessonDuplications'
+import type {
+  DuplicationLevel,
+  DuplicationSubject,
+} from '@/server/payload/collections/LessonDuplications'
 import type { ContentBlock, InlineRichText } from '@/server/payload/collections/Exercises/types'
 import type { VariationResult, VariationStrategy } from './types'
 import { isPurelyAlgebraic } from './algebraic-detector'
@@ -377,7 +380,11 @@ export function applyScriptLightVariation(exercise: Exercise, seed: number): Var
  * Falls through to AI for all other cases (non-algebraic, medium/deep, etc.).
  */
 export class ScriptVariationStrategy implements VariationStrategy {
-  async apply(exercise: Exercise, level: DuplicationLevel): Promise<VariationResult> {
+  async apply(
+    exercise: Exercise,
+    level: DuplicationLevel,
+    _subject?: DuplicationSubject,
+  ): Promise<VariationResult> {
     if (level === 'none') return { exercise }
 
     if (level !== 'light') {

--- a/src/server/services/lesson-duplication/strategies/types.ts
+++ b/src/server/services/lesson-duplication/strategies/types.ts
@@ -8,7 +8,10 @@
  */
 
 import type { Exercise } from '@/payload-types'
-import type { DuplicationLevel } from '@/server/payload/collections/LessonDuplications'
+import type {
+  DuplicationLevel,
+  DuplicationSubject,
+} from '@/server/payload/collections/LessonDuplications'
 
 /**
  * Return type for all variation strategies.
@@ -26,5 +29,9 @@ export interface VariationResult {
  * The orchestrator calls only this interface — concrete impls are private.
  */
 export interface VariationStrategy {
-  apply(exercise: Exercise, level: DuplicationLevel): Promise<VariationResult>
+  apply(
+    exercise: Exercise,
+    level: DuplicationLevel,
+    subject?: DuplicationSubject,
+  ): Promise<VariationResult>
 }

--- a/src/ui/admin/LessonDuplicateButton/LessonDuplicateButton.tsx
+++ b/src/ui/admin/LessonDuplicateButton/LessonDuplicateButton.tsx
@@ -30,12 +30,45 @@ const LEVELS: { value: 'none' | 'light' | 'medium' | 'deep'; label: string; hint
   },
 ]
 
+const SUBJECTS: {
+  value: 'algebra' | 'geometry' | 'calculus' | 'mixed' | 'other'
+  label: string
+  hint: string
+}[] = [
+  {
+    value: 'algebra',
+    label: 'Algebra',
+    hint: 'Algebraic expressions, equations, word problems.',
+  },
+  {
+    value: 'geometry',
+    label: 'Geometry',
+    hint: 'Shapes, coordinates, angles, area, perimeter.',
+  },
+  {
+    value: 'calculus',
+    label: 'Calculus',
+    hint: 'Derivatives, integrals, limits, series.',
+  },
+  {
+    value: 'mixed',
+    label: 'Mixed / General',
+    hint: 'General prompts for mixed or unknown subjects.',
+  },
+  {
+    value: 'other',
+    label: 'Other',
+    hint: 'Non-math or specialized subject matter.',
+  },
+]
+
 type Status = 'idle' | 'submitting' | 'success' | 'error'
 
 export const LessonDuplicateAction: React.FC = () => {
   const { id } = useDocumentInfo()
   const [open, setOpen] = useState(false)
   const [level, setLevel] = useState<(typeof LEVELS)[number]['value'] | ''>('')
+  const [subject, setSubject] = useState<(typeof SUBJECTS)[number]['value']>('mixed')
   const [status, setStatus] = useState<Status>('idle')
   const [error, setError] = useState<string | null>(null)
   const [resultId, setResultId] = useState<string | null>(null)
@@ -44,6 +77,7 @@ export const LessonDuplicateAction: React.FC = () => {
 
   const reset = () => {
     setLevel('')
+    setSubject('mixed')
     setStatus('idle')
     setError(null)
     setResultId(null)
@@ -63,7 +97,7 @@ export const LessonDuplicateAction: React.FC = () => {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ level }),
+        body: JSON.stringify({ level, subject }),
       })
       const data = (await res.json()) as { id?: string; error?: string }
       if (!res.ok) {
@@ -157,6 +191,44 @@ export const LessonDuplicateAction: React.FC = () => {
                     value={opt.value}
                     checked={level === opt.value}
                     onChange={() => setLevel(opt.value)}
+                  />
+                  <span>
+                    <strong>{opt.label}</strong>
+                    <br />
+                    <span style={{ fontSize: 12, color: 'var(--theme-elevation-600)' }}>
+                      {opt.hint}
+                    </span>
+                  </span>
+                </label>
+              ))}
+            </div>
+
+            <p style={{ fontSize: 13, color: 'var(--theme-elevation-600)', marginTop: 16 }}>
+              Subject area
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16 }}>
+              {SUBJECTS.map((opt) => (
+                <label
+                  key={opt.value}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    gap: 8,
+                    padding: 8,
+                    border:
+                      subject === opt.value
+                        ? '1px solid var(--theme-success-500)'
+                        : '1px solid var(--theme-elevation-200)',
+                    borderRadius: 4,
+                    cursor: 'pointer',
+                  }}
+                >
+                  <input
+                    type="radio"
+                    name="dup-subject"
+                    value={opt.value}
+                    checked={subject === opt.value}
+                    onChange={() => setSubject(opt.value)}
                   />
                   <span>
                     <strong>{opt.label}</strong>

--- a/tests/int/lesson-duplication-orchestrator.int.spec.ts
+++ b/tests/int/lesson-duplication-orchestrator.int.spec.ts
@@ -23,57 +23,69 @@ vi.mock('@/server/services/lesson-duplication/orchestrator', async (importOrigin
     ...actual,
     runStrategy: vi
       .fn()
-      .mockImplementation(async (exercise: { id: string }, _level: string, _payload: unknown) => {
-        // Force failure on the 3rd exercise (index-based)
-        if (exercise.id.includes('-3')) {
-          throw new Error('Forced failure for test')
-        }
-        return {
-          exerciseId: exercise.id,
-          strategy: 'ai' as const,
-          blocks: [
-            {
-              id: 'q-1',
-              type: 'question_select',
-              variant: 'mcq',
-              selectionMode: 'single',
-              prompt: {
-                type: 'rich_text',
-                format: 'md-math-v1',
-                value: 'What is 2+2?',
-                mediaIds: [],
+      .mockImplementation(
+        async (exercise: { id: string }, _level: string, _subject: unknown, _payload: unknown) => {
+          // Force failure on the 3rd exercise (index-based)
+          if (exercise.id.includes('-3')) {
+            throw new Error('Forced failure for test')
+          }
+          return {
+            exerciseId: exercise.id,
+            strategy: 'ai' as const,
+            blocks: [
+              {
+                id: 'q-1',
+                type: 'question_select',
+                variant: 'mcq',
+                selectionMode: 'single',
+                prompt: {
+                  type: 'rich_text',
+                  format: 'md-math-v1',
+                  value: 'What is 2+2?',
+                  mediaIds: [],
+                },
+                answer: {
+                  multiSelect: false,
+                  options: [
+                    {
+                      id: 'a',
+                      content: {
+                        type: 'rich_text',
+                        format: 'md-math-v1',
+                        value: '3',
+                        mediaIds: [],
+                      },
+                    },
+                    {
+                      id: 'b',
+                      content: {
+                        type: 'rich_text',
+                        format: 'md-math-v1',
+                        value: '4',
+                        mediaIds: [],
+                      },
+                    },
+                  ],
+                  correctOptionIds: ['b'],
+                },
+                hint: {
+                  type: 'rich_text',
+                  format: 'md-math-v1',
+                  value: 'Think arithmetic',
+                  mediaIds: [],
+                },
+                solution: { type: 'rich_text', format: 'md-math-v1', value: '2+2=4', mediaIds: [] },
+                fullSolution: {
+                  type: 'rich_text',
+                  format: 'md-math-v1',
+                  value: 'Basic addition',
+                  mediaIds: [],
+                },
               },
-              answer: {
-                multiSelect: false,
-                options: [
-                  {
-                    id: 'a',
-                    content: { type: 'rich_text', format: 'md-math-v1', value: '3', mediaIds: [] },
-                  },
-                  {
-                    id: 'b',
-                    content: { type: 'rich_text', format: 'md-math-v1', value: '4', mediaIds: [] },
-                  },
-                ],
-                correctOptionIds: ['b'],
-              },
-              hint: {
-                type: 'rich_text',
-                format: 'md-math-v1',
-                value: 'Think arithmetic',
-                mediaIds: [],
-              },
-              solution: { type: 'rich_text', format: 'md-math-v1', value: '2+2=4', mediaIds: [] },
-              fullSolution: {
-                type: 'rich_text',
-                format: 'md-math-v1',
-                value: 'Basic addition',
-                mediaIds: [],
-              },
-            },
-          ],
-        }
-      }),
+            ],
+          }
+        },
+      ),
   }
 })
 

--- a/tests/unit/server/llm/services/lesson-duplication-variation-service.test.ts
+++ b/tests/unit/server/llm/services/lesson-duplication-variation-service.test.ts
@@ -3,8 +3,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 /**
  * Tests for lesson-duplication-variation-service.
  *
- * Tests the generateVariation function with light/medium/deep levels,
- * verifying retry behavior and logging.
+ * Tests the generateVariation function with light/medium/deep levels and
+ * subject routing, verifying two-pass behavior (creative + deterministic).
  */
 
 // Mock the genkit adapter
@@ -21,12 +21,16 @@ vi.mock('@/infra/utils/logger', () => ({
   },
 }))
 
-// Mock models
+// Mock models — returns different temps per model key
 vi.mock('@/infra/llm/models', () => ({
-  getModelRegistryEntry: vi.fn().mockReturnValue({
-    temperature: 0.3,
-    maxOutputTokens: 8192,
-    capabilities: ['chat', 'generation'],
+  getModelRegistryEntry: vi.fn((key: string) => {
+    if (key === 'LESSON_DUPLICATION_VARIATION_CREATIVE') {
+      return { temperature: 0.7, maxOutputTokens: 8192, capabilities: ['chat', 'generation'] }
+    }
+    if (key === 'LESSON_DUPLICATION_VARIATION_DETERMINISTIC') {
+      return { temperature: 0.0, maxOutputTokens: 8192, capabilities: ['chat', 'generation'] }
+    }
+    return { temperature: 0.3, maxOutputTokens: 8192, capabilities: ['chat', 'generation'] }
   }),
   getProviderModelName: vi.fn().mockReturnValue('gemini-3.1-pro'),
 }))
@@ -84,56 +88,273 @@ describe('generateVariation', () => {
   let mockGenerateChatCompletion: ReturnType<typeof vi.fn>
 
   beforeEach(async () => {
-    // Use resetAllMocks to clear mockReturnValue/mocksResolvedValue queues too
     vi.resetAllMocks()
-
-    // Create fresh mock for generateChatCompletion each test
     mockGenerateChatCompletion = vi.fn()
     ;(createGenkitUnifiedAdapter as ReturnType<typeof vi.fn>).mockResolvedValue({
       generateChatCompletion: mockGenerateChatCompletion,
     })
   })
 
-  it('returns exercise with only numeric values changed for light level', async () => {
-    // Light variation: only numeric values changed, phrasing preserved
-    mockGenerateChatCompletion.mockResolvedValueOnce({
-      text: JSON.stringify({
-        content: {
-          blocks: [
-            {
-              id: 'block-1',
-              type: 'question_select',
-              variant: 'mcq',
-              prompt: {
-                type: 'rich_text',
-                format: 'md-math-v1',
-                value: 'What is $3+3$?',
-                mediaIds: [],
-              },
-              answer: {
-                options: [
+  // ── Two-pass: correct model keys and temperatures ────────────────────────
+
+  it('pass1 uses LESSON_DUPLICATION_VARIATION_CREATIVE at temp 0.7, pass2 uses LESSON_DUPLICATION_VARIATION_DETERMINISTIC at temp 0.0', async () => {
+    const callLog: Array<{ modelKey: string; temperature: number }> = []
+
+    mockGenerateChatCompletion.mockImplementation(
+      async ({ model }: { model: { modelKey?: string; temperature: number } }) => {
+        callLog.push({ modelKey: model.modelKey ?? '', temperature: model.temperature })
+
+        if (callLog.length === 1) {
+          // Pass 1: creative output
+          return {
+            text: JSON.stringify({
+              content: {
+                blocks: [
                   {
-                    id: 'a',
-                    content: { type: 'rich_text', format: 'md-math-v1', value: '6', mediaIds: [] },
-                  },
-                  {
-                    id: 'b',
-                    content: { type: 'rich_text', format: 'md-math-v1', value: '9', mediaIds: [] },
+                    id: 'block-1',
+                    type: 'question_select',
+                    variant: 'mcq',
+                    prompt: {
+                      type: 'rich_text',
+                      format: 'md-math-v1',
+                      value: 'What is $3+3$?',
+                      mediaIds: [],
+                    },
+                    hint: {
+                      type: 'rich_text',
+                      format: 'md-math-v1',
+                      value: 'Add them.',
+                      mediaIds: [],
+                    },
+                    solution: {
+                      type: 'rich_text',
+                      format: 'md-math-v1',
+                      value: '3+3',
+                      mediaIds: [],
+                    },
+                    fullSolution: {
+                      type: 'rich_text',
+                      format: 'md-math-v1',
+                      value: '3+3=6',
+                      mediaIds: [],
+                    },
+                    answer: {
+                      options: [
+                        {
+                          id: 'a',
+                          content: {
+                            type: 'rich_text',
+                            format: 'md-math-v1',
+                            value: '6',
+                            mediaIds: [],
+                          },
+                        },
+                        {
+                          id: 'b',
+                          content: {
+                            type: 'rich_text',
+                            format: 'md-math-v1',
+                            value: '9',
+                            mediaIds: [],
+                          },
+                        },
+                      ],
+                      correctOptionIds: ['WRONG'],
+                    },
                   },
                 ],
-                correctOptionIds: ['a'],
               },
+            }),
+          }
+        } else {
+          // Pass 2: correct answer derivation
+          return {
+            text: JSON.stringify({
+              solution: { type: 'rich_text', format: 'md-math-v1', value: '3+3=6', mediaIds: [] },
+              fullSolution: {
+                type: 'rich_text',
+                format: 'md-math-v1',
+                value: 'Step 1: add 3+3=6',
+                mediaIds: [],
+              },
+              answer: { correctOptionIds: ['a'] },
+            }),
+          }
+        }
+      },
+    )
+
+    const inputExercise = makeMockExercise('ex-two-pass-keys')
+    const result = await generateVariation(
+      { exercise: inputExercise, level: 'medium', subject: 'algebra' },
+      mockPayload,
+    )
+
+    expect(callLog.length).toBe(2)
+    expect(callLog[0]).toMatchObject({
+      modelKey: 'LESSON_DUPLICATION_VARIATION_CREATIVE',
+      temperature: 0.7,
+    })
+    expect(callLog[1]).toMatchObject({
+      modelKey: 'LESSON_DUPLICATION_VARIATION_DETERMINISTIC',
+      temperature: 0.0,
+    })
+    expect(result.exercise).toBeDefined()
+  })
+
+  it('pass2 correct_option overwrites the wrong pass1 correct_option', async () => {
+    mockGenerateChatCompletion.mockImplementation(async () => {
+      const callCount = mockGenerateChatCompletion.mock.calls.length
+
+      if (callCount === 1) {
+        // Pass 1: returns wrong correctOptionIds
+        return {
+          text: JSON.stringify({
+            content: {
+              blocks: [
+                {
+                  id: 'block-1',
+                  type: 'question_select',
+                  variant: 'mcq',
+                  prompt: {
+                    type: 'rich_text',
+                    format: 'md-math-v1',
+                    value: 'What is $5+5$?',
+                    mediaIds: [],
+                  },
+                  solution: { type: 'rich_text', format: 'md-math-v1', value: '5+5', mediaIds: [] },
+                  fullSolution: {
+                    type: 'rich_text',
+                    format: 'md-math-v1',
+                    value: '5+5=10',
+                    mediaIds: [],
+                  },
+                  answer: {
+                    options: [
+                      {
+                        id: 'a',
+                        content: {
+                          type: 'rich_text',
+                          format: 'md-math-v1',
+                          value: '10',
+                          mediaIds: [],
+                        },
+                      },
+                      {
+                        id: 'b',
+                        content: {
+                          type: 'rich_text',
+                          format: 'md-math-v1',
+                          value: '12',
+                          mediaIds: [],
+                        },
+                      },
+                    ],
+                    correctOptionIds: ['WRONG'],
+                  },
+                },
+              ],
             },
-          ],
-        },
-      }),
+          }),
+        }
+      } else {
+        // Pass 2: correct answer derivation
+        return {
+          text: JSON.stringify({
+            solution: { type: 'rich_text', format: 'md-math-v1', value: '5+5=10', mediaIds: [] },
+            fullSolution: {
+              type: 'rich_text',
+              format: 'md-math-v1',
+              value: 'Step 1: add 5+5=10',
+              mediaIds: [],
+            },
+            answer: { correctOptionIds: ['a'] },
+          }),
+        }
+      }
+    })
+
+    const inputExercise = makeMockExercise('ex-overwrite')
+    const result = await generateVariation(
+      { exercise: inputExercise, level: 'medium', subject: 'mixed' },
+      mockPayload,
+    )
+
+    const resultBlock = (result.exercise.content as { blocks: unknown[] }).blocks[0] as {
+      answer: { correctOptionIds: string[] }
+    }
+    expect(resultBlock.answer.correctOptionIds).toEqual(['a'])
+  })
+
+  // ── Single-pass tests (updated with subject param) ──────────────────────
+
+  it('returns exercise with only numeric values changed for light level', async () => {
+    mockGenerateChatCompletion.mockImplementation(async () => {
+      const callCount = mockGenerateChatCompletion.mock.calls.length
+
+      if (callCount === 1) {
+        // Pass 1
+        return {
+          text: JSON.stringify({
+            content: {
+              blocks: [
+                {
+                  id: 'block-1',
+                  type: 'question_select',
+                  variant: 'mcq',
+                  prompt: {
+                    type: 'rich_text',
+                    format: 'md-math-v1',
+                    value: 'What is $3+3$?',
+                    mediaIds: [],
+                  },
+                  answer: {
+                    options: [
+                      {
+                        id: 'a',
+                        content: {
+                          type: 'rich_text',
+                          format: 'md-math-v1',
+                          value: '6',
+                          mediaIds: [],
+                        },
+                      },
+                      {
+                        id: 'b',
+                        content: {
+                          type: 'rich_text',
+                          format: 'md-math-v1',
+                          value: '9',
+                          mediaIds: [],
+                        },
+                      },
+                    ],
+                    correctOptionIds: ['a'],
+                  },
+                },
+              ],
+            },
+          }),
+        }
+      } else {
+        // Pass 2
+        return {
+          text: JSON.stringify({
+            solution: { type: 'rich_text', format: 'md-math-v1', value: '3+3=6', mediaIds: [] },
+            fullSolution: { type: 'rich_text', format: 'md-math-v1', value: '3+3=6', mediaIds: [] },
+            answer: { correctOptionIds: ['a'] },
+          }),
+        }
+      }
     })
 
     const inputExercise = makeMockExercise('ex-1')
-    const result = await generateVariation({ exercise: inputExercise, level: 'light' }, mockPayload)
+    const result = await generateVariation(
+      { exercise: inputExercise, level: 'light', subject: 'mixed' },
+      mockPayload,
+    )
 
     expect(result.exercise).toBeDefined()
-    // Verify the result has different numeric values
     const resultBlock = (result.exercise.content as { blocks: unknown[] }).blocks[0] as {
       prompt: { value: string }
       answer: { options: Array<{ content: { value: string } }> }
@@ -143,48 +364,77 @@ describe('generateVariation', () => {
   })
 
   it('returns exercise with reworded phrasing for medium level', async () => {
-    // Medium variation: phrasing reworded, structure preserved
-    mockGenerateChatCompletion.mockResolvedValueOnce({
-      text: JSON.stringify({
-        content: {
-          blocks: [
-            {
-              id: 'block-1',
-              type: 'question_select',
-              variant: 'mcq',
-              prompt: {
-                type: 'rich_text',
-                format: 'md-math-v1',
-                value: 'Calculate $2+2$.',
-                mediaIds: [],
-              },
-              answer: {
-                options: [
-                  {
-                    id: 'a',
-                    content: { type: 'rich_text', format: 'md-math-v1', value: '3', mediaIds: [] },
+    mockGenerateChatCompletion.mockImplementation(async () => {
+      const callCount = mockGenerateChatCompletion.mock.calls.length
+
+      if (callCount === 1) {
+        return {
+          text: JSON.stringify({
+            content: {
+              blocks: [
+                {
+                  id: 'block-1',
+                  type: 'question_select',
+                  variant: 'mcq',
+                  prompt: {
+                    type: 'rich_text',
+                    format: 'md-math-v1',
+                    value: 'Calculate $2+2$.',
+                    mediaIds: [],
                   },
-                  {
-                    id: 'b',
-                    content: { type: 'rich_text', format: 'md-math-v1', value: '4', mediaIds: [] },
+                  solution: { type: 'rich_text', format: 'md-math-v1', value: '2+2', mediaIds: [] },
+                  fullSolution: {
+                    type: 'rich_text',
+                    format: 'md-math-v1',
+                    value: '2+2=4',
+                    mediaIds: [],
                   },
-                ],
-                correctOptionIds: ['b'],
-              },
+                  answer: {
+                    options: [
+                      {
+                        id: 'a',
+                        content: {
+                          type: 'rich_text',
+                          format: 'md-math-v1',
+                          value: '3',
+                          mediaIds: [],
+                        },
+                      },
+                      {
+                        id: 'b',
+                        content: {
+                          type: 'rich_text',
+                          format: 'md-math-v1',
+                          value: '4',
+                          mediaIds: [],
+                        },
+                      },
+                    ],
+                    correctOptionIds: ['b'],
+                  },
+                },
+              ],
             },
-          ],
-        },
-      }),
+          }),
+        }
+      } else {
+        return {
+          text: JSON.stringify({
+            solution: { type: 'rich_text', format: 'md-math-v1', value: '2+2=4', mediaIds: [] },
+            fullSolution: { type: 'rich_text', format: 'md-math-v1', value: '2+2=4', mediaIds: [] },
+            answer: { correctOptionIds: ['b'] },
+          }),
+        }
+      }
     })
 
     const inputExercise = makeMockExercise('ex-2')
     const result = await generateVariation(
-      { exercise: inputExercise, level: 'medium' },
+      { exercise: inputExercise, level: 'medium', subject: 'mixed' },
       mockPayload,
     )
 
     expect(result.exercise).toBeDefined()
-    // Verify phrasing changed (same numbers, different wording)
     const resultBlock = (result.exercise.content as { blocks: unknown[] }).blocks[0] as {
       prompt: { value: string }
     }
@@ -192,221 +442,290 @@ describe('generateVariation', () => {
   })
 
   it('may add/remove sections but produces no PNG fields for deep level', async () => {
-    // Deep variation: values, functions, sections may change
-    mockGenerateChatCompletion.mockResolvedValueOnce({
-      text: JSON.stringify({
-        content: {
-          blocks: [
-            {
-              id: 'block-1',
-              type: 'question_select',
-              variant: 'mcq',
-              prompt: {
-                type: 'rich_text',
-                format: 'md-math-v1',
-                value: 'Solve for x: $3x + 6 = 12$.',
-                mediaIds: [],
-              },
-              answer: {
-                options: [
-                  {
-                    id: 'a',
-                    content: {
-                      type: 'rich_text',
-                      format: 'md-math-v1',
-                      value: 'x=1',
-                      mediaIds: [],
-                    },
+    mockGenerateChatCompletion.mockImplementation(async () => {
+      const callCount = mockGenerateChatCompletion.mock.calls.length
+
+      if (callCount === 1) {
+        return {
+          text: JSON.stringify({
+            content: {
+              blocks: [
+                {
+                  id: 'block-1',
+                  type: 'question_select',
+                  variant: 'mcq',
+                  prompt: {
+                    type: 'rich_text',
+                    format: 'md-math-v1',
+                    value: 'Solve for x: $3x + 6 = 12$.',
+                    mediaIds: [],
                   },
-                  {
-                    id: 'b',
-                    content: {
-                      type: 'rich_text',
-                      format: 'md-math-v1',
-                      value: 'x=2',
-                      mediaIds: [],
-                    },
+                  solution: {
+                    type: 'rich_text',
+                    format: 'md-math-v1',
+                    value: '3x+6=12',
+                    mediaIds: [],
                   },
-                ],
-                correctOptionIds: ['b'],
-              },
+                  fullSolution: {
+                    type: 'rich_text',
+                    format: 'md-math-v1',
+                    value: '3x+6=12 → x=2',
+                    mediaIds: [],
+                  },
+                  answer: {
+                    options: [
+                      {
+                        id: 'a',
+                        content: {
+                          type: 'rich_text',
+                          format: 'md-math-v1',
+                          value: 'x=1',
+                          mediaIds: [],
+                        },
+                      },
+                      {
+                        id: 'b',
+                        content: {
+                          type: 'rich_text',
+                          format: 'md-math-v1',
+                          value: 'x=2',
+                          mediaIds: [],
+                        },
+                      },
+                    ],
+                    correctOptionIds: ['b'],
+                  },
+                },
+              ],
             },
-          ],
-        },
-      }),
+          }),
+        }
+      } else {
+        return {
+          text: JSON.stringify({
+            solution: { type: 'rich_text', format: 'md-math-v1', value: 'x=2', mediaIds: [] },
+            fullSolution: {
+              type: 'rich_text',
+              format: 'md-math-v1',
+              value: '3x+6=12 → x=2',
+              mediaIds: [],
+            },
+            answer: { correctOptionIds: ['b'] },
+          }),
+        }
+      }
     })
 
     const inputExercise = makeMockExercise('ex-3')
-    const result = await generateVariation({ exercise: inputExercise, level: 'deep' }, mockPayload)
+    const result = await generateVariation(
+      { exercise: inputExercise, level: 'deep', subject: 'mixed' },
+      mockPayload,
+    )
 
     expect(result.exercise).toBeDefined()
-    // Verify no PNG fields in the result
     const resultText = JSON.stringify(result.exercise)
     expect(resultText).not.toMatch(/\.png/i)
     expect(resultText).not.toMatch(/image\/png/i)
   })
 
-  it('triggers exactly one retry on invalid JSON then throws VariationGenerationError', async () => {
-    // First call returns invalid JSON → JSON.parse throws → retry
-    mockGenerateChatCompletion.mockResolvedValueOnce({
-      text: 'not json {',
-    })
-    // Second call also returns invalid JSON → JSON.parse throws → retry exhausted → throw
-    mockGenerateChatCompletion.mockResolvedValueOnce({
-      text: 'still not json',
-    })
+  // ── Error handling tests ─────────────────────────────────────────────────
 
-    const inputExercise = makeMockExercise('ex-4')
+  it('pass1 retry exhausted throws VariationGenerationError', async () => {
+    // First call returns invalid JSON → retry → still invalid → throw
+    mockGenerateChatCompletion.mockResolvedValueOnce({ text: 'not json {' })
+    mockGenerateChatCompletion.mockResolvedValueOnce({ text: 'still not json' })
+
+    const inputExercise = makeMockExercise('ex-pass1-fail')
 
     await expect(
-      generateVariation({ exercise: inputExercise, level: 'light' }, mockPayload),
+      generateVariation({ exercise: inputExercise, level: 'light', subject: 'mixed' }, mockPayload),
     ).rejects.toThrow(VariationGenerationError)
 
-    // With the fix: each generateVariation makes 2 adapter calls (initial + one retry)
-    // This first call consumed both queued responses
+    // 2 calls (initial + retry)
     expect(mockGenerateChatCompletion).toHaveBeenCalledTimes(2)
+  })
 
-    // Set up fresh queue for second call
-    mockGenerateChatCompletion.mockResolvedValueOnce({ text: 'also invalid' })
-    mockGenerateChatCompletion.mockResolvedValueOnce({ text: 'still invalid' })
+  it('pass2 retry exhausted throws VariationGenerationError (pass1 succeeds)', async () => {
+    let callCount = 0
+    mockGenerateChatCompletion.mockImplementation(async () => {
+      callCount++
+      if (callCount === 1) {
+        // Pass 1: success
+        return {
+          text: JSON.stringify({
+            content: {
+              blocks: [
+                {
+                  id: 'block-1',
+                  type: 'question_select',
+                  variant: 'mcq',
+                  prompt: {
+                    type: 'rich_text',
+                    format: 'md-math-v1',
+                    value: 'What is $3+3$?',
+                    mediaIds: [],
+                  },
+                  answer: { options: [], correctOptionIds: ['a'] },
+                },
+              ],
+            },
+          }),
+        }
+      } else if (callCount === 2) {
+        // Pass 2: invalid JSON
+        return { text: 'not json {' }
+      } else {
+        // Pass 2 retry: still invalid
+        return { text: 'still not json' }
+      }
+    })
+
+    const inputExercise = makeMockExercise('ex-pass2-fail')
 
     await expect(
-      generateVariation({ exercise: inputExercise, level: 'light' }, mockPayload),
-    ).rejects.toMatchObject({
-      exerciseId: 'ex-4',
-    })
+      generateVariation(
+        { exercise: inputExercise, level: 'medium', subject: 'algebra' },
+        mockPayload,
+      ),
+    ).rejects.toThrow(VariationGenerationError)
 
-    // Second generateVariation also makes 2 adapter calls
-    expect(mockGenerateChatCompletion).toHaveBeenCalledTimes(4)
+    // 3 calls: pass1, pass2 (fail), pass2 retry (fail)
+    expect(mockGenerateChatCompletion).toHaveBeenCalledTimes(3)
   })
 
-  it('logs latency, level, exerciseId, retryCount per successful call', async () => {
-    mockGenerateChatCompletion.mockResolvedValueOnce({
-      text: JSON.stringify({
-        content: {
-          blocks: [
-            {
-              id: 'block-1',
-              type: 'question_select',
-              variant: 'mcq',
-              prompt: {
-                type: 'rich_text',
-                format: 'md-math-v1',
-                value: 'What is $5+5$?',
-                mediaIds: [],
-              },
-              answer: {
-                options: [
-                  {
-                    id: 'a',
-                    content: { type: 'rich_text', format: 'md-math-v1', value: '10', mediaIds: [] },
+  it('logs latency, level, subject, exerciseId per successful call', async () => {
+    mockGenerateChatCompletion.mockImplementation(async () => {
+      const callCount = mockGenerateChatCompletion.mock.calls.length
+
+      if (callCount === 1) {
+        return {
+          text: JSON.stringify({
+            content: {
+              blocks: [
+                {
+                  id: 'block-1',
+                  type: 'question_select',
+                  variant: 'mcq',
+                  prompt: {
+                    type: 'rich_text',
+                    format: 'md-math-v1',
+                    value: 'What is $5+5$?',
+                    mediaIds: [],
                   },
-                ],
-                correctOptionIds: ['a'],
-              },
+                  answer: { options: [], correctOptionIds: ['a'] },
+                },
+              ],
             },
-          ],
-        },
-      }),
+          }),
+        }
+      } else {
+        return {
+          text: JSON.stringify({
+            solution: { type: 'rich_text', format: 'md-math-v1', value: '5+5=10', mediaIds: [] },
+            fullSolution: {
+              type: 'rich_text',
+              format: 'md-math-v1',
+              value: '5+5=10',
+              mediaIds: [],
+            },
+            answer: { correctOptionIds: ['a'] },
+          }),
+        }
+      }
     })
 
-    const inputExercise = makeMockExercise('ex-5')
-    await generateVariation({ exercise: inputExercise, level: 'light' }, mockPayload)
+    const inputExercise = makeMockExercise('ex-log')
+    await generateVariation(
+      { exercise: inputExercise, level: 'light', subject: 'geometry' },
+      mockPayload,
+    )
 
-    expect(logger.info).toHaveBeenCalledTimes(1)
-    const logCall = (logger.info as ReturnType<typeof vi.fn>).mock.calls[0]
-    const logObject = logCall[0] as Record<string, unknown>
+    // Last log call is the two-pass complete log
+    const logCalls = (logger.info as ReturnType<typeof vi.fn>).mock.calls
+    const logObject = logCalls[logCalls.length - 1][0] as Record<string, unknown>
     expect(logObject).toHaveProperty('latencyMs')
     expect(logObject).toHaveProperty('level', 'light')
-    expect(logObject).toHaveProperty('exerciseId', 'ex-5')
-    expect(logObject).toHaveProperty('retryCount', 0)
+    expect(logObject).toHaveProperty('subject', 'geometry')
+    expect(logObject).toHaveProperty('exerciseId', 'ex-log')
   })
 
-  it('throws VariationGenerationError with correct exerciseId and reason on non-retryable error', async () => {
-    // Simulate a non-JSON error (e.g., LLM API error)
+  it('throws VariationGenerationError with correct exerciseId on non-retryable error', async () => {
     mockGenerateChatCompletion.mockImplementation(() => Promise.reject(new Error('API timeout')))
 
-    const inputExercise = makeMockExercise('ex-6')
+    const inputExercise = makeMockExercise('ex-api-fail')
 
     let error: unknown
     try {
-      await generateVariation({ exercise: inputExercise, level: 'medium' }, mockPayload)
+      await generateVariation(
+        { exercise: inputExercise, level: 'medium', subject: 'calculus' },
+        mockPayload,
+      )
     } catch (e) {
       error = e
     }
 
     expect(error).toBeInstanceOf(VariationGenerationError)
-    expect((error as VariationGenerationError).exerciseId).toBe('ex-6')
+    expect((error as VariationGenerationError).exerciseId).toBe('ex-api-fail')
     expect((error as VariationGenerationError).reason).toBe('API timeout')
 
-    // Should not have retried for non-JSON errors (only one call made)
+    // Only one call made (non-JSON error = no retry)
     expect(mockGenerateChatCompletion).toHaveBeenCalledTimes(1)
   })
 
   it('strips markdown code fences from LLM response', async () => {
-    mockGenerateChatCompletion.mockResolvedValueOnce({
-      text:
-        '```json\n' +
-        JSON.stringify({
-          content: {
-            blocks: [
-              {
-                id: 'block-1',
-                type: 'question_select',
-                variant: 'mcq',
-                prompt: {
-                  type: 'rich_text',
-                  format: 'md-math-v1',
-                  value: 'What is $7+7$?',
-                  mediaIds: [],
-                },
-                answer: {
-                  options: [
-                    {
-                      id: 'a',
-                      content: {
-                        type: 'rich_text',
-                        format: 'md-math-v1',
-                        value: '14',
-                        mediaIds: [],
-                      },
+    let callCount = 0
+    mockGenerateChatCompletion.mockImplementation(async () => {
+      callCount++
+      if (callCount === 1) {
+        return {
+          text:
+            '```json\n' +
+            JSON.stringify({
+              content: {
+                blocks: [
+                  {
+                    id: 'block-1',
+                    type: 'question_select',
+                    variant: 'mcq',
+                    prompt: {
+                      type: 'rich_text',
+                      format: 'md-math-v1',
+                      value: 'What is $7+7$?',
+                      mediaIds: [],
                     },
-                  ],
-                  correctOptionIds: ['a'],
-                },
+                    answer: { options: [], correctOptionIds: ['a'] },
+                  },
+                ],
               },
-            ],
-          },
-        }) +
-        '\n```',
+            }) +
+            '\n```',
+        }
+      } else {
+        return {
+          text: JSON.stringify({
+            solution: { type: 'rich_text', format: 'md-math-v1', value: '7+7=14', mediaIds: [] },
+            fullSolution: {
+              type: 'rich_text',
+              format: 'md-math-v1',
+              value: '7+7=14',
+              mediaIds: [],
+            },
+            answer: { correctOptionIds: ['a'] },
+          }),
+        }
+      }
     })
 
-    const inputExercise = makeMockExercise('ex-7')
-    const result = await generateVariation({ exercise: inputExercise, level: 'deep' }, mockPayload)
+    const inputExercise = makeMockExercise('ex-fence')
+    const result = await generateVariation(
+      { exercise: inputExercise, level: 'deep', subject: 'mixed' },
+      mockPayload,
+    )
 
     expect(result.exercise).toBeDefined()
     const resultBlock = (result.exercise.content as { blocks: unknown[] }).blocks[0] as {
       prompt: { value: string }
     }
     expect(resultBlock.prompt.value).toBe('What is $7+7$?')
-  })
-
-  it('retries once and throws when LLM returns empty object missing content.blocks', async () => {
-    const inputExercise = makeMockExercise('ex-8')
-    let callCount = 0
-
-    // Directly mock createGenkitUnifiedAdapter per-call to ensure fresh mock each loop iteration
-    ;(createGenkitUnifiedAdapter as ReturnType<typeof vi.fn>).mockImplementation(async () => {
-      callCount++
-      const chatCompletion = vi.fn().mockResolvedValueOnce({ text: '{}' })
-      return { generateChatCompletion: chatCompletion }
-    })
-
-    await expect(
-      generateVariation({ exercise: inputExercise, level: 'light' }, mockPayload),
-    ).rejects.toThrow(VariationGenerationError)
-
-    // Verify the retry mechanism triggered (adapter called twice: initial + one retry)
-    expect(callCount).toBe(2)
   })
 })


### PR DESCRIPTION
## Summary

- `pnpm install --frozen-lockfile` was failing with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` because the PR's lockfile had removed the `overrides` section for `@modelcontextprotocol/sdk` while the CI runner's cached lockfile still had it.
- Running `pnpm install --no-frozen-lockfile` regenerated the lockfile, restoring the `overrides` section and aligning the resolution to the correct pinned state.
- Verified `--frozen-lockfile` now succeeds locally.

## Changes

- `pnpm-lock.yaml`
- `src/payload-types.ts`

Closes #1543

---
_Opened by kody (single-session autonomous run)._ 