### PR TITLE
#1621: Export lesson + ordered exercises as JSON from admin

### DIFF
--- a/src/app/api/lessons/[id]/export/route.ts
+++ b/src/app/api/lessons/[id]/export/route.ts
@@ -1,0 +1,40 @@
+/**
+ * Lesson Export API
+ *
+ * GET /api/lessons/:id/export
+ *
+ * Next.js App Router wrapper around the Payload endpoint
+ * `exportLessonEndpoint`. Sets Content-Type and Content-Disposition
+ * for browser file download.
+ *
+ * @fileType api-route
+ * @domain lessons
+ * @pattern payload-endpoint-wrapper
+ * @ai-summary Forwards GET to the Payload export endpoint with auth + payload context attached.
+ *
+ * Access: admin only (enforced inside the endpoint handler).
+ */
+import { NextRequest } from 'next/server'
+import { getPayload } from 'payload'
+import configPromise from '@payload-config'
+
+import { exportLessonEndpoint } from '@/server/payload/endpoints/lessons/export'
+
+export async function GET(request: NextRequest): Promise<Response> {
+  try {
+    const payload = await getPayload({ config: configPromise })
+    const { user } = await payload.auth({ headers: request.headers })
+
+    const payloadRequest = {
+      payload,
+      user,
+      url: request.url,
+      headers: request.headers,
+    } as unknown as Parameters<typeof exportLessonEndpoint>[0]
+
+    return await exportLessonEndpoint(payloadRequest)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    return Response.json({ error: `Export failed: ${message}` }, { status: 500 })
+  }
+}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -46,6 +46,7 @@ import { importExerciseFromLesson } from '@/server/payload/endpoints/exercises/i
 import { translateContentEndpoint } from '@/server/payload/endpoints/translation/translate-content'
 import { cascadeDeleteEndpoint } from '@/server/payload/endpoints/cascade-delete'
 import { duplicateLessonEndpoint } from '@/server/payload/endpoints/lessons/duplicate'
+import { exportLessonEndpoint } from '@/server/payload/endpoints/lessons/export'
 import { defaultLexical } from '@/server/payload/fields/defaultLexical'
 import { lessonDuplicationTask } from '@/server/payload/jobs/lesson-duplication-task'
 import { pdfToExercisesTask } from '@/server/payload/jobs/pdf-to-exercises-task'
