### PR TITLE
#1720: Fix lesson-duplication prompts that omit hint / fullSolution fro…

### DIFF
--- a/src/infra/llm/prompts/lesson-duplication/algebra-deep-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/algebra-deep-agent-prompt.md
@@ -30,6 +30,10 @@ Return a JSON object with the exercise content. The structure should match the i
 }
 ```
 
+## Required fields
+
+Required fields on every question\_\* block. Every question_select, question_free_response, question_table, question_matching, question_geometry, question_axis, or question_multi_axis block in your output MUST include all of the following with non-empty values: hint (rich_text), solution (rich_text), and fullSolution (rich_text). If a useful hint is hard to write, emit a one-sentence prompt like "Apply the chain rule." or "Recall the parallelogram area formula." — but never omit the field. Empty strings are not acceptable.
+
 ## Examples
 
 Each example below demonstrates the input exercise JSON and the expected output variation JSON showing deep algebraic transformations with structural changes.
@@ -87,6 +91,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "type": "free_response",
           "rubric": "g'(x) = 12x^2 - 3",
           "acceptedPatterns": []
+        },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Apply the power rule to each term separately.",
+          "mediaIds": []
         },
         "solution": {
           "type": "rich_text",
@@ -164,6 +174,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "rubric": "x - 3 (for x ≠ -3)",
           "acceptedPatterns": []
         },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Factor the numerator as a difference of squares.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",
@@ -232,6 +248,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "mediaIds": []
         },
         "answer": { "type": "free_response", "rubric": "y = 3x - 1", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Find the slope first, then use one point to find the y-intercept.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",

--- a/src/infra/llm/prompts/lesson-duplication/algebra-light-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/algebra-light-agent-prompt.md
@@ -30,6 +30,10 @@ Return a JSON object with the exercise content. The structure must match the inp
 }
 ```
 
+## Required fields
+
+Required fields on every question\_\* block. Every question_select, question_free_response, question_table, question_matching, question_geometry, question_axis, or question_multi_axis block in your output MUST include all of the following with non-empty values: hint (rich_text), solution (rich_text), and fullSolution (rich_text). If a useful hint is hard to write, emit a one-sentence prompt like "Apply the chain rule." or "Recall the parallelogram area formula." — but never omit the field. Empty strings are not acceptable.
+
 ## Examples
 
 Each example below demonstrates the input exercise JSON and the expected output variation JSON showing algebraic transformations.
@@ -164,6 +168,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "mediaIds": []
         },
         "answer": { "type": "free_response", "rubric": "12x^4", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Multiply coefficients and add the exponents.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",

--- a/src/infra/llm/prompts/lesson-duplication/algebra-light-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/algebra-light-agent-prompt.md
@@ -242,6 +242,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "mediaIds": []
         },
         "answer": { "type": "free_response", "rubric": "(x+4)(x-4)", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Recognize this as a difference of squares.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",

--- a/src/infra/llm/prompts/lesson-duplication/algebra-medium-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/algebra-medium-agent-prompt.md
@@ -30,6 +30,10 @@ Return a JSON object with the exercise content. The structure must match the inp
 }
 ```
 
+## Required fields
+
+Required fields on every question\_\* block. Every question_select, question_free_response, question_table, question_matching, question_geometry, question_axis, or question_multi_axis block in your output MUST include all of the following with non-empty values: hint (rich_text), solution (rich_text), and fullSolution (rich_text). If a useful hint is hard to write, emit a one-sentence prompt like "Apply the chain rule." or "Recall the parallelogram area formula." — but never omit the field. Empty strings are not acceptable.
+
 ## Examples
 
 Each example below demonstrates the input exercise JSON and the expected output variation JSON showing algebraic transformations with reworded phrasing.
@@ -84,6 +88,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "mediaIds": []
         },
         "answer": { "type": "free_response", "rubric": "x = 5", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Isolate the variable term first, then divide.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",
@@ -152,6 +162,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "mediaIds": []
         },
         "answer": { "type": "free_response", "rubric": "x^2 + 2x - 8", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Apply the FOIL method to expand the product.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",
@@ -220,6 +236,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "mediaIds": []
         },
         "answer": { "type": "free_response", "rubric": "x = 2 or x = 3", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Factor the quadratic and set each factor to zero.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",

--- a/src/infra/llm/prompts/lesson-duplication/calculus-deep-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/calculus-deep-agent-prompt.md
@@ -34,6 +34,10 @@ Return a JSON object with the exercise content. The structure should match the i
 }
 ```
 
