### PR TITLE
#1697: Return 400/500 on webhook signature verification failure instead…

### DIFF
--- a/src/app/api/webhooks/paypal/route.ts
+++ b/src/app/api/webhooks/paypal/route.ts
@@ -4,8 +4,9 @@
  * POST /api/webhooks/paypal
  *
  * Verifies PayPal webhook signature, updates Transaction status, and grants
- * entitlements on successful payment. Always returns 200 to satisfy PayPal's
- * requirement for fast acknowledgment.
+ * entitlements on successful payment. Returns 400 for bad signatures (no retry),
+ * 500 for transient errors (provider will retry), and 200 for downstream
+ * processing errors that should not be retried.
  *
  * @fileType api-route
  * @domain payments
@@ -60,12 +61,40 @@ export async function POST(request: NextRequest) {
   try {
     const isValid = await verifyPayPalWebhook(body, headers)
     if (!isValid) {
-      payload.logger.error('PayPal webhook signature verification failed')
-      return NextResponse.json({ received: true }, { status: 200 })
+      const sourceIp =
+        request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || 'unknown'
+      const bodySnippet = JSON.stringify(body).slice(0, 100)
+      payload.logger.warn(
+        { sourceIp, bodySnippet },
+        'PayPal webhook signature verification failed — returning 400',
+      )
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 400 })
     }
   } catch (err) {
-    payload.logger.error({ error: err }, 'PayPal webhook signature verification error')
-    return NextResponse.json({ received: true }, { status: 200 })
+    const sourceIp =
+      request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || 'unknown'
+    const bodySnippet = JSON.stringify(body).slice(0, 100)
+
+    const errorMessage = err instanceof Error ? err.message : String(err)
+
+    // Permanent errors (bad config or malformed headers) → 400, PayPal will not retry
+    if (
+      errorMessage.includes('Missing PAYPAL_WEBHOOK_ID') ||
+      errorMessage.includes('Missing required PayPal webhook headers')
+    ) {
+      payload.logger.error(
+        { error: err, sourceIp, bodySnippet },
+        'PayPal webhook misconfiguration — returning 400',
+      )
+      return NextResponse.json({ error: 'Invalid webhook configuration' }, { status: 400 })
+    }
+
+    // Transient error (network issue calling PayPal verify API) → 500, PayPal will retry
+    payload.logger.error(
+      { error: err, sourceIp, bodySnippet },
+      'PayPal webhook signature verification threw transient error — returning 500',
+    )
+    return NextResponse.json({ error: 'Verification failed' }, { status: 500 })
   }
 
   // 4. Route event by type

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -4,8 +4,9 @@
  * POST /api/webhooks/stripe
  *
  * Verifies Stripe webhook signature, updates Transaction status, and grants
- * entitlements on successful payment. Always returns 200 to satisfy Stripe's
- * requirement for fast acknowledgment.
+ * entitlements on successful payment. Returns 400 for bad signatures (no retry),
+ * 500 for transient errors (provider will retry), and 200 for downstream
+ * processing errors that should not be retried.
  *
  * @fileType api-route
  * @domain payments
@@ -33,7 +34,7 @@ export async function POST(request: NextRequest) {
   const signature = request.headers.get('stripe-signature')
   if (!signature) {
     payload.logger.error('Missing stripe-signature header')
-    return NextResponse.json({ received: true }, { status: 200 })
+    return NextResponse.json({ error: 'Missing signature header' }, { status: 400 })
   }
 
   // 3. Verify webhook signature
@@ -41,8 +42,28 @@ export async function POST(request: NextRequest) {
   try {
     event = await verifyStripeWebhook(rawBody, signature)
   } catch (err) {
-    payload.logger.error({ error: err }, 'Stripe webhook signature verification failed')
-    return NextResponse.json({ received: true }, { status: 200 })
+    const sourceIp =
+      request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || 'unknown'
+    const bodySnippet = rawBody.toString('utf8').slice(0, 100)
+
+    const isSignatureError =
+      err instanceof Stripe.errors.StripeSignatureVerificationError ||
+      (err instanceof Stripe.errors.StripeError && err.type === 'StripeSignatureVerificationError')
+
+    if (isSignatureError) {
+      payload.logger.warn(
+        { error: err, sourceIp, bodySnippet },
+        'Stripe webhook signature verification failed — returning 400',
+      )
+      return NextResponse.json({ error: 'Invalid signature' }, { status: 400 })
+    }
+
+    // Transient error (network issue, missing config, etc.) — provider should retry
+    payload.logger.error(
+      { error: err, sourceIp, bodySnippet },
+      'Stripe webhook signature verification threw transient error — returning 500',
+    )
+    return NextResponse.json({ error: 'Verification failed' }, { status: 500 })
   }
 
   // 4. Route event by type

--- a/tests/int/payment-webhook-entitlements.int.spec.ts
+++ b/tests/int/payment-webhook-entitlements.int.spec.ts
@@ -834,3 +834,127 @@ describe('PayPal webhook handler', () => {
       .catch(() => {})
   })
 })
