### PR TITLE
feat(lesson-duplication): Process Now button for manual orchestrator trigger

### DIFF
--- a/src/app/api/lesson-duplications/[id]/process-now/route.ts
+++ b/src/app/api/lesson-duplications/[id]/process-now/route.ts
@@ -1,0 +1,48 @@
+/**
+ * Manual orchestrator trigger for a single LessonDuplications record.
+ *
+ * POST /api/lesson-duplications/:id/process-now
+ *
+ * Admin-only. Calls runDuplicationOrchestrator on the record with the same
+ * deadline behaviour as the cron worker: process as many exercises as fit in
+ * the Vercel function lifetime, then return. If work remains, the record
+ * stays in `running` and the next cron tick (or manual click) continues from
+ * there.
+ *
+ * Use cases:
+ *  - Dev environments where Vercel cron schedules don't fire (preview tier).
+ *  - Production "kick now" for an admin who doesn't want to wait for the
+ *    next 1-minute cron tick.
+ *  - Resuming a record that the cron worker skipped (e.g. lock held by a
+ *    crashed previous tick — though those expire in CLAIM_LOCK_MS).
+ */
+import { withApiHandler } from '@/server/api/with-api-handler'
+import { apiSuccess, ApiErrors } from '@/server/api/responses'
+import { getPayload } from 'payload'
+import configPromise from '@payload-config'
+import { runDuplicationOrchestrator } from '@/server/services/lesson-duplication/orchestrator'
+
+// Match the cron worker's budget so an admin click has the same ceiling as
+// a cron tick — no surprise differences in how much progress each makes.
+export const maxDuration = 800
+const HEADROOM_MS = 30_000
+
+export const POST = withApiHandler<unknown, unknown>({ auth: 'admin' }, async ({ request }) => {
+  const url = new URL(request.url || 'http://localhost')
+  const match = url.pathname.match(/\/lesson-duplications\/([^/]+)\/process-now/)
+  const duplicationId = match?.[1]
+  if (!duplicationId) return ApiErrors.notFound('duplication id')
+
+  const payload = await getPayload({ config: configPromise })
+
+  const startedAt = Date.now()
+  const deadlineMs = startedAt + (maxDuration * 1000 - HEADROOM_MS)
+
+  const outcome = await runDuplicationOrchestrator(duplicationId, payload, { deadlineMs })
+
+  return apiSuccess({
+    duplicationId,
+    outcome,
+    elapsedMs: Date.now() - startedAt,
+  })
+})

--- a/src/server/payload/endpoints/lessons/export.ts
+++ b/src/server/payload/endpoints/lessons/export.ts
@@ -29,21 +29,23 @@ import type { PayloadRequest } from 'payload'
 
 type BlockEntry = { id: string; blockType: string; exercise?: string; contentPage?: string }
 
-/** Strip Payload-managed fields from a doc */
+/**
+ * Strip Payload-managed timestamp fields from a doc. The `id` is preserved —
+ * it's data (not a server-managed timestamp), and downstream consumers need
+ * it to round-trip the export back into the system. The endpoint's documented
+ * JSON shape and its integration test both require `id` to be present.
+ */
 function stripManagedFields<T extends Record<string, unknown>>(
   doc: T,
-): Omit<T, 'id' | 'createdAt' | 'updatedAt'> {
+): Omit<T, 'createdAt' | 'updatedAt'> {
   const {
-    id: _id,
     createdAt: _c,
     updatedAt: _u,
     ...rest
   } = doc as T & {
-    id?: unknown
     createdAt?: unknown
     updatedAt?: unknown
   }
-  void _id
   void _c
   void _u
   return rest
@@ -126,9 +128,10 @@ export async function exportLessonEndpoint(req: PayloadRequest): Promise<Respons
     }
   }
 
