### PR TITLE
#1733: Make pass-2 solution derivation per-block in lesson duplication

### DIFF
--- a/src/infra/llm/prompts/lesson-duplication/algebra-deep-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/algebra-deep-agent-prompt.md
@@ -17,6 +17,7 @@ Generate a deep variation of the provided exercise. Deep variation means: **nume
 7. **No unsolvable problems**: Ensure the variation still has a valid, correct answer.
 8. **No contradictions**: Question, hint, solution, and full_solution must all be consistent with each other.
 9. **NO PNG output**: Never produce or include any PNG image data. Only text and SVG are allowed.
+10. **When a deep variation produces multiple question blocks within one exercise, every block must independently carry a non-empty hint. (solution and fullSolution are re-derived in pass 2.)**
 
 ## Output Format
 
@@ -264,6 +265,236 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "type": "rich_text",
           "format": "md-math-v1",
           "value": "Step 1: slope m = (11 - 5) / (4 - 2) = 6 / 2 = 3\\nStep 2: Use point-slope: y - 5 = 3(x - 2)\\nStep 3: y - 5 = 3x - 6\\nStep 4: y = 3x - 1",
+          "mediaIds": []
+        }
+      }
+    ]
+  }
+}
+```
+
+**Example 4 — Input (multi-block):**
+
+```json
+{
+  "content": {
+    "blocks": [
+      {
+        "id": "q1",
+        "type": "question_free_response",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Simplify: $2x + 3x$",
+          "mediaIds": []
+        },
+        "answer": { "type": "free_response", "rubric": "5x", "acceptedPatterns": [] },
+        "solution": { "type": "rich_text", "format": "md-math-v1", "value": "5x", "mediaIds": [] },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Combine like terms: 2x + 3x = (2+3)x = 5x",
+          "mediaIds": []
+        }
+      },
+      {
+        "id": "q2",
+        "type": "question_select",
+        "variant": "mcq",
+        "selectionMode": "single",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Which expression is equivalent to $4(x + 2)$?",
+          "mediaIds": []
+        },
+        "options": [
+          {
+            "id": "a",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "4x + 2",
+              "mediaIds": []
+            }
+          },
+          {
+            "id": "b",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "4x + 8",
+              "mediaIds": []
+            }
+          },
+          {
+            "id": "c",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "x + 8",
+              "mediaIds": []
+            }
+          }
+        ],
+        "answer": { "selected": ["b"] },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "4x + 8",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Apply distributive property: 4(x+2) = 4x + 4·2 = 4x + 8",
+          "mediaIds": []
+        }
+      },
+      {
+        "id": "q3",
+        "type": "question_free_response",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Factor completely: $x^2 - 9$",
+          "mediaIds": []
+        },
+        "answer": { "type": "free_response", "rubric": "(x+3)(x-3)", "acceptedPatterns": [] },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "(x+3)(x-3)",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Recognize as difference of squares: x² - 9 = x² - 3² = (x+3)(x-3)",
+          "mediaIds": []
+        }
+      }
+    ]
+  }
+}
+```
+
+**Example 4 — Output (multi-block with independent hints):**
+
+```json
+{
+  "content": {
+    "blocks": [
+      {
+        "id": "q1",
+        "type": "question_free_response",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Simplify: $7y + 2y$",
+          "mediaIds": []
+        },
+        "answer": { "type": "free_response", "rubric": "9y", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Combine coefficients of like terms.",
+          "mediaIds": []
+        },
+        "solution": { "type": "rich_text", "format": "md-math-v1", "value": "9y", "mediaIds": [] },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Combine like terms: 7y + 2y = (7+2)y = 9y",
+          "mediaIds": []
+        }
+      },
+      {
+        "id": "q2",
+        "type": "question_select",
+        "variant": "mcq",
+        "selectionMode": "single",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Which expression is equivalent to $5(a - 3)$?",
+          "mediaIds": []
+        },
+        "options": [
+          {
+            "id": "a",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "5a - 3",
+              "mediaIds": []
+            }
+          },
+          {
+            "id": "b",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "5a - 15",
+              "mediaIds": []
+            }
+          },
+          {
+            "id": "c",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "a - 15",
+              "mediaIds": []
+            }
+          }
+        ],
+        "answer": { "selected": ["b"] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Use the distributive property: multiply each term inside the parentheses.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "5a - 15",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Apply distributive property: 5(a-3) = 5a - 5·3 = 5a - 15",
+          "mediaIds": []
+        }
+      },
+      {
+        "id": "q3",
+        "type": "question_free_response",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Factor completely: $x^2 - 16$",
+          "mediaIds": []
+        },
+        "answer": { "type": "free_response", "rubric": "(x+4)(x-4)", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Recognize this as a difference of two squares.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "(x+4)(x-4)",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Recognize as difference of squares: x² - 16 = x² - 4² = (x+4)(x-4)",
           "mediaIds": []
         }
       }

--- a/src/infra/llm/prompts/lesson-duplication/calculus-deep-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/calculus-deep-agent-prompt.md
@@ -17,6 +17,7 @@ Generate a deep variation of the provided exercise. Deep variation means: **nume
 7. **No unsolvable problems**: Ensure the variation still has a valid, correct answer.
 8. **No contradictions**: Question, hint, solution, and full_solution must all be consistent with each other.
 9. **NO PNG output**: Never produce or include any PNG image data. Only text and SVG are allowed.
+10. **When a deep variation produces multiple question blocks within one exercise, every block must independently carry a non-empty hint. (solution and fullSolution are re-derived in pass 2.)**
 
 ## Subject-specific rules: Calculus
 
@@ -264,6 +265,236 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "type": "rich_text",
           "format": "md-math-v1",
           "value": "Step 1: Differentiate both sides with respect to x\\nStep 2: d/dx(x³) + d/dx(y³) = d/dx(8)\\nStep 3: 3x² + 3y²(dy/dx) = 0 (chain rule on y³)\\nStep 4: Isolate dy/dx: 3y²(dy/dx) = -3x²\\nStep 5: Divide by 3y²: dy/dx = -x²/y²\\nStep 6: Final answer: dy/dx = -x²/y²",
+          "mediaIds": []
+        }
+      }
+    ]
+  }
+}
+```
+
+**Example 4 — Input (multi-block):**
+
+```json
+{
+  "content": {
+    "blocks": [
+      {
+        "id": "q1",
+        "type": "question_free_response",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Find $\\frac{d}{dx}[x^3]$",
+          "mediaIds": []
+        },
+        "answer": { "type": "free_response", "rubric": "3x²", "acceptedPatterns": [] },
+        "solution": { "type": "rich_text", "format": "md-math-v1", "value": "3x²", "mediaIds": [] },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Apply power rule: d/dx(xⁿ) = nxⁿ⁻¹ → 3x²",
+          "mediaIds": []
+        }
+      },
+      {
+        "id": "q2",
+        "type": "question_select",
+        "variant": "mcq",
+        "selectionMode": "single",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "What is the derivative of $e^{2x}$?",
+          "mediaIds": []
+        },
+        "options": [
+          {
+            "id": "a",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "e^{2x}",
+              "mediaIds": []
+            }
+          },
+          {
+            "id": "b",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "2e^{2x}",
+              "mediaIds": []
+            }
+          },
+          {
+            "id": "c",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "2xe^{2x}",
+              "mediaIds": []
+            }
+          }
+        ],
+        "answer": { "selected": ["b"] },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "2e^{2x}",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Chain rule: d/dx(e^{u}) = e^{u}·u'. Here u=2x so u'=2. Result: 2e^{2x}",
+          "mediaIds": []
+        }
+      },
+      {
+        "id": "q3",
+        "type": "question_free_response",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Find $\\frac{d}{dx}[\\ln(x^2 + 1)]$",
+          "mediaIds": []
+        },
+        "answer": { "type": "free_response", "rubric": "2x/(x²+1)", "acceptedPatterns": [] },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "2x/(x²+1)",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Chain rule: d/dx[ln(u)] = u'/u. Here u=x²+1 so u'=2x. Result: 2x/(x²+1)",
+          "mediaIds": []
+        }
+      }
+    ]
+  }
+}
+```
+
+**Example 4 — Output (multi-block with independent hints):**
+
+```json
+{
+  "content": {
+    "blocks": [
+      {
+        "id": "q1",
+        "type": "question_free_response",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Find $\\frac{d}{dx}[x^5]$",
+          "mediaIds": []
+        },
+        "answer": { "type": "free_response", "rubric": "5x⁴", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Apply the power rule to each term.",
+          "mediaIds": []
+        },
+        "solution": { "type": "rich_text", "format": "md-math-v1", "value": "5x⁴", "mediaIds": [] },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Apply power rule: d/dx(xⁿ) = nxⁿ⁻¹ → 5x⁴",
+          "mediaIds": []
+        }
+      },
+      {
+        "id": "q2",
+        "type": "question_select",
+        "variant": "mcq",
+        "selectionMode": "single",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "What is the derivative of $e^{3x}$?",
+          "mediaIds": []
+        },
+        "options": [
+          {
+            "id": "a",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "e^{3x}",
+              "mediaIds": []
+            }
+          },
+          {
+            "id": "b",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "3e^{3x}",
+              "mediaIds": []
+            }
+          },
+          {
+            "id": "c",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "3xe^{3x}",
+              "mediaIds": []
+            }
+          }
+        ],
+        "answer": { "selected": ["b"] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Remember the chain rule for exponential functions.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "3e^{3x}",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Chain rule: d/dx(e^{u}) = e^{u}·u'. Here u=3x so u'=3. Result: 3e^{3x}",
+          "mediaIds": []
+        }
+      },
+      {
+        "id": "q3",
+        "type": "question_free_response",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Find $\\frac{d}{dx}[\\ln(5x^2 + 3)]$",
+          "mediaIds": []
+        },
+        "answer": { "type": "free_response", "rubric": "10x/(5x²+3)", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Use the chain rule with the natural logarithm.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "10x/(5x²+3)",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Chain rule: d/dx[ln(u)] = u'/u. Here u=5x²+3 so u'=10x. Result: 10x/(5x²+3)",
           "mediaIds": []
         }
       }

