### PR TITLE
feat(lesson-duplication): Auto-detect lesson subject from exercise block types

### DIFF
--- a/src/app/api/lessons/[id]/suggested-subject/route.ts
+++ b/src/app/api/lessons/[id]/suggested-subject/route.ts
@@ -1,0 +1,63 @@
+/**
+ * Suggested Subject API
+ *
+ * GET /api/lessons/:id/suggested-subject
+ *
+ * Returns a suggested `DuplicationSubject` for a lesson, derived from the
+ * blocks of its exercises. Used by the lesson duplicate modal to pre-fill
+ * the subject radio before the admin submits.
+ *
+ * @fileType api-route
+ * @domain lesson-duplication
+ * @pattern subject-detection
+ * @ai-summary Reads a lesson's exercises and guesses subject by block types.
+ *
+ * Access: admin only.
+ */
+import { withApiHandler } from '@/server/api/with-api-handler'
+import { apiSuccess, ApiErrors } from '@/server/api/responses'
+import { getPayload } from 'payload'
+import configPromise from '@payload-config'
+
+import {
+  detectLessonSubject,
+  type ExerciseLikeBlocks,
+} from '@/server/services/lesson-duplication/subject-detector'
+
+export const GET = withApiHandler<unknown, unknown>({ auth: 'admin' }, async ({ request }) => {
+  const payload = await getPayload({ config: configPromise })
+
+  // Extract id from route: /api/lessons/:id/suggested-subject
+  const url = new URL(request.url || 'http://localhost')
+  const match = url.pathname.match(/\/lessons\/([^/]+)\/suggested-subject/)
+  const lessonId = match?.[1]
+  if (!lessonId) {
+    return ApiErrors.notFound('lesson id')
+  }
+
+  // Verify the lesson exists (so we return 404 instead of an empty 200).
+  try {
+    await payload.findByID({
+      collection: 'lessons',
+      id: lessonId,
+      depth: 0,
+      overrideAccess: true,
+    })
+  } catch {
+    return ApiErrors.notFound(`Lesson "${lessonId}"`)
+  }
+
+  // Fetch every exercise that belongs to the lesson. depth=0 keeps the payload small;
+  // we only need `content.blocks` for detection.
+  const exercises = await payload.find({
+    collection: 'exercises',
+    where: { lesson: { equals: lessonId } },
+    limit: 0,
+    depth: 0,
+    overrideAccess: true,
+  })
+
+  const subject = detectLessonSubject(exercises.docs as unknown as ExerciseLikeBlocks[])
+
+  return apiSuccess({ lessonId, subject, exerciseCount: exercises.docs.length })
+})

--- a/src/server/services/lesson-duplication/subject-detector.ts
+++ b/src/server/services/lesson-duplication/subject-detector.ts
@@ -1,0 +1,76 @@
+/**
+ * Subject Auto-Detection from Lesson Block Content
+ *
+ * @fileType utility
+ * @domain lesson-duplication
+ * @pattern subject-detector
+ * @ai-summary Scans the blocks of every exercise in a lesson to guess the lesson's subject (algebra/geometry/calculus/mixed).
+ *
+ * Rules:
+ *   - Any `question_geometry` block → contributes "geometry".
+ *   - Any `question_axis` or `question_multi_axis` block → contributes "calculus" (graph plots are typically
+ *     used to teach functions/derivatives/integrals at this level of curriculum).
+ *   - Both contribute → "mixed".
+ *   - Neither contribute → "algebra" (the default for non-visual math exercises).
+ *
+ * Returns one of the canonical `DuplicationSubject` values from
+ * `LessonDuplications`. Never returns null; the worst case is "algebra".
+ */
+
+import type { ContentBlock } from '@/server/payload/collections/Exercises/schemas'
+import type { DuplicationSubject } from '@/server/payload/collections/LessonDuplications'
+
+/** Shape we read from each exercise — just the blocks. */
+export interface ExerciseLikeBlocks {
+  content?: { blocks?: ContentBlock[] } | null
+}
+
+/** True for geometry-shaped blocks. */
+function isGeometryBlock(block: ContentBlock): boolean {
+  return block.type === 'question_geometry'
+}
+
+/** True for axis (single or multi) graph blocks. */
+function isAxisBlock(block: ContentBlock): boolean {
+  return block.type === 'question_axis' || block.type === 'question_multi_axis'
+}
+
+/**
+ * Inspect a single exercise's blocks for geometry / axis signal.
+ * Returns the two booleans separately so the caller can aggregate across exercises.
+ */
+function scanExerciseBlocks(exercise: ExerciseLikeBlocks): { geometry: boolean; axis: boolean } {
+  const blocks = exercise.content?.blocks ?? []
+  let geometry = false
+  let axis = false
+  for (const block of blocks) {
+    if (!geometry && isGeometryBlock(block)) geometry = true
+    if (!axis && isAxisBlock(block)) axis = true
+    if (geometry && axis) break // early exit — exercise already mixed
+  }
+  return { geometry, axis }
+}
+
+/**
+ * Detect the subject of a lesson by scanning the blocks of every exercise.
+ *
+ * @param exercises  All exercises that belong to the lesson being duplicated.
+ *                   Each item just needs `content.blocks[]`.
+ * @returns          The detected `DuplicationSubject`. Default is "algebra".
+ */
+export function detectLessonSubject(exercises: ExerciseLikeBlocks[]): DuplicationSubject {
+  let anyGeometry = false
+  let anyAxis = false
+
+  for (const exercise of exercises) {
+    const { geometry, axis } = scanExerciseBlocks(exercise)
+    if (geometry) anyGeometry = true
+    if (axis) anyAxis = true
+    if (anyGeometry && anyAxis) break // early exit — lesson is already mixed
+  }
+
+  if (anyGeometry && anyAxis) return 'mixed'
+  if (anyGeometry) return 'geometry'
+  if (anyAxis) return 'calculus'
+  return 'algebra'
+}