-  // 6) Build response — strip managed fields from lesson
-  const { id: _lid, createdAt: _lca, updatedAt: _lua, blocks: _lb, ...lessonData } = lesson
-  void _lid
+  // 6) Build response — strip managed timestamps + raw blocks (the lesson's
+  // `blocks` field is a serialized JSON string for storage; we expose the
+  // ordered exercises array via `exercises` instead). `id` is preserved.
+  const { createdAt: _lca, updatedAt: _lua, blocks: _lb, ...lessonData } = lesson
   void _lca
   void _lua
   void _lb

--- a/src/server/services/lesson-duplication/orchestrator.ts
+++ b/src/server/services/lesson-duplication/orchestrator.ts
@@ -19,7 +19,10 @@ import type { Exercise } from '@/payload-types'
 import type { ContentBlock } from '@/server/payload/collections/Exercises/schemas'
 import type { DuplicationSubject } from '@/server/payload/collections/LessonDuplications'
 import { logger } from '@/infra/utils/logger'
-import { selectExercisesScaled } from '@/server/services/lesson-duplication/selectors'
+import {
+  selectExercisesScaled,
+  selectSectionsScaled,
+} from '@/server/services/lesson-duplication/selectors'
 import { getSourceExercisesForLesson } from '@/server/services/lesson-duplication/source-exercises'
 import {
   validateExerciseStructural,
@@ -80,6 +83,35 @@ export async function runStrategy(
     exerciseId: exercise.id,
     strategy: result.needsAiFallback ? 'ai' : 'script',
     blocks: content.blocks ?? [],
+  }
+}
+
+/**
+ * Cap source-exercise block count to match the structural validator's
+ * `TOO_MANY_SECTIONS` ceiling (5). Pure: returns a NEW exercise object with
+ * a trimmed `content.blocks` array when needed, otherwise the original.
+ *
+ * Picks 5 representative blocks from the source via `selectSectionsScaled` —
+ * the same scaling-random bucketing the lesson-level selector uses. Preserves
+ * source order, so the variation reads like a natural shorter version of the
+ * original rather than a random shuffle.
+ *
+ * Rationale: without this, a 10-block source always failed validation
+ * (TOO_MANY_SECTIONS is a blocking failure → exercise dropped from output).
+ * Admins doing deep variations on real lessons would silently lose any
+ * exercise that exceeded the block cap.
+ */
+function trimSourceBlocksIfNeeded(exercise: ExerciseDoc): ExerciseDoc {
+  const blocks = exercise.content?.blocks
+  if (!Array.isArray(blocks) || blocks.length <= 5) return exercise
+  const picked = selectSectionsScaled(blocks, 5)
+  logger.info(
+    { exerciseId: exercise.id, originalCount: blocks.length, trimmedTo: picked.length },
+    'Source exercise has more than 5 blocks — trimming via scaling-random selector',
+  )
+  return {
+    ...exercise,
+    content: { ...exercise.content, blocks: picked },
   }
 }
 