--- a/src/infra/llm/prompts/lesson-duplication/geometry-deep-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/geometry-deep-agent-prompt.md
@@ -17,6 +17,7 @@ Generate a deep variation of the provided exercise. Deep variation means: **nume
 7. **No unsolvable problems**: Ensure the variation still has a valid, correct answer.
 8. **No contradictions**: Question, hint, solution, and full_solution must all be consistent with each other.
 9. **NO PNG output**: Never produce or include any PNG image data. Only text and SVG are allowed.
+10. **When a deep variation produces multiple question blocks within one exercise, every block must independently carry a non-empty hint. (solution and fullSolution are re-derived in pass 2.)**
 
 ## Subject-specific rules: Geometry
 
@@ -417,6 +418,266 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "type": "rich_text",
           "format": "md-math-v1",
           "value": "Step 1: Let O1 and O2 be centers, r1=7, r2=4, d=13\\nStep 2: Draw right triangle with tangent segment and difference of radii\\nStep 3: Length = √(d² - (r1-r2)²)\\nStep 4: = √(169 - 9) = √160 = 4√10 ≈ 12.6 cm",
+          "mediaIds": []
+        }
+      }
+    ]
+  }
+}
+```
+
+**Example 4 — Input (multi-block):**
+
+```json
+{
+  "content": {
+    "blocks": [
+      {
+        "id": "q1",
+        "type": "question_geometry",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Find the area of a rectangle with length 8 cm and width 5 cm.",
+          "mediaIds": []
+        },
+        "layout": { "displaySize": "medium" },
+        "geometry": {
+          "kind": "euclidean",
+          "canvas": { "width": 400, "height": 300 },
+          "elements": {
+            "points": [
+              { "name": "A", "x": 50, "y": 250 },
+              { "name": "B", "x": 350, "y": 250 },
+              { "name": "C", "x": 350, "y": 100 },
+              { "name": "D", "x": 50, "y": 100 }
+            ],
+            "lines": [
+              {
+                "from": "A",
+                "to": "B",
+                "style": "solid",
+                "label": { "value": "8 cm", "position": "b" }
+              },
+              {
+                "from": "B",
+                "to": "C",
+                "style": "solid",
+                "label": { "value": "5 cm", "position": "r" }
+              },
+              { "from": "C", "to": "D", "style": "solid" },
+              { "from": "D", "to": "A", "style": "solid" }
+            ],
+            "areas": [{ "polygon": ["A", "B", "C", "D"], "style": "hatch", "color": "#cccccc" }]
+          }
+        },
+        "answer": { "type": "free_response", "rubric": "40 cm²", "acceptedPatterns": [] },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Area = 8 × 5 = 40 cm²",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Area of rectangle = length × width = 8 × 5 = 40 cm²",
+          "mediaIds": []
+        }
+      },
+      {
+        "id": "q2",
+        "type": "question_select",
+        "variant": "mcq",
+        "selectionMode": "single",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "How many sides does a hexagon have?",
+          "mediaIds": []
+        },
+        "options": [
+          {
+            "id": "a",
+            "content": { "type": "rich_text", "format": "md-math-v1", "value": "5", "mediaIds": [] }
+          },
+          {
+            "id": "b",
+            "content": { "type": "rich_text", "format": "md-math-v1", "value": "6", "mediaIds": [] }
+          },
+          {
+            "id": "c",
+            "content": { "type": "rich_text", "format": "md-math-v1", "value": "7", "mediaIds": [] }
+          }
+        ],
+        "answer": { "selected": ["b"] },
+        "solution": { "type": "rich_text", "format": "md-math-v1", "value": "6", "mediaIds": [] },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "A hexagon has 6 sides (hex = 6)",
+          "mediaIds": []
+        }
+      },
+      {
+        "id": "q3",
+        "type": "question_free_response",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Find the circumference of a circle with radius 7 cm (use π ≈ 22/7).",
+          "mediaIds": []
+        },
+        "answer": { "type": "free_response", "rubric": "44 cm", "acceptedPatterns": [] },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "44 cm",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "C = 2πr = 2 × (22/7) × 7 = 44 cm",
+          "mediaIds": []
+        }
+      }
+    ]
+  }
+}
+```
+
+**Example 4 — Output (multi-block with independent hints):**
+
+```json
+{
+  "content": {
+    "blocks": [
+      {
+        "id": "q1",
+        "type": "question_geometry",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Find the area of a rectangle with length 12 cm and width 6 cm.",
+          "mediaIds": []
+        },
+        "layout": { "displaySize": "medium" },
+        "geometry": {
+          "kind": "euclidean",
+          "canvas": { "width": 400, "height": 300 },
+          "elements": {
+            "points": [
+              { "name": "A", "x": 50, "y": 250 },
+              { "name": "B", "x": 350, "y": 250 },
+              { "name": "C", "x": 350, "y": 100 },
+              { "name": "D", "x": 50, "y": 100 }
+            ],
+            "lines": [
+              {
+                "from": "A",
+                "to": "B",
+                "style": "solid",
+                "label": { "value": "12 cm", "position": "b" }
+              },
+              {
+                "from": "B",
+                "to": "C",
+                "style": "solid",
+                "label": { "value": "6 cm", "position": "r" }
+              },
+              { "from": "C", "to": "D", "style": "solid" },
+              { "from": "D", "to": "A", "style": "solid" }
+            ],
+            "areas": [{ "polygon": ["A", "B", "C", "D"], "style": "hatch", "color": "#cccccc" }]
+          }
+        },
+        "answer": { "type": "free_response", "rubric": "72 cm²", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Multiply length by width to find the area.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Area = 12 × 6 = 72 cm²",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Area of rectangle = length × width = 12 × 6 = 72 cm²",
+          "mediaIds": []
+        }
+      },
+      {
+        "id": "q2",
+        "type": "question_select",
+        "variant": "mcq",
+        "selectionMode": "single",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "How many angles does a pentagon have?",
+          "mediaIds": []
+        },
+        "options": [
+          {
+            "id": "a",
+            "content": { "type": "rich_text", "format": "md-math-v1", "value": "4", "mediaIds": [] }
+          },
+          {
+            "id": "b",
+            "content": { "type": "rich_text", "format": "md-math-v1", "value": "5", "mediaIds": [] }
+          },
+          {
+            "id": "c",
+            "content": { "type": "rich_text", "format": "md-math-v1", "value": "6", "mediaIds": [] }
+          }
+        ],
+        "answer": { "selected": ["b"] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "A pentagon has the same number of angles as sides.",
+          "mediaIds": []
+        },
+        "solution": { "type": "rich_text", "format": "md-math-v1", "value": "5", "mediaIds": [] },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "A pentagon has 5 sides and therefore 5 angles (pent = 5)",
+          "mediaIds": []
+        }
+      },
+      {
+        "id": "q3",
+        "type": "question_free_response",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Find the circumference of a circle with radius 10 cm (use π ≈ 3.14).",
+          "mediaIds": []
+        },
+        "answer": { "type": "free_response", "rubric": "62.8 cm", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Use the formula C = 2πr.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "62.8 cm",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "C = 2πr = 2 × 3.14 × 10 = 62.8 cm",
           "mediaIds": []
         }
       }

