### PR TITLE
#1519: Improve Mobile Lesson Viewing Experience

### DIFF
--- a/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/BlocksDocumentLessonView/index.tsx
+++ b/src/app/(frontend)/courses/[courseSlug]/chapters/[chapterSlug]/lessons/[lessonSlug]/_components/BlocksDocumentLessonView/index.tsx
@@ -222,7 +222,11 @@ export function BlocksDocumentLessonView({
                               {exercise.title}
                             </h2>
                           )}
-                          <ExerciseWorksheet blocks={blocks} mediaMap={mediaMap} />
+                          <ExerciseWorksheet
+                            blocks={blocks}
+                            mediaMap={mediaMap}
+                            hideLatexBlocks={false}
+                          />
                         </section>
                       ))}
                     </div>

--- a/src/ui/web/exerciserenderer/ExerciseWorksheet/index.tsx
+++ b/src/ui/web/exerciserenderer/ExerciseWorksheet/index.tsx
@@ -8,7 +8,7 @@
  *
  * Behavior per block type:
  *   - rich_text                  -> paragraph
- *   - latex                      -> hidden (matches the viewer default)
+ *   - latex                      -> rendered via LatexBlockRenderer (hideLatexBlocks prop controls visibility)
  *   - svg / media                -> figure
  *   - question_geometry          -> Hebrew label + prompt + diagram side-by-side via GraphWithPrompt
  *   - question_axis              -> Hebrew label + prompt + diagram side-by-side via GraphWithPrompt

--- a/src/ui/web/exerciserenderer/ExerciseWorksheet/index.tsx
+++ b/src/ui/web/exerciserenderer/ExerciseWorksheet/index.tsx
@@ -36,6 +36,7 @@ import { GeometryRenderer } from '../blocks/GeometryRenderer'
 import { AxisRenderer } from '../blocks/AxisRenderer'
 import { GraphWithPrompt } from '../blocks/GraphWithPrompt'
 import { MultiAxisRenderer } from '../blocks/MultiAxisRenderer'
+import { LatexBlockRenderer } from '../blocks/LatexBlockRenderer'
 import { getMediaUrl } from '@/infra/utils/getMediaUrl'
 import { HEBREW_LETTERS } from '../constants'
 import type { Media } from '@/payload-types'
@@ -61,6 +62,12 @@ interface ExerciseWorksheetProps {
   /** Pre-resolved media map keyed by ID. */
   mediaMap?: Record<string, Media>
   className?: string
+  /**
+   * When true, LaTeX blocks are hidden (returns null).
+   * When false (default), LaTeX blocks are rendered via LatexBlockRenderer.
+   * Set to true for backward compatibility with ExerciseRenderer which hides LaTeX.
+   */
+  hideLatexBlocks?: boolean
 }
 
 const EMPTY_MEDIA_MAP: Record<string, Media> = {}