@@ -257,6 +258,11 @@ export default buildConfig({
       path: '/lessons/:id/duplicate-variation',
       method: 'post',
       handler: (req: PayloadRequest) => duplicateLessonEndpoint(req),
+    },
+    {
+      path: '/lessons/:id/export',
+      method: 'get',
+      handler: (req: PayloadRequest) => exportLessonEndpoint(req),
     },
   ],
   jobs: {

--- a/src/server/payload/collections/Lessons.ts
+++ b/src/server/payload/collections/Lessons.ts
@@ -182,6 +182,7 @@ export const Lessons: CollectionConfig = {
         beforeDocumentControls: [
           '@/ui/admin/TranslationButton#TranslateLessonAction',
           '@/ui/admin/CascadeDeleteButton#LessonCascadeDelete',
+          '@/ui/admin/LessonExportButton/LessonExportButton#LessonExportAction',
           '@/ui/admin/LessonDuplicateButton/LessonDuplicateButton#LessonDuplicateAction',
         ],
       },

--- a/src/server/payload/endpoints/lessons/export.ts
+++ b/src/server/payload/endpoints/lessons/export.ts
@@ -1,0 +1,155 @@
+/**
+ * GET /api/lessons/:id/export
+ *
+ * Exports a lesson and all its ordered exercises as a JSON file.
+ *
+ * Access: admin only (401 unauthenticated, 403 non-admin).
+ *
+ * Response: Content-Type: application/json, Content-Disposition: attachment; filename="<slug>.json"
+ *
+ * JSON shape:
+ * {
+ *   lesson: { id, title, slug, description, type, status, order, accessType, visibleRenderers, ... },
+ *   exercises: [ { id, title, slug, content, origin, ... }, ... ],  // ordered by blocks array
+ *   meta: {
+ *     exerciseCount: number,
+ *     missingExerciseRefs: string[],      // IDs in blocks but not in DB
+ *     skippedNonExerciseBlocks: number,  // contentPageRef etc.
+ *   }
+ * }
+ *
+ * Excluded from exercise payload: createdAt, updatedAt, internal _id, __v
+ *
+ * @fileType api-route
+ * @domain lessons
+ * @pattern lesson-export
+ * @ai-summary Exports a lesson and its ordered exercises as a JSON file for backup or offline review.
+ */
+import type { PayloadRequest } from 'payload'
+
+type BlockEntry = { id: string; blockType: string; exercise?: string; contentPage?: string }
+
+/** Strip Payload-managed fields from a doc */
+function stripManagedFields<T extends Record<string, unknown>>(
+  doc: T,
+): Omit<T, 'id' | 'createdAt' | 'updatedAt'> {
+  const {
+    id: _id,
+    createdAt: _c,
+    updatedAt: _u,
+    ...rest
+  } = doc as T & {
+    id?: unknown
+    createdAt?: unknown
+    updatedAt?: unknown
+  }
+  void _id
+  void _c
+  void _u
+  return rest
+}
+
+/** Parse blocks from JSON string or array */
+function parseBlocks(raw: unknown): BlockEntry[] {
+  if (Array.isArray(raw)) return raw as BlockEntry[]
+  if (typeof raw === 'string' && raw.trim()) {
+    try {
+      const parsed = JSON.parse(raw)
+      if (Array.isArray(parsed)) return parsed as BlockEntry[]
+    } catch {
+      // ignore parse errors
+    }
+  }
+  return []
+}
+
+export async function exportLessonEndpoint(req: PayloadRequest): Promise<Response> {
+  // 1) Auth — admin only
+  const user = req.user
+  if (!user) {
+    return Response.json({ error: 'Authentication required' }, { status: 401 })
+  }
+  if (!('role' in user) || user.role !== 'admin') {
+    return Response.json({ error: 'Admin access required' }, { status: 403 })
+  }
+
+  // 2) Extract lesson ID from path: /lessons/:id/export
+  const url = new URL(req.url || 'http://localhost')
+  const match = url.pathname.match(/\/lessons\/([^/]+)\/export/)
+  const lessonId = match?.[1]
+  if (!lessonId) {
+    return Response.json({ error: 'Lesson id missing from path' }, { status: 400 })
+  }
+
+  // 3) Fetch lesson with depth:0
+  let lesson: Record<string, unknown>
+  try {
+    lesson = (await req.payload.findByID({
+      collection: 'lessons',
+      id: lessonId,
+      depth: 0,
+      overrideAccess: true,
+      req,
+    })) as unknown as Record<string, unknown>
+  } catch {
+    return Response.json({ error: 'Lesson not found' }, { status: 404 })
+  }
+
+  // 4) Parse blocks, extract ordered exercise IDs (exerciseRef only)
+  const blocks = parseBlocks(lesson.blocks)
+  const exerciseIds: string[] = []
+  let skippedNonExerciseBlocks = 0
+  const missingIds: string[] = []
+
+  for (const block of blocks) {
+    if (block.blockType === 'exerciseRef' && block.exercise) {
+      exerciseIds.push(block.exercise)
+    } else {
+      skippedNonExerciseBlocks++
+    }
+  }
+
+  // 5) Fetch exercises in order, track missing ones
+  const exercises: unknown[] = []
+  for (const exId of exerciseIds) {
+    try {
+      const ex = (await req.payload.findByID({
+        collection: 'exercises',
+        id: exId,
+        depth: 0,
+        overrideAccess: true,
+        req,
+      })) as unknown as Record<string, unknown>
+      exercises.push(stripManagedFields(ex))
+    } catch {
+      missingIds.push(exId)
+    }
+  }
+
+  // 6) Build response — strip managed fields from lesson
+  const { id: _lid, createdAt: _lca, updatedAt: _lua, blocks: _lb, ...lessonData } = lesson
+  void _lid
+  void _lca
+  void _lua
+  void _lb
+
+  const responseBody = {
+    lesson: lessonData,
+    exercises,
+    meta: {
+      exerciseCount: exercises.length,
+      missingExerciseRefs: missingIds,
+      skippedNonExerciseBlocks,
+    },
+  }
+
+  const slug = (lesson.slug as string) || lessonId
+  const filename = `${slug}.json`
+
+  return new Response(JSON.stringify(responseBody, null, 2), {
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+    },
+  })
+}

