### PR TITLE
#1694: Switch PayPal API base on env flag + require webhook secrets at …

### DIFF
--- a/src/lib/payment/env.ts
+++ b/src/lib/payment/env.ts
@@ -42,11 +42,11 @@ export function getPaymentEnv(): PaymentEnv {
   const vars: PaymentEnvValidation[] = [
     { name: 'STRIPE_SECRET_KEY', required: true, value: process.env.STRIPE_SECRET_KEY },
     { name: 'STRIPE_PUBLISHABLE_KEY', required: false, value: process.env.STRIPE_PUBLISHABLE_KEY },
-    { name: 'STRIPE_WEBHOOK_SECRET', required: false, value: process.env.STRIPE_WEBHOOK_SECRET },
+    { name: 'STRIPE_WEBHOOK_SECRET', required: true, value: process.env.STRIPE_WEBHOOK_SECRET },
     { name: 'STRIPE_CURRENCY', required: false, value: process.env.STRIPE_CURRENCY },
     { name: 'PAYPAL_CLIENT_ID', required: true, value: process.env.PAYPAL_CLIENT_ID },
     { name: 'PAYPAL_CLIENT_SECRET', required: true, value: process.env.PAYPAL_CLIENT_SECRET },
-    { name: 'PAYPAL_WEBHOOK_ID', required: false, value: process.env.PAYPAL_WEBHOOK_ID },
+    { name: 'PAYPAL_WEBHOOK_ID', required: true, value: process.env.PAYPAL_WEBHOOK_ID },
     { name: 'PAYPAL_SANDBOX', required: false, value: process.env.PAYPAL_SANDBOX },
   ]
 
@@ -65,7 +65,7 @@ export function getPaymentEnv(): PaymentEnv {
     paypalClientId: process.env.PAYPAL_CLIENT_ID ?? '',
     paypalClientSecret: process.env.PAYPAL_CLIENT_SECRET ?? '',
     paypalWebhookId: process.env.PAYPAL_WEBHOOK_ID ?? '',
-    paypalSandbox: process.env.PAYPAL_SANDBOX === 'true',
+    paypalSandbox: process.env.PAYPAL_SANDBOX !== 'false',
   }
 
   return validatedEnv

--- a/src/lib/payment/paypal.ts
+++ b/src/lib/payment/paypal.ts
@@ -8,7 +8,13 @@
 import { getPaymentEnv } from './env'
 import type { CreateCheckoutOptions, CheckoutResult } from './types'
 
-const PAYPAL_API_BASE = 'https://api-m.sandbox.paypal.com'
+const PAYPAL_SANDBOX_BASE = 'https://api-m.sandbox.paypal.com'
+const PAYPAL_PRODUCTION_BASE = 'https://api-m.paypal.com'
+
+function getPayPalApiBase(): string {
+  const { paypalSandbox } = getPaymentEnv()
+  return paypalSandbox ? PAYPAL_SANDBOX_BASE : PAYPAL_PRODUCTION_BASE
+}
 
 interface PayPalTokenResponse {
   access_token: string
@@ -26,6 +32,13 @@ interface PayPalOrderResponse {
 let _cachedToken: { token: string; expiresAt: number } | null = null
 
 /**
+ * Reset the token cache (useful for testing)
+ */
+export function resetPayPalTokenCache(): void {
+  _cachedToken = null
+}
+
+/**
  * Get or refresh PayPal access token
  */
 async function getPayPalAccessToken(): Promise<string> {
@@ -40,7 +53,7 @@ async function getPayPalAccessToken(): Promise<string> {
 
   const credentials = Buffer.from(`${paypalClientId}:${paypalClientSecret}`).toString('base64')
 
-  const response = await fetch(`${PAYPAL_API_BASE}/v1/oauth2/token`, {
+  const response = await fetch(`${getPayPalApiBase()}/v1/oauth2/token`, {
     method: 'POST',
     headers: {
       Authorization: `Basic ${credentials}`,
@@ -70,7 +83,7 @@ export async function createPayPalOrder(options: CreateCheckoutOptions): Promise
   const { productId, productName, amount, currency, userId, successUrl, cancelUrl } = options
   const token = await getPayPalAccessToken()
 
-  const response = await fetch(`${PAYPAL_API_BASE}/v2/checkout/orders`, {
+  const response = await fetch(`${getPayPalApiBase()}/v2/checkout/orders`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,
@@ -136,7 +149,7 @@ export async function verifyPayPalWebhook(body: object, headers: object): Promis
 
   const token = await getPayPalAccessToken()
 
-  const response = await fetch(`${PAYPAL_API_BASE}/v1/notifications/verify-webhook-signature`, {
+  const response = await fetch(`${getPayPalApiBase()}/v1/notifications/verify-webhook-signature`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,
@@ -181,7 +194,7 @@ export async function refundPayPal(
   }
 
   const response = await fetch(
-    `${PAYPAL_API_BASE}/v2/payments/captures/${providerTransactionId}/refund`,
+    `${getPayPalApiBase()}/v2/payments/captures/${providerTransactionId}/refund`,
     {
       method: 'POST',
       headers: {
@@ -206,7 +219,7 @@ export async function cancelPayPalOrder(providerTransactionId: string): Promise<
   const token = await getPayPalAccessToken()
 
   const response = await fetch(
-    `${PAYPAL_API_BASE}/v2/checkout/orders/${providerTransactionId}/void`,
+    `${getPayPalApiBase()}/v2/checkout/orders/${providerTransactionId}/void`,
     {
       method: 'POST',
       headers: {

--- a/tests/unit/lib/payment/env.spec.ts
+++ b/tests/unit/lib/payment/env.spec.ts
@@ -41,14 +41,16 @@ describe('Payment Environment Helper', () => {
       expect(env.paypalSandbox).toBe(true)
     })
 
-    it('should return PAYPAL_SANDBOX as false when not set', () => {
+    it('should return PAYPAL_SANDBOX as true when not set (defaults to sandbox)', () => {
       process.env.STRIPE_SECRET_KEY = 'sk_test_xxx'
+      process.env.STRIPE_WEBHOOK_SECRET = 'whsec_xxx'
       process.env.PAYPAL_CLIENT_SECRET = 'client_secret_xxx'
+      process.env.PAYPAL_WEBHOOK_ID = 'webhook_id_xxx'
       delete process.env.PAYPAL_SANDBOX
 
       const env = getPaymentEnv()
 
-      expect(env.paypalSandbox).toBe(false)
+      expect(env.paypalSandbox).toBe(true)
     })
 
     it('should return PAYPAL_SANDBOX as true when set to "true"', () => {
@@ -73,7 +75,9 @@ describe('Payment Environment Helper', () => {
 
     it('should throw when STRIPE_SECRET_KEY is missing', () => {
       delete process.env.STRIPE_SECRET_KEY
+      process.env.STRIPE_WEBHOOK_SECRET = 'whsec_xxx'
       process.env.PAYPAL_CLIENT_SECRET = 'client_secret_xxx'
+      process.env.PAYPAL_WEBHOOK_ID = 'webhook_id_xxx'
 
       expect(() => getPaymentEnv()).toThrow(
         'Missing required payment environment variables: STRIPE_SECRET_KEY',
@@ -82,6 +86,8 @@ describe('Payment Environment Helper', () => {
 
     it('should throw when PAYPAL_CLIENT_SECRET is missing', () => {
       process.env.STRIPE_SECRET_KEY = 'sk_test_xxx'
+      process.env.STRIPE_WEBHOOK_SECRET = 'whsec_xxx'
+      process.env.PAYPAL_WEBHOOK_ID = 'webhook_id_xxx'
       delete process.env.PAYPAL_CLIENT_SECRET
 
       expect(() => getPaymentEnv()).toThrow(
@@ -90,6 +96,8 @@ describe('Payment Environment Helper', () => {
     })
 
     it('should throw when both required keys are missing', () => {
+      process.env.STRIPE_WEBHOOK_SECRET = 'whsec_xxx'
+      process.env.PAYPAL_WEBHOOK_ID = 'webhook_id_xxx'
       delete process.env.STRIPE_SECRET_KEY
       delete process.env.PAYPAL_CLIENT_SECRET
 
@@ -100,7 +108,9 @@ describe('Payment Environment Helper', () => {
 
     it('should cache result on subsequent calls', () => {
       process.env.STRIPE_SECRET_KEY = 'sk_test_xxx'
+      process.env.STRIPE_WEBHOOK_SECRET = 'whsec_xxx'
       process.env.PAYPAL_CLIENT_SECRET = 'client_secret_xxx'
+      process.env.PAYPAL_WEBHOOK_ID = 'webhook_id_xxx'
 
       const env1 = getPaymentEnv()
       const env2 = getPaymentEnv()
@@ -110,26 +120,50 @@ describe('Payment Environment Helper', () => {
 
     it('should return empty string for optional vars when not set', () => {
       process.env.STRIPE_SECRET_KEY = 'sk_test_xxx'
+      process.env.STRIPE_WEBHOOK_SECRET = 'whsec_xxx'
       process.env.PAYPAL_CLIENT_ID = 'client_id_xxx'
       process.env.PAYPAL_CLIENT_SECRET = 'client_secret_xxx'
+      process.env.PAYPAL_WEBHOOK_ID = 'webhook_id_xxx'
       delete process.env.STRIPE_PUBLISHABLE_KEY
-      delete process.env.STRIPE_WEBHOOK_SECRET
-      delete process.env.PAYPAL_WEBHOOK_ID
+      delete process.env.STRIPE_CURRENCY
 
       const env = getPaymentEnv()
 
       expect(env.stripePublishableKey).toBe('')
-      expect(env.stripeWebhookSecret).toBe('')
+      expect(env.stripeCurrency).toBe('ILS')
       expect(env.paypalClientId).toBe('client_id_xxx')
-      expect(env.paypalWebhookId).toBe('')
+    })
+
+    it('should throw when STRIPE_WEBHOOK_SECRET is missing', () => {
+      process.env.STRIPE_SECRET_KEY = 'sk_test_xxx'
+      delete process.env.STRIPE_WEBHOOK_SECRET
+      process.env.PAYPAL_CLIENT_SECRET = 'client_secret_xxx'
+      process.env.PAYPAL_WEBHOOK_ID = 'webhook_id_xxx'
+
+      expect(() => getPaymentEnv()).toThrow(
+        'Missing required payment environment variables: STRIPE_WEBHOOK_SECRET',
+      )
+    })
+
+    it('should throw when PAYPAL_WEBHOOK_ID is missing', () => {
+      process.env.STRIPE_SECRET_KEY = 'sk_test_xxx'
+      process.env.STRIPE_WEBHOOK_SECRET = 'whsec_xxx'
+      process.env.PAYPAL_CLIENT_SECRET = 'client_secret_xxx'
+      delete process.env.PAYPAL_WEBHOOK_ID
+
+      expect(() => getPaymentEnv()).toThrow(
+        'Missing required payment environment variables: PAYPAL_WEBHOOK_ID',
+      )
     })
   })
 
   describe('resetPaymentEnvCache', () => {
     it('should clear cached env and return new values', () => {
       process.env.STRIPE_SECRET_KEY = 'sk_test_xxx'
+      process.env.STRIPE_WEBHOOK_SECRET = 'whsec_xxx'
       process.env.PAYPAL_CLIENT_ID = 'client_id_xxx'
       process.env.PAYPAL_CLIENT_SECRET = 'client_secret_xxx'
+      process.env.PAYPAL_WEBHOOK_ID = 'webhook_id_xxx'
 
       const env1 = getPaymentEnv()
       expect(env1.stripeSecretKey).toBe('sk_test_xxx')

--- a/tests/unit/lib/payment/paypal.spec.ts
+++ b/tests/unit/lib/payment/paypal.spec.ts
@@ -8,6 +8,7 @@
  */
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { resetPaymentEnvCache } from '@/lib/payment/env'
+import { resetPayPalTokenCache } from '@/lib/payment/paypal'
 
 // Store original fetch
 const originalFetch = globalThis.fetch
@@ -46,11 +47,15 @@ describe('PayPal Payment Service', () => {
     resetPaymentEnvCache()
     // Set all required payment env vars
     process.env.STRIPE_SECRET_KEY = 'sk_test_xxx'
+    process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test_xxx'
+    process.env.PAYPAL_WEBHOOK_ID = 'webhook_test_xxx'
   })
 
   afterEach(() => {
     // Restore original fetch
     globalThis.fetch = originalFetch
+    // Reset modules after each test to ensure clean state
+    vi.resetModules()
   })
 
   describe('createPayPalOrder', () => {
@@ -146,6 +151,8 @@ describe('PayPal Payment Service', () => {
     it('should return checkoutUrl and providerSessionId', async () => {
       process.env.PAYPAL_CLIENT_ID = 'test_client_id'
       process.env.PAYPAL_CLIENT_SECRET = 'test_secret'
+      process.env.PAYPAL_WEBHOOK_ID = 'webhook_id_xxx'
+      process.env.STRIPE_WEBHOOK_SECRET = 'whsec_xxx'
 
       globalThis.fetch = vi.fn().mockImplementation((url: string) => {
         if (url.includes('/v1/oauth2/token')) {
@@ -168,6 +175,82 @@ describe('PayPal Payment Service', () => {
 
       expect(result.checkoutUrl).toBe('https://paypal.com/approve')
       expect(result.providerSessionId).toBe('ORDER123')
+    })
+
+    it('should use production API URL when PAYPAL_SANDBOX=false', async () => {
+      process.env.PAYPAL_CLIENT_ID = 'test_client_id'
+      process.env.PAYPAL_CLIENT_SECRET = 'test_secret'
+      process.env.PAYPAL_WEBHOOK_ID = 'webhook_id_xxx'
+      process.env.STRIPE_WEBHOOK_SECRET = 'whsec_xxx'
+      process.env.PAYPAL_SANDBOX = 'false'
+      resetPaymentEnvCache()
+
+      const capturedUrls: string[] = []
+
+      globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+        capturedUrls.push(url)
+        if (url.includes('/v1/oauth2/token')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockTokenResponse),
+          }) as unknown as Response
+        }
+        if (url.includes('/v2/checkout/orders')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockOrderResponse),
+          }) as unknown as Response
+        }
+        return Promise.reject(new Error('Unexpected URL'))
+      })
+
+      const { createPayPalOrder, resetPayPalTokenCache } = await import('@/lib/payment/paypal')
+      resetPayPalTokenCache()
+      await createPayPalOrder(mockOptions)
+
+      // Verify production URL is used when PAYPAL_SANDBOX=false
+      // First URL should be token, second should be checkout
+      expect(capturedUrls[0]).toMatch(/^https:\/\/api-m\.paypal\.com\/v1\/oauth2\/token$/)
+      expect(capturedUrls[1]).toMatch(/^https:\/\/api-m\.paypal\.com\/v2\/checkout\/orders$/)
+    })
+
+    it('should use sandbox API URL when PAYPAL_SANDBOX=true', async () => {
+      process.env.PAYPAL_CLIENT_ID = 'test_client_id'
+      process.env.PAYPAL_CLIENT_SECRET = 'test_secret'
+      process.env.PAYPAL_WEBHOOK_ID = 'webhook_id_xxx'
+      process.env.STRIPE_WEBHOOK_SECRET = 'whsec_xxx'
+      process.env.PAYPAL_SANDBOX = 'true'
+      resetPaymentEnvCache()
+
+      const capturedUrls: string[] = []
+
+      globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+        capturedUrls.push(url)
+        if (url.includes('/v1/oauth2/token')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockTokenResponse),
+          }) as unknown as Response
+        }
+        if (url.includes('/v2/checkout/orders')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockOrderResponse),
+          }) as unknown as Response
+        }
+        return Promise.reject(new Error('Unexpected URL'))
+      })
+
+      const { createPayPalOrder, resetPayPalTokenCache } = await import('@/lib/payment/paypal')
+      resetPayPalTokenCache()
+      await createPayPalOrder(mockOptions)
+
+      // Verify sandbox URL is used when PAYPAL_SANDBOX=true
+      // First URL should be token, second should be checkout
+      expect(capturedUrls[0]).toMatch(/^https:\/\/api-m\.sandbox\.paypal\.com\/v1\/oauth2\/token$/)
+      expect(capturedUrls[1]).toMatch(
+        /^https:\/\/api-m\.sandbox\.paypal\.com\/v2\/checkout\/orders$/,
+      )
     })
 
     it('should convert amount from smallest unit', async () => {
@@ -214,11 +297,12 @@ describe('PayPal Payment Service', () => {
     it('should throw error when PAYPAL_WEBHOOK_ID is missing', async () => {
       delete process.env.PAYPAL_WEBHOOK_ID
       resetPaymentEnvCache()
+      vi.resetModules()
 
       const { verifyPayPalWebhook } = await import('@/lib/payment/paypal')
 
       await expect(verifyPayPalWebhook({ type: 'test' }, mockHeaders)).rejects.toThrow(
-        'Missing PAYPAL_WEBHOOK_ID environment variable',
+        'Missing required payment environment variables: PAYPAL_WEBHOOK_ID',
       )
     })
 

--- a/tests/unit/lib/payment/stripe.spec.ts
+++ b/tests/unit/lib/payment/stripe.spec.ts
@@ -71,6 +71,7 @@ describe('Stripe Payment Service', () => {
     process.env.STRIPE_WEBHOOK_SECRET = 'whsec_xxx'
     process.env.PAYPAL_CLIENT_ID = 'paypal_client_id_xxx'
     process.env.PAYPAL_CLIENT_SECRET = 'paypal_secret_xxx'
+    process.env.PAYPAL_WEBHOOK_ID = 'paypal_webhook_id_xxx'
     // Reset module to clear singletons
     vi.resetModules()
   })
@@ -113,7 +114,7 @@ describe('Stripe Payment Service', () => {
 
       await expect(
         verifyStripeWebhook(Buffer.from('test payload'), 'test_signature'),
-      ).rejects.toThrow('Missing STRIPE_WEBHOOK_SECRET environment variable')
+      ).rejects.toThrow('Missing required payment environment variables: STRIPE_WEBHOOK_SECRET')
     })
 
     it('should verify webhook payload and signature', async () => {


### PR DESCRIPTION
## Summary

- **Repro test**: `tests/unit/lib/payment/paypal.spec.ts` — added tests `should use production API URL when PAYPAL_SANDBOX=false` and `should use sandbox API URL when PAYPAL_SANDBOX=true` that assert correct URL routing
- **Root cause**: `PAYPAL_API_BASE` was hardcoded to `https://api-m.sandbox.paypal.com` and `paypalSandbox` was never read
- **Files changed**:
  - `src/lib/payment/paypal.ts`: Replaced hardcoded `PAYPAL_API_BASE` with `getPayPalApiBase()` function that returns sandbox (`api-m.sandbox.paypal.com`) or production (`api-m.paypal.com`) based on `getPaymentEnv().paypalSandbox`. Added `resetPayPalTokenCache()` export for test isolation
  - `src/lib/payment/env.ts`: Changed `STRIPE_WEBHOOK_SECRET` and `PAYPAL_WEBHOOK_ID` from `required: false` to `required: true`. Fixed `paypalSandbox` default from `false` to `true` when unset (defaults to sandbox)
  - `tests/unit/lib/payment/paypal.spec.ts`: Added sandbox/production URL tests, added webhook secrets to all tests, updated error message assertions
  - `tests/unit/lib/payment/env.spec.ts`: Added tests for required webhook secrets, updated existing tests to set required secrets
  - `tests/unit/lib/payment/stripe.spec.ts`: Added `PAYPAL_WEBHOOK_ID` to beforeEach setup

## Changes

- `src/lib/payment/env.ts`
- `src/lib/payment/paypal.ts`
- `tests/unit/lib/payment/env.spec.ts`
- `tests/unit/lib/payment/paypal.spec.ts`
- `tests/unit/lib/payment/stripe.spec.ts`

Closes #1694

---
_Opened by kody (single-session autonomous run)._ 