@@ -69,6 +76,7 @@ export function ExerciseWorksheet({
   blocks,
   mediaMap = EMPTY_MEDIA_MAP,
   className,
+  hideLatexBlocks = false,
 }: ExerciseWorksheetProps) {
   const locale = useLocale()
   const isRtl = locale?.toLowerCase().startsWith('he') ?? false
@@ -92,6 +100,7 @@ export function ExerciseWorksheet({
             sideBySideLayout,
             isRtl,
             questionIndex,
+            hideLatexBlocks,
           })
           if (incremented) questionIndex++
           return <React.Fragment key={getBlockKey(block, i)}>{renderedBlock}</React.Fragment>
@@ -121,6 +130,7 @@ interface RenderBlockParams {
   sideBySideLayout: GraphLayout
   isRtl: boolean
   questionIndex: number
+  hideLatexBlocks: boolean
 }
 
 /**
@@ -134,6 +144,7 @@ function renderBlockWithLabel({
   sideBySideLayout,
   isRtl,
   questionIndex,
+  hideLatexBlocks,
 }: RenderBlockParams): { block: React.ReactNode; incremented: boolean } {
   const isLabelledQuestion = LABELLED_QUESTION_TYPES.has(block.type)
 
@@ -141,7 +152,7 @@ function renderBlockWithLabel({
     const label = isRtl
       ? `${HEBREW_LETTERS[questionIndex] || String(questionIndex + 1)}.`
       : `${questionIndex + 1}.`
-    const inner = renderBlockContent({ block, mediaMap, sideBySideLayout })
+    const inner = renderBlockContent({ block, mediaMap, sideBySideLayout, hideLatexBlocks })
     return {
       block: (
         <>
@@ -154,7 +165,7 @@ function renderBlockWithLabel({
   }
 
   return {
-    block: renderBlockContent({ block, mediaMap, sideBySideLayout }),
+    block: renderBlockContent({ block, mediaMap, sideBySideLayout, hideLatexBlocks }),
     incremented: false,
   }
 }
@@ -164,10 +175,16 @@ function renderBlockContent({
   block,
   mediaMap,
   sideBySideLayout,
+  hideLatexBlocks,
 }: Omit<RenderBlockParams, 'isRtl' | 'questionIndex'>): React.ReactNode {
-  // LaTeX blocks: hidden, parsed structured blocks beside them already cover
-  // the content. Matches ExerciseRenderer's default.
-  if (block.type === 'latex') return null
+  if (block.type === 'latex') {
+    if (hideLatexBlocks) return null
+    return (
+      <LatexBlockRenderer
+        block={block as import('@/server/payload/collections/Exercises/types').LatexBlock}
+      />
+    )
+  }
 
   if (block.type === 'rich_text') {
     return (

--- a/tests/unit/ui/exercise-worksheet.test.tsx
+++ b/tests/unit/ui/exercise-worksheet.test.tsx
@@ -43,10 +43,10 @@ vi.mock('@/ui/web/exerciserenderer/blocks/LatexBlockRenderer', () => ({
   ),
 }))
 
-function renderWith(locale: 'en' | 'he', blocks: ContentBlock[]) {
+function renderWith(locale: 'en' | 'he', blocks: ContentBlock[], hideLatexBlocks?: boolean) {
   return render(
     <I18nProvider locale={locale} messages={locale === 'en' ? enMessages : heMessages}>
-      <ExerciseWorksheet blocks={blocks} />
+      <ExerciseWorksheet blocks={blocks} hideLatexBlocks={hideLatexBlocks} />
     </I18nProvider>,
   )
 }
@@ -59,7 +59,13 @@ describe('ExerciseWorksheet', () => {
   it('renders latex blocks for mobile exercise viewing (issue #1519)', () => {
     const blocks = [
       { id: 'lx-1', type: 'latex' as const, latex: 'E = mc^2', renderMode: 'block' as const },
-      { id: 'rt-1', type: 'rich_text' as const, format: 'md-math-v1' as const, value: 'Formula:', mediaIds: [] },
+      {
+        id: 'rt-1',
+        type: 'rich_text' as const,
+        format: 'md-math-v1' as const,
+        value: 'Formula:',
+        mediaIds: [],
+      },
     ] as unknown as ContentBlock[]
 
     renderWith('en', blocks)
@@ -80,7 +86,7 @@ describe('ExerciseWorksheet', () => {
       { id: 'lx-1', type: 'latex', latex: 'E = mc^2', renderMode: 'block' },
     ] as unknown as ContentBlock[]
 
-    renderWith('en', blocks)
+    renderWith('en', blocks, true) // hideLatexBlocks={true} to test backward-compatible hiding
     expect(screen.getByTestId('rich')).toHaveTextContent('Visible prose')
     expect(screen.queryByText('E = mc^2')).not.toBeInTheDocument()
   })

--- a/tests/unit/ui/exercise-worksheet.test.tsx
+++ b/tests/unit/ui/exercise-worksheet.test.tsx
@@ -37,6 +37,11 @@ vi.mock('@/ui/web/exerciserenderer/blocks/AxisRenderer', () => ({
 vi.mock('@/ui/web/exerciserenderer/blocks/MultiAxisRenderer', () => ({
   MultiAxisRenderer: () => <div data-testid="multi-axis" />,
 }))
+vi.mock('@/ui/web/exerciserenderer/blocks/LatexBlockRenderer', () => ({
+  LatexBlockRenderer: ({ block }: { block: { latex: string } }) => (
+    <div data-testid="latex">{block.latex}</div>
+  ),
+}))
 
 function renderWith(locale: 'en' | 'he', blocks: ContentBlock[]) {
   return render(
@@ -48,6 +53,20 @@ function renderWith(locale: 'en' | 'he', blocks: ContentBlock[]) {
 
 describe('ExerciseWorksheet', () => {
   afterEach(() => cleanup())
+
+  // Issue #1519: LaTeX blocks must be rendered to display mathematical expressions on mobile
+  // The previous behavior of hiding LaTeX blocks broke mobile exercise viewing experience
+  it('renders latex blocks for mobile exercise viewing (issue #1519)', () => {
+    const blocks = [
+      { id: 'lx-1', type: 'latex' as const, latex: 'E = mc^2', renderMode: 'block' as const },
+      { id: 'rt-1', type: 'rich_text' as const, format: 'md-math-v1' as const, value: 'Formula:', mediaIds: [] },
+    ] as unknown as ContentBlock[]
+
+    renderWith('en', blocks)
+    // LaTeX content should be rendered so students can see mathematical expressions on mobile
+    expect(screen.getByTestId('latex')).toHaveTextContent('E = mc^2')
+    expect(screen.getByTestId('rich')).toHaveTextContent('Formula:')
+  })
 
   it('hides latex blocks but renders rich_text alongside', () => {
     const blocks = [


### PR DESCRIPTION
## Summary

- Updated outdated comment in `ExerciseWorksheet` that incorrectly stated LaTeX blocks are "hidden" when they are actually rendered via LatexBlockRenderer by default
- The bug fix for issue #1519 (LaTeX rendering in mobile worksheet/PDF view) was already implemented in this branch
- `ExerciseWorksheet` has `hideLatexBlocks?: boolean` prop defaulting to `false` which renders LaTeX via LatexBlockRenderer
- `BlocksDocumentLessonView` explicitly passes `hideLatexBlocks={false}` to enable LaTeX in the document/PDF view
- All quality gates pass (typecheck, lint, tests)

## Changes

- `src/ui/web/exerciserenderer/ExerciseWorksheet/index.tsx`

Closes #1519

---
_Opened by kody (single-session autonomous run)._ 