### PR TITLE
fix(tests): Unblock stuck-record tests (6 failing on dev)

### DIFF
--- a/tests/int/process-duplications-stuck.int.spec.ts
+++ b/tests/int/process-duplications-stuck.int.spec.ts
@@ -17,14 +17,17 @@
  *  - Verify auto-fail fires on tick 5
  *  - Create a "real" record that makes progress, verify counter resets
  */
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getPayload, type Payload } from 'payload'
 import config from '@payload-config'
 import { NextRequest } from 'next/server'
 
 import { getDefaultTenantSlug } from '@/server/repos/tenant/get-default-tenant'
 import { GET as processDuplicationsGET } from '@/app/api/cron/process-duplications/route'
-import { STUCK_FAILURE_CODE } from '@/server/services/lesson-duplication/orchestrator'
+import {
+  runDuplicationOrchestrator,
+  STUCK_FAILURE_CODE,
+} from '@/server/services/lesson-duplication/orchestrator'
 
 // Mock orchestrator to always return 'in_progress' (simulates a record that
 // never makes progress — e.g. source lesson with no exercises)
@@ -224,6 +227,40 @@ describe('process-duplications stuck record auto-fail — integration', () => {
     await payload.db?.destroy?.()
   })
 
+  /**
+   * Per-test cleanup: the cron's claim query picks the oldest `pending` or
+   * `running` record by `createdAt`. Without wiping leftover records between
+   * tests, the cron would claim a record from a *previous* test instead of
+   * the one the current test just created — every assertion about
+   * "the record I just created" would fail because the cron operated on a
+   * different one.
+   *
+   * We delete only pending/running records (not terminal `failed`/`succeeded`),
+   * which is exactly the slice the cron's filter looks at.
+   */
+  beforeEach(async () => {
+    const stale = await payload.find({
+      collection: 'lesson-duplications',
+      where: {
+        or: [{ status: { equals: 'pending' } }, { status: { equals: 'running' } }],
+      },
+      limit: 0,
+      depth: 0,
+      overrideAccess: true,
+    })
+    for (const doc of stale.docs) {
+      try {
+        await payload.delete({
+          collection: 'lesson-duplications',
+          id: doc.id,
+          overrideAccess: true,
+        })
+      } catch {
+        // ignore — another test may have already cleaned it up
+      }
+    }
+  })
+
   it('claimAttempts field exists and defaults to 0 on new records', async () => {
     const record = await payload.create({
       collection: 'lesson-duplications',
@@ -317,13 +354,26 @@ describe('process-duplications stuck record auto-fail — integration', () => {
       overrideAccess: true,
     })
 
-    // record2 should now be claimed instead (record1 is stuck/excluded)
+    // record2 should now be claimed instead (record1 is stuck/excluded).
+    // record2 starts with claimAttempts=0, so the cron increments it to 1
+    // — well below the auto-fail threshold — and runs the orchestrator
+    // normally (mocked to return 'in_progress'). The body2 outcome reflects
+    // that, NOT 'failed'. Auto-fail behaviour is tested separately in the
+    // next case.
     const resp2 = await makeCronRequest()
     expect(resp2.status).toBe(200)
     const body2 = (await resp2.json()) as { duplicationId?: string; outcome?: string }
     expect(body2.duplicationId).toBe(record2.id)
-    expect(body2.outcome).toBe('failed') // auto-fails at 5
-    expect((body2 as { reason?: string }).reason).toBe(STUCK_FAILURE_CODE)
+    expect(body2.outcome).toBe('in_progress')
+
+    // Verify the original (excluded) record was auto-failed during tick 1.
+    const finalRecord1 = await payload.findByID({
+      collection: 'lesson-duplications',
+      id: record1.id,
+      depth: 0,
+      overrideAccess: true,
+    })
+    expect(finalRecord1.status).toBe('failed')
   })
 
   it('cron auto-fails record with claimAttempts >= 5 — status=failed + STUCK_AFTER_MAX_ATTEMPTS entry', async () => {
@@ -388,7 +438,32 @@ describe('process-duplications stuck record auto-fail — integration', () => {
       overrideAccess: true,
     })
 
-    // Tick: orchestrator should process the 1 exercise → outputExercises grows → claimAttempts resets
+    // Override the global mock for this tick: simulate the orchestrator
+    // actually doing work — append one outputExercise mapping to the record
+    // mid-run. The cron's "progress detected" branch reads outputExercises
+    // pre/post and only resets claimAttempts when the count grows. The global
+    // mock returns 'in_progress' without touching the record, so without
+    // this override the reset branch never fires.
+    vi.mocked(runDuplicationOrchestrator).mockImplementationOnce(async (id) => {
+      await payload.update({
+        collection: 'lesson-duplications',
+        id,
+        data: {
+          outputExercises: [
+            {
+              sourceExerciseId: 'simulated-src',
+              outputExerciseId: 'simulated-out',
+              strategy: 'script',
+            },
+          ],
+        } as never,
+        overrideAccess: true,
+      })
+      return 'in_progress'
+    })
+
+    // Tick: orchestrator (mocked) writes one outputExercise → cron sees
+    // growth → resets claimAttempts to 0.
     const resp = await makeCronRequest()
     expect(resp.status).toBe(200)
 


### PR DESCRIPTION
## Why
`tests/int/process-duplications-stuck.int.spec.ts` had 6 failing tests on dev that have been blocking every PR's CI. Confirmed by checking unrelated PRs (e.g. #1680 canonical export, #1673 retry endpoint) — both fail the same 6 tests despite touching nothing in the cron/orchestrator.

## Root cause
The cron's claim query picks the **oldest** pending/running record by `createdAt`. The test file has no per-test cleanup of `lesson-duplications` records, so each test's freshly-created record was OLDER than leftover records from earlier tests in the same file. The cron would claim a stale record and increment **its** `claimAttempts`, leaving the test's record untouched. Every assertion that reads "the record I just created" then saw default values.

Two test cases had additional bugs:
- **"progress (outputExercises grew) resets claimAttempts to 0"** — the global mock of `runDuplicationOrchestrator` returns `'in_progress'` without modifying the record, so the cron's "growth detected" branch never fires. The test expected `claimAttempts: 0` but never simulated growth.
- **"record with claimAttempts=4 is still claimed; claimAttempts=5 is excluded"** — second tick claims a record that starts at `claimAttempts: 0`, which the cron increments to 1. Test asserted `outcome === 'failed'` but the auto-fail boundary is `>= 5`, so the actual outcome is `'in_progress'`.

## Fixes
1. **`beforeEach` cleanup** — deletes all pending/running `lesson-duplications` records before each test runs. Restores the cron's "pick oldest" semantics to the test's own record.
2. **`mockImplementationOnce` for the progress-reset test** — overrides the global mock so the orchestrator simulates progress by writing one `outputExercises` mapping mid-run. This exercises the cron's reset branch as intended.
3. **Corrected assertions** for the boundary test — `outcome: 'in_progress'` for record2 (claimAttempts=0 → 1), plus a new assertion that record1 was auto-failed during tick 1.

## Test plan
- [ ] CI integration tests on this PR all pass (especially the 6 in question)
- [ ] No new failures introduced in `lesson-duplication-*.int.spec.ts`
- [ ] PRs #1673 and #1680 rebase cleanly on top of this fix and have their stuck-record failures clear

## Out of scope
Pre-existing typecheck errors on dev around `import 'stripe'` (modules not installed). Unrelated; not blocking this fix. Local commit used `SKIP_HOOKS=1` for that reason.