--- a/src/infra/llm/prompts/lesson-duplication/mixed-deep-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/mixed-deep-agent-prompt.md
@@ -17,6 +17,7 @@ Generate a deep variation of the provided exercise. Deep variation means: **nume
 7. **No unsolvable problems**: Ensure the variation still has a valid, correct answer.
 8. **No contradictions**: Question, hint, solution, and full_solution must all be consistent with each other.
 9. **NO PNG output**: Never produce or include any PNG image data. Only text and SVG are allowed.
+10. **When a deep variation produces multiple question blocks within one exercise, every block must independently carry a non-empty hint. (solution and fullSolution are re-derived in pass 2.)**
 
 ## Output Format
 
@@ -460,6 +461,206 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "type": "rich_text",
           "format": "md-math-v1",
           "value": "Step 1: Use the conversion formula F = C × 9/5 + 32.\\nStep 2: Substitute each Celsius value into the formula. Example: 100 × 9/5 + 32 = 180 + 32 = 212°F.\\nStep 3: Fill the editable cells with the computed Fahrenheit values to complete the table.",
+          "mediaIds": []
+        }
+      }
+    ]
+  }
+}
+```
+
+**Example 4 — Input (multi-block):**
+
+```json
+{
+  "content": {
+    "blocks": [
+      {
+        "id": "q1",
+        "type": "question_free_response",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Solve for x: $2x + 6 = 14$",
+          "mediaIds": []
+        },
+        "answer": { "type": "free_response", "rubric": "x = 4", "acceptedPatterns": [] },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "x = 4",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "2x + 6 = 14 → 2x = 8 → x = 4",
+          "mediaIds": []
+        }
+      },
+      {
+        "id": "q2",
+        "type": "question_select",
+        "variant": "mcq",
+        "selectionMode": "single",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Which of the following is a prime number?",
+          "mediaIds": []
+        },
+        "options": [
+          {
+            "id": "a",
+            "content": { "type": "rich_text", "format": "md-math-v1", "value": "4", "mediaIds": [] }
+          },
+          {
+            "id": "b",
+            "content": { "type": "rich_text", "format": "md-math-v1", "value": "9", "mediaIds": [] }
+          },
+          {
+            "id": "c",
+            "content": { "type": "rich_text", "format": "md-math-v1", "value": "7", "mediaIds": [] }
+          }
+        ],
+        "answer": { "selected": ["c"] },
+        "solution": { "type": "rich_text", "format": "md-math-v1", "value": "7", "mediaIds": [] },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "7 is prime (divisible only by 1 and itself). 4 = 2×2 and 9 = 3×3 are composite.",
+          "mediaIds": []
+        }
+      },
+      {
+        "id": "q3",
+        "type": "question_free_response",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Find 25% of 80.",
+          "mediaIds": []
+        },
+        "answer": { "type": "free_response", "rubric": "20", "acceptedPatterns": [] },
+        "solution": { "type": "rich_text", "format": "md-math-v1", "value": "20", "mediaIds": [] },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "25% = 25/100 = 1/4. So 25% of 80 = (1/4) × 80 = 20",
+          "mediaIds": []
+        }
+      }
+    ]
+  }
+}
+```
+
+**Example 4 — Output (multi-block with independent hints):**
+
+```json
+{
+  "content": {
+    "blocks": [
+      {
+        "id": "q1",
+        "type": "question_free_response",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Solve for x: $3x + 9 = 24$",
+          "mediaIds": []
+        },
+        "answer": { "type": "free_response", "rubric": "x = 5", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Isolate the term with x on one side first.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "x = 5",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "3x + 9 = 24 → 3x = 15 → x = 5",
+          "mediaIds": []
+        }
+      },
+      {
+        "id": "q2",
+        "type": "question_select",
+        "variant": "mcq",
+        "selectionMode": "single",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Which of the following is a prime number?",
+          "mediaIds": []
+        },
+        "options": [
+          {
+            "id": "a",
+            "content": { "type": "rich_text", "format": "md-math-v1", "value": "6", "mediaIds": [] }
+          },
+          {
+            "id": "b",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "11",
+              "mediaIds": []
+            }
+          },
+          {
+            "id": "c",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "15",
+              "mediaIds": []
+            }
+          }
+        ],
+        "answer": { "selected": ["b"] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Check divisibility by primes less than the square root.",
+          "mediaIds": []
+        },
+        "solution": { "type": "rich_text", "format": "md-math-v1", "value": "11", "mediaIds": [] },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "11 is prime (not divisible by 2, 3, 5, or 7). 6 = 2×3, 15 = 3×5 are composite.",
+          "mediaIds": []
+        }
+      },
+      {
+        "id": "q3",
+        "type": "question_free_response",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Find 40% of 65.",
+          "mediaIds": []
+        },
+        "answer": { "type": "free_response", "rubric": "26", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Convert 40% to a fraction first.",
+          "mediaIds": []
+        },
+        "solution": { "type": "rich_text", "format": "md-math-v1", "value": "26", "mediaIds": [] },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "40% = 40/100 = 2/5. So 40% of 65 = (2/5) × 65 = 26",
           "mediaIds": []
         }
       }

--- a/src/infra/llm/prompts/lesson-duplication/other-deep-agent-prompt.md
+++ b/src/infra/llm/prompts/lesson-duplication/other-deep-agent-prompt.md
@@ -17,6 +17,7 @@ Generate a deep variation of the provided exercise. Deep variation means: **nume
 7. **No unsolvable problems**: Ensure the variation still has a valid, correct answer.
 8. **No contradictions**: Question, hint, solution, and full_solution must all be consistent with each other.
 9. **NO PNG output**: Never produce or include any PNG image data. Only text and SVG are allowed.
+10. **When a deep variation produces multiple question blocks within one exercise, every block must independently carry a non-empty hint. (solution and fullSolution are re-derived in pass 2.)**
 
 ## Output Format
 
@@ -476,6 +477,298 @@ Each example below demonstrates the input exercise JSON and the expected output 
           "type": "rich_text",
           "format": "md-math-v1",
           "value": "Step 1: Evaluate the claim about the Amazon River.\nStep 2: The Amazon is the largest river by discharge volume.\nStep 3: However, the Nile River is generally recognized as the longest at approximately 6,650 km.\nStep 4: The Amazon is about 6,400 km, making it slightly shorter than the Nile.\nStep 5: The statement is therefore false.\nStep 6: Final answer: False",
