### PR TITLE
#1846: [P1] Exercise answer check triggers 400 on /api/agent/chat/stream

### DIFF
--- a/.kody/tasks/1846/context.json
+++ b/.kody/tasks/1846/context.json
@@ -1,0 +1,17 @@
+{
+  "taskId": "1846",
+  "taskType": "issue",
+  "target": "GitHub issue #1846: [P1] Exercise answer check triggers 400 on /api/agent/chat/stream",
+  "outcome": "success",
+  "exitCode": 0,
+  "reason": "Fixed Zod schema max(1000) to max(5000) in chat request validation. The sendContextualHelp prompt includes full exercise context (~2000 chars from formatExerciseContextMessage) plus prefix/suffix (~250 chars), totaling ~2250 chars, which exceeded the old 1000-char server limit.",
+  "prUrl": null,
+  "runUrl": null,
+  "filesTouched": [
+    "src/server/payload/endpoints/agent/chat/request-validation.ts",
+    "tests/unit/server/services/api-service.test.ts"
+  ],
+  "sessionLog": ".kody/sessions/1846.jsonl",
+  "startedAt": "2026-05-22T23:30:00.000Z",
+  "finishedAt": "2026-05-22T23:57:00.000Z"
+}

--- a/.kody/tasks/1846/followups.json
+++ b/.kody/tasks/1846/followups.json
@@ -1,0 +1,8 @@
+[
+  {
+    "title": "Add integration test for oversized message to /api/agent/chat/stream",
+    "body": "The new unit test in api-service.test.ts verifies that the client correctly propagates a 400 error from the server. However, it cannot verify that the server NOW accepts messages >1000 chars (since it mocks the API). Add an integration test (in tests/int/agent-chat-streaming.int.spec.ts or a new file) that calls the actual route with a message >1000 chars and asserts it does NOT return 400.",
+    "rationale": "The unit test is a proxy test — it doesn't actually test the fix (schema max change). A real integration test with a 1500+ char message would directly verify the fix.",
+    "priority": "medium"
+  }
+]

--- a/.kody/tasks/1846/handoff-notes.md
+++ b/.kody/tasks/1846/handoff-notes.md
@@ -1,0 +1,28 @@
+## Issue #1846: Exercise answer check triggers 400 on /api/agent/chat/stream
+
+### Root Cause
+The `sendContextualHelp` function (called when a student answers incorrectly) sends a prompt that includes the full exercise context formatted by `formatExerciseContextMessage` (~2000 chars, capped at `MAX_OUTPUT_LENGTH = 2000` in `src/infra/llm/exercise-context.ts`). This is wrapped with a prefix (~50 chars) and suffix (~200 chars), producing a prompt of ~2250 chars.
+
+The backend Zod schema in `src/server/payload/endpoints/agent/chat/request-validation.ts` had `message.max(1000)`, causing the server to return HTTP 400 for any contextual help request.
+
+Normal user messages (typed into the chat input) are typically <1000 chars, so they never triggered this bug.
+
+### Fix Applied
+Changed `message.max(1000)` → `message.max(5000)` in `chatRequestSchema`. This accommodates:
+- Exercise context: up to 2000 chars (formatExerciseContextMessage MAX_OUTPUT_LENGTH)
+- Prefixes/suffixes: ~250 chars
+- Total ~2250 chars for contextual help prompts
+
+The frontend already allowed up to 5000 chars (no explicit enforcement on the input).
+
+### Files Changed
+- `src/server/payload/endpoints/agent/chat/request-validation.ts` — Zod schema max increased 1000→5000
+- `tests/unit/server/services/api-service.test.ts` — Added regression test for 400 error handling
+
+### Verification
+- All 3264 unit tests pass (243 test files)
+- TypeScript typecheck passes
+- ESLint passes (no new warnings)
+
+### Follow-up
+Add an integration test that calls `/api/agent/chat/stream` with a >1000 char message to directly verify the schema change (see `.kody/tasks/1846/followups.json`).

--- a/.kody/tasks/1846/memory-recs.json
+++ b/.kody/tasks/1846/memory-recs.json
@@ -1,0 +1,10 @@
+[
+  {
+    "type": "lesson",
+    "name": "zod-schema-backend-limit-must-match-frontend",
+    "hook": "Backend Zod schema max() must track frontend practical limits",
+    "body": "When a frontend operation (sendContextualHelp) can produce messages far larger than the frontend's visible input limit (e.g. formatExerciseContextMessage produces ~2000 chars, wrapped in a prompt to ~2250 chars), the backend Zod schema max() must be set to accommodate the practical maximum — not just the visible input field limit. The previous max(1000) caused a 400 on contextual help calls while normal user messages (<1000 chars) worked fine.",
+    "why": "This bug was a silent regression — the UI worked fine (exercise feedback displayed) but the AI help silently failed. It would have been caught by an integration test with a realistic exercise context.",
+    "confidence": 0.9
+  }
+]

--- a/src/server/payload/endpoints/agent/chat/request-validation.ts
+++ b/src/server/payload/endpoints/agent/chat/request-validation.ts
@@ -5,7 +5,7 @@
 import { z } from 'zod'
 
 export const chatRequestSchema = z.object({
-  message: z.string().min(1).max(1000),
+  message: z.string().min(1).max(5000),
   acknowledgment: z.string().min(1),
   // Context parameters (prefer IDs over slugs)
   exerciseId: z.string().optional(),

--- a/tests/unit/server/services/api-service.test.ts
+++ b/tests/unit/server/services/api-service.test.ts
@@ -145,5 +145,27 @@ describe('apiService', () => {
       const chunkTexts = events.filter((e) => e.type === 'chunk').map((e) => e.text)
       expect(chunkTexts).toEqual(['hello'])
     })
+
+    it('yields error event when server returns 400 (e.g. message too long for Zod schema)', async () => {
+      // Regression for #1846: sendContextualHelp sends prompts > 1000 chars (exercise context
+      // is ~2000 chars). The server Zod schema previously had max(1000) causing 400.
+      vi.mocked(fetch).mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: 'Invalid request',
+            details: [{ message: 'String must be at most 1000 characters' }],
+          }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+
+      // Use a message longer than the old 1000-char limit but within the new 5000-char limit
+      const longMessage = 'A'.repeat(1500)
+      const events = await collectChunks(
+        apiService.chatStream(longMessage, 'ack', { exerciseId: 'ex-1', lessonId: 'lesson-1' }),
+      )
+
+      expect(events).toContainEqual({ type: 'error', error: 'Invalid request' })
+    })
   })
 })


### PR DESCRIPTION
## Summary

Implementation of issue #1846 — [P1] Exercise answer check triggers 400 on /api/agent/chat/stream

_(agent did not supply PR_SUMMARY)_

## Changes

- `.kody/tasks/1846/context.json`
- `.kody/tasks/1846/followups.json`
- `.kody/tasks/1846/handoff-notes.md`
- `.kody/tasks/1846/memory-recs.json`
- `src/server/payload/endpoints/agent/chat/request-validation.ts`
- `tests/unit/server/services/api-service.test.ts`

Closes #1846

---
_Opened by kody (single-session autonomous run)._ 