+## Required fields
+
+Required fields on every question\_\* block. Every question_select, question_free_response, question_table, question_matching, question_geometry, question_axis, or question_multi_axis block in your output MUST include all of the following with non-empty values: hint (rich_text), solution (rich_text), and fullSolution (rich_text). If a useful hint is hard to write, emit a one-sentence prompt like "Apply the chain rule." or "Recall the parallelogram area formula." — but never omit the field. Empty strings are not acceptable.
+
 ## Examples
 
 Each example below demonstrates the input exercise JSON and the expected output variation JSON. The calculus solution must include a `full_solution` field with step-by-step derivation showing each rule applied.
@@ -91,6 +95,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "type": "free_response",
           "rubric": "(6x + 2)e^(3x² + 2x)",
           "acceptedPatterns": []
+        },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Treat the exponent as a composite function and apply the chain rule.",
+          "mediaIds": []
         },
         "solution": {
           "type": "rich_text",
@@ -164,6 +174,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "rubric": "(15x² + 2)/(5x³ + 2x)",
           "acceptedPatterns": []
         },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Use the chain rule with the natural logarithm.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",
@@ -232,6 +248,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "mediaIds": []
         },
         "answer": { "type": "free_response", "rubric": "dy/dx = -x²/y²", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Differentiate both sides with respect to x, treating y as a function of x.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",

--- a/src/infra/llm/prompts/lesson-duplication/calculus-light-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/calculus-light-agent-prompt.md
@@ -34,6 +34,10 @@ Return a JSON object with the exercise content. The structure must match the inp
 }
 ```
 
+## Required fields
+
+Required fields on every question\_\* block. Every question_select, question_free_response, question_table, question_matching, question_geometry, question_axis, or question_multi_axis block in your output MUST include all of the following with non-empty values: hint (rich_text), solution (rich_text), and fullSolution (rich_text). If a useful hint is hard to write, emit a one-sentence prompt like "Apply the chain rule." or "Recall the parallelogram area formula." — but never omit the field. Empty strings are not acceptable.
+
 ## Examples
 
 Each example below demonstrates the input exercise JSON and the expected output variation JSON. The calculus solution must include a `full_solution` field with step-by-step derivation showing each rule applied.
@@ -54,6 +58,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "mediaIds": []
         },
         "answer": { "type": "free_response", "rubric": "f'(x) = 6x + 5", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Apply the power rule to each term.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",

--- a/src/infra/llm/prompts/lesson-duplication/calculus-light-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/calculus-light-agent-prompt.md
@@ -98,6 +98,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "mediaIds": []
         },
         "answer": { "type": "free_response", "rubric": "f'(x) = 8x + 7", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Apply the power rule to each term separately.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",
@@ -166,6 +172,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "mediaIds": []
         },
         "answer": { "type": "free_response", "rubric": "15x² + 3", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Bring each exponent down and reduce it by one.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",
@@ -241,6 +253,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "type": "free_response",
           "rubric": "4cos(x) - 6sin(x)",
           "acceptedPatterns": []
+        },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Recall: d/dx[sin(x)] = cos(x) and d/dx[cos(x)] = -sin(x).",
+          "mediaIds": []
         },
         "solution": {
           "type": "rich_text",

--- a/src/infra/llm/prompts/lesson-duplication/calculus-medium-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/calculus-medium-agent-prompt.md
@@ -34,6 +34,10 @@ Return a JSON object with the exercise content. The structure must match the inp
 }
 ```
 
+## Required fields
+
+Required fields on every question\_\* block. Every question_select, question_free_response, question_table, question_matching, question_geometry, question_axis, or question_multi_axis block in your output MUST include all of the following with non-empty values: hint (rich_text), solution (rich_text), and fullSolution (rich_text). If a useful hint is hard to write, emit a one-sentence prompt like "Apply the chain rule." or "Recall the parallelogram area formula." — but never omit the field. Empty strings are not acceptable.
+
 ## Examples
 
 Each example below demonstrates the input exercise JSON and the expected output variation JSON. The calculus solution must include a `full_solution` field with step-by-step derivation showing each rule applied.
@@ -95,6 +99,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "type": "free_response",
           "rubric": "g'(x) = 18(3x - 5)^5",
           "acceptedPatterns": []
+        },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Identify the outer and inner functions, then apply the chain rule.",
+          "mediaIds": []
         },
         "solution": {
           "type": "rich_text",
@@ -172,6 +182,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "rubric": "h'(x) = 5e^(5x-3)",
           "acceptedPatterns": []
         },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Use the chain rule with the exponential function.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",
