### PR TITLE
#1711: Record refundedAmount, refundedBy, refundedAt on refund

### DIFF
--- a/src/app/api/admin/transactions/[id]/refund/route.ts
+++ b/src/app/api/admin/transactions/[id]/refund/route.ts
@@ -93,11 +93,17 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     return NextResponse.json({ error: 'Refund operation failed' }, { status: 500 })
   }
 
-  // 6. Update status to refunded
+  // 6. Update status to refunded with audit fields
   await payload.update({
     collection: 'transactions',
     id,
-    data: { status: 'refunded' },
+    data: {
+      status: 'refunded',
+      refundedAmount: amount,
+      refundedBy: authResult.user.id,
+      refundedAt: new Date().toISOString(),
+    },
+    context: { skipTransitionGuard: false },
     overrideAccess: true,
   })
 

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1945,6 +1945,18 @@ export interface Transaction {
    */
   errorMessage?: string | null;
   /**
+   * Amount refunded in agorot (smallest currency unit)
+   */
+  refundedAmount?: number | null;
+  /**
+   * Admin who processed the refund
+   */
+  refundedBy?: (string | null) | User;
+  /**
+   * When the refund was processed
+   */
+  refundedAt?: string | null;
+  /**
    * User who created this document
    */
   createdBy?: (string | null) | User;
@@ -4437,6 +4449,9 @@ export interface TransactionsSelect<T extends boolean = true> {
   successUrl?: T;
   cancelUrl?: T;
   errorMessage?: T;
+  refundedAmount?: T;
+  refundedBy?: T;
+  refundedAt?: T;
   createdBy?: T;
   updatedAt?: T;
   createdAt?: T;

--- a/src/server/payload/collections/Transactions.ts
+++ b/src/server/payload/collections/Transactions.ts
@@ -172,6 +172,33 @@ export const Transactions: CollectionConfig = {
       },
     },
 
+    // Refund audit fields (set when transaction is refunded)
+    {
+      name: 'refundedAmount',
+      type: 'number',
+      admin: {
+        description: 'Amount refunded in agorot (smallest currency unit)',
+        readOnly: true,
+      },
+    },
+    {
+      name: 'refundedBy',
+      type: 'relationship',
+      relationTo: 'users',
+      admin: {
+        description: 'Admin who processed the refund',
+        readOnly: true,
+      },
+    },
+    {
+      name: 'refundedAt',
+      type: 'date',
+      admin: {
+        description: 'When the refund was processed',
+        readOnly: true,
+      },
+    },
+
     createdByField,
   ],
   timestamps: true,

--- a/tests/int/transaction-refund.int.spec.ts
+++ b/tests/int/transaction-refund.int.spec.ts
@@ -41,6 +41,7 @@ let adminUserId: string
 let studentUserId: string
 let stripeTransactionId: string
 let paypalTransactionId: string
+let refundedFieldsTransactionId: string
 let refundedTransactionId: string
 let pendingTransactionId: string
 let failedTransactionId: string
@@ -151,6 +152,23 @@ beforeAll(async () => {
     overrideAccess: true,
   })
   paypalTransactionId = paypalTx.id
+
+  // Create succeeded stripe transaction for testing refund fields
+  const refundFieldsTx = await payload.create({
+    collection: 'transactions',
+    data: {
+      user: adminUserId,
+      product: product.id,
+      provider: 'stripe',
+      providerTransactionId: `cs_refund_fields_test_${Date.now()}`,
+      status: 'succeeded',
+      amount: 2500,
+      currency: 'ILS',
+      tenant: tenantId,
+    } as any,
+    overrideAccess: true,
+  })
+  refundedFieldsTransactionId = refundFieldsTx.id
 
   // Create already-refunded transaction
   const refundedTx = await payload.create({
@@ -373,6 +391,36 @@ describe('POST /api/admin/transactions/{id}/refund', () => {
       overrideAccess: true,
     })
     expect(updated.status).toBe('refunded')
+  })
+
+  it('successfully refunds and sets refundedAmount, refundedBy, refundedAt fields', async () => {
+    const req = new NextRequest(
+      `http://localhost:3000/api/admin/transactions/${refundedFieldsTransactionId}/refund`,
+      {
+        method: 'POST',
+        headers: { Authorization: `JWT ${adminToken}` },
+      },
+    )
+    const res = await transactionRefundHandler(req, {
+      params: Promise.resolve({ id: refundedFieldsTransactionId }),
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+
+    // Verify transaction status and refund audit fields were updated
+    const updated = await payload.findByID({
+      collection: 'transactions',
+      id: refundedFieldsTransactionId,
+      overrideAccess: true,
+    })
+    expect(updated.status).toBe('refunded')
+
+    // Verify refund audit fields are set
+    expect((updated as any).refundedAmount).toBe(2500)
+    expect((updated as any).refundedBy?.id).toBe(adminUserId)
+    expect((updated as any).refundedAt).toBeDefined()
+    expect(new Date((updated as any).refundedAt).getTime()).toBeCloseTo(Date.now(), -3) // within ~1 second
   })
 
   it('double-refund attempt returns 400 with Hebrew message', async () => {


### PR DESCRIPTION
## Summary

- **Repro test**: `tests/int/transaction-refund.int.spec.ts` — new test "successfully refunds and sets refundedAmount, refundedBy, refundedAt fields" verifies all three audit fields are populated after refund
- **Root cause**: The refund endpoint only wrote `status: 'refunded'` without recording who, when, or how much
- **Files changed**:
  - `src/server/payload/collections/Transactions.ts` — added `refundedAmount` (number), `refundedBy` (relationship to users), `refundedAt` (date) fields, all `admin: { readOnly: true }`
  - `src/app/api/admin/transactions/[id]/refund/route.ts` — updated `payload.update` to write `refundedAmount`, `refundedBy`, `refundedAt` atomically with status change, using `context: { skipTransitionGuard: false }` to keep transition guard active
  - `tests/int/transaction-refund.int.spec.ts` — added `refundedFieldsTransactionId` fixture and test case verifying the three fields are set correctly after refund

## Changes

- `src/app/api/admin/transactions/[id]/refund/route.ts`
- `src/payload-types.ts`
- `src/server/payload/collections/Transactions.ts`
- `tests/int/transaction-refund.int.spec.ts`

Closes #1711

---
_Opened by kody (single-session autonomous run)._ 