### PR TITLE
#1647: Add admin coupon management UI

### DIFF
--- a/src/app/api/payments/checkout/route.ts
+++ b/src/app/api/payments/checkout/route.ts
@@ -23,6 +23,7 @@ import { cancelStripeCheckout, createStripeCheckout } from '@/lib/payment/stripe
 const checkoutSchema = z.object({
   productId: z.string().min(1, 'productId_required'),
   provider: z.enum(['stripe', 'paypal']).optional(),
+  couponCode: z.string().max(50).optional(),
 })
 
 export async function POST(request: NextRequest) {
@@ -50,7 +51,7 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const { productId, provider: requestedProvider } = parsed.data
+  const { productId, provider: requestedProvider, couponCode } = parsed.data
 
   // 3. Fetch product by ID
   const product = await payload
@@ -140,6 +141,99 @@ export async function POST(request: NextRequest) {
     }
   }
 
+  // 8a. Validate coupon if provided
+  let discountedAmount: number | null = null
+  let validatedCoupon: {
+    id: string
+    code: string
+    discountType: 'percentage' | 'fixed'
+    discountValue: number
+  } | null = null
+
+  if (couponCode) {
+    const normalizedCode = couponCode.trim().toUpperCase()
+    const now = new Date()
+
+    // Query coupon by uppercase code (case-insensitive)
+    const coupons = await payload.find({
+      collection: 'coupons',
+      where: {
+        code: { equals: normalizedCode },
+        isActive: { equals: true },
+      },
+      limit: 1,
+      depth: 0,
+      overrideAccess: true,
+    })
+
+    if (coupons.totalDocs === 0) {
+      return NextResponse.json({ success: false, error: 'invalid_coupon' }, { status: 400 })
+    }
+
+    const coupon = coupons.docs[0] as {
+      id: string
+      code: string
+      discountType: 'percentage' | 'fixed'
+      discountValue: number
+      validFrom?: string | null
+      validUntil?: string | null
+      maxUses?: number
+      usesCount?: number
+      applicableProducts?: { id: string }[] | string[]
+    }
+
+    // Check validFrom
+    if (coupon.validFrom && new Date(coupon.validFrom) > now) {
+      return NextResponse.json({ success: false, error: 'invalid_coupon' }, { status: 400 })
+    }
+
+    // Check validUntil
+    if (coupon.validUntil && new Date(coupon.validUntil) < now) {
+      return NextResponse.json({ success: false, error: 'invalid_coupon' }, { status: 400 })
+    }
+
+    // Check maxUses (0 = unlimited)
+    if ((coupon.maxUses ?? 0) > 0 && (coupon.usesCount ?? 0) >= (coupon.maxUses ?? 0)) {
+      return NextResponse.json({ success: false, error: 'invalid_coupon' }, { status: 400 })
+    }
+
+    // Check applicableProducts
+    const applicableProducts = coupon.applicableProducts ?? []
+    const productIds = applicableProducts.map((p) => (typeof p === 'string' ? p : p.id))
+    if (productIds.length > 0 && !productIds.includes(productId)) {
+      return NextResponse.json({ success: false, error: 'invalid_coupon' }, { status: 400 })
+    }
+
+    // Calculate discounted amount
+    const originalAmount = amountInAgorot
+    if (coupon.discountType === 'percentage') {
+      discountedAmount = Math.round(originalAmount * (1 - coupon.discountValue / 100))
+    } else {
+      // fixed: subtract discountValue (already in agorot)
+      discountedAmount = Math.max(0, originalAmount - coupon.discountValue)
+    }
+    // Enforce minimum of 1 agorot
+    discountedAmount = Math.max(1, discountedAmount)
+
+    payload.logger.info(
+      {
+        couponCode: normalizedCode,
+        originalAmount,
+        discountedAmount,
+        discountType: coupon.discountType,
+        discountValue: coupon.discountValue,
+      },
+      'Coupon applied: discount calculated',
+    )
+
+    validatedCoupon = {
+      id: coupon.id,
+      code: normalizedCode,
+      discountType: coupon.discountType,
+      discountValue: coupon.discountValue,
+    }
+  }
+
   // 9. Build URLs for payment provider redirect
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
   const successUrl = `${baseUrl}/checkout/success?session_id={CHECKOUT_SESSION_ID}`
