### PR TITLE
#1696: Pass idempotencyKey to stripe.refunds.create

### DIFF
--- a/src/app/api/admin/transactions/[id]/refund/route.ts
+++ b/src/app/api/admin/transactions/[id]/refund/route.ts
@@ -82,7 +82,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
 
   try {
     if (provider === 'stripe') {
-      await refundStripe(providerTransactionId, amount)
+      await refundStripe(id, providerTransactionId, amount)
     } else if (provider === 'paypal') {
       await refundPayPal(providerTransactionId, amount)
     } else {

--- a/src/lib/payment/stripe.ts
+++ b/src/lib/payment/stripe.ts
@@ -78,8 +78,15 @@ export async function verifyStripeWebhook(
 
 /**
  * Create a Stripe refund
+ * @param transactionId - Payload transaction document ID (used for idempotency key)
+ * @param providerTransactionId - Stripe payment intent ID
+ * @param amount - Optional refund amount in smallest currency unit
  */
-export async function refundStripe(providerTransactionId: string, amount?: number): Promise<void> {
+export async function refundStripe(
+  transactionId: string,
+  providerTransactionId: string,
+  amount?: number,
+): Promise<void> {
   const stripe = getStripeClient()
   const refundParams: Stripe.RefundCreateParams = {
     payment_intent: providerTransactionId,
@@ -87,7 +94,9 @@ export async function refundStripe(providerTransactionId: string, amount?: numbe
   if (amount !== undefined) {
     refundParams.amount = amount // in smallest currency unit
   }
-  await stripe.refunds.create(refundParams)
+  await stripe.refunds.create(refundParams, {
+    idempotencyKey: `refund-${transactionId}`,
+  })
 }
 
 /**

--- a/tests/unit/lib/payment/stripe.spec.ts
+++ b/tests/unit/lib/payment/stripe.spec.ts
@@ -129,25 +129,26 @@ describe('Stripe Payment Service', () => {
   })
 
   describe('refundStripe', () => {
-    it('should create refund with transaction id', async () => {
+    it('should create refund with idempotency key', async () => {
       const { refundStripe } = await import('@/lib/payment/stripe')
 
-      await refundStripe('pi_test_transaction_id')
+      await refundStripe('tx_123', 'pi_test_transaction_id')
 
-      expect(refundsCreateMock).toHaveBeenCalledWith({
-        payment_intent: 'pi_test_transaction_id',
-      })
+      expect(refundsCreateMock).toHaveBeenCalledWith(
+        { payment_intent: 'pi_test_transaction_id' },
+        { idempotencyKey: 'refund-tx_123' },
+      )
     })
 
-    it('should create refund with amount when provided', async () => {
+    it('should create refund with amount and idempotency key when provided', async () => {
       const { refundStripe } = await import('@/lib/payment/stripe')
 
-      await refundStripe('pi_test_transaction_id', 500)
+      await refundStripe('tx_456', 'pi_test_transaction_id', 500)
 
-      expect(refundsCreateMock).toHaveBeenCalledWith({
-        payment_intent: 'pi_test_transaction_id',
-        amount: 500,
-      })
+      expect(refundsCreateMock).toHaveBeenCalledWith(
+        { payment_intent: 'pi_test_transaction_id', amount: 500 },
+        { idempotencyKey: 'refund-tx_456' },
+      )
     })
   })
 })


### PR DESCRIPTION
## Summary

- **Repro test**: `tests/unit/lib/payment/stripe.spec.ts` — `refundStripe` now asserts that `stripe.refunds.create` is called with `{ payment_intent, amount? }` as first arg and `{ idempotencyKey: 'refund-<transactionId>' }` as second arg; previously no idempotency key was passed
- **Root cause**: `refundStripe` called `stripe.refunds.create(params)` with no second argument, so Stripe retries could produce duplicate refunds
- **Files changed**:
  - `src/lib/payment/stripe.ts` — `refundStripe(transactionId, providerTransactionId, amount?)` now passes `{ idempotencyKey: 'refund-' + transactionId }` as second arg to `stripe.refunds.create`
  - `src/app/api/admin/transactions/[id]/refund/route.ts` — now calls `refundStripe(id, providerTransactionId, amount)` with the Payload document `id` as the idempotency key source
  - `tests/unit/lib/payment/stripe.spec.ts` — updated test assertions to verify idempotency key is passed with both params

## Changes

- `src/app/api/admin/transactions/[id]/refund/route.ts`
- `src/lib/payment/stripe.ts`
- `tests/unit/lib/payment/stripe.spec.ts`

Closes #1696

---
_Opened by kody (single-session autonomous run)._ 