@@ -352,10 +384,19 @@ async function processExercise(
 ): Promise<StrategyResult | null> {
   const exerciseRef = exercise.id
 
+  // Pre-trim source blocks. The structural validator caps exercises at 5
+  // blocks (TOO_MANY_SECTIONS — renderer / UX limit). Source exercises with
+  // 9-10 blocks would always fail variation. We sub-sample to 5 using the
+  // same scaling-random selector that picks exercises from a lesson: pick 1
+  // block per evenly-spaced bucket across the source, seeded for
+  // reproducibility. Preserves source order, so the variation feels like a
+  // natural truncation of the original.
+  const trimmedExercise = trimSourceBlocksIfNeeded(exercise)
+
   // Step 1: Run strategy
   let strategyResult: StrategyResult
   try {
-    strategyResult = await runStrategy(exercise, level, subject, payload)
+    strategyResult = await runStrategy(trimmedExercise, level, subject, payload)
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown strategy error'
     logger.error({ exerciseRef, level, err }, 'Strategy generation failed')
@@ -368,11 +409,11 @@ async function processExercise(
   // screen). Warning-only exercises still ship, with TODO placeholders filled
   // in for missing hint/solution/fullSolution so the lesson stays renderable.
   //
-  // We pass the source exercise's blocks so the validator can suppress
-  // MISSING_QUESTION when the source itself had an empty prompt (e.g. legacy
-  // geometry exercises where the question is in the figure, not as text).
-  // Otherwise every such variation would falsely fail.
-  const sourceBlocks = (exercise.content?.blocks ?? []) as ContentBlock[]
+  // We pass the source exercise's blocks (post-trim) so the validator can
+  // suppress MISSING_QUESTION when the source itself had an empty prompt
+  // (e.g. legacy geometry exercises where the question is in the figure, not
+  // as text). Otherwise every such variation would falsely fail.
+  const sourceBlocks = (trimmedExercise.content?.blocks ?? []) as ContentBlock[]
   const structuralFailures: StructuralFailure[] = validateExerciseStructural(
     strategyResult.blocks,
     sourceBlocks,

--- a/src/server/services/lesson-duplication/orchestrator.ts
+++ b/src/server/services/lesson-duplication/orchestrator.ts
@@ -367,7 +367,16 @@ async function processExercise(
   // exercise — renderer would crash) and warnings (admin fills from review
   // screen). Warning-only exercises still ship, with TODO placeholders filled
   // in for missing hint/solution/fullSolution so the lesson stays renderable.
-  const structuralFailures: StructuralFailure[] = validateExerciseStructural(strategyResult.blocks)
+  //
+  // We pass the source exercise's blocks so the validator can suppress
+  // MISSING_QUESTION when the source itself had an empty prompt (e.g. legacy
+  // geometry exercises where the question is in the figure, not as text).
+  // Otherwise every such variation would falsely fail.
+  const sourceBlocks = (exercise.content?.blocks ?? []) as ContentBlock[]
+  const structuralFailures: StructuralFailure[] = validateExerciseStructural(
+    strategyResult.blocks,
+    sourceBlocks,
+  )
   const blockingFailures = structuralFailures.filter((f) => BLOCKING_FAILURE_CODES.has(f.code))
   const warningFailures = structuralFailures.filter((f) => !BLOCKING_FAILURE_CODES.has(f.code))
 

--- a/src/server/services/lesson-duplication/validators/structural.ts
+++ b/src/server/services/lesson-duplication/validators/structural.ts
@@ -161,10 +161,32 @@ function isInvalidSvg(block: { value: string }): boolean {
   return !v.startsWith('<svg')
 }
 
+/**
+ * True if a question block's `prompt.value` is missing or whitespace-only.
+ * Used to compare source vs. generated: if both are empty, the variation is
+ * faithfully preserving an intentionally-empty prompt (e.g. geometry/axis
+ * exercises where the question is conveyed by the figure itself) and we
+ * should not fire MISSING_QUESTION.
+ */
+function hasEmptyPrompt(block: ContentBlock): boolean {
+  const prompt = (block as { prompt?: { value?: string } }).prompt
+  return !prompt?.value?.trim()
+}
+
 /** Check a single block for structural failures.
  *  Returns array of failures (empty = pass).
+ *
+ *  `sourceBlock` is the corresponding block from the input exercise (matched
+ *  by index). When provided, MISSING_QUESTION is suppressed if the source
+ *  block also had an empty prompt — that's a passthrough, not a generation
+ *  failure. Without it, legacy exercises where the prompt was intentionally
+ *  empty (geometry/axis question-in-figure) would always fail the variation.
  */
-function validateBlock(block: ContentBlock, blockIndex: number): StructuralFailure[] {
+function validateBlock(
+  block: ContentBlock,
+  blockIndex: number,
+  sourceBlock?: ContentBlock,
+): StructuralFailure[] {
   const failures: StructuralFailure[] = []
 
   // SVG block: value must be empty or start with <svg
@@ -216,14 +238,19 @@ function validateBlock(block: ContentBlock, blockIndex: number): StructuralFailu
     block.type === 'question_geometry' ||
     block.type === 'question_axis'
   ) {
-    // prompt check — always required
+    // prompt check — required unless the source block was also empty
+    // (faithfully preserved passthrough, e.g. geometry-in-figure questions).
     const prompt = (block as { prompt?: { value?: string } }).prompt
     if (!prompt?.value?.trim()) {
-      failures.push({
-        code: FAILURE_CODES.MISSING_QUESTION,
-        message: `Question block at index ${blockIndex} missing prompt`,
-        blockIndex,
-      })
+      const sourceWasAlsoEmpty =
+        sourceBlock !== undefined && sourceBlock.type === block.type && hasEmptyPrompt(sourceBlock)
+      if (!sourceWasAlsoEmpty) {
+        failures.push({
+          code: FAILURE_CODES.MISSING_QUESTION,
+          message: `Question block at index ${blockIndex} missing prompt`,
+          blockIndex,
+        })
+      }
     }
 
     // hint check
@@ -348,8 +375,18 @@ function validateBlock(block: ContentBlock, blockIndex: number): StructuralFailu
 /**
  * Validate a single exercise's content blocks for structural correctness.
  * Returns an array of failures (empty = valid).
+ *
+ * `sourceBlocks` is the input exercise's blocks (matched by index). When
+ * provided, the validator suppresses MISSING_QUESTION for blocks whose source
+ * counterpart also had an empty prompt — this is the variation faithfully
+ * preserving an intentionally-empty prompt (most common case: geometry/axis
+ * exercises that pose the question through the figure itself). Without this,
+ * legacy exercises with no prompt text always failed structural validation.
  */
-export function validateExerciseStructural(blocks: ContentBlock[]): StructuralFailure[] {
+export function validateExerciseStructural(
+  blocks: ContentBlock[],
+  sourceBlocks?: ContentBlock[],
+): StructuralFailure[] {
   const failures: StructuralFailure[] = []
 
   // 1. Block count check
@@ -362,7 +399,7 @@ export function validateExerciseStructural(blocks: ContentBlock[]): StructuralFa
 
   // 2. Per-block validation
   for (let i = 0; i < blocks.length; i++) {
-    failures.push(...validateBlock(blocks[i], i))
+    failures.push(...validateBlock(blocks[i], i, sourceBlocks?.[i]))
   }
 
   return failures

--- a/src/ui/admin/LessonDuplicationReview/index.tsx
+++ b/src/ui/admin/LessonDuplicationReview/index.tsx
@@ -174,6 +174,9 @@ export function LessonDuplicationReview({ duplicationId }: { duplicationId: stri
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [allResolved, setAllResolved] = useState(false)
   const [reviewedIds, setReviewedIds] = useState<Set<string>>(new Set())
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [processError, setProcessError] = useState<string | null>(null)
+  const [processOutcome, setProcessOutcome] = useState<string | null>(null)
   const diffPreviewRef = useRef<HTMLDivElement>(null)
 
   const fetchRecord = useCallback(async () => {
@@ -246,6 +249,34 @@ export function LessonDuplicationReview({ duplicationId }: { duplicationId: stri
       next.set(index, { action, level })
       return next
     })
+  }
+
+  /**
+   * Manually kick the orchestrator for this record. Useful on dev (where
+   * Vercel cron doesn't fire on preview deploys) and for "run it now" in
+   * production. The request can take several minutes — same model as a cron
+   * tick: process as many exercises as fit in the function lifetime, then
+   * return. If work remains, status stays `running` and the next click (or
+   * cron tick) continues from there.
+   */
+  async function handleProcessNow() {
+    setIsProcessing(true)
+    setProcessError(null)
+    setProcessOutcome(null)
+    try {
+      const res = await fetch(`/api/lesson-duplications/${duplicationId}/process-now`, {
+        method: 'POST',
+        credentials: 'include',
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error?.message ?? data.error ?? `HTTP ${res.status}`)
+      setProcessOutcome(data.data?.outcome ?? 'unknown')
+      await fetchRecord()
+    } catch (e) {
+      setProcessError(e instanceof Error ? e.message : 'Process failed')
+    } finally {
+      setIsProcessing(false)
+    }
   }
 
   function jumpToExercise(outputExerciseId: string) {
@@ -355,6 +386,74 @@ export function LessonDuplicationReview({ duplicationId }: { duplicationId: stri
     )
   }
 
+  // Lets admins kick the orchestrator manually (essential on dev where Vercel
+  // cron doesn't fire on preview deploys; nice-to-have in prod for "do it
+  // now" overrides). Visible in both the empty-state panel and the sticky
+  // bar of the normal review view.
+  const canProcess = record.status === 'pending' || record.status === 'running'
+
+  // Pending/running with nothing to show yet — render a focused "Process Now"
+  // panel instead of the empty review UI.
+  const hasNoProgress =
+    (record.outputExercises?.length ?? 0) === 0 && (record.failures?.length ?? 0) === 0
+  if (canProcess && hasNoProgress) {
+    return (
+      <div style={pageStyle}>
+        <div style={headerStyle}>
+          <p style={breadcrumbStyle}>
+            <Link href="/admin">Dashboard</Link> /{' '}
+            <Link href="/admin/collections/lesson-duplications">Lesson Duplications</Link> / Review
+          </p>
+          <h1 style={titleStyle}>Lesson Duplication Review</h1>
+          <p style={metaStyle}>
+            Source: <strong>{sourceLessonTitle ?? record.sourceLesson}</strong> · Level:{' '}
+            <strong>{record.level}</strong> · Status: <strong>{record.status}</strong>
+          </p>
+        </div>
+        <div
+          style={{
+            padding: 24,
+            border: '1px solid var(--theme-elevation-200)',
+            borderRadius: 4,
+            backgroundColor: 'var(--theme-elevation-0)',
+          }}
+        >
+          <p style={{ fontSize: 14, marginBottom: 16 }}>
+            {record.status === 'pending'
+              ? 'This duplication is queued and hasn’t started yet. It will be picked up automatically by the cron worker within ~1 minute on production. Click below to start it immediately.'
+              : 'This duplication is running but no exercises have been recorded yet. The cron worker will continue it on its next tick. Click below to advance it right now.'}
+          </p>
+          <button
+            style={{
+              ...buttonStyle,
+              backgroundColor: 'var(--theme-success)',
+              color: '#fff',
+              border: 'none',
+              padding: '8px 16px',
+              fontSize: 14,
+            }}
+            onClick={handleProcessNow}
+            disabled={isProcessing}
+          >
+            {isProcessing ? 'Processing… (this can take several minutes)' : 'Process Now'}
+          </button>
+          {processOutcome && (
+            <div style={{ marginTop: 12, fontSize: 13, color: 'var(--theme-elevation-700)' }}>
+              Last run outcome: <strong>{processOutcome}</strong>
+              {processOutcome === 'in_progress' &&
+                ' — more work remains; click Process Now again or wait for the next cron tick.'}
+            </div>
+          )}
+          {processError && (
+            <div style={{ marginTop: 12, fontSize: 13, color: 'var(--theme-error)' }}>
+              {processError}
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div style={pageStyle}>
       {/* Header */}
@@ -385,6 +484,20 @@ export function LessonDuplicationReview({ duplicationId }: { duplicationId: stri
           )}
         </span>
         <div style={{ flex: 1 }} />
+        {canProcess && (
+          <button
+            style={{
+              ...buttonStyle,
+              backgroundColor: 'var(--theme-elevation-150)',
+              color: 'var(--theme-elevation-800)',
+            }}
+            onClick={handleProcessNow}
+            disabled={isProcessing}
+            title="Run the orchestrator immediately on this record. Useful on dev where Vercel cron doesn't auto-fire."
+          >
+            {isProcessing ? 'Processing…' : 'Process Now'}
+          </button>
+        )}
         {pendingActions.size > 0 && (
           <>
             <span style={{ fontSize: 13, color: 'var(--theme-elevation-600)' }}>

--- a/tests/unit/server/services/lesson-duplication/validators/structural.spec.ts
+++ b/tests/unit/server/services/lesson-duplication/validators/structural.spec.ts
@@ -384,6 +384,56 @@ describe('validateExerciseStructural', () => {
       const failures = validateExerciseStructural(blocks)
       expect(failures.some((f) => f.code === FAILURE_CODES.MISSING_QUESTION)).toBe(true)
     })
+
+    it('passes-through empty prompt when source block was also empty (geometry-in-figure)', () => {
+      // Real-world case: legacy geometry exercises pose the question via the
+      // figure, not separate prompt text. Source has empty prompt; the
+      // variation faithfully preserves that. Validator must not fail.
+      const generatedBlock = makeMcqNoPrompt(
+        'mcq-1',
+        [
+          { id: 'a', content: { value: 'A' } },
+          { id: 'b', content: { value: 'B' } },
+        ],
+        ['a'],
+        false, // hasPrompt = false on the generated block
+      )
+      const sourceBlock = makeMcqNoPrompt(
+        'mcq-1',
+        [
+          { id: 'a', content: { value: 'A' } },
+          { id: 'b', content: { value: 'B' } },
+        ],
+        ['a'],
+        false, // hasPrompt = false on the SOURCE too
+      )
+      const failures = validateExerciseStructural([generatedBlock], [sourceBlock])
+      expect(failures.some((f) => f.code === FAILURE_CODES.MISSING_QUESTION)).toBe(false)
+    })
+
+    it('still fails MISSING_QUESTION when source had a prompt but generated does not', () => {
+      // The variation pipeline dropped the prompt — real regression.
+      const generatedBlock = makeMcqNoPrompt(
+        'mcq-1',
+        [
+          { id: 'a', content: { value: 'A' } },
+          { id: 'b', content: { value: 'B' } },
+        ],
+        ['a'],
+        false, // hasPrompt = false on generated
+      )
+      const sourceBlock = makeMcqNoPrompt(
+        'mcq-1',
+        [
+          { id: 'a', content: { value: 'A' } },
+          { id: 'b', content: { value: 'B' } },
+        ],
+        ['a'],
+        true, // hasPrompt = true on source — prompt was dropped by the LLM
+      )
+      const failures = validateExerciseStructural([generatedBlock], [sourceBlock])
+      expect(failures.some((f) => f.code === FAILURE_CODES.MISSING_QUESTION)).toBe(true)
+    })
   })
 
   describe('MISSING_HINT', () => {


### PR DESCRIPTION
## Summary
Vercel only runs `vercel.json` cron schedules on the **Production** deployment of a project. On `dev.aguy.co.il` (preview tier), the cron worker added in #1602 never fires, so duplication records sit at `pending` forever unless an admin shells in to trigger them. This PR adds a button.

## Changes
- **`POST /api/lesson-duplications/[id]/process-now`** — admin-only endpoint, `maxDuration=800`, calls `runDuplicationOrchestrator` with the same deadline behaviour as the cron tick. Returns the outcome (`succeeded` / `needs_review` / `in_progress` / `failed`).
- **`LessonDuplicationReview` UI** — adds a "Process Now" button in two places:
  - **Empty-state panel:** when the record is `pending`/`running` with zero output exercises and zero failures, the page now renders a focused "this record hasn't started yet, click to begin" panel instead of an empty review list.
  - **Sticky bar:** small secondary button visible for any `pending`/`running` record so admins can advance partially-complete runs without leaving the review screen.

## Use cases
- **Dev:** primary trigger (since cron doesn't fire there).
- **Prod:** "run it now" override when an admin doesn't want to wait up to a minute for the next cron tick.
- **Recovery:** resuming a record that an earlier tick stranded (e.g. function killed mid-flight; admin can click to continue from the streamed checkpoint).

## Test plan
- [x] `pnpm typecheck` — clean
- [x] Endpoint reuses the same orchestrator path that's been exercised live across 6+ runs in #1602
- [ ] Manual verification on PR preview deploy: trigger a duplication on the calculus lesson, navigate to its review page, see the "Process Now" panel, click it, wait, confirm `succeeded` with output exercises