### PR TITLE
chore: Pin pnpm to 10.33.0 via packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,5 +235,6 @@
     "overrides": {
       "@modelcontextprotocol/sdk": ">=1.25.2"
     }
-  }
+  },
+  "packageManager": "pnpm@10.33.0"
 }


### PR DESCRIPTION
## Summary
- Adds `"packageManager": "pnpm@10.33.0"` to package.json
- No lockfile regeneration needed (frozen install already passes under pnpm 10 locally)

## Why
The kody runner image activates `pnpm@latest` (11.x) via corepack. Pnpm 11 applies a stricter overrides-config check and rejects this lockfile with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`, blocking vibe execution at the verify install step. Pnpm 10 reads the same files as consistent.

Pinning makes the pnpm version explicit and reproducible across the runner, local dev, and CI.

## Test plan
- [x] `pnpm install --frozen-lockfile` passes locally under pnpm 10.33.0
- [ ] Next vibe execution clones with the pin → corepack picks up 10.33.0 → install passes