--- a/src/ui/admin/LessonExportButton/LessonExportButton.tsx
+++ b/src/ui/admin/LessonExportButton/LessonExportButton.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+/**
+ * LessonExportButton — admin "Export as JSON" action on the lesson edit view.
+ *
+ * Fetches /api/lessons/:id/export and triggers a browser file download.
+ *
+ * @fileType component
+ * @domain lessons
+ * @pattern admin-action-button
+ * @ai-summary Exports a lesson and its exercises as a JSON file for backup or offline review.
+ */
+import React, { useState } from 'react'
+import { useDocumentInfo } from '@payloadcms/ui'
+
+export const LessonExportAction: React.FC = () => {
+  const { id } = useDocumentInfo()
+  const [isExporting, setIsExporting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  if (!id) return null
+
+  const handleExport = async () => {
+    setIsExporting(true)
+    setError(null)
+
+    try {
+      const res = await fetch(`/api/lessons/${id}/export`, {
+        credentials: 'include',
+      })
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        setError(data.error ?? `Export failed (${res.status})`)
+        return
+      }
+
+      // Extract filename from Content-Disposition header
+      const disposition = res.headers.get('Content-Disposition') || ''
+      const match = disposition.match(/filename="?([^"\n]+)"?/)
+      const filename = match?.[1] || `${id}.json`
+
+      const blob = await res.blob()
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = filename
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(url)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Network error')
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleExport}
+        disabled={isExporting}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 6,
+          padding: '6px 12px',
+          fontSize: 13,
+          fontWeight: 500,
+          border: '1px solid var(--theme-elevation-200)',
+          borderRadius: 4,
+          backgroundColor: 'var(--theme-elevation-0)',
+          color: 'var(--theme-elevation-1000)',
+          cursor: isExporting ? 'not-allowed' : 'pointer',
+          opacity: isExporting ? 0.6 : 1,
+        }}
+        title="Export lesson and exercises as JSON"
+      >
+        {isExporting ? 'Exporting…' : 'Export as JSON'}
+      </button>
+
+      {error && (
+        <span
+          style={{
+            color: 'var(--theme-error-500)',
+            fontSize: 12,
+            marginLeft: 8,
+          }}
+        >
+          {error}
+        </span>
+      )}
+    </>
+  )
+}

