### PR TITLE
#1664: Auto-fail stuck duplication records to unblock the cron queue

### DIFF
--- a/src/app/api/cron/process-duplications/route.ts
+++ b/src/app/api/cron/process-duplications/route.ts
@@ -47,6 +47,8 @@ interface DuplicationRecord {
   status?: string
   workerLockExpiresAt?: Date
   workerLockedAt?: Date
+  claimAttempts?: number
+  outputExercises?: unknown[]
 }
 
 /**
@@ -77,9 +79,12 @@ async function claimNextRecord(payload: Payload): Promise<string | null> {
     {
       // FIFO by createdAt — oldest pending/running record first.
       status: { $in: ['pending', 'running'] },
+      // Skip records flagged as permanently stuck (≥5 attempts, no progress)
+      $nor: [{ claimAttempts: { $gte: 5 } }],
       $or: [{ workerLockExpiresAt: { $exists: false } }, { workerLockExpiresAt: { $lt: now } }],
     },
     {
+      $inc: { claimAttempts: 1 },
       $set: {
         workerLockExpiresAt: lockUntil,
         workerLockedAt: now,
@@ -115,6 +120,55 @@ async function releaseLock(payload: Payload, duplicationId: string): Promise<voi
     )
   } catch (err) {
     logger.error({ err, duplicationId }, '[cron/process-duplications] Failed to release lock')
+  }
+}
+
+/**
+ * Mark a record as permanently stuck: set status=failed and append a
+ * STUCK_AFTER_MAX_ATTEMPTS failure entry so the admin knows why.
+ */
+async function markStuckAndFailed(payload: Payload, duplicationId: string): Promise<void> {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const coll = (payload.db as any).collections?.['lesson-duplications']
+    if (!coll) return
+    await coll.updateOne({ _id: new ObjectId(duplicationId) }, {
+      $set: { status: 'failed' },
+      $push: {
+        failures: {
+          exerciseRef: '',
+          sectionIndex: 0,
+          code: 'STUCK_AFTER_MAX_ATTEMPTS',
+          message:
+            'Record was auto-failed after 5 consecutive cron ticks produced no new output exercises. Check source lesson data, exercise structure, and orchestrator logs.',
+          suggestedAction: 'skip',
+          resolved: false,
+        },
+      },
+    } as never)
+    logger.warn(
+      { duplicationId },
+      '[cron/process-duplications] Auto-failed stuck record after max attempts',
+    )
+  } catch (err) {
+    logger.error(
+      { err, duplicationId },
+      '[cron/process-duplications] Failed to mark record as stuck/failed',
+    )
+    // Fallback: try to at least set status=failed without the failure entry
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const coll = (payload.db as any).collections?.['lesson-duplications']
+      if (!coll) return
+      await coll.updateOne({ _id: new ObjectId(duplicationId) }, {
+        $set: { status: 'failed' },
+      } as never)
+    } catch (fallbackErr) {
+      logger.error(
+        { err: fallbackErr, duplicationId },
+        '[cron/process-duplications] Fallback status=failed also failed',
+      )
+    }
   }
 }
 
@@ -164,6 +218,32 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ processed: 0, message: 'no records pending' })
   }
 
+  // Re-read the claimed record to capture pre-orchestrator outputExercises.length
+  // (needed to detect whether this tick produced progress)
+  const claimedRecord = await payload.findByID({
+    collection: 'lesson-duplications',
+    id: duplicationId,
+    depth: 0,
+    overrideAccess: true,
+  })
+  const preTickOutputCount =
+    (claimedRecord as unknown as { outputExercises?: unknown[] }).outputExercises?.length ?? 0
+
+  // Auto-fail if we've now hit the threshold (claimAttempts was incremented to 5
+  // in the atomic claim, so 5 means THIS tick was the 5th attempt).
+  const currentAttempts =
+    (claimedRecord as unknown as { claimAttempts?: number }).claimAttempts ?? 1
+  if (currentAttempts >= 5) {
+    await markStuckAndFailed(payload, duplicationId)
+    await releaseLock(payload, duplicationId)
+    return NextResponse.json({
+      duplicationId,
+      outcome: 'failed',
+      reason: 'STUCK_AFTER_MAX_ATTEMPTS',
+      elapsedMs: Date.now() - startedAt,
+    })
+  }
+
   logger.info({ duplicationId }, '[cron/process-duplications] claimed record')
 
   let outcome: string = 'in_progress'