@@ -247,6 +263,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "type": "free_response",
           "rubric": "g'(x) = (3 - 3x²)/(x² + 1)²",
           "acceptedPatterns": []
+        },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Apply the quotient rule with u on top and v on the bottom.",
+          "mediaIds": []
         },
         "solution": {
           "type": "rich_text",

--- a/src/infra/llm/prompts/lesson-duplication/geometry-deep-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/geometry-deep-agent-prompt.md
@@ -39,6 +39,10 @@ Return a JSON object with the exercise content. The structure should match the i
 }
 ```
 
+## Required fields
+
+Required fields on every question\_\* block. Every question_select, question_free_response, question_table, question_matching, question_geometry, question_axis, or question_multi_axis block in your output MUST include all of the following with non-empty values: hint (rich_text), solution (rich_text), and fullSolution (rich_text). If a useful hint is hard to write, emit a one-sentence prompt like "Apply the chain rule." or "Recall the parallelogram area formula." — but never omit the field. Empty strings are not acceptable.
+
 ## Examples
 
 Each example below demonstrates the input exercise JSON and the expected output variation JSON. The geometry specification must use the `GeometrySpecV1` format for the `geometry` field within `question_geometry` blocks.
@@ -159,10 +163,22 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "rubric": "Yes, by Pythagorean theorem: 9² + 12² = 81 + 144 = 225 = 15²",
           "acceptedPatterns": []
         },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Check if the Pythagorean theorem holds for these three side lengths.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",
           "value": "Checking: 9² + 12² = 81 + 144 = 225 = 15². Yes, it is a right triangle.",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Identify the three side lengths: 9 cm, 12 cm, 15 cm\\nStep 2: Check Pythagorean theorem: 9² + 12² = 15²?\\nStep 3: 9² + 12² = 81 + 144 = 225\\nStep 4: 15² = 225\\nStep 5: Since 9² + 12² = 15², the triangle is a right triangle.",
           "mediaIds": []
         }
       }
@@ -265,10 +281,22 @@ Each example below demonstrates the input exercise JSON and the expected output 
           }
         },
         "answer": { "type": "numeric", "value": 112, "tolerance": 0.1 },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Apply the formula for the area of a parallelogram.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",
           "value": "Area = base × height = 14 × 8 = 112 cm²",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Identify base = 14 cm and height = 8 cm\\nStep 2: Apply area formula for parallelogram: A = base × height\\nStep 3: A = 14 × 8 = 112 cm²",
           "mediaIds": []
         }
       }
@@ -373,6 +401,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           }
         },
         "answer": { "type": "free_response", "rubric": "12 cm", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Use the formula for the length of a direct common tangent between two circles.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",

--- a/src/infra/llm/prompts/lesson-duplication/geometry-light-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/geometry-light-agent-prompt.md
@@ -39,6 +39,10 @@ Return a JSON object with the exercise content. The structure must match the inp
 }
 ```
 
+## Required fields
+
+Required fields on every question\_\* block. Every question_select, question_free_response, question_table, question_matching, question_geometry, question_axis, or question_multi_axis block in your output MUST include all of the following with non-empty values: hint (rich_text), solution (rich_text), and fullSolution (rich_text). If a useful hint is hard to write, emit a one-sentence prompt like "Apply the chain rule." or "Recall the parallelogram area formula." — but never omit the field. Empty strings are not acceptable.
+
 ## Examples
 
 Each example below demonstrates the input exercise JSON and the expected output variation JSON. The geometry specification must use the `GeometrySpecV1` format for the `geometry` field within `question_geometry` blocks.
@@ -139,10 +143,22 @@ Each example below demonstrates the input exercise JSON and the expected output 
           }
         },
         "answer": { "type": "numeric", "value": 7, "tolerance": 0.1 },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Apply the law of cosines using the two given sides and the included angle.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",
           "value": "Using law of cosines: AC² = 6² + 8² - 2(6)(8)cos(60°) = 36 + 64 - 48 = 52, so AC ≈ 7.21 cm",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Identify the two sides and the included angle\\nStep 2: Apply law of cosines: c² = a² + b² - 2ab·cos(C)\\nStep 3: AC² = 6² + 8² - 2(6)(8)cos(60°)\\nStep 4: AC² = 36 + 64 - 48 = 52\\nStep 5: AC = √52 ≈ 7.21 cm",
           "mediaIds": []
         }
       }
