### PR TITLE
fix(husky): Allow legacy issue-number branch names

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -56,8 +56,12 @@ if [ -n "$GITHUB_ACTIONS" ] || [ "$branch" = "dev" ]; then
   echo "ℹ️  CI environment detected. Skipping branch naming convention check."
   echo ""
 else
-  # Allowed patterns: feat/, fix/, chore/, docs/, refactor/, test/, security/
-  if ! echo "$branch" | grep -qE '^(feat|fix|chore|docs|refactor|test|security)/[a-z0-9-]+$'; then
+  # Allowed patterns:
+  #   - Conventional: feat|fix|chore|docs|refactor|test|security/<description>
+  #   - Legacy issue-number: <number>-<description> (e.g. 1552-track-ai-tokens)
+  #     Some in-flight branches predate the conventional scheme and are tied to
+  #     GitHub issue numbers; keep them passing so their PRs aren't blocked.
+  if ! echo "$branch" | grep -qE '^((feat|fix|chore|docs|refactor|test|security)/[a-z0-9-]+|[0-9]+-[a-z0-9-]+)$'; then
     echo ""
     echo "❌ ERROR: Invalid branch name: '$branch'"
     echo ""

--- a/docs/specs/COMMIT_GUIDE.md
+++ b/docs/specs/COMMIT_GUIDE.md
@@ -33,8 +33,9 @@ Make commits that pass all pre-commit hooks in <15 seconds.
 ### Branch Naming
 
 ```
-Pattern: <type>/<description-in-kebab-case>
-Regex:   ^(feat|fix|chore|docs|refactor|test|security)/[a-z0-9-]+$
+Preferred: <type>/<description-in-kebab-case>
+Legacy:    <issue-number>-<description-in-kebab-case>
+Regex:     ^((feat|fix|chore|docs|refactor|test|security)/[a-z0-9-]+|[0-9]+-[a-z0-9-]+)$
 ```
 
 | Type | Use Case | Example |
@@ -46,6 +47,10 @@ Regex:   ^(feat|fix|chore|docs|refactor|test|security)/[a-z0-9-]+$
 | `refactor/` | Code restructuring | `refactor/auth-service` |
 | `test/` | Tests | `test/integration` |
 | `security/` | Security fixes | `fix/xss-vuln` |
+| `<num>-` | Legacy, tied to GitHub issue | `1552-track-ai-tokens` |
+
+> Use the conventional prefixes for new branches. The legacy issue-number form
+> is accepted to keep in-flight PRs that pre-date this rule from being blocked.
 
 **Rename:** `git branch -m feat/new-name`
 


### PR DESCRIPTION
## Summary

- Extend the pre-commit branch-name regex to accept the legacy `<issue-number>-<kebab-desc>` form (e.g. `1552-track-ai-tokens`) alongside the conventional `feat|fix|chore|docs|refactor|test|security/<desc>` prefixes.
- Update `docs/specs/COMMIT_GUIDE.md` to document the legacy pattern as accepted-but-not-preferred.

## Why

A handful of in-flight branches (notably #1561) pre-date the conventional-prefix rule and use the GitHub issue-number naming pattern. After the latest `dev` hook update, those branches couldn't commit at all — even merge commits were blocked locally. Renaming would orphan the PR. Loosening the regex is the minimum-blast-radius fix.

## Test plan

- [x] Regex still rejects `BAD_NAME`, `feat/Bad-Caps`, `1552`, `1552-`
- [x] Regex accepts `feat/user-auth`, `fix/login-bug`, `1552-track-ai-tokens-cost-and-run-duration-on-each-less`
- [x] Self-hosted: this PR's branch (`fix/branch-name-allow-legacy-numeric`) commits cleanly