### PR TITLE
#1712: URL-encode cancelUrl params and validate productId as ObjectId

### DIFF
--- a/src/app/api/payments/checkout/route.ts
+++ b/src/app/api/payments/checkout/route.ts
@@ -19,9 +19,12 @@ import config from '@payload-config'
 import { cancelPayPalOrder, createPayPalOrder } from '@/lib/payment/paypal'
 import { cancelStripeCheckout, createStripeCheckout } from '@/lib/payment/stripe'
 
+// MongoDB ObjectId: 24 hex characters
+const objectIdRegex = /^[0-9a-fA-F]{24}$/
+
 // Schema for checkout request body
 const checkoutSchema = z.object({
-  productId: z.string().min(1, 'productId_required'),
+  productId: z.string().regex(objectIdRegex, 'invalid_product_id'),
   provider: z.enum(['stripe', 'paypal']).optional(),
   couponCode: z.string().max(50).optional(),
 })
@@ -45,6 +48,12 @@ export async function POST(request: NextRequest) {
 
   const parsed = checkoutSchema.safeParse(body)
   if (!parsed.success) {
+    const productIdIssue = parsed.error.issues.find(
+      (issue) => issue.path[0] === 'productId' && issue.message === 'invalid_product_id',
+    )
+    if (productIdIssue) {
+      return NextResponse.json({ success: false, error: 'invalid_product_id' }, { status: 400 })
+    }
     return NextResponse.json(
       { success: false, error: 'invalid_request', details: parsed.error.flatten() },
       { status: 400 },
@@ -237,7 +246,8 @@ export async function POST(request: NextRequest) {
   // 9. Build URLs for payment provider redirect
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
   const successUrl = `${baseUrl}/checkout/success?session_id={CHECKOUT_SESSION_ID}`
-  const cancelUrl = `${baseUrl}/checkout/cancel?product_id=${productId}`
+  const cancelParams = new URLSearchParams({ product_id: productId })
+  const cancelUrl = `${baseUrl}/checkout/cancel?${cancelParams.toString()}`
 
   // 10. Call payment provider to create checkout session
   let providerResult: { checkoutUrl: string; providerSessionId: string } | null = null

--- a/tests/unit/api/payments/checkout-validation.spec.ts
+++ b/tests/unit/api/payments/checkout-validation.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit Tests — checkout request validation & cancelUrl encoding
+ *
+ * Covers two hardening changes in `src/app/api/payments/checkout/route.ts`:
+ *   1) productId must match strict MongoDB ObjectId regex (^[0-9a-fA-F]{24}$)
+ *   2) cancelUrl interpolates productId via URLSearchParams so reserved
+ *      characters (& #) round-trip safely.
+ */
+import { describe, expect, it } from 'vitest'
+
+const objectIdRegex = /^[0-9a-fA-F]{24}$/
+
+describe('checkout productId ObjectId validation', () => {
+  it('accepts a valid 24-char hex ObjectId', () => {
+    expect(objectIdRegex.test('507f1f77bcf86cd799439011')).toBe(true)
+  })
+
+  it('rejects a short string', () => {
+    expect(objectIdRegex.test('abc123')).toBe(false)
+  })
+
+  it('rejects a string with non-hex characters', () => {
+    expect(objectIdRegex.test('zzzzzzzzzzzzzzzzzzzzzzzz')).toBe(false)
+  })
+
+  it('rejects an empty string', () => {
+    expect(objectIdRegex.test('')).toBe(false)
+  })
+
+  it('rejects a string of 25 hex chars (off-by-one)', () => {
+    expect(objectIdRegex.test('507f1f77bcf86cd7994390111')).toBe(false)
+  })
+})
+
+describe('checkout cancelUrl encoding', () => {
+  const buildCancelUrl = (baseUrl: string, productId: string) => {
+    const params = new URLSearchParams({ product_id: productId })
+    return `${baseUrl}/checkout/cancel?${params.toString()}`
+  }
+
+  it('encodes a valid ObjectId without modification (hex is URL-safe)', () => {
+    const url = buildCancelUrl('https://example.com', '507f1f77bcf86cd799439011')
+    expect(url).toBe('https://example.com/checkout/cancel?product_id=507f1f77bcf86cd799439011')
+  })
+
+  it('encodes & in a productId-shaped value so it round-trips', () => {
+    const raw = 'abc&evil=1'
+    const url = buildCancelUrl('https://example.com', raw)
+    const parsed = new URL(url)
+    expect(parsed.searchParams.get('product_id')).toBe(raw)
+    expect(parsed.searchParams.get('evil')).toBeNull()
+  })
+
+  it('encodes # so the fragment is not split off', () => {
+    const raw = 'abc#frag'
+    const url = buildCancelUrl('https://example.com', raw)
+    const parsed = new URL(url)
+    expect(parsed.searchParams.get('product_id')).toBe(raw)
+    expect(parsed.hash).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary

Implementation of issue #1712 — URL-encode cancelUrl params and validate productId as ObjectId.

Two hardening fixes to `src/app/api/payments/checkout/route.ts`:

1. **Strict ObjectId validation** — `productId` is now validated via `^[0-9a-fA-F]{24}$` in the Zod schema. Non-matching values get a 400 with `error: invalid_product_id` instead of being passed to Payload and surfacing internal errors.
2. **URL-safe cancelUrl** — replaced string concatenation with `URLSearchParams` so reserved characters (`&`, `#`) in interpolated values round-trip safely.

Tenant/auth/coupon logic unchanged.

## Changes

- `src/app/api/payments/checkout/route.ts`
- `tests/unit/api/payments/checkout-validation.spec.ts` (new — covers regex + encoding)

Closes #1712