+
+// ─── Stripe webhook signature failure tests ───────────────────────────────────
+
+describe('Stripe webhook signature failure responses', () => {
+  it('should return 400 when stripe-signature header is missing', async () => {
+    const req = new NextRequest('http://localhost/api/webhooks/stripe', {
+      method: 'POST',
+      // No stripe-signature header
+    })
+
+    const res = await stripeWebhookHandler(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('should return 400 when Stripe signature verification fails (StripeSignatureVerificationError)', async () => {
+    const { Stripe } = await import('stripe')
+    const { verifyStripeWebhook } = await import('@/lib/payment/stripe')
+
+    // StripeSignatureVerificationError constructor signature differs from TypeScript types;
+    // cast through `any` to satisfy the type checker while passing correct runtime args.
+    const SignatureVerificationError = Stripe.errors
+      .StripeSignatureVerificationError as unknown as new (
+      header: string,
+      payload: string,
+      raw: Record<string, unknown>,
+    ) => Error
+
+    vi.mocked(verifyStripeWebhook).mockRejectedValue(
+      new SignatureVerificationError('some-header', 'some-payload', { signature: 'sig_test' }),
+    )
+
+    const req = new NextRequest('http://localhost/api/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'stripe-signature': 'sig_test' },
+    })
+
+    const res = await stripeWebhookHandler(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('should return 500 when Stripe verification throws a transient error (network/config)', async () => {
+    const { verifyStripeWebhook } = await import('@/lib/payment/stripe')
+
+    vi.mocked(verifyStripeWebhook).mockRejectedValue(new Error('Network timeout'))
+
+    const req = new NextRequest('http://localhost/api/webhooks/stripe', {
+      method: 'POST',
+      headers: { 'stripe-signature': 'sig_test' },
+    })
+
+    const res = await stripeWebhookHandler(req)
+    expect(res.status).toBe(500)
+  })
+})
+
+// ─── PayPal webhook signature failure tests ────────────────────────────────────
+
+describe('PayPal webhook signature failure responses', () => {
+  it('should return 400 when verifyPayPalWebhook returns false (signature mismatch)', async () => {
+    const { verifyPayPalWebhook } = await import('@/lib/payment/paypal')
+    vi.mocked(verifyPayPalWebhook).mockResolvedValueOnce(false)
+
+    const req = new NextRequest('http://localhost/api/webhooks/paypal', {
+      method: 'POST',
+      headers: {
+        'paypal-transmission-id': 'test-tx-id',
+        'paypal-transmission-time': new Date().toISOString(),
+        'paypal-transmission-sig': 'bad-sig',
+        'paypal-cert-url': 'https://cert.url',
+        'paypal-auth-algo': 'SHA256withRSA',
+      },
+      body: JSON.stringify({
+        event_type: 'CHECKOUT.ORDER.APPROVED',
+        resource: { id: 'order_123' },
+      }),
+    })
+
+    const res = await paypalWebhookHandler(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('should return 500 when verifyPayPalWebhook throws a transient error (network error)', async () => {
+    const { verifyPayPalWebhook } = await import('@/lib/payment/paypal')
+    vi.mocked(verifyPayPalWebhook).mockRejectedValueOnce(new Error('PayPal API network timeout'))
+
+    const req = new NextRequest('http://localhost/api/webhooks/paypal', {
+      method: 'POST',
+      headers: {
+        'paypal-transmission-id': 'test-tx-id',
+        'paypal-transmission-time': new Date().toISOString(),
+        'paypal-transmission-sig': 'test-sig',
+        'paypal-cert-url': 'https://cert.url',
+        'paypal-auth-algo': 'SHA256withRSA',
+      },
+      body: JSON.stringify({
+        event_type: 'CHECKOUT.ORDER.APPROVED',
+        resource: { id: 'order_123' },
+      }),
+    })
+
+    const res = await paypalWebhookHandler(req)
+    expect(res.status).toBe(500)
+  })
+
+  it('should return 400 when PayPal webhook is missing required headers', async () => {
+    const { verifyPayPalWebhook } = await import('@/lib/payment/paypal')
+    // Simulate the header validation error (thrown before env var check in the real function)
+    vi.mocked(verifyPayPalWebhook).mockRejectedValueOnce(
+      new Error('Missing required PayPal webhook headers'),
+    )
+
+    const req = new NextRequest('http://localhost/api/webhooks/paypal', {
+      method: 'POST',
+      headers: {}, // Missing all PayPal headers
+      body: JSON.stringify({
+        event_type: 'CHECKOUT.ORDER.APPROVED',
+        resource: { id: 'order_123' },
+      }),
+    })
+
+    const res = await paypalWebhookHandler(req)
+    expect(res.status).toBe(400)
+  })
+})


### PR DESCRIPTION
## Summary

- **Repro**: Added 6 failing integration tests in `tests/int/payment-webhook-entitlements.int.spec.ts` — 3 for Stripe (missing header → 400, StripeSignatureVerificationError → 400, transient Error → 500) and 3 for PayPal (false return → 400, network error → 500, missing headers → 400). All 6 now pass.
- **Root cause**: Both `route.ts` handlers returned `200 { received: true }` for all error cases, masking signature failures and removing retry incentives for transient errors.
- **Stripe fix** (`src/app/api/webhooks/stripe/route.ts`): `verifyStripeWebhook` catch block now distinguishes `Stripe.errors.StripeSignatureVerificationError` (or `err.type === 'StripeSignatureVerificationError'`) → 400; all other errors → 500; missing `stripe-signature` header → 400. Each failure logs source IP and body snippet at warn/error level.
- **PayPal fix** (`src/app/api/webhooks/paypal/route.ts`): `verifyPayPalWebhook` returning `false` → 400 with warn log; throws "Missing required PayPal webhook headers" or "Missing PAYPAL_WEBHOOK_ID" → 400 (permanent config error); throws any other error (e.g. network timeout) → 500 (transient, provider retries). Each failure logs source IP and body snippet.
- **No regression**: All 13 original tests continue to pass; valid webhooks with downstream processing errors still return 200 per the edge-case requirement.

## Changes

- `src/app/api/webhooks/paypal/route.ts`
- `src/app/api/webhooks/stripe/route.ts`
- `tests/int/payment-webhook-entitlements.int.spec.ts`

Closes #1697

---
_Opened by kody (single-session autonomous run)._ 