### PR TITLE
#1595: [P2] Vercel feedback script blocked by CSP script-src directive …

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -174,7 +174,7 @@ const nextConfig = {
           {
             key: 'Content-Security-Policy',
             value:
-              "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.googletagmanager.com https://cdn.mxpnl.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' *.blob.vercel-storage.com img.youtube.com avatars.githubusercontent.com github.com *.githubusercontent.com data: blob:; font-src 'self' data:; connect-src 'self' *.sentry.io https://blob.vercel-storage.com https://*.blob.vercel-storage.com https://api-js.mixpanel.com https://*.mxpnl.com; frame-src 'self' www.youtube.com vercel.live; frame-ancestors 'self' https://kody-dashboard-aguy.vercel.app; object-src 'none'; base-uri 'self'; form-action 'self'",
+              "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://vercel.live https://www.googletagmanager.com https://cdn.mxpnl.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' *.blob.vercel-storage.com img.youtube.com avatars.githubusercontent.com github.com *.githubusercontent.com data: blob:; font-src 'self' data:; connect-src 'self' *.sentry.io https://vercel.live https://blob.vercel-storage.com https://*.blob.vercel-storage.com https://api-js.mixpanel.com https://*.mxpnl.com; frame-src 'self' www.youtube.com vercel.live; frame-ancestors 'self' https://kody-dashboard-aguy.vercel.app; object-src 'none'; base-uri 'self'; form-action 'self'",
           },
           { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' },
           { key: 'X-Content-Type-Options', value: 'nosniff' },

--- a/tests/int/csp-vercel-feedback-admin.int.spec.ts
+++ b/tests/int/csp-vercel-feedback-admin.int.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import fs from 'fs'
+
+/**
+ * CSP Configuration Tests - Issue #1595
+ *
+ * Tests that Content-Security-Policy headers allow Vercel feedback script
+ * to load on /admin routes.
+ *
+ * Bug: Vercel feedback script (https://vercel.live/_next-live/feedback/feedback.js)
+ * is blocked on /admin because vercel.live is not in the script-src directive.
+ */
+
+describe('CSP Configuration - Vercel Feedback Script on /admin', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url))
+  const projectRoot = path.resolve(__dirname, '../..')
+  const nextConfigPath = path.join(projectRoot, 'next.config.js')
+
+  // Helper to extract CSP value from headers array
+  function extractCSPValue(headers: Array<{ key: string; value: string }>): string | null {
+    const cspHeader = headers.find((h) => h.key === 'Content-Security-Policy')
+    return cspHeader?.value ?? null
+  }
+
+  // Helper to extract script-src directive from CSP string
+  function extractScriptSrc(csp: string): string | null {
+    const match = csp.match(/script-src\s+([^;]+)/)
+    return match ? match[1] : null
+  }
+
+  it('should include vercel.live in script-src for general routes', async () => {
+    const configContent = fs.readFileSync(nextConfigPath, 'utf8')
+
+    // Extract the general routes CSP (the first one, not /admin/:path*)
+    const generalRouteMatch = configContent.match(
+      /source:\s*'\/\(\(\?!api\/pdfjs-viewer\)\.\*\)'[\s\S]*?Content-Security-Policy[\s\S]*?value:\s*"([^"]+)"/,
+    )
+    expect(generalRouteMatch).not.toBeNull()
+
+    const csp = generalRouteMatch![1]
+    const scriptSrc = extractScriptSrc(csp)
+
+    expect(scriptSrc).not.toBeNull()
+    // General routes SHOULD have vercel.live in script-src (this is the baseline)
+    expect(scriptSrc).toContain('vercel.live')
+  })
+
+  it('should include vercel.live in script-src for /admin routes', async () => {
+    const configContent = fs.readFileSync(nextConfigPath, 'utf8')
+
+    // Extract the /admin route CSP
+    const adminRouteMatch = configContent.match(
+      /source:\s*'\/admin\/:path\*'[\s\S]*?Content-Security-Policy[\s\S]*?value:\s*"([^"]+)"/,
+    )
+    expect(adminRouteMatch).not.toBeNull()
+
+    const csp = adminRouteMatch![1]
+    const scriptSrc = extractScriptSrc(csp)
+
+    expect(scriptSrc).not.toBeNull()
+    // Admin routes MUST have vercel.live in script-src for Vercel feedback to work
+    expect(scriptSrc).toContain('vercel.live')
+  })
+
+  it('should include vercel.live in connect-src for /admin routes', async () => {
+    const configContent = fs.readFileSync(nextConfigPath, 'utf8')
+
+    // Extract the /admin route CSP
+    const adminRouteMatch = configContent.match(
+      /source:\s*'\/admin\/:path\*'[\s\S]*?Content-Security-Policy[\s\S]*?value:\s*"([^"]+)"/,
+    )
+    expect(adminRouteMatch).not.toBeNull()
+
+    const csp = adminRouteMatch![1]
+    const connectSrcMatch = csp.match(/connect-src\s+([^;]+)/)
+
+    expect(connectSrcMatch).not.toBeNull()
+    const connectSrc = connectSrcMatch![1]
+    // Admin routes should have vercel.live in connect-src for WebSocket connections
+    expect(connectSrc).toContain('vercel.live')
+  })
+})


### PR DESCRIPTION
## Summary

- `next.config.js` (line 177): Added `https://vercel.live` to the admin route's `script-src` and `connect-src` CSP directives, matching the general route CSP pattern
- `tests/int/csp-vercel-feedback-admin.int.spec.ts`: Fixed 4 TypeScript null-check errors by adding non-null assertions (`!`) after `expect().not.toBeNull()` guards

## Changes

- `next.config.js`
- `tests/int/csp-vercel-feedback-admin.int.spec.ts`

Closes #1595

---
_Opened by kody (single-session autonomous run)._ 