@@ -215,10 +231,22 @@ Each example below demonstrates the input exercise JSON and the expected output 
           }
         },
         "answer": { "type": "numeric", "value": 78.54, "tolerance": 0.1 },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Recall the formula for the area of a circle.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",
           "value": "Area = πr² = π(5)² = 25π ≈ 78.54 cm²",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Identify the radius r = 5 cm\\nStep 2: Apply area formula: A = πr²\\nStep 3: A = π × 5² = π × 25\\nStep 4: A = 25π ≈ 78.54 cm²",
           "mediaIds": []
         }
       }
@@ -339,10 +367,22 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "rubric": "45°, 135°, 45°, 135°",
           "acceptedPatterns": []
         },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Corresponding angles are equal; interior angles on the same side are supplementary.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",
           "value": "Corresponding angles are equal: 45°. Interior angles on same side are supplementary: 180° - 45° = 135°.",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Identify the given corresponding angle: 45°\\nStep 2: Corresponding angles on parallel lines are equal: 45°\\nStep 3: Interior angles on the same side sum to 180°\\nStep 4: 180° - 45° = 135°\\nStep 5: Angles are 45°, 135°, 45°, 135°",
           "mediaIds": []
         }
       }

--- a/src/infra/llm/prompts/lesson-duplication/geometry-medium-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/geometry-medium-agent-prompt.md
@@ -39,6 +39,10 @@ Return a JSON object with the exercise content. The structure must match the inp
 }
 ```
 
+## Required fields
+
+Required fields on every question\_\* block. Every question_select, question_free_response, question_table, question_matching, question_geometry, question_axis, or question_multi_axis block in your output MUST include all of the following with non-empty values: hint (rich_text), solution (rich_text), and fullSolution (rich_text). If a useful hint is hard to write, emit a one-sentence prompt like "Apply the chain rule." or "Recall the parallelogram area formula." — but never omit the field. Empty strings are not acceptable.
+
 ## Examples
 
 Each example below demonstrates the input exercise JSON and the expected output variation JSON. The geometry specification must use the `GeometrySpecV1` format for the `geometry` field within `question_geometry` blocks.
@@ -167,10 +171,22 @@ Each example below demonstrates the input exercise JSON and the expected output 
           }
         },
         "answer": { "type": "numeric", "value": 32, "tolerance": 0.1 },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Add all four side lengths together.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",
           "value": "Perimeter = 12 + 5 + 8 + 7 = 32 cm",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Identify all four side lengths: 12 cm, 5 cm, 8 cm, 7 cm\\nStep 2: Perimeter is the sum of all sides\\nStep 3: Perimeter = 12 + 5 + 8 + 7 = 32 cm",
           "mediaIds": []
         }
       }
@@ -289,10 +305,22 @@ Each example below demonstrates the input exercise JSON and the expected output 
           }
         },
         "answer": { "type": "numeric", "value": 70, "tolerance": 1 },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "The sum of angles in a triangle is 180 degrees.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",
           "value": "Angle C = 180° - 40° - 70° = 70° (angle sum of triangle)",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Identify the two known angles: 40° and 70°\\nStep 2: Apply the angle sum property of triangles\\nStep 3: Angle C = 180° - 40° - 70° = 70°",
           "mediaIds": []
         }
       }
@@ -407,6 +435,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           }
         },
         "answer": { "type": "numeric", "value": 13, "tolerance": 0.1 },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Identify the right triangle and apply the Pythagorean theorem.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",

--- a/src/infra/llm/prompts/lesson-duplication/mixed-deep-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/mixed-deep-agent-prompt.md
@@ -30,6 +30,10 @@ Return a JSON object with the exercise content. The structure should match the i
 }
 ```
 
+## Required fields
+
+Required fields on every question\_\* block. Every question_select, question_free_response, question_table, question_matching, question_geometry, question_axis, or question_multi_axis block in your output MUST include all of the following with non-empty values: hint (rich_text), solution (rich_text), and fullSolution (rich_text). If a useful hint is hard to write, emit a one-sentence prompt like "Apply the chain rule." or "Recall the parallelogram area formula." — but never omit the field. Empty strings are not acceptable.
+
 ## Examples
 
 Each example below demonstrates the input exercise JSON and the expected output variation JSON showing deep mixed-subject transformations.