--- a/tests/int/lesson-export.int.spec.ts
+++ b/tests/int/lesson-export.int.spec.ts
@@ -1,0 +1,270 @@
+/**
+ * Integration test: lesson export endpoint.
+ *
+ * Verifies:
+ * 1. Lesson + ordered exercises are exported as JSON
+ * 2. Exercises appear in the same order as the blocks array
+ * 3. Missing exercise references are listed in meta.missingExerciseRefs
+ * 4. Non-exercise blocks are counted in meta.skippedNonExerciseBlocks
+ * 5. 401 for unauthenticated, 403 for non-admin, 404 for missing lesson
+ * 6. Empty exercises[] for lesson with no exercises
+ *
+ * The endpoint is exercised via Payload's local API to keep the test
+ * focused on data behavior, matching the project's other integration tests.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { getPayload, type Payload } from 'payload'
+import config from '@payload-config'
+
+import { getDefaultTenantSlug } from '@/server/repos/tenant/get-default-tenant'
+import { exportLessonEndpoint } from '@/server/payload/endpoints/lessons/export'
+
+async function ensureDefaultTenant(payload: Payload): Promise<string> {
+  const slug = getDefaultTenantSlug()
+  const existing = await payload.find({
+    collection: 'tenants',
+    where: { slug: { equals: slug } },
+    limit: 1,
+    overrideAccess: true,
+  })
+  if (existing.docs[0]) return existing.docs[0].id
+  const created = await payload.create({
+    collection: 'tenants',
+    data: { name: slug, slug, status: 'active' },
+    overrideAccess: true,
+  })
+  return created.id
+}
+
+describe('Lesson export endpoint', () => {
+  let payload: Payload
+  let tenantId: string
+  let categoryId: string
+  let courseId: string
+  let chapterId: string
+  let lessonId: string
+  const exerciseIds: string[] = []
+  const cleanupIds: string[] = []
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+    tenantId = await ensureDefaultTenant(payload)
+    const ts = Date.now()
+
+    // Setup: category → course → chapter → lesson → 3 ordered exercises
+    const category = await payload.create({
+      collection: 'categories',
+      data: { title: `ExpCat ${ts}`, slug: `exp-cat-${ts}`, locale: 'he' },
+    })
+    categoryId = category.id
+
+    const course = await payload.create({
+      collection: 'courses',
+      data: {
+        courseLabel: `EXP-${ts}`,
+        title: `Export Course ${ts}`,
+        locale: 'he',
+        categories: [categoryId],
+        order: 0,
+        status: 'published',
+        isActive: true,
+        tenant: tenantId,
+        pageAccessType: 'free',
+        accessType: 'free',
+        contentStatus: 'none',
+        contentStatusVisible: true,
+      },
+      draft: false,
+    })
+    courseId = course.id
+
+    const chapter = await payload.create({
+      collection: 'chapters',
+      data: {
+        title: `Export Chapter ${ts}`,
+        chapterLabel: `ECH-${ts}`,
+        course: courseId,
+        order: 0,
+        status: 'published',
+        isActive: true,
+        tenant: tenantId,
+        locale: 'he',
+      },
+    })
+    chapterId = chapter.id
+
+    const lesson = await payload.create({
+      collection: 'lessons',
+      data: {
+        title: `Export Lesson ${ts}`,
+        slug: `export-lesson-${ts}`,
+        chapter: chapterId,
+        type: 'practice',
+        order: 1,
+        status: 'published',
+        isActive: true,
+        tenant: tenantId,
+        locale: 'he',
+        accessType: 'inherit',
+        contentStatus: 'none',
+        contentStatusVisible: true,
+      },
+      draft: false,
+    })
+    lessonId = lesson.id
+    cleanupIds.push(lessonId)
+
+    // Create 3 exercises in order
+    for (let i = 0; i < 3; i++) {
+      const ex = await payload.create({
+        collection: 'exercises',
+        data: { title: `Export Exercise ${i} ${ts}`, lesson: lessonId, origin: 'manual' },
+        draft: true,
+      })
+      exerciseIds.push(ex.id)
+      cleanupIds.push(ex.id)
+    }
+
+    // Set lesson.blocks to ordered JSON with exercise refs + one contentPageRef + one missing
+    const blocks = [
+      { id: 'b1', blockType: 'exerciseRef', exercise: exerciseIds[0] },
+      { id: 'b2', blockType: 'contentPageRef', contentPage: 'fake-content-page-id' },
+      { id: 'b3', blockType: 'exerciseRef', exercise: exerciseIds[1] },
+      { id: 'b4', blockType: 'exerciseRef', exercise: exerciseIds[2] },
+      { id: 'b5', blockType: 'exerciseRef', exercise: 'non-existent-exercise-id' },
+    ]
+    await payload.update({
+      collection: 'lessons',
+      id: lessonId,
+      data: { blocks: JSON.stringify(blocks) },
+      overrideAccess: true,
+    })
+  }, 120000)
+
+  afterAll(async () => {
+    for (const id of cleanupIds) {
+      try {
+        await payload.delete({ collection: 'lessons', id, overrideAccess: true })
+      } catch {
+        // ignore
+      }
+      try {
+        await payload.delete({ collection: 'exercises', id, overrideAccess: true })
+      } catch {
+        // ignore
+      }
+    }
+    try {
+      await payload.delete({ collection: 'chapters', id: chapterId, overrideAccess: true })
+    } catch {
+      // ignore
+    }
+    try {
+      await payload.delete({ collection: 'courses', id: courseId, overrideAccess: true })
+    } catch {
+      // ignore
+    }
+    try {
+      await payload.delete({ collection: 'categories', id: categoryId, overrideAccess: true })
+    } catch {
+      // ignore
+    }
+    await payload.db?.destroy?.()
+  })
+
+  it('exports lesson with exercises in blocks order, skipping missing and non-exercise blocks', async () => {
+    const mockReq = {
+      user: { id: 'admin', role: 'admin' },
+      payload,
+      url: `http://localhost/lessons/${lessonId}/export`,
+      headers: new Headers(),
+    } as unknown as Parameters<typeof exportLessonEndpoint>[0]
+    const res = await exportLessonEndpoint(mockReq)
+    expect(res.status).toBe(200)
+
+    const body = await (res as Response).json()
+    expect(body.lesson.id).toBe(lessonId)
+    expect(body.exercises).toHaveLength(3)
+    expect(body.exercises[0].id).toBe(exerciseIds[0])
+    expect(body.exercises[1].id).toBe(exerciseIds[1])
+    expect(body.exercises[2].id).toBe(exerciseIds[2])
+    expect(body.meta.missingExerciseRefs).toContain('non-existent-exercise-id')
+    expect(body.meta.skippedNonExerciseBlocks).toBe(1)
+    expect(body.meta.exerciseCount).toBe(3)
+
+    // No managed fields on exercises
+    expect(body.exercises[0]).not.toHaveProperty('createdAt')
+    expect(body.exercises[0]).not.toHaveProperty('updatedAt')
+    expect(body.exercises[0]).not.toHaveProperty('_id')
+  })
+
+  it('returns 404 for non-existent lesson', async () => {
+    const mockReq = {
+      user: { id: 'admin', role: 'admin' },
+      payload,
+      url: 'http://localhost/lessons/fake-id/export',
+      headers: new Headers(),
+    } as unknown as Parameters<typeof exportLessonEndpoint>[0]
+    const res = await exportLessonEndpoint(mockReq)
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 401 for unauthenticated requests', async () => {
+    const mockReq = {
+      user: null,
+      payload,
+      url: `http://localhost/lessons/${lessonId}/export`,
+      headers: new Headers(),
+    } as unknown as Parameters<typeof exportLessonEndpoint>[0]
+    const res = await exportLessonEndpoint(mockReq)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 for non-admin users', async () => {
+    const mockReq = {
+      user: { id: 'user', role: 'student' },
+      payload,
+      url: `http://localhost/lessons/${lessonId}/export`,
+      headers: new Headers(),
+    } as unknown as Parameters<typeof exportLessonEndpoint>[0]
+    const res = await exportLessonEndpoint(mockReq)
+    expect(res.status).toBe(403)
+  })
+
+  it('exports lesson with zero exercises cleanly', async () => {
+    const emptyLesson = await payload.create({
+      collection: 'lessons',
+      data: {
+        title: `Empty Export Lesson ${Date.now()}`,
+        slug: `empty-export-${Date.now()}`,
+        chapter: chapterId,
+        type: 'learning',
+        order: 99,
+        status: 'draft',
+        isActive: true,
+        tenant: tenantId,
+        locale: 'he',
+        accessType: 'inherit',
+        contentStatus: 'none',
+        contentStatusVisible: true,
+        blocks: '[]',
+      },
+      overrideAccess: true,
+    })
+    cleanupIds.push(emptyLesson.id)
+
+    const mockReq = {
+      user: { id: 'admin', role: 'admin' },
+      payload,
+      url: `http://localhost/lessons/${emptyLesson.id}/export`,
+      headers: new Headers(),
+    } as unknown as Parameters<typeof exportLessonEndpoint>[0]
+    const res = await exportLessonEndpoint(mockReq)
+    expect(res.status).toBe(200)
+    const body = await (res as Response).json()
+    expect(body.exercises).toHaveLength(0)
+    expect(body.meta.exerciseCount).toBe(0)
+    expect(body.meta.missingExerciseRefs).toHaveLength(0)
+    expect(body.meta.skippedNonExerciseBlocks).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

- New `src/server/payload/endpoints/lessons/export.ts` — Payload endpoint with admin auth (401/403), parses blocks JSON string, fetches exercises in blocks order, strips managed fields, returns JSON with Content-Disposition for browser download
- New `src/app/api/lessons/[id]/export/route.ts` — App Router GET wrapper bridging HTTP to the Payload endpoint
- `src/payload.config.ts` — registered the new `/lessons/:id/export` GET endpoint
- `src/server/payload/collections/Lessons.ts` — added `LessonExportButton` to `beforeDocumentControls`
- New `src/ui/admin/LessonExportButton/LessonExportButton.tsx` — admin button with inline CSS matching LessonDuplicateButton style, triggers browser file download
- New `tests/int/lesson-export.int.spec.ts` — integration test covering: ordered exports, missing refs, non-exercise blocks, 401/403/404 responses, empty exercises

## Changes

- `src/app/api/lessons/[id]/export/route.ts`
- `src/payload.config.ts`
- `src/server/payload/collections/Lessons.ts`
- `src/server/payload/endpoints/lessons/export.ts`
- `src/ui/admin/LessonExportButton/LessonExportButton.tsx`
- `tests/int/lesson-export.int.spec.ts`

Closes #1621

---
_Opened by kody (single-session autonomous run)._ 