### PR TITLE
#1549: Lower temperature on deterministic pass, raise thinking budget f…

### DIFF
--- a/src/infra/llm/models.ts
+++ b/src/infra/llm/models.ts
@@ -63,6 +63,7 @@ export type AIModelKey =
   | 'ANSWER_VALIDATION'
   | 'SUPPORT_GENERATION'
   | 'CONTENT_TRANSLATION'
+  /** @deprecated Use LESSON_DUPLICATION_VARIATION_CREATIVE or LESSON_DUPLICATION_VARIATION_DETERMINISTIC */
   | 'LESSON_DUPLICATION_VARIATION'
   | 'LESSON_DUPLICATION_VARIATION_CREATIVE'
   | 'LESSON_DUPLICATION_VARIATION_DETERMINISTIC'
@@ -120,11 +121,13 @@ export const MODEL_REGISTRY: Record<AIModelKey, Omit<AIModel, 'name'>> = {
   LESSON_DUPLICATION_VARIATION_CREATIVE: {
     temperature: 0.7,
     maxOutputTokens: 8192,
+    thinkingBudget: 4000,
     capabilities: ['chat', 'generation'],
   },
   LESSON_DUPLICATION_VARIATION_DETERMINISTIC: {
     temperature: 0.0,
     maxOutputTokens: 8192,
+    thinkingBudget: 6000,
     capabilities: ['chat', 'generation'],
   },
 } as const

--- a/tests/unit/server/llm/services/lesson-duplication-variation-service-repro-1549.test.ts
+++ b/tests/unit/server/llm/services/lesson-duplication-variation-service-repro-1549.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+
+/**
+ * Repro test for issue #1549:
+ * Lower temperature on deterministic pass, raise thinking budget for medium/deep
+ *
+ * Requirements:
+ * - LESSON_DUPLICATION_VARIATION_CREATIVE: temperature 0.7, thinkingBudget 4000, maxOutputTokens 8192
+ * - LESSON_DUPLICATION_VARIATION_DETERMINISTIC: temperature 0.0, thinkingBudget 6000, maxOutputTokens 8192
+ *
+ * Both use Gemini 3.1 Pro on the Gemini provider and MiniMax-M2.1 on the OpenAI-compatible fallback.
+ */
+import { MODEL_REGISTRY, getModelRegistryEntry } from '@/infra/llm/models'
+
+describe('issue #1549 - thinking budget for creative and deterministic passes', () => {
+  describe('LESSON_DUPLICATION_VARIATION_CREATIVE model config', () => {
+    it('should have temperature 0.7', () => {
+      const config = getModelRegistryEntry('LESSON_DUPLICATION_VARIATION_CREATIVE')
+      expect(config.temperature).toBe(0.7)
+    })
+
+    it('should have thinkingBudget 4000', () => {
+      const config = getModelRegistryEntry('LESSON_DUPLICATION_VARIATION_CREATIVE')
+      expect(config.thinkingBudget).toBe(4000)
+    })
+
+    it('should have maxOutputTokens 8192', () => {
+      const config = getModelRegistryEntry('LESSON_DUPLICATION_VARIATION_CREATIVE')
+      expect(config.maxOutputTokens).toBe(8192)
+    })
+  })
+
+  describe('LESSON_DUPLICATION_VARIATION_DETERMINISTIC model config', () => {
+    it('should have temperature 0.0', () => {
+      const config = getModelRegistryEntry('LESSON_DUPLICATION_VARIATION_DETERMINISTIC')
+      expect(config.temperature).toBe(0.0)
+    })
+
+    it('should have thinkingBudget 6000', () => {
+      const config = getModelRegistryEntry('LESSON_DUPLICATION_VARIATION_DETERMINISTIC')
+      expect(config.thinkingBudget).toBe(6000)
+    })
+
+    it('should have maxOutputTokens 8192', () => {
+      const config = getModelRegistryEntry('LESSON_DUPLICATION_VARIATION_DETERMINISTIC')
+      expect(config.maxOutputTokens).toBe(8192)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- `src/infra/llm/models.ts`: Added `thinkingBudget: 4000` to `LESSON_DUPLICATION_VARIATION_CREATIVE` and `thinkingBudget: 6000` to `LESSON_DUPLICATION_VARIATION_DETERMINISTIC` in `MODEL_REGISTRY`; added `@deprecated` JSDoc to `LESSON_DUPLICATION_VARIATION` in the `AIModelKey` type union
- All 6 repro assertions now pass (thinkingBudget 4000/6000 confirmed in registry)
- All 10 existing service tests pass
- 224 unit test files pass (2982 tests), 0 failures
- `pnpm typecheck` zero errors, `pnpm lint` zero errors

## Changes

- `src/infra/llm/models.ts`

Closes #1549

---
_Opened by kody (single-session autonomous run)._ 