@@ -158,6 +162,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           }
         ],
         "answer": { "selected": ["b"] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Circumference is the perimeter of a circle.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",
@@ -220,6 +230,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "mediaIds": []
         },
         "answer": { "type": "free_response", "rubric": "5.6% per year", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Calculate the total percentage growth first, then divide by the number of years.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",
@@ -421,6 +437,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
               ]
             }
           ]
+        },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Use the conversion formula F = C × 9/5 + 32 for each temperature.",
+          "mediaIds": []
         }
       }
     ]

--- a/src/infra/llm/prompts/lesson-duplication/mixed-deep-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/mixed-deep-agent-prompt.md
@@ -173,6 +173,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "format": "md-math-v1",
           "value": "C = πd (circumference equals pi times diameter)",
           "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Recall that the circumference of a circle is the distance around its boundary.\\nStep 2: Two equivalent formulas are C = πd (where d is the diameter) and C = 2πr (where r is the radius).\\nStep 3: Option (b) C = πd matches this definition, so it is the correct formula.",
+          "mediaIds": []
         }
       }
     ]
@@ -442,6 +448,18 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "type": "rich_text",
           "format": "md-math-v1",
           "value": "Use the conversion formula F = C × 9/5 + 32 for each temperature.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Missing Fahrenheit values follow from F = C × 9/5 + 32 (e.g. 100°C → 212°F).",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Use the conversion formula F = C × 9/5 + 32.\\nStep 2: Substitute each Celsius value into the formula. Example: 100 × 9/5 + 32 = 180 + 32 = 212°F.\\nStep 3: Fill the editable cells with the computed Fahrenheit values to complete the table.",
           "mediaIds": []
         }
       }

--- a/src/infra/llm/prompts/lesson-duplication/mixed-light-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/mixed-light-agent-prompt.md
@@ -30,6 +30,10 @@ Return a JSON object with the exercise content. The structure must match the inp
 }
 ```
 
+## Required fields
+
+Required fields on every question\_\* block. Every question_select, question_free_response, question_table, question_matching, question_geometry, question_axis, or question_multi_axis block in your output MUST include all of the following with non-empty values: hint (rich_text), solution (rich_text), and fullSolution (rich_text). If a useful hint is hard to write, emit a one-sentence prompt like "Apply the chain rule." or "Recall the parallelogram area formula." — but never omit the field. Empty strings are not acceptable.
+
 ## Examples
 
 Each example below demonstrates the input exercise JSON and the expected output variation JSON showing mixed-subject transformations.
@@ -84,6 +88,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "mediaIds": []
         },
         "answer": { "type": "free_response", "rubric": "x = 3", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Isolate the variable on one side of the equation.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",
@@ -187,7 +197,13 @@ Each example below demonstrates the input exercise JSON and the expected output 
             }
           }
         ],
-        "answer": { "selected": ["true"] }
+        "answer": { "selected": ["true"] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Recall that the sum of interior angles in any triangle equals 180 degrees.",
+          "mediaIds": []
+        }
       }
     ]
   }
@@ -365,6 +381,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
               ]
             }
           ]
+        },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Multiply each column header by the row header to fill in the table cells.",
+          "mediaIds": []
         }
       }
     ]

--- a/src/infra/llm/prompts/lesson-duplication/mixed-light-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/mixed-light-agent-prompt.md
@@ -203,6 +203,18 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "format": "md-math-v1",
           "value": "Recall that the sum of interior angles in any triangle equals 180 degrees.",
           "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "True",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: The triangle angle sum theorem states that the three interior angles of any triangle add up to 180°.\\nStep 2: This holds for every triangle in Euclidean geometry, so the statement is True.",
+          "mediaIds": []
         }
       }
     ]
@@ -386,6 +398,18 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "type": "rich_text",
           "format": "md-math-v1",
           "value": "Multiply each column header by the row header to fill in the table cells.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "2×4 = 8, 2×5 = 10",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Identify the operation indicated by the row header (×).\\nStep 2: For the column under 4, compute 2 × 4 = 8.\\nStep 3: For the column under 5, compute 2 × 5 = 10.",
           "mediaIds": []
         }
       }

--- a/src/infra/llm/prompts/lesson-duplication/mixed-medium-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/mixed-medium-agent-prompt.md
@@ -30,6 +30,10 @@ Return a JSON object with the exercise content. The structure must match the inp
 }
 ```
 
