### PR TITLE
fix(prompts): Add missing hint/solution/fullSolution to example outputs

### DIFF
--- a/src/infra/llm/prompts/lesson-duplication/algebra-light-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/algebra-light-agent-prompt.md
@@ -242,6 +242,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "mediaIds": []
         },
         "answer": { "type": "free_response", "rubric": "(x+4)(x-4)", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Recognize this as a difference of squares.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",

--- a/src/infra/llm/prompts/lesson-duplication/calculus-light-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/calculus-light-agent-prompt.md
@@ -98,6 +98,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "mediaIds": []
         },
         "answer": { "type": "free_response", "rubric": "f'(x) = 8x + 7", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Apply the power rule to each term separately.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",
@@ -166,6 +172,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "mediaIds": []
         },
         "answer": { "type": "free_response", "rubric": "15x² + 3", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Bring each exponent down and reduce it by one.",
+          "mediaIds": []
+        },
         "solution": {
           "type": "rich_text",
           "format": "md-math-v1",
@@ -241,6 +253,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "type": "free_response",
           "rubric": "4cos(x) - 6sin(x)",
           "acceptedPatterns": []
+        },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Recall: d/dx[sin(x)] = cos(x) and d/dx[cos(x)] = -sin(x).",
+          "mediaIds": []
         },
         "solution": {
           "type": "rich_text",

--- a/src/infra/llm/prompts/lesson-duplication/mixed-deep-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/mixed-deep-agent-prompt.md
@@ -173,6 +173,12 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "format": "md-math-v1",
           "value": "C = πd (circumference equals pi times diameter)",
           "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Recall that the circumference of a circle is the distance around its boundary.\\nStep 2: Two equivalent formulas are C = πd (where d is the diameter) and C = 2πr (where r is the radius).\\nStep 3: Option (b) C = πd matches this definition, so it is the correct formula.",
+          "mediaIds": []
         }
       }
     ]
@@ -442,6 +448,18 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "type": "rich_text",
           "format": "md-math-v1",
           "value": "Use the conversion formula F = C × 9/5 + 32 for each temperature.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Missing Fahrenheit values follow from F = C × 9/5 + 32 (e.g. 100°C → 212°F).",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Use the conversion formula F = C × 9/5 + 32.\\nStep 2: Substitute each Celsius value into the formula. Example: 100 × 9/5 + 32 = 180 + 32 = 212°F.\\nStep 3: Fill the editable cells with the computed Fahrenheit values to complete the table.",
           "mediaIds": []
         }
       }

--- a/src/infra/llm/prompts/lesson-duplication/mixed-light-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/mixed-light-agent-prompt.md
@@ -203,6 +203,18 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "format": "md-math-v1",
           "value": "Recall that the sum of interior angles in any triangle equals 180 degrees.",
           "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "True",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: The triangle angle sum theorem states that the three interior angles of any triangle add up to 180°.\\nStep 2: This holds for every triangle in Euclidean geometry, so the statement is True.",
+          "mediaIds": []
         }
       }
     ]
@@ -386,6 +398,18 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "type": "rich_text",
           "format": "md-math-v1",
           "value": "Multiply each column header by the row header to fill in the table cells.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "2×4 = 8, 2×5 = 10",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Identify the operation indicated by the row header (×).\\nStep 2: For the column under 4, compute 2 × 4 = 8.\\nStep 3: For the column under 5, compute 2 × 5 = 10.",
           "mediaIds": []
         }
       }

--- a/src/infra/llm/prompts/lesson-duplication/mixed-medium-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/mixed-medium-agent-prompt.md
@@ -121,6 +121,18 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "format": "md-math-v1",
           "value": "A prime number has exactly two distinct positive divisors.",
           "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "7",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Check divisibility of each option. 4 = 2×2 (composite). 6 = 2×3 (composite). 9 = 3×3 (composite).\\nStep 2: 7 has no positive divisors other than 1 and 7, so 7 is prime.\\nStep 3: The correct answer is 7.",
+          "mediaIds": []
         }
       }
     ]
@@ -340,6 +352,18 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "type": "rich_text",
           "format": "md-math-v1",
           "value": "Count the number of sides on each polygon shape.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Triangle → 3, Square → 4, Pentagon → 5",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Step 1: Count edges for each polygon. A triangle has 3 edges; a square has 4 edges; a pentagon has 5 edges.\\nStep 2: Pair each polygon with its edge count: Triangle ↔ 3, Square ↔ 4, Pentagon ↔ 5.",
           "mediaIds": []
         }
       }


### PR DESCRIPTION
Targets #1722 — adds 8 missing fields across 6 example output blocks that Kody's PR left out.

## Gaps closed (verified with em-dash-aware walker, not just \`grep\`)
- \`algebra-light\` Example 3 — added \`hint\`
- \`calculus-light\` Examples 1, 2, 3 — added \`hint\` to each (the original problem case — ALL outputs were missing it)
- \`mixed-deep\` Example 1 — added \`fullSolution\`
- \`mixed-deep\` Example 3 — added \`solution\` + \`fullSolution\`
- \`mixed-light\` Examples 2, 3 — added \`solution\` + \`fullSolution\`
- \`mixed-medium\` Examples 1, 3 — added \`solution\` + \`fullSolution\`

## Why this is a separate PR

#1722's rule text says "every question_* block must include hint/solution/fullSolution" — and Kody's \`grep -L\` acceptance check passed because the rule paragraph mentions those fields somewhere. But examples are what Gemini actually learns from, and #1722 left ~8 example outputs without the required fields.

Without this fix, the original ~95% \`MISSING_HINT\`-placeholder problem would still happen on calculus-light variations.

## Test plan
- [x] After-edit audit: every Example Output across all 15 prompts now contains \`hint\`, \`solution\`, AND \`fullSolution\` on every question block.
- [x] \`pnpm generate:types\` + \`pnpm typecheck\` clean
- [x] No code files modified — only 5 \`.md\` files

## Merge order
Merge this PR INTO the #1722 branch first, then merge #1722 into dev as one combined fix.