--- a/src/ui/admin/LessonDuplicateButton/LessonDuplicateButton.tsx
+++ b/src/ui/admin/LessonDuplicateButton/LessonDuplicateButton.tsx
@@ -8,7 +8,7 @@
  * @pattern admin-action-modal
  * @ai-summary Opens a modal to pick a variation level, then POSTs to /api/lessons/:id/duplicate.
  */
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useDocumentInfo } from '@payloadcms/ui'
 
 const LEVELS: { value: 'none' | 'light' | 'medium' | 'deep'; label: string; hint: string }[] = [
@@ -69,15 +69,45 @@ export const LessonDuplicateAction: React.FC = () => {
   const [open, setOpen] = useState(false)
   const [level, setLevel] = useState<(typeof LEVELS)[number]['value'] | ''>('')
   const [subject, setSubject] = useState<(typeof SUBJECTS)[number]['value']>('mixed')
+  const [subjectAutoDetected, setSubjectAutoDetected] = useState(false)
   const [status, setStatus] = useState<Status>('idle')
   const [error, setError] = useState<string | null>(null)
   const [resultId, setResultId] = useState<string | null>(null)
+
+  // When the modal opens, ask the server to suggest a subject based on the
+  // lesson's exercise blocks (geometry / axis / both / none → mixed/geo/calc/algebra).
+  // Admin can still override the radio selection.
+  useEffect(() => {
+    if (!open || !id) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await fetch(`/api/lessons/${id}/suggested-subject`, {
+          credentials: 'include',
+        })
+        if (!res.ok) return
+        const data = (await res.json()) as {
+          data?: { subject?: (typeof SUBJECTS)[number]['value'] }
+        }
+        const suggested = data.data?.subject
+        if (cancelled || !suggested) return
+        setSubject(suggested)
+        setSubjectAutoDetected(true)
+      } catch {
+        // Soft-fail: keep the default ('mixed').
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [open, id])
 
   if (!id) return null
 
   const reset = () => {
     setLevel('')
     setSubject('mixed')
+    setSubjectAutoDetected(false)
     setStatus('idle')
     setError(null)
     setResultId(null)
@@ -205,6 +235,18 @@ export const LessonDuplicateAction: React.FC = () => {
 
             <p style={{ fontSize: 13, color: 'var(--theme-elevation-600)', marginTop: 16 }}>
               Subject area
+              {subjectAutoDetected && (
+                <span
+                  style={{
+                    marginLeft: 8,
+                    fontSize: 11,
+                    color: 'var(--theme-success-500)',
+                    fontWeight: 500,
+                  }}
+                >
+                  · auto-detected (override below if wrong)
+                </span>
+              )}
             </p>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 16 }}>
               {SUBJECTS.map((opt) => (

--- a/tests/unit/server/services/lesson-duplication/subject-detector.spec.ts
+++ b/tests/unit/server/services/lesson-duplication/subject-detector.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for src/server/services/lesson-duplication/subject-detector.ts
+ */
+import { describe, expect, it } from 'vitest'
+
+import { detectLessonSubject } from '@/server/services/lesson-duplication/subject-detector'
+
+// Block factories — only fields the detector reads matter, the rest can be
+// loose; cast through unknown so we don't have to satisfy the full Zod schema.
+const geometryBlock = { id: 'g', type: 'question_geometry' } as unknown
+const axisBlock = { id: 'a', type: 'question_axis' } as unknown
+const multiAxisBlock = { id: 'ma', type: 'question_multi_axis' } as unknown
+const richTextBlock = { id: 'r', type: 'rich_text' } as unknown
+const mcqBlock = { id: 'q', type: 'question_select' } as unknown
+
+function exerciseWith(blocks: unknown[]) {
+  return { content: { blocks } } as never
+}
+
+describe('detectLessonSubject', () => {
+  it('returns "algebra" when no exercises are provided', () => {
+    expect(detectLessonSubject([])).toBe('algebra')
+  })
+
+  it('returns "algebra" when exercises have no geometry / axis blocks', () => {
+    const exercises = [exerciseWith([richTextBlock, mcqBlock]), exerciseWith([richTextBlock])]
+    expect(detectLessonSubject(exercises)).toBe('algebra')
+  })
+
+  it('returns "geometry" when any exercise has a geometry block and none have axis', () => {
+    const exercises = [
+      exerciseWith([richTextBlock]),
+      exerciseWith([geometryBlock, richTextBlock]),
+      exerciseWith([mcqBlock]),
+    ]
+    expect(detectLessonSubject(exercises)).toBe('geometry')
+  })
+
+  it('returns "calculus" when any exercise has an axis block and none have geometry', () => {
+    const exercises = [exerciseWith([axisBlock, richTextBlock]), exerciseWith([mcqBlock])]
+    expect(detectLessonSubject(exercises)).toBe('calculus')
+  })
+
+  it('treats question_multi_axis the same as question_axis', () => {
+    expect(detectLessonSubject([exerciseWith([multiAxisBlock])])).toBe('calculus')
+  })
+
+  it('returns "mixed" when both geometry and axis blocks appear across exercises', () => {
+    const exercises = [exerciseWith([geometryBlock]), exerciseWith([axisBlock])]
+    expect(detectLessonSubject(exercises)).toBe('mixed')
+  })
+
+  it('returns "mixed" when one exercise contains both geometry and axis blocks', () => {
+    const exercises = [exerciseWith([geometryBlock, axisBlock, richTextBlock])]
+    expect(detectLessonSubject(exercises)).toBe('mixed')
+  })
+
+  it('handles missing content / blocks gracefully', () => {
+    const exercises = [
+      { content: null } as never,
+      { content: { blocks: undefined } } as never,
+      {} as never,
+    ]
+    expect(detectLessonSubject(exercises)).toBe('algebra')
+  })
+})


### PR DESCRIPTION
Hand-rolled implementation of the subject auto-detector (was originally tracked as #1550 but Kody kept aborting on that issue's branch).

## Detection rule
- Any \`question_geometry\` block in any exercise → **geometry**
- Any \`question_axis\` or \`question_multi_axis\` block → **calculus**
- Both present → **mixed**
- Neither → **algebra** (default)

## Changes
- New helper \`detectLessonSubject(exercises)\` in \`src/server/services/lesson-duplication/subject-detector.ts\` — pure function, no I/O, walks each exercise's \`content.blocks[]\` and aggregates.
- New endpoint \`GET /api/lessons/:id/suggested-subject\` (admin-only) — fetches the lesson's exercises and returns \`{ subject, exerciseCount }\`.
- Modal (\`LessonDuplicateButton.tsx\`) calls the endpoint when it opens, pre-selects the returned subject, and shows an "auto-detected (override below if wrong)" badge.

## Test plan
- [x] 8 unit tests covering all rule combinations + missing-content edge cases
- [x] \`pnpm typecheck\` clean
- [x] Pre-push verification passed
- [ ] CI green
- [ ] Manual smoke in admin