+## Required fields
+
+Required fields on every question\_\* block. Every question_select, question_free_response, question_table, question_matching, question_geometry, question_axis, or question_multi_axis block in your output MUST include all of the following with non-empty values: hint (rich_text), solution (rich_text), and fullSolution (rich_text). If a useful hint is hard to write, emit a one-sentence prompt like "Apply the chain rule." or "Recall the parallelogram area formula." — but never omit the field. Empty strings are not acceptable.
+
 ## Examples
 
 Each example below demonstrates the input exercise JSON and the expected output variation JSON showing mixed-subject transformations with reworded phrasing.
@@ -111,7 +115,13 @@ Each example below demonstrates the input exercise JSON and the expected output 
             "content": { "type": "rich_text", "format": "md-math-v1", "value": "9", "mediaIds": [] }
           }
         ],
-        "answer": { "selected": ["c"] }
+        "answer": { "selected": ["c"] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "A prime number has exactly two distinct positive divisors.",
+          "mediaIds": []
+        }
       }
     ]
   }
@@ -168,6 +178,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "mediaIds": []
         },
         "answer": { "type": "free_response", "rubric": "84 m²", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Multiply the length by the width to find the area.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",
@@ -319,7 +335,13 @@ Each example below demonstrates the input exercise JSON and the expected output 
           { "leftId": "l2", "rightId": "r2" },
           { "leftId": "l3", "rightId": "r3" }
         ],
-        "shuffleRightColumn": true
+        "shuffleRightColumn": true,
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Count the number of sides on each polygon shape.",
+          "mediaIds": []
+        }
       }
     ]
   }

--- a/src/infra/llm/prompts/lesson-duplication/mixed-medium-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/mixed-medium-agent-prompt.md
@@ -121,6 +121,18 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "format": "md-math-v1",
           "value": "A prime number has exactly two distinct positive divisors.",
           "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "7",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Check divisibility of each option. 4 = 2×2 (composite). 6 = 2×3 (composite). 9 = 3×3 (composite).\\nStep 2: 7 has no positive divisors other than 1 and 7, so 7 is prime.\\nStep 3: The correct answer is 7.",
+          "mediaIds": []
         }
       }
     ]
@@ -340,6 +352,18 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "type": "rich_text",
           "format": "md-math-v1",
           "value": "Count the number of sides on each polygon shape.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Triangle → 3, Square → 4, Pentagon → 5",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Count edges for each polygon. A triangle has 3 edges; a square has 4 edges; a pentagon has 5 edges.\\nStep 2: Pair each polygon with its edge count: Triangle ↔ 3, Square ↔ 4, Pentagon ↔ 5.",
           "mediaIds": []
         }
       }

--- a/src/infra/llm/prompts/lesson-duplication/other-deep-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/other-deep-agent-prompt.md
@@ -30,6 +30,10 @@ Return a JSON object with the exercise content. The structure should match the i
 }
 ```
 
+## Required fields
+
+Required fields on every question\_\* block. Every question_select, question_free_response, question_table, question_matching, question_geometry, question_axis, or question_multi_axis block in your output MUST include all of the following with non-empty values: hint (rich_text), solution (rich_text), and fullSolution (rich_text). If a useful hint is hard to write, emit a one-sentence prompt like "Apply the chain rule." or "Recall the parallelogram area formula." — but never omit the field. Empty strings are not acceptable.
+
 ## Examples
 
 Each example below demonstrates the input exercise JSON and the expected output variation JSON for deep non-math exercise transformations.
@@ -151,7 +155,25 @@ Each example below demonstrates the input exercise JSON and the expected output 
             }
           }
         ],
-        "answer": { "selected": ["b"] }
+        "answer": { "selected": ["b"] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Consider the reddish iron oxide (rust) that coats the surface of Mars.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Mars — the fourth planet is known as the Red Planet due to iron oxide on its surface.",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Examine each planetary option.\nStep 2: Venus — covered in thick yellow clouds of sulfuric acid.\nStep 3: Mars — surface appearance is distinctly reddish due to iron oxide (rust).\nStep 4: Jupiter — gas giant with orange and brown cloud bands.\nStep 5: Saturn — gas giant with pale gold hues.\nStep 6: Only Mars matches the description of reddish appearance.\nStep 7: Final answer: Mars (option b)",
+          "mediaIds": []
+        }
       }
     ]
   }
@@ -321,7 +343,25 @@ Each example below demonstrates the input exercise JSON and the expected output 
           { "leftId": "l2", "rightId": "r2" },
           { "leftId": "l3", "rightId": "r3" }
         ],
-        "shuffleRightColumn": true
+        "shuffleRightColumn": true,
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Recall the originators of the theory of relativity, the law of gravitation, and the antibiotic penicillin.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Theory of Relativity → Einstein, Gravity → Newton, Penicillin → Fleming",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Review each discovery in the left column.\nStep 2: Theory of Relativity — developed by Albert Einstein.\nStep 3: Law of Universal Gravitation — formulated by Isaac Newton.\nStep 4: Penicillin — discovered by Alexander Fleming.\nStep 5: Match each left item to its correct right item.\nStep 6: Final answer: Theory of Relativity→Einstein, Gravity→Newton, Penicillin→Fleming",
+          "mediaIds": []
+        }
       }
     ]
   }
@@ -420,10 +460,22 @@ Each example below demonstrates the input exercise JSON and the expected output 
           }
         ],
         "answer": { "selected": ["false"] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Research or recall the verified lengths of the world's major rivers.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",
           "value": "False. The Nile River is generally considered the longest at approximately 6,650 km.",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Evaluate the claim about the Amazon River.\nStep 2: The Amazon is the largest river by discharge volume.\nStep 3: However, the Nile River is generally recognized as the longest at approximately 6,650 km.\nStep 4: The Amazon is about 6,400 km, making it slightly shorter than the Nile.\nStep 5: The statement is therefore false.\nStep 6: Final answer: False",
           "mediaIds": []
         }
       }

--- a/src/infra/llm/prompts/lesson-duplication/other-light-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/other-light-agent-prompt.md
@@ -30,6 +30,10 @@ Return a JSON object with the exercise content. The structure must match the inp
 }
 ```
 
