### PR TITLE
chore: Pin pnpm to 10.33.0 via packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -236,5 +236,6 @@
     "overrides": {
       "@modelcontextprotocol/sdk": ">=1.25.2"
     }
-  }
+  },
+  "packageManager": "pnpm@10.33.0"
 }


### PR DESCRIPTION
## Summary
- Adds `"packageManager": "pnpm@10.33.0"` to package.json
- No lockfile regeneration needed (frozen install already passes under pnpm 10)

## Why
Kody runner image activates `pnpm@latest` (11.x). Pnpm 11 rejects this lockfile with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` due to stricter overrides-config checks — pnpm 10 reads the same files as consistent.

Pinning makes the pnpm version explicit + reproducible across runner, local dev, and CI.

## Test plan
- [x] `pnpm install --frozen-lockfile` passes locally under pnpm 10.33.0
- [ ] Next vibe execution (after runner is updated to clone the default branch) picks up the pin → install passes