+          "mediaIds": []
+        }
+      }
+    ]
+  }
+}
+```
+
+**Example 4 — Input (multi-block):**
+
+```json
+{
+  "content": {
+    "blocks": [
+      {
+        "id": "q1",
+        "type": "question_select",
+        "variant": "mcq",
+        "selectionMode": "single",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Which planet is known as the Red Planet?",
+          "mediaIds": []
+        },
+        "options": [
+          {
+            "id": "a",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "Venus",
+              "mediaIds": []
+            }
+          },
+          {
+            "id": "b",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "Mars",
+              "mediaIds": []
+            }
+          },
+          {
+            "id": "c",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "Jupiter",
+              "mediaIds": []
+            }
+          }
+        ],
+        "answer": { "selected": ["b"] },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Mars",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Mars is called the Red Planet due to iron oxide (rust) on its surface.",
+          "mediaIds": []
+        }
+      },
+      {
+        "id": "q2",
+        "type": "question_free_response",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "What is the chemical symbol for gold?",
+          "mediaIds": []
+        },
+        "answer": { "type": "free_response", "rubric": "Au", "acceptedPatterns": [] },
+        "solution": { "type": "rich_text", "format": "md-math-v1", "value": "Au", "mediaIds": [] },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Au comes from the Latin word 'aurum', meaning gold.",
+          "mediaIds": []
+        }
+      },
+      {
+        "id": "q3",
+        "type": "question_select",
+        "variant": "mcq",
+        "selectionMode": "single",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "What is the capital of Japan?",
+          "mediaIds": []
+        },
+        "options": [
+          {
+            "id": "a",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "Osaka",
+              "mediaIds": []
+            }
+          },
+          {
+            "id": "b",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "Kyoto",
+              "mediaIds": []
+            }
+          },
+          {
+            "id": "c",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "Tokyo",
+              "mediaIds": []
+            }
+          }
+        ],
+        "answer": { "selected": ["c"] },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Tokyo",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Tokyo has been the capital of Japan since 1868, when the Emperor moved there from Kyoto.",
+          "mediaIds": []
+        }
+      }
+    ]
+  }
+}
+```
+
+**Example 4 — Output (multi-block with independent hints):**
+
+```json
+{
+  "content": {
+    "blocks": [
+      {
+        "id": "q1",
+        "type": "question_select",
+        "variant": "mcq",
+        "selectionMode": "single",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Which planet is known as the Blue Planet?",
+          "mediaIds": []
+        },
+        "options": [
+          {
+            "id": "a",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "Earth",
+              "mediaIds": []
+            }
+          },
+          {
+            "id": "b",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "Neptune",
+              "mediaIds": []
+            }
+          },
+          {
+            "id": "c",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "Uranus",
+              "mediaIds": []
+            }
+          }
+        ],
+        "answer": { "selected": ["a"] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "This planet is the only one known to support life.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Earth",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Earth is called the Blue Planet due to the abundance of water on its surface.",
+          "mediaIds": []
+        }
+      },
+      {
+        "id": "q2",
+        "type": "question_free_response",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "What is the chemical symbol for silver?",
+          "mediaIds": []
+        },
+        "answer": { "type": "free_response", "rubric": "Ag", "acceptedPatterns": [] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "The symbol comes from the Latin name for silver.",
+          "mediaIds": []
+        },
+        "solution": { "type": "rich_text", "format": "md-math-v1", "value": "Ag", "mediaIds": [] },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Ag comes from the Latin word 'argentum', meaning silver.",
+          "mediaIds": []
+        }
+      },
+      {
+        "id": "q3",
+        "type": "question_select",
+        "variant": "mcq",
+        "selectionMode": "single",
+        "prompt": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "What is the capital of Australia?",
+          "mediaIds": []
+        },
+        "options": [
+          {
+            "id": "a",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "Sydney",
+              "mediaIds": []
+            }
+          },
+          {
+            "id": "b",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "Canberra",
+              "mediaIds": []
+            }
+          },
+          {
+            "id": "c",
+            "content": {
+              "type": "rich_text",
+              "format": "md-math-v1",
+              "value": "Melbourne",
+              "mediaIds": []
+            }
+          }
+        ],
+        "answer": { "selected": ["b"] },
+        "hint": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "It is not the largest city in the country.",
+          "mediaIds": []
+        },
+        "solution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Canberra",
+          "mediaIds": []
+        },
+        "fullSolution": {
+          "type": "rich_text",
+          "format": "md-math-v1",
+          "value": "Canberra was selected as the capital in 1908 as a compromise between Sydney and Melbourne.",
           "mediaIds": []
         }
       }

--- a/src/infra/llm/schemas/lesson-duplication-output.ts
+++ b/src/infra/llm/schemas/lesson-duplication-output.ts
@@ -212,16 +212,11 @@ export function buildPass1JsonSchemaForExercise(exercise: unknown): GeminiJsonSc
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Schema for pass 2's output. The model independently re-solves the new
- * question and returns just the solution/fullSolution/answer fields — these
- * overwrite whatever pass 1 wrote for the same fields (pass 1 cannot be
- * trusted to solve correctly at temp 0.7).
- *
- * `answer.correctOptionIds` is optional: not every question type carries it
- * (e.g. free-response, geometry, axis). The merge step in the variation
- * service only applies it when present.
+ * Per-block patch entry — one entry per question block, keyed by block id.
+ * Only the fields that need to be updated are required; others are optional.
  */