+## Required fields
+
+Required fields on every question\_\* block. Every question_select, question_free_response, question_table, question_matching, question_geometry, question_axis, or question_multi_axis block in your output MUST include all of the following with non-empty values: hint (rich_text), solution (rich_text), and fullSolution (rich_text). If a useful hint is hard to write, emit a one-sentence prompt like "Apply the chain rule." or "Recall the parallelogram area formula." — but never omit the field. Empty strings are not acceptable.
+
 ## Examples
 
 Each example below demonstrates the input exercise JSON and the expected output variation JSON for non-math exercises like true/false and matching.
@@ -119,7 +123,25 @@ Each example below demonstrates the input exercise JSON and the expected output 
             }
           }
         ],
-        "answer": { "selected": ["true"] }
+        "answer": { "selected": ["true"] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Recall the standard boiling point of water under normal atmospheric pressure.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "True — water boils at 100°C at sea level.",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Identify the factual claim — water's boiling point at sea level.\nStep 2: Recall standard chemistry reference: water boils at 100 degrees Celsius under 1 atmosphere of pressure.\nStep 3: The statement is factually correct.\nStep 4: Final answer: True",
+          "mediaIds": []
+        }
       }
     ]
   }
@@ -211,7 +233,25 @@ Each example below demonstrates the input exercise JSON and the expected output 
             }
           }
         ],
-        "answer": { "selected": ["true"] }
+        "answer": { "selected": ["true"] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Remember the direction from which the sun appears in the sky each morning.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "True — the sun rises in the east due to Earth's rotation.",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Identify the claim about solar direction.\nStep 2: Recall Earth's rotation direction — west to east.\nStep 3: From Earth's surface, the sun appears to rise in the east.\nStep 4: The statement is factually correct.\nStep 5: Final answer: True",
+          "mediaIds": []
+        }
       }
     ]
   }
@@ -303,7 +343,25 @@ Each example below demonstrates the input exercise JSON and the expected output 
             }
           }
         ],
-        "answer": { "selected": ["true"] }
+        "answer": { "selected": ["true"] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Think about what process allows plants to convert light energy into chemical energy.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "True — photosynthesis requires sunlight as an energy source.",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Identify the claim about plant biology.\nStep 2: Recall the process of photosynthesis: light + water + CO₂ → glucose + oxygen.\nStep 3: Sunlight provides the energy needed for this chemical process.\nStep 4: Without sunlight, photosynthesis cannot occur.\nStep 5: The statement is factually correct.\nStep 6: Final answer: True",
+          "mediaIds": []
+        }
       }
     ]
   }