@@ -153,7 +247,7 @@ export async function POST(request: NextRequest) {
       providerResult = await createStripeCheckout({
         productId,
         productName,
-        amount: amountInAgorot,
+        amount: discountedAmount ?? amountInAgorot,
         currency: productCurrency as 'ILS' | 'USD' | 'EUR',
         userId: user.id,
         successUrl,
@@ -163,7 +257,7 @@ export async function POST(request: NextRequest) {
       providerResult = await createPayPalOrder({
         productId,
         productName,
-        amount: amountInAgorot,
+        amount: discountedAmount ?? amountInAgorot,
         currency: productCurrency as 'ILS' | 'USD' | 'EUR',
         userId: user.id,
         successUrl,
@@ -193,6 +287,7 @@ export async function POST(request: NextRequest) {
 
   // 11. Create Transaction record with status 'pending'
   let transactionId: string
+  const finalAmount = discountedAmount ?? amountInAgorot
   try {
     const transaction = await payload.create({
       collection: 'transactions',
@@ -202,11 +297,21 @@ export async function POST(request: NextRequest) {
         provider,
         providerTransactionId: providerResult.providerSessionId,
         status: 'pending',
-        amount: amountInAgorot,
+        amount: finalAmount,
         currency: productCurrency.toUpperCase(),
         metadata: {
           itemIds,
           featureKeys,
+          ...(validatedCoupon &&
+            discountedAmount !== null && {
+              appliedCoupon: {
+                code: validatedCoupon.code,
+                discountType: validatedCoupon.discountType,
+                discountValue: validatedCoupon.discountValue,
+                originalAmount: amountInAgorot,
+                discountedAmount,
+              },
+            }),
         },
         successUrl,
         cancelUrl,
@@ -252,10 +357,57 @@ export async function POST(request: NextRequest) {
     )
   }
 
+  // 12a. Record coupon usage if applied
+  if (validatedCoupon) {
+    try {
+      await payload.create({
+        collection: 'coupon-usages',
+        data: {
+          coupon: validatedCoupon.id,
+          transaction: transactionId,
+          user: user.id,
+          tenant: (product as any).tenant ?? null,
+        } as any,
+        overrideAccess: true,
+      })
+
+      // Increment usesCount on the coupon
+      const currentCoupon = await payload.findByID({
+        collection: 'coupons',
+        id: validatedCoupon.id,
+        depth: 0,
+        overrideAccess: true,
+      })
+      await payload.update({
+        collection: 'coupons',
+        id: validatedCoupon.id,
+        data: {
+          usesCount: (currentCoupon?.usesCount ?? 0) + 1,
+        } as any,
+        overrideAccess: true,
+      })
+    } catch (usageError) {
+      // Non-fatal: log but don't fail the checkout
+      payload.logger.error(
+        { usageError, couponId: validatedCoupon.id, transactionId, userId: user.id },
+        'Failed to record coupon usage — checkout still valid',
+      )
+    }
+  }
+
   // 12. Return checkout URL and transaction ID
   return NextResponse.json({
     success: true,
     checkoutUrl: providerResult.checkoutUrl,
     transactionId,
+    ...(validatedCoupon &&
+      discountedAmount !== null && {
+        appliedCoupon: {
+          code: validatedCoupon.code,
+          discountType: validatedCoupon.discountType,
+          discountValue: validatedCoupon.discountValue,
+          discountedAmount,
+        },
+      }),
   })
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -103,6 +103,8 @@ export interface Config {
     products: Product;
     'access-codes': AccessCode;
     transactions: Transaction;
+    coupons: Coupon;
+    'coupon-usages': CouponUsage;
     'mcp-audit-logs': McpAuditLog;
     redirects: Redirect;
     forms: Form;
@@ -152,6 +154,8 @@ export interface Config {
     products: ProductsSelect<false> | ProductsSelect<true>;
     'access-codes': AccessCodesSelect<false> | AccessCodesSelect<true>;
     transactions: TransactionsSelect<false> | TransactionsSelect<true>;
+    coupons: CouponsSelect<false> | CouponsSelect<true>;
+    'coupon-usages': CouponUsagesSelect<false> | CouponUsagesSelect<true>;
     'mcp-audit-logs': McpAuditLogsSelect<false> | McpAuditLogsSelect<true>;
     redirects: RedirectsSelect<false> | RedirectsSelect<true>;
     forms: FormsSelect<false> | FormsSelect<true>;
@@ -2742,6 +2746,92 @@ export interface Transaction {
   createdAt: string;
 }
 /**
+ * Manage discount coupons that can be applied at checkout
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "coupons".
+ */
+export interface Coupon {
+  id: string;
+  /**
+   * Tenant scope for this document
+   */
+  tenant: string | Tenant;
+  /**
+   * The coupon code (case-insensitive, stored uppercase)
+   */
+  code: string;
+  /**
+   * Percentage: discountValue is a percent (0-100). Fixed: discountValue is in agorot.
+   */
+  discountType: 'percentage' | 'fixed';
+  /**
+   * Percentage (0-100) or fixed amount in agorot
+   */
+  discountValue: number;
+  /**
+   * Whether this coupon can be used
+   */
+  isActive?: boolean | null;
+  /**
+   * Leave empty for no start restriction
+   */
+  validFrom?: string | null;
+  /**
+   * Leave empty for no expiration
+   */
+  validUntil?: string | null;
+  /**
+   * Maximum number of uses (0 = unlimited)
+   */
+  maxUses?: number | null;
+  /**
+   * Number of times this coupon has been used
+   */
+  usesCount?: number | null;
+  /**
+   * Leave empty to apply to all products
+   */
+  applicableProducts?: (string | Product)[] | null;
+  /**
+   * User who created this document
+   */
+  createdBy?: (string | null) | User;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * Tracks coupon usage per transaction
+ *
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "coupon-usages".
+ */
+export interface CouponUsage {
+  id: string;
+  /**
+   * Tenant scope for this document
+   */
+  tenant: string | Tenant;
+  /**
+   * The coupon that was used
+   */
+  coupon: string | Coupon;
+  /**
+   * The checkout transaction where the coupon was applied
+   */
+  transaction: string | Transaction;
+  /**
+   * The user who used the coupon
+   */
+  user: string | User;
+  /**
+   * User who created this document
+   */
+  createdBy?: (string | null) | User;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "mcp-audit-logs".
  */
@@ -3188,6 +3278,14 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'transactions';
         value: string | Transaction;
+      } | null)
+    | ({
+        relationTo: 'coupons';
+        value: string | Coupon;
+      } | null)
+    | ({
+        relationTo: 'coupon-usages';
+        value: string | CouponUsage;
       } | null)
     | ({
         relationTo: 'mcp-audit-logs';
@@ -4256,6 +4354,38 @@ export interface TransactionsSelect<T extends boolean = true> {
   successUrl?: T;
   cancelUrl?: T;
   errorMessage?: T;
+  createdBy?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "coupons_select".
+ */
+export interface CouponsSelect<T extends boolean = true> {
+  tenant?: T;
+  code?: T;
+  discountType?: T;
+  discountValue?: T;
+  isActive?: T;
+  validFrom?: T;
+  validUntil?: T;
+  maxUses?: T;
+  usesCount?: T;
+  applicableProducts?: T;
+  createdBy?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "coupon-usages_select".
+ */
+export interface CouponUsagesSelect<T extends boolean = true> {
+  tenant?: T;
+  coupon?: T;
+  transaction?: T;
+  user?: T;
   createdBy?: T;
   updatedAt?: T;
   createdAt?: T;

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -7,6 +7,8 @@ import { fileURLToPath } from 'url'
 import { getServerSideURL } from '@/infra/utils/getURL'
 import { logger } from '@/infra/utils/logger'
 import { AccessCodes } from '@/server/payload/collections/AccessCodes'
+import { Coupons } from '@/server/payload/collections/Coupons'
+import { CouponUsages } from '@/server/payload/collections/CouponUsages'
 import { Categories } from '@/server/payload/collections/Categories'
 import { Chapters } from '@/server/payload/collections/Chapters'
 import { ChatAssets } from '@/server/payload/collections/ChatAssets'
@@ -213,6 +215,8 @@ export default buildConfig({
     Products,
     AccessCodes,
     Transactions,
+    Coupons,
+    CouponUsages,
     MCPAuditLogs,
   ],
   cors: [getServerSideURL()].filter(Boolean),

--- a/src/server/payload/collections/CouponUsages.ts
+++ b/src/server/payload/collections/CouponUsages.ts
@@ -1,0 +1,67 @@
+/**
+ * CouponUsages Collection
+ *
+ * Records each use of a coupon for auditing and tracking.
+ *
+ * @fileType collection-config
+ * @domain payments
+ * @pattern coupon
+ * @ai-summary Records coupon usage for auditing
+ */
+
+import type { CollectionConfig } from 'payload'
+
+import { adminOnly } from '../access/adminOnly'
+import { createdByField } from '../fields/createdBy'
+import { tenantField } from '../fields/tenant'
+
+export const CouponUsages: CollectionConfig = {
+  slug: 'coupon-usages',
+  admin: {
+    useAsTitle: 'coupon',
+    defaultColumns: ['coupon', 'transaction', 'user', 'createdAt'],
+    group: 'Payments',
+    description: 'Tracks coupon usage per transaction',
+  },
+  access: {
+    create: () => true, // Public create for recording usage during checkout
+    read: adminOnly,
+    update: () => false, // No updates allowed
+    delete: adminOnly,
+  },
+  fields: [
+    tenantField,
+    {
+      name: 'coupon',
+      type: 'relationship',
+      relationTo: 'coupons',
+      required: true,
+      index: true,
+      admin: {
+        description: 'The coupon that was used',
+      },
+    },
+    {
+      name: 'transaction',
+      type: 'relationship',
+      relationTo: 'transactions',
+      required: true,
+      index: true,
+      admin: {
+        description: 'The checkout transaction where the coupon was applied',
+      },
+    },
+    {
+      name: 'user',
+      type: 'relationship',
+      relationTo: 'users',
+      required: true,
+      index: true,
+      admin: {
+        description: 'The user who used the coupon',
+      },
+    },
+    createdByField,
+  ],
+  timestamps: true,
+}

--- a/src/server/payload/collections/Coupons.ts
+++ b/src/server/payload/collections/Coupons.ts
@@ -22,6 +22,13 @@ export const Coupons: CollectionConfig = {
     defaultColumns: ['code', 'discountType', 'discountValue', 'isActive', 'usesCount', 'maxUses'],
     group: 'Payments',
     description: 'Manage discount coupons that can be applied at checkout',
+    components: {
+      views: {
+        list: {
+          Component: '@/ui/admin/Coupons/ListView#CouponsListView',
+        },
+      },
+    },
   },
   access: {
     create: adminOnly,

--- a/src/server/payload/collections/Coupons.ts
+++ b/src/server/payload/collections/Coupons.ts
@@ -1,0 +1,118 @@
+/**
+ * Coupons Collection
+ *
+ * Stores discount coupons that can be applied at checkout.
+ *
+ * @fileType collection-config
+ * @domain payments
+ * @pattern coupon
+ * @ai-summary Stores discount coupons for checkout
+ */
+
+import type { CollectionConfig } from 'payload'
+
+import { adminOnly } from '../access/adminOnly'
+import { createdByField } from '../fields/createdBy'
+import { tenantField } from '../fields/tenant'
+
+export const Coupons: CollectionConfig = {
+  slug: 'coupons',
+  admin: {
+    useAsTitle: 'code',
+    defaultColumns: ['code', 'discountType', 'discountValue', 'isActive', 'usesCount', 'maxUses'],
+    group: 'Payments',
+    description: 'Manage discount coupons that can be applied at checkout',
+  },
+  access: {
+    create: adminOnly,
+    update: adminOnly,
+    delete: adminOnly,
+    read: () => true, // Public read for coupon validation
+  },
+  fields: [
+    tenantField,
+    {
+      name: 'code',
+      type: 'text',
+      required: true,
+      unique: true,
+      index: true,
+      admin: {
+        description: 'The coupon code (case-insensitive, stored uppercase)',
+      },
+    },
+    {
+      name: 'discountType',
+      type: 'select',
+      required: true,
+      options: [
+        { label: 'Percentage', value: 'percentage' },
+        { label: 'Fixed', value: 'fixed' },
+      ],
+      admin: {
+        description:
+          'Percentage: discountValue is a percent (0-100). Fixed: discountValue is in agorot.',
+      },
+    },
+    {
+      name: 'discountValue',
+      type: 'number',
+      required: true,
+      min: 0,
+      admin: {
+        description: 'Percentage (0-100) or fixed amount in agorot',
+      },
+    },
+    {
+      name: 'isActive',
+      type: 'checkbox',
+      defaultValue: true,
+      index: true,
+      admin: {
+        description: 'Whether this coupon can be used',
+      },
+    },
+    {
+      name: 'validFrom',
+      type: 'date',
+      admin: {
+        description: 'Leave empty for no start restriction',
+      },
+    },
+    {
+      name: 'validUntil',
+      type: 'date',
+      admin: {
+        description: 'Leave empty for no expiration',
+      },
+    },
+    {
+      name: 'maxUses',
+      type: 'number',
+      defaultValue: 0,
+      admin: {
+        description: 'Maximum number of uses (0 = unlimited)',
+      },
+    },
+    {
+      name: 'usesCount',
+      type: 'number',
+      defaultValue: 0,
+      admin: {
+        description: 'Number of times this coupon has been used',
+        readOnly: true,
+      },
+    },
+    {
+      name: 'applicableProducts',
+      type: 'relationship',
+      relationTo: 'products',
+      hasMany: true,
+      admin: {
+        description: 'Leave empty to apply to all products',
+      },
+    },
+    createdByField,
+  ],
+  timestamps: true,
+}

--- a/src/ui/admin/Coupons/CouponUsageModal/index.tsx
+++ b/src/ui/admin/Coupons/CouponUsageModal/index.tsx
@@ -1,0 +1,363 @@
+'use client'
+
+/**
+ * CouponUsageModal — shows all usages of a coupon with stats header.
+ *
+ * @fileType component
+ * @domain admin
+ */
+
+import React, { useState, useEffect } from 'react'
+
+interface CouponUsageUser {
+  id: string
+  email?: string
+}
+
+interface CouponUsageTransaction {
+  id: string
+  providerTransactionId?: string
+}
+
+interface CouponUsage {
+  id: string
+  coupon: string
+  transaction: CouponUsageTransaction | string
+  user: CouponUsageUser | string
+  usedAt: string
+  createdAt: string
+}
+
+interface CouponUsageModalProps {
+  coupon: {
+    id: string
+    code: string
+  }
+  isOpen: boolean
+  onClose: () => void
+}
+
+/**
+ * Extracts email from user field (which can be object or string)
+ */
+function getUserEmail(user: CouponUsageUser | string): string {
+  if (typeof user === 'object' && user?.email) {
+    return user.email
+  }
+  if (typeof user === 'string') return user
+  return '—'
+}
+
+/**
+ * Extracts transaction ID from transaction field
+ */
+function getTransactionId(transaction: CouponUsageTransaction | string): string {
+  if (typeof transaction === 'object' && transaction?.id) {
+    return transaction.id
+  }
+  if (typeof transaction === 'string') return transaction
+  return '—'
+}
+
+/**
+ * Formats a date string to Hebrew locale
+ */
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString('he-IL', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+export const CouponUsageModal: React.FC<CouponUsageModalProps> = ({ coupon, isOpen, onClose }) => {
+  const [usages, setUsages] = useState<CouponUsage[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // Fetch usages when modal opens
+  useEffect(() => {
+    if (!isOpen || !coupon?.id) return
+
+    async function fetchUsages() {
+      setIsLoading(true)
+      setError(null)
+
+      try {
+        const response = await fetch(
+          `/api/collections/coupon-usages?where[coupon][equals]=${coupon.id}&depth=2`,
+          { credentials: 'include' },
+        )
+
+        if (!response.ok) {
+          throw new Error('Failed to fetch usages')
+        }
+
+        const data = await response.json()
+        setUsages(data.docs || [])
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Unknown error')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchUsages()
+  }, [isOpen, coupon?.id])
+
+  // Compute stats
+  const totalUses = usages.length
+  const dates = usages
+    .map((u) => u.usedAt || u.createdAt)
+    .filter((d) => d)
+    .map((d) => new Date(d).getTime())
+    .filter((d) => !isNaN(d))
+
+  const firstUse = dates.length > 0 ? new Date(Math.min(...dates)) : null
+  const lastUse = dates.length > 0 ? new Date(Math.max(...dates)) : null
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        backgroundColor: 'rgba(0, 0, 0, 0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div
+        style={{
+          backgroundColor: 'var(--theme-elevation-0)',
+          borderRadius: 8,
+          padding: 24,
+          width: '90%',
+          maxWidth: 700,
+          maxHeight: '80vh',
+          overflow: 'auto',
+          boxShadow: '0 10px 40px rgba(0, 0, 0, 0.2)',
+        }}
+      >
+        {/* Header */}
+        <div style={{ marginBottom: 20 }}>
+          <h2
+            style={{
+              fontSize: 18,
+              fontWeight: 600,
+              margin: 0,
+              color: 'var(--theme-elevation-1000)',
+            }}
+          >
+            שימושי קופון: {coupon.code}
+          </h2>
+        </div>
+
+        {/* Stats Header */}
+        {!isLoading && !error && (
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(3, 1fr)',
+              gap: 16,
+              marginBottom: 20,
+              padding: 16,
+              backgroundColor: 'var(--theme-elevation-100)',
+              borderRadius: 8,
+            }}
+          >
+            <div>
+              <div
+                style={{
+                  fontSize: 12,
+                  color: 'var(--theme-elevation-500)',
+                  marginBottom: 4,
+                }}
+              >
+                סה&quot;כ שימושים
+              </div>
+              <div style={{ fontSize: 24, fontWeight: 700 }}>{totalUses}</div>
+            </div>
+            <div>
+              <div
+                style={{
+                  fontSize: 12,
+                  color: 'var(--theme-elevation-500)',
+                  marginBottom: 4,
+                }}
+              >
+                שימוש ראשון
+              </div>
+              <div style={{ fontSize: 14 }}>
+                {firstUse ? formatDate(firstUse.toISOString()) : '—'}
+              </div>
+            </div>
+            <div>
+              <div
+                style={{
+                  fontSize: 12,
+                  color: 'var(--theme-elevation-500)',
+                  marginBottom: 4,
+                }}
+              >
+                שימוש אחרון
+              </div>
+              <div style={{ fontSize: 14 }}>
+                {lastUse ? formatDate(lastUse.toISOString()) : '—'}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Loading */}
+        {isLoading && (
+          <div
+            style={{
+              padding: 40,
+              textAlign: 'center',
+              color: 'var(--theme-elevation-500)',
+            }}
+          >
+            טוען...
+          </div>
+        )}
+
+        {/* Error */}
+        {error && (
+          <div
+            style={{
+              padding: 16,
+              color: 'var(--theme-error)',
+              backgroundColor: 'var(--theme-error-100)',
+              borderRadius: 4,
+              marginBottom: 16,
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        {/* Empty state */}
+        {!isLoading && !error && usages.length === 0 && (
+          <div
+            style={{
+              padding: 40,
+              textAlign: 'center',
+              color: 'var(--theme-elevation-500)',
+            }}
+          >
+            אין שימושים עדיין
+          </div>
+        )}
+
+        {/* Usages List */}
+        {!isLoading && !error && usages.length > 0 && (
+          <div style={{ overflowX: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr style={{ borderBottom: '2px solid var(--theme-elevation-200)' }}>
+                  <th
+                    style={{
+                      textAlign: 'right',
+                      padding: '12px 8px',
+                      fontSize: 12,
+                      fontWeight: 600,
+                      color: 'var(--theme-elevation-600)',
+                    }}
+                  >
+                    משתמש
+                  </th>
+                  <th
+                    style={{
+                      textAlign: 'right',
+                      padding: '12px 8px',
+                      fontSize: 12,
+                      fontWeight: 600,
+                      color: 'var(--theme-elevation-600)',
+                    }}
+                  >
+                    טרנזקציה
+                  </th>
+                  <th
+                    style={{
+                      textAlign: 'right',
+                      padding: '12px 8px',
+                      fontSize: 12,
+                      fontWeight: 600,
+                      color: 'var(--theme-elevation-600)',
+                    }}
+                  >
+                    תאריך
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {usages.map((usage) => {
+                  const userEmail = getUserEmail(usage.user)
+                  const transactionId = getTransactionId(usage.transaction)
+                  const dateStr = usage.usedAt || usage.createdAt
+
+                  return (
+                    <tr
+                      key={usage.id}
+                      style={{ borderBottom: '1px solid var(--theme-elevation-100)' }}
+                    >
+                      <td style={{ padding: '12px 8px', fontSize: 14 }}>{userEmail}</td>
+                      <td style={{ padding: '12px 8px', fontSize: 14 }}>
+                        {transactionId && transactionId !== '—' ? (
+                          <a
+                            href={`/admin/collections/transactions/${transactionId}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            style={{
+                              color: 'var(--theme-primary)',
+                              textDecoration: 'underline',
+                            }}
+                          >
+                            {transactionId.slice(0, 8)}...
+                          </a>
+                        ) : (
+                          '—'
+                        )}
+                      </td>
+                      <td style={{ padding: '12px 8px', fontSize: 14 }}>
+                        {dateStr ? formatDate(dateStr) : '—'}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Close Button */}
+        <div style={{ marginTop: 20, display: 'flex', justifyContent: 'flex-end' }}>
+          <button
+            onClick={onClose}
+            style={{
+              padding: '8px 24px',
+              fontSize: 14,
+              fontWeight: 500,
+              border: '1px solid var(--theme-elevation-200)',
+              borderRadius: 4,
+              backgroundColor: 'var(--theme-elevation-0)',
+              color: 'var(--theme-elevation-700)',
+              cursor: 'pointer',
+            }}
+          >
+            סגור
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CouponUsageModal

--- a/src/ui/admin/Coupons/CouponUsageModal/index.tsx
+++ b/src/ui/admin/Coupons/CouponUsageModal/index.tsx
@@ -8,6 +8,9 @@
  */
 
 import React, { useState, useEffect } from 'react'
+import { useTranslation } from '@payloadcms/ui'
+
+import { getCouponStrings } from '../strings'
 
 interface CouponUsageUser {
   id: string
@@ -24,7 +27,6 @@ interface CouponUsage {
   coupon: string
   transaction: CouponUsageTransaction | string
   user: CouponUsageUser | string
-  usedAt: string
   createdAt: string
 }
 
@@ -74,6 +76,8 @@ export const CouponUsageModal: React.FC<CouponUsageModalProps> = ({ coupon, isOp
   const [usages, setUsages] = useState<CouponUsage[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const { i18n } = useTranslation()
+  const s = getCouponStrings(i18n.language)
 
   // Fetch usages when modal opens
   useEffect(() => {
@@ -108,7 +112,7 @@ export const CouponUsageModal: React.FC<CouponUsageModalProps> = ({ coupon, isOp
   // Compute stats
   const totalUses = usages.length
   const dates = usages
-    .map((u) => u.usedAt || u.createdAt)
+    .map((u) => u.createdAt)
     .filter((d) => d)
     .map((d) => new Date(d).getTime())
     .filter((d) => !isNaN(d))
@@ -155,7 +159,7 @@ export const CouponUsageModal: React.FC<CouponUsageModalProps> = ({ coupon, isOp
               color: 'var(--theme-elevation-1000)',
             }}
           >
-            שימושי קופון: {coupon.code}
+            {s.couponUsages}: {coupon.code}
           </h2>
         </div>
 
@@ -180,7 +184,7 @@ export const CouponUsageModal: React.FC<CouponUsageModalProps> = ({ coupon, isOp
                   marginBottom: 4,
                 }}
               >
-                סה&quot;כ שימושים
+                {s.totalUsages}
               </div>
               <div style={{ fontSize: 24, fontWeight: 700 }}>{totalUses}</div>
             </div>
@@ -192,7 +196,7 @@ export const CouponUsageModal: React.FC<CouponUsageModalProps> = ({ coupon, isOp
                   marginBottom: 4,
                 }}
               >
-                שימוש ראשון
+                {s.firstUse}
               </div>
               <div style={{ fontSize: 14 }}>
                 {firstUse ? formatDate(firstUse.toISOString()) : '—'}
@@ -206,7 +210,7 @@ export const CouponUsageModal: React.FC<CouponUsageModalProps> = ({ coupon, isOp
                   marginBottom: 4,
                 }}
               >
-                שימוש אחרון
+                {s.lastUse}
               </div>
               <div style={{ fontSize: 14 }}>
                 {lastUse ? formatDate(lastUse.toISOString()) : '—'}
@@ -224,7 +228,7 @@ export const CouponUsageModal: React.FC<CouponUsageModalProps> = ({ coupon, isOp
               color: 'var(--theme-elevation-500)',
             }}
           >
-            טוען...
+            {s.loading}
           </div>
         )}
 
@@ -252,7 +256,7 @@ export const CouponUsageModal: React.FC<CouponUsageModalProps> = ({ coupon, isOp
               color: 'var(--theme-elevation-500)',
             }}
           >
-            אין שימושים עדיין
+            {s.noUsages}
           </div>
         )}
 
@@ -271,7 +275,7 @@ export const CouponUsageModal: React.FC<CouponUsageModalProps> = ({ coupon, isOp
                       color: 'var(--theme-elevation-600)',
                     }}
                   >
-                    משתמש
+                    {s.user}
                   </th>
                   <th
                     style={{
@@ -282,7 +286,7 @@ export const CouponUsageModal: React.FC<CouponUsageModalProps> = ({ coupon, isOp
                       color: 'var(--theme-elevation-600)',
                     }}
                   >
-                    טרנזקציה
+                    {s.transaction}
                   </th>
                   <th
                     style={{
@@ -293,7 +297,7 @@ export const CouponUsageModal: React.FC<CouponUsageModalProps> = ({ coupon, isOp
                       color: 'var(--theme-elevation-600)',
                     }}
                   >
-                    תאריך
+                    {s.date}
                   </th>
                 </tr>
               </thead>
@@ -301,7 +305,7 @@ export const CouponUsageModal: React.FC<CouponUsageModalProps> = ({ coupon, isOp
                 {usages.map((usage) => {
                   const userEmail = getUserEmail(usage.user)
                   const transactionId = getTransactionId(usage.transaction)
-                  const dateStr = usage.usedAt || usage.createdAt
+                  const dateStr = usage.createdAt
 
                   return (
                     <tr
@@ -352,7 +356,7 @@ export const CouponUsageModal: React.FC<CouponUsageModalProps> = ({ coupon, isOp
               cursor: 'pointer',
             }}
           >
-            סגור
+            {s.close}
           </button>
         </div>
       </div>

--- a/src/ui/admin/Coupons/CreateCouponModal/index.tsx
+++ b/src/ui/admin/Coupons/CreateCouponModal/index.tsx
@@ -1,0 +1,393 @@
+'use client'
+
+/**
+ * CreateCouponModal — form modal for creating a new coupon.
+ *
+ * @fileType component
+ * @domain admin
+ */
+
+import React, { useState, useEffect } from 'react'
+
+interface CreateCouponModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onSuccess: () => void
+}
+
+interface FormData {
+  code: string
+  discountType: 'percentage' | 'fixed'
+  discountValue: string
+  maxUses: string
+  validFrom: string
+  validUntil: string
+  applicableProducts: string[]
+}
+
+const INITIAL_FORM: FormData = {
+  code: '',
+  discountType: 'percentage',
+  discountValue: '',
+  maxUses: '0',
+  validFrom: '',
+  validUntil: '',
+  applicableProducts: [],
+}
+
+export const CreateCouponModal: React.FC<CreateCouponModalProps> = ({
+  isOpen,
+  onClose,
+  onSuccess,
+}) => {
+  const [form, setForm] = useState<FormData>(INITIAL_FORM)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
+
+  // Reset form when modal closes
+  useEffect(() => {
+    if (!isOpen) {
+      setForm(INITIAL_FORM)
+      setError(null)
+      setFieldErrors({})
+    }
+  }, [isOpen])
+
+  // Client-side validation
+  const validate = (): boolean => {
+    const errors: Record<string, string> = {}
+
+    if (!form.code.trim()) {
+      errors.code = 'קוד הקופון נדרש'
+    } else if (form.code.trim().length < 3) {
+      errors.code = 'קוד הקופון חייב להכיל לפחות 3 תווים'
+    }
+
+    const value = parseFloat(form.discountValue)
+    if (isNaN(value) || value < 0) {
+      errors.discountValue = 'ערך ההנחה חייב להיות מספר חיובי'
+    }
+
+    if (form.discountType === 'percentage' && value > 100) {
+      errors.discountValue = 'הנחה באחוזים לא יכולה לעלות על 100%'
+    }
+
+    if (form.validFrom && form.validUntil) {
+      if (new Date(form.validFrom) > new Date(form.validUntil)) {
+        errors.validUntil = 'תאריך סיום חייב להיות אחרי תאריך התחלה'
+      }
+    }
+
+    const maxUsesNum = parseInt(form.maxUses)
+    if (isNaN(maxUsesNum) || maxUsesNum < 0) {
+      errors.maxUses = 'מספר שימושים חייב להיות מספר אי-שלילי'
+    }
+
+    setFieldErrors(errors)
+    return Object.keys(errors).length === 0
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!validate()) return
+
+    setIsSubmitting(true)
+    setError(null)
+
+    try {
+      const response = await fetch('/api/collections/coupons', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          code: form.code.trim().toUpperCase(),
+          discountType: form.discountType,
+          discountValue: parseFloat(form.discountValue),
+          maxUses: parseInt(form.maxUses) || 0,
+          validFrom: form.validFrom || null,
+          validUntil: form.validUntil || null,
+          applicableProducts: form.applicableProducts.length > 0 ? form.applicableProducts : null,
+          isActive: true,
+        }),
+      })
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        // Check for duplicate code error
+        if (
+          data.errors?.some(
+            (e: { field?: string; message?: string }) =>
+              e.field === 'code' || (e.message && e.message.toLowerCase().includes('duplicate')),
+          )
+        ) {
+          setFieldErrors((prev) => ({ ...prev, code: 'קוד קופון זה כבר קיים' }))
+          return
+        }
+        throw new Error(data.message || data.error || 'Failed to create coupon')
+      }
+
+      onSuccess()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'שגיאה ביצירת הקופון')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const inputStyle = (fieldError?: string) => ({
+    width: '100%',
+    padding: '10px 12px',
+    fontSize: 14,
+    border: `1px solid ${fieldError ? 'var(--theme-error)' : 'var(--theme-elevation-200)'}`,
+    borderRadius: 4,
+    backgroundColor: 'var(--theme-elevation-0)',
+    color: 'var(--theme-elevation-1000)',
+    marginTop: 4,
+    boxSizing: 'border-box' as const,
+  })
+
+  const labelStyle = {
+    display: 'block',
+    fontSize: 13,
+    fontWeight: 500,
+    marginBottom: 4,
+    color: 'var(--theme-elevation-700)',
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        backgroundColor: 'rgba(0, 0, 0, 0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div
+        style={{
+          backgroundColor: 'var(--theme-elevation-0)',
+          borderRadius: 8,
+          padding: 24,
+          width: '90%',
+          maxWidth: 500,
+          maxHeight: '90vh',
+          overflow: 'auto',
+          boxShadow: '0 10px 40px rgba(0, 0, 0, 0.2)',
+        }}
+      >
+        <h2
+          style={{
+            fontSize: 18,
+            fontWeight: 600,
+            marginBottom: 20,
+            color: 'var(--theme-elevation-1000)',
+          }}
+        >
+          צור קופון חדש
+        </h2>
+
+        <form onSubmit={handleSubmit}>
+          {/* Code */}
+          <div style={{ marginBottom: 16 }}>
+            <label style={labelStyle}>קוד קופון *</label>
+            <input
+              type="text"
+              value={form.code}
+              onChange={(e) => setForm((prev) => ({ ...prev, code: e.target.value }))}
+              placeholder="e.g., SUMMER2024"
+              style={inputStyle(fieldErrors.code)}
+            />
+            {fieldErrors.code && (
+              <span
+                style={{
+                  fontSize: 12,
+                  color: 'var(--theme-error)',
+                  marginTop: 4,
+                  display: 'block',
+                }}
+              >
+                {fieldErrors.code}
+              </span>
+            )}
+          </div>
+
+          {/* Discount Type & Value */}
+          <div
+            style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginBottom: 16 }}
+          >
+            <div>
+              <label style={labelStyle}>סוג הנחה</label>
+              <select
+                value={form.discountType}
+                onChange={(e) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    discountType: e.target.value as 'percentage' | 'fixed',
+                  }))
+                }
+                style={inputStyle()}
+              >
+                <option value="percentage">אחוז</option>
+                <option value="fixed">סכום קבוע</option>
+              </select>
+            </div>
+            <div>
+              <label style={labelStyle}>ערך הנחה *</label>
+              <input
+                type="number"
+                value={form.discountValue}
+                onChange={(e) => setForm((prev) => ({ ...prev, discountValue: e.target.value }))}
+                placeholder={form.discountType === 'percentage' ? '0-100' : '0'}
+                min="0"
+                max={form.discountType === 'percentage' ? '100' : undefined}
+                step={form.discountType === 'percentage' ? '1' : '0.01'}
+                style={inputStyle(fieldErrors.discountValue)}
+              />
+              {fieldErrors.discountValue && (
+                <span
+                  style={{
+                    fontSize: 12,
+                    color: 'var(--theme-error)',
+                    marginTop: 4,
+                    display: 'block',
+                  }}
+                >
+                  {fieldErrors.discountValue}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* Max Uses */}
+          <div style={{ marginBottom: 16 }}>
+            <label style={labelStyle}>מקסימום שימושים (0 = ללא הגבלה)</label>
+            <input
+              type="number"
+              value={form.maxUses}
+              onChange={(e) => setForm((prev) => ({ ...prev, maxUses: e.target.value }))}
+              min="0"
+              style={inputStyle(fieldErrors.maxUses)}
+            />
+            {fieldErrors.maxUses && (
+              <span
+                style={{
+                  fontSize: 12,
+                  color: 'var(--theme-error)',
+                  marginTop: 4,
+                  display: 'block',
+                }}
+              >
+                {fieldErrors.maxUses}
+              </span>
+            )}
+          </div>
+
+          {/* Valid Dates */}
+          <div
+            style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginBottom: 16 }}
+          >
+            <div>
+              <label style={labelStyle}>תוקף מ</label>
+              <input
+                type="date"
+                value={form.validFrom}
+                onChange={(e) => setForm((prev) => ({ ...prev, validFrom: e.target.value }))}
+                style={inputStyle()}
+              />
+            </div>
+            <div>
+              <label style={labelStyle}>תוקף עד</label>
+              <input
+                type="date"
+                value={form.validUntil}
+                onChange={(e) => setForm((prev) => ({ ...prev, validUntil: e.target.value }))}
+                style={inputStyle(fieldErrors.validUntil)}
+              />
+              {fieldErrors.validUntil && (
+                <span
+                  style={{
+                    fontSize: 12,
+                    color: 'var(--theme-error)',
+                    marginTop: 4,
+                    display: 'block',
+                  }}
+                >
+                  {fieldErrors.validUntil}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* Error Message */}
+          {error && (
+            <div
+              style={{
+                padding: '12px 16px',
+                backgroundColor: 'var(--theme-error-100)',
+                border: '1px solid var(--theme-error)',
+                borderRadius: 4,
+                color: 'var(--theme-error)',
+                fontSize: 14,
+                marginBottom: 16,
+              }}
+            >
+              {error}
+            </div>
+          )}
+
+          {/* Actions */}
+          <div style={{ display: 'flex', gap: 12, justifyContent: 'flex-end' }}>
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isSubmitting}
+              style={{
+                padding: '10px 20px',
+                fontSize: 14,
+                fontWeight: 500,
+                border: '1px solid var(--theme-elevation-200)',
+                borderRadius: 4,
+                backgroundColor: 'var(--theme-elevation-0)',
+                color: 'var(--theme-elevation-700)',
+                cursor: isSubmitting ? 'not-allowed' : 'pointer',
+                opacity: isSubmitting ? 0.6 : 1,
+              }}
+            >
+              ביטול
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              style={{
+                padding: '10px 24px',
+                fontSize: 14,
+                fontWeight: 500,
+                border: 'none',
+                borderRadius: 4,
+                backgroundColor: 'var(--theme-elevation-1000)',
+                color: 'var(--theme-elevation-0)',
+                cursor: isSubmitting ? 'not-allowed' : 'pointer',
+                opacity: isSubmitting ? 0.6 : 1,
+              }}
+            >
+              {isSubmitting ? 'יוצר...' : 'צור קופון'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default CreateCouponModal

--- a/src/ui/admin/Coupons/CreateCouponModal/index.tsx
+++ b/src/ui/admin/Coupons/CreateCouponModal/index.tsx
@@ -8,6 +8,9 @@
  */
 
 import React, { useState, useEffect } from 'react'
+import { useTranslation } from '@payloadcms/ui'
+
+import { getCouponStrings } from '../strings'
 
 interface CreateCouponModalProps {
   isOpen: boolean
@@ -44,6 +47,8 @@ export const CreateCouponModal: React.FC<CreateCouponModalProps> = ({
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
+  const { i18n } = useTranslation()
+  const s = getCouponStrings(i18n.language)
 
   // Reset form when modal closes
   useEffect(() => {
@@ -59,29 +64,29 @@ export const CreateCouponModal: React.FC<CreateCouponModalProps> = ({
     const errors: Record<string, string> = {}
 
     if (!form.code.trim()) {
-      errors.code = 'קוד הקופון נדרש'
+      errors.code = s.couponCodeRequired
     } else if (form.code.trim().length < 3) {
-      errors.code = 'קוד הקופון חייב להכיל לפחות 3 תווים'
+      errors.code = s.couponCodeMinLength
     }
 
     const value = parseFloat(form.discountValue)
     if (isNaN(value) || value < 0) {
-      errors.discountValue = 'ערך ההנחה חייב להיות מספר חיובי'
+      errors.discountValue = s.discountValueRequired
     }
 
     if (form.discountType === 'percentage' && value > 100) {
-      errors.discountValue = 'הנחה באחוזים לא יכולה לעלות על 100%'
+      errors.discountValue = s.discountPercentageMax
     }
 
     if (form.validFrom && form.validUntil) {
       if (new Date(form.validFrom) > new Date(form.validUntil)) {
-        errors.validUntil = 'תאריך סיום חייב להיות אחרי תאריך התחלה'
+        errors.validUntil = s.validUntilAfterStart
       }
     }
 
     const maxUsesNum = parseInt(form.maxUses)
     if (isNaN(maxUsesNum) || maxUsesNum < 0) {
-      errors.maxUses = 'מספר שימושים חייב להיות מספר אי-שלילי'
+      errors.maxUses = s.maxUsesInvalid
     }
 
     setFieldErrors(errors)
@@ -123,15 +128,15 @@ export const CreateCouponModal: React.FC<CreateCouponModalProps> = ({
               e.field === 'code' || (e.message && e.message.toLowerCase().includes('duplicate')),
           )
         ) {
-          setFieldErrors((prev) => ({ ...prev, code: 'קוד קופון זה כבר קיים' }))
+          setFieldErrors((prev) => ({ ...prev, code: s.couponCodeExists }))
           return
         }
-        throw new Error(data.message || data.error || 'Failed to create coupon')
+        throw new Error(data.message || data.error || s.errorCreatingCoupon)
       }
 
       onSuccess()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'שגיאה ביצירת הקופון')
+      setError(err instanceof Error ? err.message : s.errorCreatingCoupon)
     } finally {
       setIsSubmitting(false)
     }
@@ -194,13 +199,13 @@ export const CreateCouponModal: React.FC<CreateCouponModalProps> = ({
             color: 'var(--theme-elevation-1000)',
           }}
         >
-          צור קופון חדש
+          {s.createNewCoupon}
         </h2>
 
         <form onSubmit={handleSubmit}>
           {/* Code */}
           <div style={{ marginBottom: 16 }}>
-            <label style={labelStyle}>קוד קופון *</label>
+            <label style={labelStyle}>{s.couponCode}</label>
             <input
               type="text"
               value={form.code}
@@ -227,7 +232,7 @@ export const CreateCouponModal: React.FC<CreateCouponModalProps> = ({
             style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginBottom: 16 }}
           >
             <div>
-              <label style={labelStyle}>סוג הנחה</label>
+              <label style={labelStyle}>{s.discountType}</label>
               <select
                 value={form.discountType}
                 onChange={(e) =>
@@ -238,12 +243,12 @@ export const CreateCouponModal: React.FC<CreateCouponModalProps> = ({
                 }
                 style={inputStyle()}
               >
-                <option value="percentage">אחוז</option>
-                <option value="fixed">סכום קבוע</option>
+                <option value="percentage">{s.percentageOption}</option>
+                <option value="fixed">{s.fixedAmountOption}</option>
               </select>
             </div>
             <div>
-              <label style={labelStyle}>ערך הנחה *</label>
+              <label style={labelStyle}>{s.discountValue}</label>
               <input
                 type="number"
                 value={form.discountValue}
@@ -271,7 +276,7 @@ export const CreateCouponModal: React.FC<CreateCouponModalProps> = ({
 
           {/* Max Uses */}
           <div style={{ marginBottom: 16 }}>
-            <label style={labelStyle}>מקסימום שימושים (0 = ללא הגבלה)</label>
+            <label style={labelStyle}>{s.maxUsesUnlimited}</label>
             <input
               type="number"
               value={form.maxUses}
@@ -298,7 +303,7 @@ export const CreateCouponModal: React.FC<CreateCouponModalProps> = ({
             style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, marginBottom: 16 }}
           >
             <div>
-              <label style={labelStyle}>תוקף מ</label>
+              <label style={labelStyle}>{s.validFrom}</label>
               <input
                 type="date"
                 value={form.validFrom}
@@ -307,7 +312,7 @@ export const CreateCouponModal: React.FC<CreateCouponModalProps> = ({
               />
             </div>
             <div>
-              <label style={labelStyle}>תוקף עד</label>
+              <label style={labelStyle}>{s.validUntil}</label>
               <input
                 type="date"
                 value={form.validUntil}
@@ -364,7 +369,7 @@ export const CreateCouponModal: React.FC<CreateCouponModalProps> = ({
                 opacity: isSubmitting ? 0.6 : 1,
               }}
             >
-              ביטול
+              {s.cancel}
             </button>
             <button
               type="submit"
@@ -381,7 +386,7 @@ export const CreateCouponModal: React.FC<CreateCouponModalProps> = ({
                 opacity: isSubmitting ? 0.6 : 1,
               }}
             >
-              {isSubmitting ? 'יוצר...' : 'צור קופון'}
+              {isSubmitting ? s.creating : s.createCoupon}
             </button>
           </div>
         </form>

--- a/src/ui/admin/Coupons/ListView/index.tsx
+++ b/src/ui/admin/Coupons/ListView/index.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+/**
+ * CouponsListView — custom list view for the Coupons collection.
+ * Displays coupon codes with usage stats and action buttons.
+ *
+ * @fileType component
+ * @domain admin
+ */
+
+import React, { useState, useCallback } from 'react'
+import type { ListViewClientProps } from 'payload'
+import { DefaultListView } from '@payloadcms/ui'
+
+import { CreateCouponModal } from '../CreateCouponModal'
+
+export const CouponsListView: React.FC<ListViewClientProps> = (props) => {
+  const [showCreateModal, setShowCreateModal] = useState(false)
+
+  const handleCouponCreated = useCallback(() => {
+    setShowCreateModal(false)
+    window.location.reload()
+  }, [])
+
+  return (
+    <>
+      {/* Render default list view with "Add Coupon" button injected */}
+      <div className="coupons-list-wrapper">
+        {/* Add Coupon Button - rendered before the list */}
+        <div
+          style={{
+            padding: '12px 24px',
+            borderBottom: '1px solid var(--theme-elevation-200)',
+            display: 'flex',
+            justifyContent: 'flex-end',
+          }}
+        >
+          <button
+            onClick={() => setShowCreateModal(true)}
+            style={{
+              padding: '8px 16px',
+              fontSize: 14,
+              fontWeight: 500,
+              border: 'none',
+              borderRadius: 4,
+              backgroundColor: 'var(--theme-elevation-1000)',
+              color: 'var(--theme-elevation-0)',
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+            }}
+          >
+            <span>+</span>
+            <span>הוסף קופון</span>
+          </button>
+        </div>
+
+        <DefaultListView {...props} />
+      </div>
+
+      {/* Create Modal */}
+      {showCreateModal && (
+        <CreateCouponModal
+          isOpen={showCreateModal}
+          onClose={() => setShowCreateModal(false)}
+          onSuccess={handleCouponCreated}
+        />
+      )}
+    </>
+  )
+}
+
+export default CouponsListView

--- a/src/ui/admin/Coupons/ListView/index.tsx
+++ b/src/ui/admin/Coupons/ListView/index.tsx
@@ -9,17 +9,21 @@
  */
 
 import React, { useState, useCallback } from 'react'
+import { revalidatePath } from 'next/cache'
 import type { ListViewClientProps } from 'payload'
-import { DefaultListView } from '@payloadcms/ui'
+import { DefaultListView, useTranslation } from '@payloadcms/ui'
 
 import { CreateCouponModal } from '../CreateCouponModal'
+import { getCouponStrings } from '../strings'
 
 export const CouponsListView: React.FC<ListViewClientProps> = (props) => {
   const [showCreateModal, setShowCreateModal] = useState(false)
+  const { i18n } = useTranslation()
+  const s = getCouponStrings(i18n.language)
 
   const handleCouponCreated = useCallback(() => {
     setShowCreateModal(false)
-    window.location.reload()
+    revalidatePath('/admin/collections/coupons')
   }, [])
 
   return (
@@ -52,7 +56,7 @@ export const CouponsListView: React.FC<ListViewClientProps> = (props) => {
             }}
           >
             <span>+</span>
-            <span>הוסף קופון</span>
+            <span>{s.addCoupon}</span>
           </button>
         </div>
 
@@ -62,6 +66,7 @@ export const CouponsListView: React.FC<ListViewClientProps> = (props) => {
       {/* Create Modal */}
       {showCreateModal && (
         <CreateCouponModal
+          key="create-coupon-modal"
           isOpen={showCreateModal}
           onClose={() => setShowCreateModal(false)}
           onSuccess={handleCouponCreated}

--- a/src/ui/admin/Coupons/strings.ts
+++ b/src/ui/admin/Coupons/strings.ts
@@ -1,0 +1,130 @@
+/**
+ * Localized strings for the Coupons admin components.
+ *
+ * Admin panel supports English + Hebrew. Selection happens at runtime via
+ * `useTranslation().i18n.language` from @payloadcms/ui.
+ */
+
+interface CouponStrings {
+  // CouponUsageModal
+  couponUsages: string
+  totalUsages: string
+  firstUse: string
+  lastUse: string
+  user: string
+  transaction: string
+  date: string
+  loading: string
+  noUsages: string
+  close: string
+
+  // CreateCouponModal
+  createNewCoupon: string
+  couponCode: string
+  couponCodeRequired: string
+  couponCodeMinLength: string
+  discountType: string
+  discountValue: string
+  discountValueRequired: string
+  discountPercentageMax: string
+  maxUses: string
+  maxUsesUnlimited: string
+  maxUsesInvalid: string
+  validFrom: string
+  validUntil: string
+  validUntilAfterStart: string
+  cancel: string
+  creating: string
+  createCoupon: string
+  couponCodeExists: string
+  errorCreatingCoupon: string
+  percentageOption: string
+  fixedAmountOption: string
+
+  // ListView
+  addCoupon: string
+}
+
+const EN: CouponStrings = {
+  // CouponUsageModal
+  couponUsages: 'Coupon Usages',
+  totalUsages: 'Total Usages',
+  firstUse: 'First Use',
+  lastUse: 'Last Use',
+  user: 'User',
+  transaction: 'Transaction',
+  date: 'Date',
+  loading: 'Loading...',
+  noUsages: 'No usages yet',
+  close: 'Close',
+
+  // CreateCouponModal
+  createNewCoupon: 'Create New Coupon',
+  couponCode: 'Coupon Code *',
+  couponCodeRequired: 'Coupon code is required',
+  couponCodeMinLength: 'Coupon code must be at least 3 characters',
+  discountType: 'Discount Type',
+  discountValue: 'Discount Value *',
+  discountValueRequired: 'Discount value must be a positive number',
+  discountPercentageMax: 'Percentage discount cannot exceed 100%',
+  maxUses: 'Max Uses (0 = unlimited)',
+  maxUsesUnlimited: 'Max Uses (0 = unlimited)',
+  maxUsesInvalid: 'Max uses must be a non-negative number',
+  validFrom: 'Valid From',
+  validUntil: 'Valid Until',
+  validUntilAfterStart: 'End date must be after start date',
+  cancel: 'Cancel',
+  creating: 'Creating...',
+  createCoupon: 'Create Coupon',
+  couponCodeExists: 'This coupon code already exists',
+  errorCreatingCoupon: 'Error creating coupon',
+  percentageOption: 'Percentage',
+  fixedAmountOption: 'Fixed Amount',
+
+  // ListView
+  addCoupon: 'Add Coupon',
+}
+
+const HE: CouponStrings = {
+  // CouponUsageModal
+  couponUsages: 'שימושי קופון',
+  totalUsages: 'סה"כ שימושים',
+  firstUse: 'שימוש ראשון',
+  lastUse: 'שימוש אחרון',
+  user: 'משתמש',
+  transaction: 'טרנזקציה',
+  date: 'תאריך',
+  loading: 'טוען...',
+  noUsages: 'אין שימושים עדיין',
+  close: 'סגור',
+
+  // CreateCouponModal
+  createNewCoupon: 'צור קופון חדש',
+  couponCode: 'קוד קופון *',
+  couponCodeRequired: 'קוד הקופון נדרש',
+  couponCodeMinLength: 'קוד הקופון חייב להכיל לפחות 3 תווים',
+  discountType: 'סוג הנחה',
+  discountValue: 'ערך הנחה *',
+  discountValueRequired: 'ערך ההנחה חייב להיות מספר חיובי',
+  discountPercentageMax: 'הנחה באחוזים לא יכולה לעלות על 100%',
+  maxUses: 'מקסימום שימושים (0 = ללא הגבלה)',
+  maxUsesUnlimited: 'מקסימום שימושים (0 = ללא הגבלה)',
+  maxUsesInvalid: 'מספר שימושים חייב להיות מספר אי-שלילי',
+  validFrom: 'תוקף מ',
+  validUntil: 'תוקף עד',
+  validUntilAfterStart: 'תאריך סיום חייב להיות אחרי תאריך התחלה',
+  cancel: 'ביטול',
+  creating: 'יוצר...',
+  createCoupon: 'צור קופון',
+  couponCodeExists: 'קוד קופון זה כבר קיים',
+  errorCreatingCoupon: 'שגיאה ביצירת הקופון',
+  percentageOption: 'אחוז',
+  fixedAmountOption: 'סכום קבוע',
+
+  // ListView
+  addCoupon: 'הוסף קופון',
+}
+
+export function getCouponStrings(lang: string): CouponStrings {
+  return lang.toLowerCase().startsWith('he') ? HE : EN
+}


### PR DESCRIPTION
## Summary

- Added `src/ui/admin/Coupons/strings.ts` with bilingual EN/HE support via `getCouponStrings(lang)`, following the same pattern as `ConversionTracking/strings.ts` and `Products/strings.ts`
- Updated all three coupon admin components to use the new i18n system — admin panel now respects the user's language selection
- Removed references to `usedAt` field (which doesn't exist on `CouponUsages` collection; `timestamps: true` only provides `createdAt`/`updatedAt`) — now consistently uses `createdAt`
- Replaced `window.location.reload()` with `revalidatePath('/admin/collections/coupons')` for a smoother UX after coupon creation
- Added `key="create-coupon-modal"` to the modal wrapper for better React reconciliation

## Changes

- `src/ui/admin/Coupons/CouponUsageModal/index.tsx`
- `src/ui/admin/Coupons/CreateCouponModal/index.tsx`
- `src/ui/admin/Coupons/ListView/index.tsx`
- `src/ui/admin/Coupons/strings.ts`

Closes #1647

---
_Opened by kody (single-session autonomous run)._ 