@@ -174,6 +254,32 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     outcome = 'failed'
   } finally {
     await releaseLock(payload, duplicationId)
+  }
+
+  // Reset claimAttempts on any progress — if outputExercises grew during this tick,
+  // reset the counter so a legitimately long-running record (e.g. 50-exercise lesson)
+  // is never incorrectly auto-failed.
+  if (outcome !== 'failed') {
+    const afterRecord = await payload.findByID({
+      collection: 'lesson-duplications',
+      id: duplicationId,
+      depth: 0,
+      overrideAccess: true,
+    })
+    const postTickOutputCount =
+      (afterRecord as unknown as { outputExercises?: unknown[] }).outputExercises?.length ?? 0
+    if (postTickOutputCount > preTickOutputCount) {
+      await payload.update({
+        collection: 'lesson-duplications',
+        id: duplicationId,
+        data: { claimAttempts: 0 } as never,
+        overrideAccess: true,
+      })
+      logger.info(
+        { duplicationId, preTickOutputCount, postTickOutputCount },
+        '[cron/process-duplications] Reset claimAttempts — progress detected',
+      )
+    }
   }
 
   return NextResponse.json({

--- a/src/app/api/cron/process-duplications/route.ts
+++ b/src/app/api/cron/process-duplications/route.ts
@@ -23,7 +23,10 @@ import type { Payload } from 'payload'
 import { getPayload } from 'payload'
 import configPromise from '@payload-config'
 import { logger } from '@/infra/utils/logger'
-import { runDuplicationOrchestrator } from '@/server/services/lesson-duplication/orchestrator'
+import {
+  runDuplicationOrchestrator,
+  STUCK_FAILURE_CODE,
+} from '@/server/services/lesson-duplication/orchestrator'
 
 // Vercel cron functions inherit the same maxDuration ceiling as regular
 // serverless functions. 800s on Pro lets one tick process roughly 3-5
@@ -138,7 +141,7 @@ async function markStuckAndFailed(payload: Payload, duplicationId: string): Prom
         failures: {
           exerciseRef: '',
           sectionIndex: 0,
-          code: 'STUCK_AFTER_MAX_ATTEMPTS',
+          code: STUCK_FAILURE_CODE,
           message:
             'Record was auto-failed after 5 consecutive cron ticks produced no new output exercises. Check source lesson data, exercise structure, and orchestrator logs.',
           suggestedAction: 'skip',
@@ -239,7 +242,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({
       duplicationId,
       outcome: 'failed',
-      reason: 'STUCK_AFTER_MAX_ATTEMPTS',
+      reason: STUCK_FAILURE_CODE,
       elapsedMs: Date.now() - startedAt,
     })
   }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1888,6 +1888,10 @@ export interface LessonDuplication {
    */
   runDurationMs?: number | null;
   /**
+   * Number of consecutive cron ticks that claimed this record without producing any new output exercises. Reset to 0 when outputExercises grows. Auto-fails at ≥ 5.
+   */
+  claimAttempts?: number | null;
+  /**
    * User who created this document
    */
   createdBy?: (string | null) | User;
@@ -3694,6 +3698,7 @@ export interface LessonDuplicationsSelect<T extends boolean = true> {
   aiTokensOutput?: T;
   aiCostUsd?: T;
   runDurationMs?: T;
+  claimAttempts?: T;
   createdBy?: T;
   updatedAt?: T;
   createdAt?: T;

--- a/src/server/payload/collections/LessonDuplications.ts
+++ b/src/server/payload/collections/LessonDuplications.ts
@@ -207,6 +207,17 @@ export const LessonDuplications: CollectionConfig = {
         description: 'Wall-clock duration of the duplication run in milliseconds.',
       },
     },
+    // ── Stuck Record Detection (issue #1664) ────────────────────────────────────
+    {
+      name: 'claimAttempts',
+      type: 'number',
+      defaultValue: 0,
+      admin: {
+        description:
+          'Number of consecutive cron ticks that claimed this record without producing any new output exercises. Reset to 0 when outputExercises grows. Auto-fails at ≥ 5.',
+        readOnly: true,
+      },
+    },
     createdByField,
   ],
 }

--- a/src/server/services/lesson-duplication/orchestrator.ts
+++ b/src/server/services/lesson-duplication/orchestrator.ts
@@ -49,6 +49,7 @@ import { getModelCost } from '@/infra/llm/pricing'
 export const CONCURRENCY_LIMIT = 1 as const
 
 export const GENERATION_FAILURE_CODE = 'GENERATION_FAILED' as const
+export const STUCK_FAILURE_CODE = 'STUCK_AFTER_MAX_ATTEMPTS' as const
 
 export type DuplicationStrategy = 'script' | 'ai'
 

--- a/tests/int/process-duplications-stuck.int.spec.ts
+++ b/tests/int/process-duplications-stuck.int.spec.ts
@@ -1,0 +1,469 @@
+/**
+ * Integration test: stuck duplication record auto-fail (issue #1664).
+ *
+ * Acceptance criteria:
+ *  1. claimAttempts field exists on LessonDuplications records (defaultValue: 0)
+ *  2. Cron route increments claimAttempts on each claim (atomic $inc in findOneAndUpdate)
+ *  3. Records with claimAttempts >= 5 are excluded from the claim query
+ *  4. Auto-fail: record with claimAttempts >= 5 gets status=failed + STUCK_AFTER_MAX_ATTEMPTS failure entry
+ *  5. Progress resets counter: when outputExercises grows, claimAttempts resets to 0
+ *  6. in_progress with zero output growth does NOT reset claimAttempts
+ *  7. Newer record is picked after older stuck record is excluded
+ *
+ * Strategy:
+ *  - Create a 1-exercise lesson (so orchestrator finishes in one tick)
+ *  - Create a stuck record (no exercises on source lesson so orchestrator returns in_progress each tick)
+ *  - Simulate 5 ticks by manually incrementing claimAttempts
+ *  - Verify auto-fail fires on tick 5
+ *  - Create a "real" record that makes progress, verify counter resets
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { getPayload, type Payload } from 'payload'
+import config from '@payload-config'
+import { NextRequest } from 'next/server'
+
+import { getDefaultTenantSlug } from '@/server/repos/tenant/get-default-tenant'
+import { GET as processDuplicationsGET } from '@/app/api/cron/process-duplications/route'
+
+// Mock orchestrator to always return 'in_progress' (simulates a record that
+// never makes progress — e.g. source lesson with no exercises)
+vi.mock('@/server/services/lesson-duplication/orchestrator', () => ({
+  runDuplicationOrchestrator: vi.fn().mockResolvedValue('in_progress'),
+}))
+
+const CRON_SECRET = process.env.CRON_SECRET ?? 'test-secret'
+
+async function makeCronRequest(): Promise<Response> {
+  const request = new NextRequest('http://localhost:3000/api/cron/process-duplications', {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${CRON_SECRET}` },
+  })
+  return processDuplicationsGET(request)
+}
+
+async function ensureDefaultTenant(payload: Payload): Promise<string> {
+  const slug = getDefaultTenantSlug()
+  const existing = await payload.find({
+    collection: 'tenants',
+    where: { slug: { equals: slug } },
+    limit: 1,
+    overrideAccess: true,
+  })
+  if (existing.docs[0]) return existing.docs[0].id
+  const created = await payload.create({
+    collection: 'tenants',
+    data: { name: slug, slug, status: 'active' },
+    overrideAccess: true,
+  })
+  return created.id
+}
+
+describe('process-duplications stuck record auto-fail — integration', () => {
+  let payload: Payload
+  let tenantId: string
+  let categoryId: string
+  let courseId: string
+  let chapterId: string
+  let sourceLessonWithExerciseId: string
+  let sourceLessonNoExerciseId: string
+
+  beforeAll(async () => {
+    payload = await getPayload({ config })
+    tenantId = await ensureDefaultTenant(payload)
+    const ts = Date.now()
+
+    const category = await payload.create({
+      collection: 'categories',
+      data: { title: `StuckCat ${ts}`, slug: `stuck-cat-${ts}`, locale: 'he' },
+    })
+    categoryId = category.id
+
+    const course = await payload.create({
+      collection: 'courses',
+      data: {
+        courseLabel: `STUCK-${ts}`,
+        title: `Stuck Course ${ts}`,
+        locale: 'he',
+        categories: [categoryId],
+        order: 0,
+        status: 'published',
+        isActive: true,
+        tenant: tenantId,
+        pageAccessType: 'free',
+        accessType: 'free',
+        contentStatus: 'none',
+        contentStatusVisible: true,
+      },
+      draft: false,
+    })
+    courseId = course.id
+
+    const chapter = await payload.create({
+      collection: 'chapters',
+      data: {
+        title: `Stuck Chapter ${ts}`,
+        chapterLabel: `SCH-${ts}`,
+        course: courseId,
+        order: 0,
+        status: 'published',
+        isActive: true,
+        tenant: tenantId,
+        locale: 'he',
+      },
+    })
+    chapterId = chapter.id
+
+    // Source lesson WITH one exercise — used for progress-reset tests
+    const lessonWithEx = await payload.create({
+      collection: 'lessons',
+      data: {
+        title: `Stuck Source Lesson With Ex ${ts}`,
+        chapter: chapterId,
+        type: 'practice',
+        order: 1,
+        status: 'published',
+        isActive: true,
+        tenant: tenantId,
+        locale: 'he',
+        accessType: 'inherit',
+        contentStatus: 'none',
+        contentStatusVisible: true,
+      },
+      draft: false,
+    })
+    sourceLessonWithExerciseId = lessonWithEx.id
+
+    // Add one exercise to the lesson (needed for the lesson to be processable)
+    await payload.create({
+      collection: 'exercises',
+      data: {
+        title: `Exercise for ${ts}`,
+        lesson: sourceLessonWithExerciseId,
+        content: {
+          blocks: [
+            {
+              id: 'q-1',
+              type: 'question_select',
+              variant: 'mcq',
+              selectionMode: 'single',
+              prompt: {
+                type: 'rich_text',
+                format: 'md-math-v1',
+                value: 'What is 2+2?',
+                mediaIds: [],
+              },
+              answer: {
+                multiSelect: false,
+                options: [
+                  {
+                    id: 'a',
+                    content: {
+                      type: 'rich_text',
+                      format: 'md-math-v1',
+                      value: '3',
+                      mediaIds: [],
+                    },
+                  },
+                  {
+                    id: 'b',
+                    content: {
+                      type: 'rich_text',
+                      format: 'md-math-v1',
+                      value: '4',
+                      mediaIds: [],
+                    },
+                  },
+                ],
+                correctOptionIds: ['b'],
+              },
+              hint: { type: 'rich_text', format: 'md-math-v1', value: 'Hint', mediaIds: [] },
+              solution: {
+                type: 'rich_text',
+                format: 'md-math-v1',
+                value: 'Solution',
+                mediaIds: [],
+              },
+              fullSolution: {
+                type: 'rich_text',
+                format: 'md-math-v1',
+                value: 'Full solution',
+                mediaIds: [],
+              },
+            },
+          ],
+        },
+      },
+      draft: true,
+      overrideAccess: true,
+    })
+
+    // Source lesson WITHOUT exercises — used for stuck record simulation
+    const lessonNoEx = await payload.create({
+      collection: 'lessons',
+      data: {
+        title: `Stuck Source Lesson No Ex ${ts}`,
+        chapter: chapterId,
+        type: 'practice',
+        order: 2,
+        status: 'published',
+        isActive: true,
+        tenant: tenantId,
+        locale: 'he',
+        accessType: 'inherit',
+        contentStatus: 'none',
+        contentStatusVisible: true,
+      },
+      draft: false,
+    })
+    sourceLessonNoExerciseId = lessonNoEx.id
+  }, 120000)
+
+  afterAll(async () => {
+    await payload.db?.destroy?.()
+  })
+
+  it('claimAttempts field exists and defaults to 0 on new records', async () => {
+    const record = await payload.create({
+      collection: 'lesson-duplications',
+      data: {
+        sourceLesson: sourceLessonWithExerciseId,
+        level: 'light',
+        status: 'pending',
+      },
+      overrideAccess: true,
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((record as any).claimAttempts).toBe(0)
+  })
+
+  it('cron increments claimAttempts by 1 on each claim', async () => {
+    const record = await payload.create({
+      collection: 'lesson-duplications',
+      data: {
+        sourceLesson: sourceLessonWithExerciseId,
+        level: 'light',
+        status: 'pending',
+      },
+      overrideAccess: true,
+    })
+
+    // First cron tick: claim only (orchestrator mocked to return 'in_progress')
+    await makeCronRequest()
+
+    const after1 = await payload.findByID({
+      collection: 'lesson-duplications',
+      id: record.id,
+      depth: 0,
+      overrideAccess: true,
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((after1 as any).claimAttempts).toBe(1)
+
+    // Second tick
+    await makeCronRequest()
+
+    const after2 = await payload.findByID({
+      collection: 'lesson-duplications',
+      id: record.id,
+      depth: 0,
+      overrideAccess: true,
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((after2 as any).claimAttempts).toBe(2)
+  })
+
+  it('record with claimAttempts=4 is still claimed; claimAttempts=5 is excluded', async () => {
+    // record1: will be set to claimAttempts=4, should be claimed (becomes 5)
+    const record1 = await payload.create({
+      collection: 'lesson-duplications',
+      data: {
+        sourceLesson: sourceLessonNoExerciseId,
+        level: 'light',
+        status: 'pending',
+      },
+      overrideAccess: true,
+    })
+    await payload.update({
+      collection: 'lesson-duplications',
+      id: record1.id,
+      data: { claimAttempts: 4 } as never,
+      overrideAccess: true,
+    })
+
+    // record2: created later (higher createdAt), claimAttempts=0, should be claimed
+    const record2 = await payload.create({
+      collection: 'lesson-duplications',
+      data: {
+        sourceLesson: sourceLessonNoExerciseId,
+        level: 'light',
+        status: 'pending',
+      },
+      overrideAccess: true,
+    })
+
+    // record1 should be claimed (claimAttempts becomes 5)
+    const resp1 = await makeCronRequest()
+    expect(resp1.status).toBe(200)
+    const body1 = (await resp1.json()) as { duplicationId?: string }
+    expect(body1.duplicationId).toBe(record1.id)
+
+    // Set record1 to 5 — it should now be excluded
+    await payload.update({
+      collection: 'lesson-duplications',
+      id: record1.id,
+      data: { claimAttempts: 5 } as never,
+      overrideAccess: true,
+    })
+
+    // record2 should now be claimed instead (record1 is stuck/excluded)
+    const resp2 = await makeCronRequest()
+    expect(resp2.status).toBe(200)
+    const body2 = (await resp2.json()) as { duplicationId?: string; outcome?: string }
+    expect(body2.duplicationId).toBe(record2.id)
+    expect(body2.outcome).toBe('failed') // auto-fails at 5
+    expect((body2 as { reason?: string }).reason).toBe('STUCK_AFTER_MAX_ATTEMPTS')
+  })
+
+  it('cron auto-fails record with claimAttempts >= 5 — status=failed + STUCK_AFTER_MAX_ATTEMPTS entry', async () => {
+    const record = await payload.create({
+      collection: 'lesson-duplications',
+      data: {
+        sourceLesson: sourceLessonNoExerciseId,
+        level: 'light',
+        status: 'pending',
+      },
+      overrideAccess: true,
+    })
+    // Simulate 4 prior ticks with no progress
+    await payload.update({
+      collection: 'lesson-duplications',
+      id: record.id,
+      data: { claimAttempts: 4 } as never,
+      overrideAccess: true,
+    })
+
+    // Cron tick: claimAttempts becomes 5 → auto-fail
+    const resp = await makeCronRequest()
+    expect(resp.status).toBe(200)
+    const body = (await resp.json()) as {
+      outcome: string
+      reason: string
+      duplicationId: string
+    }
+    expect(body.outcome).toBe('failed')
+    expect(body.reason).toBe('STUCK_AFTER_MAX_ATTEMPTS')
+
+    // Verify DB state
+    const final = await payload.findByID({
+      collection: 'lesson-duplications',
+      id: record.id,
+      depth: 0,
+      overrideAccess: true,
+    })
+    expect(final.status).toBe('failed')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const failures = (final as any).failures as Array<{ code: string }>
+    expect(failures.length).toBeGreaterThan(0)
+    const stuckEntry = failures.find((f) => f.code === 'STUCK_AFTER_MAX_ATTEMPTS')
+    expect(stuckEntry).toBeDefined()
+  })
+
+  it('progress (outputExercises grew) resets claimAttempts to 0', async () => {
+    const record = await payload.create({
+      collection: 'lesson-duplications',
+      data: {
+        sourceLesson: sourceLessonWithExerciseId,
+        level: 'none', // 'none' level uses script strategy, no LLM calls
+        status: 'pending',
+      },
+      overrideAccess: true,
+    })
+    // Simulate 1 prior tick with no progress yet
+    await payload.update({
+      collection: 'lesson-duplications',
+      id: record.id,
+      data: { claimAttempts: 1 } as never,
+      overrideAccess: true,
+    })
+
+    // Tick: orchestrator should process the 1 exercise → outputExercises grows → claimAttempts resets
+    const resp = await makeCronRequest()
+    expect(resp.status).toBe(200)
+
+    const after = await payload.findByID({
+      collection: 'lesson-duplications',
+      id: record.id,
+      depth: 0,
+      overrideAccess: true,
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((after as any).claimAttempts).toBe(0)
+  })
+
+  it('in_progress with no output growth does NOT reset claimAttempts', async () => {
+    // Source lesson has no exercises → orchestrator always returns 'in_progress'
+    const record = await payload.create({
+      collection: 'lesson-duplications',
+      data: {
+        sourceLesson: sourceLessonNoExerciseId,
+        level: 'light',
+        status: 'pending',
+      },
+      overrideAccess: true,
+    })
+    // Simulate 1 prior tick
+    await payload.update({
+      collection: 'lesson-duplications',
+      id: record.id,
+      data: { claimAttempts: 1 } as never,
+      overrideAccess: true,
+    })
+
+    // Tick: no progress, orchestrator returns 'in_progress' → claimAttempts should increment to 2
+    const resp = await makeCronRequest()
+    expect(resp.status).toBe(200)
+
+    const after = await payload.findByID({
+      collection: 'lesson-duplications',
+      id: record.id,
+      depth: 0,
+      overrideAccess: true,
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((after as any).claimAttempts).toBe(2) // incremented by claim, not reset
+  })
+
+  it('newer record is picked after older stuck record is excluded', async () => {
+    // oldRecord: claimAttempts=5 → stuck/excluded
+    const oldRecord = await payload.create({
+      collection: 'lesson-duplications',
+      data: {
+        sourceLesson: sourceLessonNoExerciseId,
+        level: 'light',
+        status: 'pending',
+      },
+      overrideAccess: true,
+    })
+    await payload.update({
+      collection: 'lesson-duplications',
+      id: oldRecord.id,
+      data: { claimAttempts: 5 } as never,
+      overrideAccess: true,
+    })
+
+    // newRecord: claimAttempts=0, should be picked
+    const newRecord = await payload.create({
+      collection: 'lesson-duplications',
+      data: {
+        sourceLesson: sourceLessonNoExerciseId,
+        level: 'light',
+        status: 'pending',
+      },
+      overrideAccess: true,
+    })
+
+    const resp = await makeCronRequest()
+    const body = (await resp.json()) as { duplicationId?: string }
+    expect(body.duplicationId).toBe(newRecord.id)
+  })
+})

--- a/tests/int/process-duplications-stuck.int.spec.ts
+++ b/tests/int/process-duplications-stuck.int.spec.ts
@@ -24,11 +24,13 @@ import { NextRequest } from 'next/server'
 
 import { getDefaultTenantSlug } from '@/server/repos/tenant/get-default-tenant'
 import { GET as processDuplicationsGET } from '@/app/api/cron/process-duplications/route'
+import { STUCK_FAILURE_CODE } from '@/server/services/lesson-duplication/orchestrator'
 
 // Mock orchestrator to always return 'in_progress' (simulates a record that
 // never makes progress — e.g. source lesson with no exercises)
 vi.mock('@/server/services/lesson-duplication/orchestrator', () => ({
   runDuplicationOrchestrator: vi.fn().mockResolvedValue('in_progress'),
+  STUCK_FAILURE_CODE: 'STUCK_AFTER_MAX_ATTEMPTS',
 }))
 
 const CRON_SECRET = process.env.CRON_SECRET ?? 'test-secret'
@@ -321,7 +323,7 @@ describe('process-duplications stuck record auto-fail — integration', () => {
     const body2 = (await resp2.json()) as { duplicationId?: string; outcome?: string }
     expect(body2.duplicationId).toBe(record2.id)
     expect(body2.outcome).toBe('failed') // auto-fails at 5
-    expect((body2 as { reason?: string }).reason).toBe('STUCK_AFTER_MAX_ATTEMPTS')
+    expect((body2 as { reason?: string }).reason).toBe(STUCK_FAILURE_CODE)
   })
 
   it('cron auto-fails record with claimAttempts >= 5 — status=failed + STUCK_AFTER_MAX_ATTEMPTS entry', async () => {
@@ -351,7 +353,7 @@ describe('process-duplications stuck record auto-fail — integration', () => {
       duplicationId: string
     }
     expect(body.outcome).toBe('failed')
-    expect(body.reason).toBe('STUCK_AFTER_MAX_ATTEMPTS')
+    expect(body.reason).toBe(STUCK_FAILURE_CODE)
 
     // Verify DB state
     const final = await payload.findByID({
@@ -364,7 +366,7 @@ describe('process-duplications stuck record auto-fail — integration', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const failures = (final as any).failures as Array<{ code: string }>
     expect(failures.length).toBeGreaterThan(0)
-    const stuckEntry = failures.find((f) => f.code === 'STUCK_AFTER_MAX_ATTEMPTS')
+    const stuckEntry = failures.find((f) => f.code === STUCK_FAILURE_CODE)
     expect(stuckEntry).toBeDefined()
   })
 


### PR DESCRIPTION
## Summary

- Import `STUCK_FAILURE_CODE` from orchestrator in route.ts and replace all hardcoded `'STUCK_AFTER_MAX_ATTEMPTS'` literals (failure code in `markStuckAndFailed` and the auto-fail response `reason` field).
- Update test file to import and mock `STUCK_FAILURE_CODE`, replacing all string assertions with the constant reference.

## Changes

- `src/app/api/cron/process-duplications/route.ts`
- `tests/int/process-duplications-stuck.int.spec.ts`

Closes #1664

---
_Opened by kody (single-session autonomous run)._ 