--- a/src/infra/llm/prompts/lesson-duplication/other-medium-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/other-medium-agent-prompt.md
@@ -30,6 +30,10 @@ Return a JSON object with the exercise content. The structure must match the inp
 }
 ```
 
+## Required fields
+
+Required fields on every question\_\* block. Every question_select, question_free_response, question_table, question_matching, question_geometry, question_axis, or question_multi_axis block in your output MUST include all of the following with non-empty values: hint (rich_text), solution (rich_text), and fullSolution (rich_text). If a useful hint is hard to write, emit a one-sentence prompt like "Apply the chain rule." or "Recall the parallelogram area formula." — but never omit the field. Empty strings are not acceptable.
+
 ## Examples
 
 Each example below demonstrates the input exercise JSON and the expected output variation JSON for non-math exercises with reworded phrasing.
@@ -197,7 +201,25 @@ Each example below demonstrates the input exercise JSON and the expected output 
           { "leftId": "l2", "rightId": "r2" },
           { "leftId": "l3", "rightId": "r3" }
         ],
-        "shuffleRightColumn": true
+        "shuffleRightColumn": true,
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Recall the administrative centers and capital cities of France, Japan, and Brazil.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "France → Paris, Japan → Tokyo, Brazil → Brasilia",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Review each country in the left column.\nStep 2: Recall the capital city of France — Paris.\nStep 3: Recall the capital city of Japan — Tokyo.\nStep 4: Recall the capital city of Brazil — Brasilia.\nStep 5: Match each left item to its correct right item.\nStep 6: Final answer: France→Paris, Japan→Tokyo, Brazil→Brasilia",
+          "mediaIds": []
+        }
       }
     ]
   }
@@ -289,7 +311,25 @@ Each example below demonstrates the input exercise JSON and the expected output 
             }
           }
         ],
-        "answer": { "selected": ["true"] }
+        "answer": { "selected": ["true"] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Count the number of bones in an adult human skeletal system.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "True — an adult human body contains 206 bones.",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Identify the factual claim about human anatomy.\nStep 2: Recall standard anatomy: an adult human skeleton has 206 bones.\nStep 3: Babies are born with ~270 bones, some of which fuse as the body matures.\nStep 4: The statement is factually correct.\nStep 5: Final answer: True",
+          "mediaIds": []
+        }
       }
     ]
   }
@@ -439,7 +479,25 @@ Each example below demonstrates the input exercise JSON and the expected output 
           { "leftId": "l2", "rightId": "r2" },
           { "leftId": "l3", "rightId": "r3" }
         ],
-        "shuffleRightColumn": true
+        "shuffleRightColumn": true,
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Remember the chemical symbols for oxygen, carbon, and gold from the periodic table.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Oxygen → O, Carbon → C, Gold → Au",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Review each element in the left column.\nStep 2: Recall the periodic table symbol for oxygen — O.\nStep 3: Recall the periodic table symbol for carbon — C.\nStep 4: Recall the periodic table symbol for gold — Au (from Latin 'aurum').\nStep 5: Match each left item to its correct right item.\nStep 6: Final answer: Oxygen→O, Carbon→C, Gold→Au",
+          "mediaIds": []
+        }
       }
     ]
   }


### PR DESCRIPTION
## Summary

Implementation of issue #1720 —  Fix lesson-duplication prompts that omit hint / fullSolution from examples

_(agent did not supply PR_SUMMARY)_

## Changes

- `src/infra/llm/prompts/lesson-duplication/algebra-deep-agent-prompt.md`
- `src/infra/llm/prompts/lesson-duplication/algebra-light-agent-prompt.md`
- `src/infra/llm/prompts/lesson-duplication/algebra-medium-agent-prompt.md`
- `src/infra/llm/prompts/lesson-duplication/calculus-deep-agent-prompt.md`
- `src/infra/llm/prompts/lesson-duplication/calculus-light-agent-prompt.md`
- `src/infra/llm/prompts/lesson-duplication/calculus-medium-agent-prompt.md`
- `src/infra/llm/prompts/lesson-duplication/geometry-deep-agent-prompt.md`
- `src/infra/llm/prompts/lesson-duplication/geometry-light-agent-prompt.md`
- `src/infra/llm/prompts/lesson-duplication/geometry-medium-agent-prompt.md`
- `src/infra/llm/prompts/lesson-duplication/mixed-deep-agent-prompt.md`
- `src/infra/llm/prompts/lesson-duplication/mixed-light-agent-prompt.md`
- `src/infra/llm/prompts/lesson-duplication/mixed-medium-agent-prompt.md`
- `src/infra/llm/prompts/lesson-duplication/other-deep-agent-prompt.md`
- `src/infra/llm/prompts/lesson-duplication/other-light-agent-prompt.md`
- `src/infra/llm/prompts/lesson-duplication/other-medium-agent-prompt.md`

Closes #1720

---
_Opened by kody (single-session autonomous run)._ 