-export const SolutionDerivationOutputSchema = z.object({
+const SolutionDerivationBlockSchema = z.object({
+  id: z.string(),
   solution: InlineRichTextSchema.optional(),
   fullSolution: InlineRichTextSchema.optional(),
   answer: z
@@ -229,6 +224,23 @@ export const SolutionDerivationOutputSchema = z.object({
       correctOptionIds: z.array(z.string()).optional(),
     })
     .optional(),
+})
+
+/**
+ * Schema for pass 2's output. The model independently re-solves each
+ * question block (identified by id) and returns an array of per-block patches.
+ * These overwrite whatever pass 1 wrote for the same fields (pass 1 cannot be
+ * trusted to solve correctly at temp 0.7).
+ *
+ * Blocks that have no patch entry are left untouched (validator emits a
+ * warning, which is correct). Non-question blocks are never included in the
+ * blocks array.
+ *
+ * Empty blocks array is valid — an exercise with zero question blocks
+ * (all rich_text / svg) produces no patches.
+ */
+export const SolutionDerivationOutputSchema = z.object({
+  blocks: z.array(SolutionDerivationBlockSchema),
 })
 
 export type SolutionDerivationOutput = z.infer<typeof SolutionDerivationOutputSchema>

--- a/src/infra/llm/services/lesson-duplication-variation-service.ts
+++ b/src/infra/llm/services/lesson-duplication-variation-service.ts
@@ -408,8 +408,28 @@ function buildUserPrompt(exercise: Exercise): string {
 }
 
 function buildSolutionDerivationPrompt(exercise: Exercise, pass1Output: Partial<Exercise>): string {
+  // Collect all question blocks from pass 1 output with their ids.
+  const pass1Blocks = (pass1Output.content as { blocks: unknown[] } | undefined)?.blocks ?? []
+  const questionBlocks = pass1Blocks.filter(
+    (b: unknown) =>
+      typeof (b as Record<string, unknown>).type === 'string' &&
+      String((b as Record<string, unknown>).type).startsWith('question_'),
+  ) as Array<{ id: string; type: string }>
+
+  if (questionBlocks.length === 0) {
+    // No question blocks — return empty blocks array.
+    return `You are a strict mathematical derivation assistant.
+There are NO question blocks in this exercise. Return ONLY:
+{ "blocks": [] }
+
+Return ONLY the JSON. No markdown fences, no explanation.`
+  }
+
+  // Enumerate each question block by id so the model solves each independently.
+  const blockList = questionBlocks.map((b) => `  - id "${b.id}" (type: ${b.type})`).join('\n')
+
   return `You are a strict mathematical derivation assistant. Given a newly generated exercise question,
-re-derive the correct answer from first principles and return only the solution fields.
+re-derive the correct answer from first principles and return per-block solution patches.
 
 Input original exercise:
 ${JSON.stringify(exercise, null, 2)}
@@ -417,15 +437,22 @@ ${JSON.stringify(exercise, null, 2)}
 Pass 1 generated question/phrasing:
 ${JSON.stringify(pass1Output, null, 2)}
 
+Question blocks found in pass 1 output:
+${blockList}
+
 Task:
-1. Solve the new question independently (do not trust any answer provided in pass 1 output).
+For EACH question block listed above:
+1. Solve that question independently (do not trust any answer provided in pass 1 output).
 2. Write the complete step-by-step solution in fullSolution (show every step).
 3. Write a brief solution in solution.
-4. Return ONLY these fields (do not include any other fields):
+4. For MCQ/select blocks, include answer with correctOptionIds.
+
+Return ONLY this JSON structure (an array with one entry per question block):
 {
-  "solution": <rich_text object>,
-  "fullSolution": <rich_text object>,
-  "answer": { "correctOptionIds": [<correct option id>] }
+  "blocks": [
+    { "id": "<block id>", "solution": <rich_text object>, "fullSolution": <rich_text object>, "answer": { "correctOptionIds": [<id>] } },
+    ...
+  ]
 }
 
 rich_text object format: { "type": "rich_text", "format": "md-math-v1", "value": "...", "mediaIds": [] }
@@ -433,10 +460,15 @@ rich_text object format: { "type": "rich_text", "format": "md-math-v1", "value":
 Return ONLY the JSON. No markdown fences, no explanation.`
 }
 
-interface Pass2Patch {
+interface Pass2PatchBlock {
+  id: string
   solution?: unknown
   fullSolution?: unknown
   answer?: { correctOptionIds: string[] }
+}
+
+interface Pass2Patch {
+  blocks: Pass2PatchBlock[]
 }
 
 /**
@@ -472,12 +504,41 @@ function extractPass1Output(result: AdapterResult): Partial<Exercise> {
 /**
  * Pull pass-2's solution patch out of the adapter result. Same precedence:
  * structured output first, text fallback.
+ *
+ * Normalizes legacy flat format (pass-2 returned one solution for all blocks)
+ * to the current per-block format for backward compatibility with older
+ * responses or malformed output.
  */
 function extractPass2Patch(result: AdapterResult): Pass2Patch {
   if (result.output && typeof result.output === 'object') {
-    return result.output as Pass2Patch
+    return normalizePass2Patch(result.output as Record<string, unknown>)
   }
   return parseSolutionDerivationResponseFromText(result.text)
+}
+
+/**
+ * Normalize a raw pass-2 response to the current per-block format.
+ * Handles the legacy flat format { solution, fullSolution, answer } where
+ * a single solution was smeared across all question blocks (deprecated),
+ * the current per-block format { blocks: [...] }, and edge cases where
+ * the blocks array is missing/empty.
+ */
+function normalizePass2Patch(raw: Record<string, unknown>): Pass2Patch {
+  // Current per-block format: already has blocks array.
+  if (Array.isArray(raw.blocks)) {
+    return raw as unknown as Pass2Patch
+  }
+
+  // Legacy flat format: single solution broadcast to all question blocks.
+  // We still emit the { blocks: [] } shape so mergePassOutputs can handle
+  // it (it will find no patches and leave blocks untouched — the correct
+  // behavior for a malformed/broadcast response).
+  if (raw.solution !== undefined || raw.fullSolution !== undefined || raw.answer !== undefined) {
+    return { blocks: [] }
+  }
+
+  // Unknown shape — return empty blocks rather than crashing.
+  return { blocks: [] }
 }
 
 function parseVariationResponseFromText(text: string): Partial<Exercise> {
@@ -507,6 +568,12 @@ function stripCodeFences(text: string): string {
 function mergePassOutputs(pass1Output: Partial<Exercise>, pass2Patch: Pass2Patch): unknown[] {
   const pass1Blocks = (pass1Output.content as { blocks: unknown[] } | undefined)?.blocks ?? []
 
+  // Build a map of block id -> patch for fast lookup.
+  const patchById = new Map<string, Pass2PatchBlock>()
+  for (const blockPatch of pass2Patch.blocks) {
+    patchById.set(blockPatch.id, blockPatch)
+  }
+
   // Only question blocks own the solution/answer fields. Applying pass-2's
   // solution/fullSolution to non-question blocks (rich_text, svg, latex, …)
   // would attach fields the block schemas don't allow, breaking Zod strict
@@ -520,18 +587,27 @@ function mergePassOutputs(pass1Output: Partial<Exercise>, pass2Patch: Pass2Patch
       return b
     }
 
+    const blockId = typeof b.id === 'string' ? b.id : String(b.id ?? '')
+    const patch = patchById.get(blockId)
+
     const result: Record<string, unknown> = { ...b }
-    if (pass2Patch.solution !== undefined) {
-      result.solution = pass2Patch.solution
+
+    // If no patch for this block id (unmatched), leave block as-is.
+    if (!patch) {
+      return result
     }
-    if (pass2Patch.fullSolution !== undefined) {
-      result.fullSolution = pass2Patch.fullSolution
+
+    if (patch.solution !== undefined) {
+      result.solution = patch.solution
     }
-    if (pass2Patch.answer?.correctOptionIds !== undefined) {
+    if (patch.fullSolution !== undefined) {
+      result.fullSolution = patch.fullSolution
+    }
+    if (patch.answer?.correctOptionIds !== undefined) {
       const existingAnswer = (result.answer as Record<string, unknown> | undefined) ?? {}
       result.answer = {
         ...existingAnswer,
-        correctOptionIds: pass2Patch.answer.correctOptionIds,
+        correctOptionIds: patch.answer.correctOptionIds,
       }
     }
     return result

--- a/tests/unit/infra/llm/schemas/lesson-duplication-output.test.ts
+++ b/tests/unit/infra/llm/schemas/lesson-duplication-output.test.ts
@@ -58,32 +58,56 @@ describe('LessonVariationOutputSchema', () => {
 })
 
 describe('SolutionDerivationOutputSchema', () => {
-  it('accepts the full canonical pass-2 shape', () => {
+  it('accepts the full canonical pass-2 per-block shape', () => {
     const result = SolutionDerivationOutputSchema.safeParse({
-      solution: { type: 'rich_text', format: 'md-math-v1', value: 's', mediaIds: [] },
-      fullSolution: { type: 'rich_text', format: 'md-math-v1', value: 'fs', mediaIds: [] },
-      answer: { correctOptionIds: ['a'] },
+      blocks: [
+        {
+          id: 'q1',
+          solution: { type: 'rich_text', format: 'md-math-v1', value: 's', mediaIds: [] },
+          fullSolution: { type: 'rich_text', format: 'md-math-v1', value: 'fs', mediaIds: [] },
+          answer: { correctOptionIds: ['a'] },
+        },
+      ],
     })
     expect(result.success).toBe(true)
   })
 
-  it('accepts empty object (every field is optional for non-MCQ blocks)', () => {
-    expect(SolutionDerivationOutputSchema.safeParse({}).success).toBe(true)
+  it('accepts empty blocks array (exercise with no question blocks)', () => {
+    expect(SolutionDerivationOutputSchema.safeParse({ blocks: [] }).success).toBe(true)
   })
 
-  it('rejects non-rich_text solution', () => {
-    expect(SolutionDerivationOutputSchema.safeParse({ solution: 'plain string' }).success).toBe(
-      false,
-    )
+  it('accepts block with only solution (no answer needed for free_response)', () => {
+    const result = SolutionDerivationOutputSchema.safeParse({
+      blocks: [
+        {
+          id: 'q1',
+          solution: { type: 'rich_text', format: 'md-math-v1', value: 's', mediaIds: [] },
+        },
+      ],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects non-rich_text solution in a block', () => {
+    expect(
+      SolutionDerivationOutputSchema.safeParse({
+        blocks: [{ id: 'q1', solution: 'plain string' }],
+      }).success,
+    ).toBe(false)
   })
 
   it('strips extra answer fields without failing', () => {
     // Zod's default is to strip unknown keys silently, so the parse succeeds
     // and returns only the schema-declared fields.
     const result = SolutionDerivationOutputSchema.parse({
-      answer: { correctOptionIds: ['a'], extra: 'ignored-not-rejected' },
-    }) as { answer: Record<string, unknown> }
-    expect(result.answer.correctOptionIds).toEqual(['a'])
+      blocks: [
+        {
+          id: 'q1',
+          answer: { correctOptionIds: ['a'], extra: 'ignored-not-rejected' },
+        },
+      ],
+    }) as { blocks: Array<{ id: string; answer: Record<string, unknown> }> }
+    expect(result.blocks[0].answer.correctOptionIds).toEqual(['a'])
   })
 })
 

--- a/tests/unit/server/llm/services/lesson-duplication-variation-service.test.ts
+++ b/tests/unit/server/llm/services/lesson-duplication-variation-service.test.ts
@@ -167,17 +167,27 @@ describe('generateVariation', () => {
             }),
           }
         } else {
-          // Pass 2: correct answer derivation
+          // Pass 2: correct answer derivation (per-block format)
           return {
             text: JSON.stringify({
-              solution: { type: 'rich_text', format: 'md-math-v1', value: '3+3=6', mediaIds: [] },
-              fullSolution: {
-                type: 'rich_text',
-                format: 'md-math-v1',
-                value: 'Step 1: add 3+3=6',
-                mediaIds: [],
-              },
-              answer: { correctOptionIds: ['a'] },
+              blocks: [
+                {
+                  id: 'block-1',
+                  solution: {
+                    type: 'rich_text',
+                    format: 'md-math-v1',
+                    value: '3+3=6',
+                    mediaIds: [],
+                  },
+                  fullSolution: {
+                    type: 'rich_text',
+                    format: 'md-math-v1',
+                    value: 'Step 1: add 3+3=6',
+                    mediaIds: [],
+                  },
+                  answer: { correctOptionIds: ['a'] },
+                },
+              ],
             }),
           }
         }
@@ -258,17 +268,27 @@ describe('generateVariation', () => {
           }),
         }
       } else {
-        // Pass 2: correct answer derivation
+        // Pass 2: correct answer derivation (per-block format)
         return {
           text: JSON.stringify({
-            solution: { type: 'rich_text', format: 'md-math-v1', value: '5+5=10', mediaIds: [] },
-            fullSolution: {
-              type: 'rich_text',
-              format: 'md-math-v1',
-              value: 'Step 1: add 5+5=10',
-              mediaIds: [],
-            },
-            answer: { correctOptionIds: ['a'] },
+            blocks: [
+              {
+                id: 'block-1',
+                solution: {
+                  type: 'rich_text',
+                  format: 'md-math-v1',
+                  value: '5+5=10',
+                  mediaIds: [],
+                },
+                fullSolution: {
+                  type: 'rich_text',
+                  format: 'md-math-v1',
+                  value: 'Step 1: add 5+5=10',
+                  mediaIds: [],
+                },
+                answer: { correctOptionIds: ['a'] },
+              },
+            ],
           }),
         }
       }
@@ -337,12 +357,22 @@ describe('generateVariation', () => {
           }),
         }
       } else {
-        // Pass 2
+        // Pass 2 (per-block format)
         return {
           text: JSON.stringify({
-            solution: { type: 'rich_text', format: 'md-math-v1', value: '3+3=6', mediaIds: [] },
-            fullSolution: { type: 'rich_text', format: 'md-math-v1', value: '3+3=6', mediaIds: [] },
-            answer: { correctOptionIds: ['a'] },
+            blocks: [
+              {
+                id: 'block-1',
+                solution: { type: 'rich_text', format: 'md-math-v1', value: '3+3=6', mediaIds: [] },
+                fullSolution: {
+                  type: 'rich_text',
+                  format: 'md-math-v1',
+                  value: '3+3=6',
+                  mediaIds: [],
+                },
+                answer: { correctOptionIds: ['a'] },
+              },
+            ],
           }),
         }
       }
@@ -420,9 +450,19 @@ describe('generateVariation', () => {
       } else {
         return {
           text: JSON.stringify({
-            solution: { type: 'rich_text', format: 'md-math-v1', value: '2+2=4', mediaIds: [] },
-            fullSolution: { type: 'rich_text', format: 'md-math-v1', value: '2+2=4', mediaIds: [] },
-            answer: { correctOptionIds: ['b'] },
+            blocks: [
+              {
+                id: 'block-1',
+                solution: { type: 'rich_text', format: 'md-math-v1', value: '2+2=4', mediaIds: [] },
+                fullSolution: {
+                  type: 'rich_text',
+                  format: 'md-math-v1',
+                  value: '2+2=4',
+                  mediaIds: [],
+                },
+                answer: { correctOptionIds: ['b'] },
+              },
+            ],
           }),
         }
       }
@@ -503,14 +543,19 @@ describe('generateVariation', () => {
       } else {
         return {
           text: JSON.stringify({
-            solution: { type: 'rich_text', format: 'md-math-v1', value: 'x=2', mediaIds: [] },
-            fullSolution: {
-              type: 'rich_text',
-              format: 'md-math-v1',
-              value: '3x+6=12 → x=2',
-              mediaIds: [],
-            },
-            answer: { correctOptionIds: ['b'] },
+            blocks: [
+              {
+                id: 'block-1',
+                solution: { type: 'rich_text', format: 'md-math-v1', value: 'x=2', mediaIds: [] },
+                fullSolution: {
+                  type: 'rich_text',
+                  format: 'md-math-v1',
+                  value: '3x+6=12 → x=2',
+                  mediaIds: [],
+                },
+                answer: { correctOptionIds: ['b'] },
+              },
+            ],
           }),
         }
       }
@@ -621,14 +666,24 @@ describe('generateVariation', () => {
       } else {
         return {
           text: JSON.stringify({
-            solution: { type: 'rich_text', format: 'md-math-v1', value: '5+5=10', mediaIds: [] },
-            fullSolution: {
-              type: 'rich_text',
-              format: 'md-math-v1',
-              value: '5+5=10',
-              mediaIds: [],
-            },
-            answer: { correctOptionIds: ['a'] },
+            blocks: [
+              {
+                id: 'block-1',
+                solution: {
+                  type: 'rich_text',
+                  format: 'md-math-v1',
+                  value: '5+5=10',
+                  mediaIds: [],
+                },
+                fullSolution: {
+                  type: 'rich_text',
+                  format: 'md-math-v1',
+                  value: '5+5=10',
+                  mediaIds: [],
+                },
+                answer: { correctOptionIds: ['a'] },
+              },
+            ],
           }),
         }
       }
@@ -707,9 +762,19 @@ describe('generateVariation', () => {
       return {
         text: '',
         output: {
-          solution: { type: 'rich_text', format: 'md-math-v1', value: '4+4=8', mediaIds: [] },
-          fullSolution: { type: 'rich_text', format: 'md-math-v1', value: '4+4=8', mediaIds: [] },
-          answer: { correctOptionIds: ['a'] },
+          blocks: [
+            {
+              id: 'block-1',
+              solution: { type: 'rich_text', format: 'md-math-v1', value: '4+4=8', mediaIds: [] },
+              fullSolution: {
+                type: 'rich_text',
+                format: 'md-math-v1',
+                value: '4+4=8',
+                mediaIds: [],
+              },
+              answer: { correctOptionIds: ['a'] },
+            },
+          ],
         },
       }
     })
@@ -756,9 +821,14 @@ describe('generateVariation', () => {
       }
       return {
         text: JSON.stringify({
-          solution: { type: 'rich_text', format: 'md-math-v1', value: 's', mediaIds: [] },
-          fullSolution: { type: 'rich_text', format: 'md-math-v1', value: 'fs', mediaIds: [] },
-          answer: { correctOptionIds: ['a'] },
+          blocks: [
+            {
+              id: 'block-1',
+              solution: { type: 'rich_text', format: 'md-math-v1', value: 's', mediaIds: [] },
+              fullSolution: { type: 'rich_text', format: 'md-math-v1', value: 'fs', mediaIds: [] },
+              answer: { correctOptionIds: ['a'] },
+            },
+          ],
         }),
       }
     })
@@ -818,9 +888,19 @@ describe('generateVariation', () => {
         }
         return {
           text: JSON.stringify({
-            solution: { type: 'rich_text', format: 'md-math-v1', value: 's', mediaIds: [] },
-            fullSolution: { type: 'rich_text', format: 'md-math-v1', value: 'fs', mediaIds: [] },
-            answer: { correctOptionIds: ['a'] },
+            blocks: [
+              {
+                id: 'block-1',
+                solution: { type: 'rich_text', format: 'md-math-v1', value: 's', mediaIds: [] },
+                fullSolution: {
+                  type: 'rich_text',
+                  format: 'md-math-v1',
+                  value: 'fs',
+                  mediaIds: [],
+                },
+                answer: { correctOptionIds: ['a'] },
+              },
+            ],
           }),
         }
       },
@@ -881,14 +961,23 @@ describe('generateVariation', () => {
       } else {
         return {
           text: JSON.stringify({
-            solution: { type: 'rich_text', format: 'md-math-v1', value: '7+7=14', mediaIds: [] },
-            fullSolution: {
-              type: 'rich_text',
-              format: 'md-math-v1',
-              value: '7+7=14',
-              mediaIds: [],
-            },
-            answer: { correctOptionIds: ['a'] },
+            blocks: [
+              {
+                id: 'block-1',
+                solution: {
+                  type: 'rich_text',
+                  format: 'md-math-v1',
+                  value: '7+7=14',
+                  mediaIds: [],
+                },
+                fullSolution: {
+                  type: 'rich_text',
+                  format: 'md-math-v1',
+                  value: '7+7=14',
+                  mediaIds: [],
+                },
+              },
+            ],
           }),
         }
       }
@@ -905,5 +994,503 @@ describe('generateVariation', () => {
       prompt: { value: string }
     }
     expect(resultBlock.prompt.value).toBe('What is $7+7$?')
+  })
+
+  // ── Per-block pass-2 tests ─────────────────────────────────────────────────
+
+  it('given 3 question blocks and 3 per-block patches, each block receives its own solution', async () => {
+    mockGenerateChatCompletion.mockImplementation(async () => {
+      const callCount = mockGenerateChatCompletion.mock.calls.length
+
+      if (callCount === 1) {
+        return {
+          text: JSON.stringify({
+            content: {
+              blocks: [
+                {
+                  id: 'q1',
+                  type: 'question_select',
+                  variant: 'mcq',
+                  prompt: { type: 'rich_text', format: 'md-math-v1', value: 'Q1', mediaIds: [] },
+                  answer: { options: [], correctOptionIds: ['a'] },
+                },
+                {
+                  id: 'q2',
+                  type: 'question_select',
+                  variant: 'mcq',
+                  prompt: { type: 'rich_text', format: 'md-math-v1', value: 'Q2', mediaIds: [] },
+                  answer: { options: [], correctOptionIds: ['a'] },
+                  solution: {
+                    type: 'rich_text',
+                    format: 'md-math-v1',
+                    value: 'orig-sol',
+                    mediaIds: [],
+                  },
+                },
+                {
+                  id: 'q3',
+                  type: 'question_free_response',
+                  prompt: { type: 'rich_text', format: 'md-math-v1', value: 'Q3', mediaIds: [] },
+                  answer: { type: 'free_response', rubric: 'x', acceptedPatterns: [] },
+                },
+              ],
+            },
+          }),
+        }
+      }
+      // Pass 2: per-block patches, one per question block
+      return {
+        text: JSON.stringify({
+          blocks: [
+            {
+              id: 'q1',
+              solution: { type: 'rich_text', format: 'md-math-v1', value: 'sol-q1', mediaIds: [] },
+              fullSolution: {
+                type: 'rich_text',
+                format: 'md-math-v1',
+                value: 'full-q1',
+                mediaIds: [],
+              },
+              answer: { correctOptionIds: ['b'] },
+            },
+            {
+              id: 'q2',
+              solution: { type: 'rich_text', format: 'md-math-v1', value: 'sol-q2', mediaIds: [] },
+              fullSolution: {
+                type: 'rich_text',
+                format: 'md-math-v1',
+                value: 'full-q2',
+                mediaIds: [],
+              },
+              answer: { correctOptionIds: ['c'] },
+            },
+            {
+              id: 'q3',
+              solution: { type: 'rich_text', format: 'md-math-v1', value: 'sol-q3', mediaIds: [] },
+              fullSolution: {
+                type: 'rich_text',
+                format: 'md-math-v1',
+                value: 'full-q3',
+                mediaIds: [],
+              },
+            },
+          ],
+        }),
+      }
+    })
+
+    const exercise = makeMockExercise('ex-multi-block')
+    exercise.content = {
+      blocks: [
+        {
+          id: 'q1',
+          type: 'question_select',
+          variant: 'mcq',
+          prompt: { type: 'rich_text', format: 'md-math-v1', value: 'Q1', mediaIds: [] },
+          answer: { options: [], correctOptionIds: ['a'] },
+        },
+        {
+          id: 'q2',
+          type: 'question_select',
+          variant: 'mcq',
+          prompt: { type: 'rich_text', format: 'md-math-v1', value: 'Q2', mediaIds: [] },
+          answer: { options: [], correctOptionIds: ['a'] },
+        },
+        {
+          id: 'q3',
+          type: 'question_free_response',
+          prompt: { type: 'rich_text', format: 'md-math-v1', value: 'Q3', mediaIds: [] },
+          answer: { type: 'free_response', rubric: 'x', acceptedPatterns: [] },
+        },
+      ],
+    } as Exercise['content']
+
+    const result = await generateVariation(
+      { exercise, level: 'deep', subject: 'mixed' },
+      mockPayload,
+    )
+
+    const blocks = (result.exercise.content as { blocks: unknown[] }).blocks as Array<{
+      id: string
+      solution?: { value: string }
+      fullSolution?: { value: string }
+      answer?: { correctOptionIds: string[] }
+    }>
+
+    const q1 = blocks.find((b) => b.id === 'q1')!
+    const q2 = blocks.find((b) => b.id === 'q2')!
+    const q3 = blocks.find((b) => b.id === 'q3')!
+
+    expect(q1.solution?.value).toBe('sol-q1')
+    expect(q1.fullSolution?.value).toBe('full-q1')
+    expect(q1.answer?.correctOptionIds).toEqual(['b'])
+
+    expect(q2.solution?.value).toBe('sol-q2')
+    expect(q2.fullSolution?.value).toBe('full-q2')
+    expect(q2.answer?.correctOptionIds).toEqual(['c'])
+
+    expect(q3.solution?.value).toBe('sol-q3')
+    expect(q3.fullSolution?.value).toBe('full-q3')
+  })
+
+  it('given 3 question blocks and 2 per-block patches, unmatched block has no solution set (no smearing)', async () => {
+    mockGenerateChatCompletion.mockImplementation(async () => {
+      const callCount = mockGenerateChatCompletion.mock.calls.length
+
+      if (callCount === 1) {
+        return {
+          text: JSON.stringify({
+            content: {
+              blocks: [
+                {
+                  id: 'q1',
+                  type: 'question_select',
+                  variant: 'mcq',
+                  prompt: { type: 'rich_text', format: 'md-math-v1', value: 'Q1', mediaIds: [] },
+                  answer: { options: [], correctOptionIds: ['a'] },
+                  solution: {
+                    type: 'rich_text',
+                    format: 'md-math-v1',
+                    value: 'orig-sol',
+                    mediaIds: [],
+                  },
+                },
+                {
+                  id: 'q2',
+                  type: 'question_select',
+                  variant: 'mcq',
+                  prompt: { type: 'rich_text', format: 'md-math-v1', value: 'Q2', mediaIds: [] },
+                  answer: { options: [], correctOptionIds: ['a'] },
+                  solution: {
+                    type: 'rich_text',
+                    format: 'md-math-v1',
+                    value: 'orig-sol',
+                    mediaIds: [],
+                  },
+                },
+                {
+                  id: 'q3',
+                  type: 'question_select',
+                  variant: 'mcq',
+                  prompt: { type: 'rich_text', format: 'md-math-v1', value: 'Q3', mediaIds: [] },
+                  answer: { options: [], correctOptionIds: ['a'] },
+                  solution: {
+                    type: 'rich_text',
+                    format: 'md-math-v1',
+                    value: 'orig-sol',
+                    mediaIds: [],
+                  },
+                },
+              ],
+            },
+          }),
+        }
+      }
+      // Pass 2: only 2 patches (q1 and q3), q2 has no patch
+      return {
+        text: JSON.stringify({
+          blocks: [
+            {
+              id: 'q1',
+              solution: { type: 'rich_text', format: 'md-math-v1', value: 'sol-q1', mediaIds: [] },
+              fullSolution: {
+                type: 'rich_text',
+                format: 'md-math-v1',
+                value: 'full-q1',
+                mediaIds: [],
+              },
+              answer: { correctOptionIds: ['b'] },
+            },
+            {
+              id: 'q3',
+              solution: { type: 'rich_text', format: 'md-math-v1', value: 'sol-q3', mediaIds: [] },
+              fullSolution: {
+                type: 'rich_text',
+                format: 'md-math-v1',
+                value: 'full-q3',
+                mediaIds: [],
+              },
+              answer: { correctOptionIds: ['c'] },
+            },
+          ],
+        }),
+      }
+    })
+
+    const exercise = makeMockExercise('ex-partial-patch')
+    exercise.content = {
+      blocks: [
+        {
+          id: 'q1',
+          type: 'question_select',
+          variant: 'mcq',
+          prompt: { type: 'rich_text', format: 'md-math-v1', value: 'Q1', mediaIds: [] },
+          answer: { options: [], correctOptionIds: ['a'] },
+          solution: { type: 'rich_text', format: 'md-math-v1', value: 'orig-sol', mediaIds: [] },
+        },
+        {
+          id: 'q2',
+          type: 'question_select',
+          variant: 'mcq',
+          prompt: { type: 'rich_text', format: 'md-math-v1', value: 'Q2', mediaIds: [] },
+          answer: { options: [], correctOptionIds: ['a'] },
+          solution: { type: 'rich_text', format: 'md-math-v1', value: 'orig-sol', mediaIds: [] },
+        },
+        {
+          id: 'q3',
+          type: 'question_select',
+          variant: 'mcq',
+          prompt: { type: 'rich_text', format: 'md-math-v1', value: 'Q3', mediaIds: [] },
+          answer: { options: [], correctOptionIds: ['a'] },
+          solution: { type: 'rich_text', format: 'md-math-v1', value: 'orig-sol', mediaIds: [] },
+        },
+      ],
+    } as Exercise['content']
+
+    const result = await generateVariation(
+      { exercise, level: 'deep', subject: 'mixed' },
+      mockPayload,
+    )
+
+    const blocks = (result.exercise.content as { blocks: unknown[] }).blocks as Array<{
+      id: string
+      solution?: { value: string }
+      fullSolution?: { value: string }
+      answer?: { correctOptionIds: string[] }
+    }>
+
+    const q1 = blocks.find((b) => b.id === 'q1')!
+    const q2 = blocks.find((b) => b.id === 'q2')!
+    const q3 = blocks.find((b) => b.id === 'q3')!
+
+    // q1 and q3 get their patches applied
+    expect(q1.solution?.value).toBe('sol-q1')
+    expect(q3.solution?.value).toBe('sol-q3')
+
+    // q2 has NO patch — solution must NOT be smeared from pass-2
+    // It should retain its original pass-1 value (or be undefined if pass-1 didn't set it)
+    expect(q2.solution?.value).toBe('orig-sol')
+  })
+
+  it('extractPass2Patch handles structured output in per-block format', async () => {
+    mockGenerateChatCompletion.mockImplementation(async () => {
+      const callCount = mockGenerateChatCompletion.mock.calls.length
+
+      if (callCount === 1) {
+        return {
+          text: JSON.stringify({
+            content: {
+              blocks: [
+                {
+                  id: 'block-1',
+                  type: 'question_select',
+                  variant: 'mcq',
+                  prompt: { type: 'rich_text', format: 'md-math-v1', value: 'Q1', mediaIds: [] },
+                  answer: { options: [], correctOptionIds: ['a'] },
+                },
+              ],
+            },
+          }),
+        }
+      }
+      // Structured output path: Genkit parsed per-block response into result.output
+      return {
+        text: '',
+        output: {
+          blocks: [
+            {
+              id: 'block-1',
+              solution: {
+                type: 'rich_text',
+                format: 'md-math-v1',
+                value: 'structured-sol',
+                mediaIds: [],
+              },
+              fullSolution: {
+                type: 'rich_text',
+                format: 'md-math-v1',
+                value: 'structured-full',
+                mediaIds: [],
+              },
+              answer: { correctOptionIds: ['b'] },
+            },
+          ],
+        },
+      }
+    })
+
+    const exercise = makeMockExercise('ex-structured-output')
+    const result = await generateVariation(
+      { exercise, level: 'medium', subject: 'algebra' },
+      mockPayload,
+    )
+
+    const block = (result.exercise.content as { blocks: unknown[] }).blocks[0] as {
+      solution?: { value: string }
+      answer?: { correctOptionIds: string[] }
+    }
+    expect(block.solution?.value).toBe('structured-sol')
+    expect(block.answer?.correctOptionIds).toEqual(['b'])
+  })
+
+  it('extractPass2Patch handles text-fallback in per-block format', async () => {
+    mockGenerateChatCompletion.mockImplementation(async () => {
+      const callCount = mockGenerateChatCompletion.mock.calls.length
+
+      if (callCount === 1) {
+        return {
+          text: JSON.stringify({
+            content: {
+              blocks: [
+                {
+                  id: 'block-1',
+                  type: 'question_select',
+                  variant: 'mcq',
+                  prompt: { type: 'rich_text', format: 'md-math-v1', value: 'Q1', mediaIds: [] },
+                  answer: { options: [], correctOptionIds: ['a'] },
+                },
+              ],
+            },
+          }),
+        }
+      }
+      // Text fallback path: no structured output, text contains per-block JSON
+      return {
+        text: JSON.stringify({
+          blocks: [
+            {
+              id: 'block-1',
+              solution: {
+                type: 'rich_text',
+                format: 'md-math-v1',
+                value: 'text-fallback-sol',
+                mediaIds: [],
+              },
+              fullSolution: {
+                type: 'rich_text',
+                format: 'md-math-v1',
+                value: 'text-fallback-full',
+                mediaIds: [],
+              },
+              answer: { correctOptionIds: ['c'] },
+            },
+          ],
+        }),
+      }
+    })
+
+    const exercise = makeMockExercise('ex-text-fallback-per-block')
+    const result = await generateVariation(
+      { exercise, level: 'light', subject: 'algebra' },
+      mockPayload,
+    )
+
+    const block = (result.exercise.content as { blocks: unknown[] }).blocks[0] as {
+      solution?: { value: string }
+      answer?: { correctOptionIds: string[] }
+    }
+    expect(block.solution?.value).toBe('text-fallback-sol')
+    expect(block.answer?.correctOptionIds).toEqual(['c'])
+  })
+
+  it('non-question blocks are untouched by pass-2 merge', async () => {
+    mockGenerateChatCompletion.mockImplementation(async () => {
+      const callCount = mockGenerateChatCompletion.mock.calls.length
+
+      if (callCount === 1) {
+        return {
+          text: JSON.stringify({
+            content: {
+              blocks: [
+                {
+                  id: 'rt1',
+                  type: 'rich_text',
+                  prompt: {
+                    type: 'rich_text',
+                    format: 'md-math-v1',
+                    value: 'Intro text',
+                    mediaIds: [],
+                  },
+                },
+                {
+                  id: 'q1',
+                  type: 'question_select',
+                  variant: 'mcq',
+                  prompt: { type: 'rich_text', format: 'md-math-v1', value: 'Q1', mediaIds: [] },
+                  answer: { options: [], correctOptionIds: ['a'] },
+                },
+                {
+                  id: 'svg1',
+                  type: 'svg',
+                  content: {
+                    type: 'rich_text',
+                    format: 'md-math-v1',
+                    value: '<svg/>',
+                    mediaIds: [],
+                  },
+                },
+              ],
+            },
+          }),
+        }
+      }
+      return {
+        text: JSON.stringify({
+          blocks: [
+            {
+              id: 'q1',
+              solution: { type: 'rich_text', format: 'md-math-v1', value: 'sol-q1', mediaIds: [] },
+              fullSolution: {
+                type: 'rich_text',
+                format: 'md-math-v1',
+                value: 'full-q1',
+                mediaIds: [],
+              },
+              answer: { correctOptionIds: ['b'] },
+            },
+          ],
+        }),
+      }
+    })
+
+    const exercise = makeMockExercise('ex-non-question')
+    exercise.content = {
+      blocks: [
+        {
+          id: 'rt1',
+          type: 'rich_text',
+          prompt: { type: 'rich_text', format: 'md-math-v1', value: 'Intro text', mediaIds: [] },
+        },
+        {
+          id: 'q1',
+          type: 'question_select',
+          variant: 'mcq',
+          prompt: { type: 'rich_text', format: 'md-math-v1', value: 'Q1', mediaIds: [] },
+          answer: { options: [], correctOptionIds: ['a'] },
+        },
+        {
+          id: 'svg1',
+          type: 'svg',
+          content: { type: 'rich_text', format: 'md-math-v1', value: '<svg/>', mediaIds: [] },
+        },
+      ],
+    } as Exercise['content']
+
+    const result = await generateVariation(
+      { exercise, level: 'deep', subject: 'mixed' },
+      mockPayload,
+    )
+
+    const blocks = (result.exercise.content as { blocks: unknown[] }).blocks as Array<{
+      id: string
+      type: string
+    }>
+
+    const rt1 = blocks.find((b) => b.id === 'rt1')!
+    const svg1 = blocks.find((b) => b.id === 'svg1')!
+
+    expect(rt1.type).toBe('rich_text')
+    expect(svg1.type).toBe('svg')
+    // q1 gets the patch applied (tested by other tests)
   })
 })


### PR DESCRIPTION
## Summary

- **Repro test**: New unit tests in `lesson-duplication-variation-service.test.ts` prove the per-block merge behavior: 3 blocks + 3 patches → each gets own solution; 3 blocks + 2 patches → unmatched block retains original (no smearing); structured-output and text-fallback paths both handle per-block format.
- **Root cause**: Pass2Patch was a flat `{solution, fullSolution, answer}` object broadcast to all question blocks. Multi-block exercises caused field smearing and missing per-block solutions.
- **Schema** (`lesson-duplication-output.ts`): `SolutionDerivationOutputSchema` changed from flat `{solution?, fullSolution?, answer?}` to per-block `{blocks: [{id, solution?, fullSolution?, answer?}]}`.
- **Service** (`lesson-duplication-variation-service.ts`): `buildSolutionDerivationPrompt` now enumerates every question block by id from pass-1 output; `mergePassOutputs` builds an id-keyed patch map and applies per-block; `normalizePass2Patch` added for backward compat with legacy flat responses.
- **5 deep prompts** (`algebra/calculus/geometry/mixed/other-deep-agent-prompt.md`): Each gains Rule #10 (multi-block hint rule) and Example 4 with 3 question blocks, each carrying non-empty hint + solution + fullSolution.
- **Schema tests** (`lesson-duplication-output.test.ts`): Updated to match new per-block shape; added tests for empty blocks array and partial block entries.
- **No regressions**: All existing tests updated to per-block pass-2 format; typecheck + integration tests pass on second attempt.

## Changes

- `src/infra/llm/prompts/lesson-duplication/algebra-deep-agent-prompt.md`
- `src/infra/llm/prompts/lesson-duplication/calculus-deep-agent-prompt.md`
- `src/infra/llm/prompts/lesson-duplication/geometry-deep-agent-prompt.md`
- `src/infra/llm/prompts/lesson-duplication/mixed-deep-agent-prompt.md`
- `src/infra/llm/prompts/lesson-duplication/other-deep-agent-prompt.md`
- `src/infra/llm/schemas/lesson-duplication-output.ts`
- `src/infra/llm/services/lesson-duplication-variation-service.ts`
- `tests/unit/infra/llm/schemas/lesson-duplication-output.test.ts`
- `tests/unit/server/llm/services/lesson-duplication-variation-service.test.ts`

Closes #1733

---
_Opened by kody (single-session autonomous run)._ 