### PR TITLE
#1863: [P1] Study page shows empty for course that has content in Pract…

### DIFF
--- a/.kody/tasks/1863/context.json
+++ b/.kody/tasks/1863/context.json
@@ -1,0 +1,17 @@
+{
+  "taskId": "1863",
+  "taskType": "issue",
+  "target": "1863-p1-study-page-shows-empty-for-course-that-has-cont",
+  "outcome": "success",
+  "exitCode": 0,
+  "reason": "Study page lessonType changed from 'learning' to 'practice' (default) to match Practice page; both pages now show consistent content",
+  "prUrl": null,
+  "runUrl": null,
+  "filesTouched": [
+    "src/app/(frontend)/study/page.tsx",
+    "tests/int/study-page-prefetch.int.spec.ts"
+  ],
+  "sessionLog": ".kody/sessions/1241.jsonl",
+  "startedAt": "2026-05-23T05:04:00Z",
+  "finishedAt": "2026-05-23T05:39:46Z"
+}

--- a/.kody/tasks/1863/followups.json
+++ b/.kody/tasks/1863/followups.json
@@ -1,0 +1,14 @@
+[
+  {
+    "title": "DEFAULT_LESSON_TYPE is 'learning' but Study/Practice both use 'practice'",
+    "body": "The constant DEFAULT_LESSON_TYPE in src/server/constants/lesson-types.ts is 'learning', but both Study and Practice pages use 'practice'. This constant may be unused by these pages or used elsewhere — worth auditing to understand if it should be changed to 'practice' for consistency.",
+    "rationale": "DEFAULT_LESSON_TYPE being 'learning' while actual usage is 'practice' suggests a potential misalignment or that the constant is used in a different context (e.g., StudyContent component's default prop)",
+    "priority": "low"
+  },
+  {
+    "title": "Consider adding lessonType parameter to /api/chapters/by-grade fallback",
+    "body": "The client-side fallback in StudyContent (used when no grade cookie) calls /api/chapters/by-grade without a lessonType parameter. This API hardcodes 'practice'. If Study page were ever changed to use a different lessonType, the server prefetch would differ from client fallback. Consider adding lessonType as a query parameter to the API for consistency.",
+    "rationale": "The API endpoint already accepts lessonType (line 25-31 in route.ts) but the client fallback never passes it, creating a potential inconsistency if the Study page lessonType ever diverges from 'practice'",
+    "priority": "low"
+  }
+]

--- a/.kody/tasks/1863/handoff-notes.md
+++ b/.kody/tasks/1863/handoff-notes.md
@@ -1,0 +1,26 @@
+# Bug #1863 Fix: Study Page Empty for Course with Practice Lessons
+
+## What was fixed
+
+**File:** `src/app/(frontend)/study/page.tsx`
+
+**Root cause:** The Study page was calling `prefetchStudyData(grade, contentLocale, 'learning')` — explicitly passing `'learning'` as the lessonType — while the Practice page called `prefetchStudyData(grade, contentLocale)` using the default `'practice'`. When a course has only `'practice'` lessons (no `'learning'` lessons), the Study page's query returns chapters with empty lessons arrays, causing the "No topics available" message.
+
+**Fix:** Changed Study page to call `prefetchStudyData(grade, contentLocale)` (no third argument, defaulting to `'practice'`) and updated the `StudyContent` prop from `lessonType="learning"` to `lessonType="practice"`. Both Study and Practice now use the same lessonType.
+
+## Changes made
+
+1. **`src/app/(frontend)/study/page.tsx`** (2 lines changed):
+   - `prefetchStudyData(grade, contentLocale, 'learning')` → `prefetchStudyData(grade, contentLocale)`
+   - `<StudyContent lessonType="learning" …>` → `<StudyContent lessonType="practice" …>`
+
+2. **`tests/int/study-page-prefetch.int.spec.ts`** (new file):
+   - Integration tests verifying prefetchStudyData returns correct lessonType-filtered results
+   - Documents the bug condition (learning vs practice return different lessons)
+   - Note: Tests verify function behavior rather than page-level behavior due to Next.js server component complexity
+
+## Verification
+
+- All 3 integration tests pass
+- `pnpm ci:local` (typecheck, lint, tests) passes with `ok: true`
+- Study and Practice pages now use identical lessonType parameters

--- a/.kody/tasks/1863/memory-recs.json
+++ b/.kody/tasks/1863/memory-recs.json
@@ -1,0 +1,10 @@
+[
+  {
+    "type": "lesson",
+    "name": "study-practice-lesson-type-mismatch",
+    "hook": "Study/Practice page lessonType mismatch causes empty page",
+    "body": "The Study page (src/app/(frontend)/study/page.tsx) was passing 'learning' as the lessonType to prefetchStudyData while Practice page relied on default 'practice'. When a course only has 'practice' lessons, Study shows 'No topics available' while Practice shows the full course. Both pages should use the same lessonType.\n\n**Why:** The prefetchStudyData function's default is 'practice', so if Study explicitly passes 'learning' and the course has no learning lessons, it returns empty chapters.\n\n**How to apply:** When adding new lesson types to study/practice pages, ensure both use the same lessonType filter.",
+    "why": "Root cause of Bug #1863 — a simple argument mismatch caused the Study page to show empty for any course without 'learning' lessons",
+    "confidence": 0.9
+  }
+]

--- a/src/app/(frontend)/study/page.tsx
+++ b/src/app/(frontend)/study/page.tsx
@@ -12,11 +12,11 @@ export default async function StudyPage() {
   const contentLocale = isValidContentLocale(locale) ? locale : undefined
 
   // Server-side prefetch when grade is known (direct DB, no HTTP round-trip)
-  const prefetchedData = grade ? await prefetchStudyData(grade, contentLocale, 'learning') : null
+  const prefetchedData = grade ? await prefetchStudyData(grade, contentLocale) : null
 
   return (
     <div>
-      <StudyContent lessonType="learning" prefetchedData={prefetchedData} />
+      <StudyContent lessonType="practice" prefetchedData={prefetchedData} />
     </div>
   )
 }

--- a/tests/int/study-page-prefetch.int.spec.ts
+++ b/tests/int/study-page-prefetch.int.spec.ts
@@ -1,0 +1,198 @@
+// @vitest-environment node
+// Node.js environment required: payload.login() uses jose JWT signing which depends on
+// Node.js's native TextEncoder/Uint8Array. The jsdom environment can cause a
+// Uint8Array realm mismatch that breaks jose's FlattenedSign constructor check.
+
+/**
+ * Integration tests: study page prefetchData lessonType consistency
+ *
+ * Bug #1863: Study page shows empty while Practice shows content because
+ * Study page calls prefetchStudyData with lessonType='learning' while Practice
+ * uses the default lessonType='practice'.
+ *
+ * This means courses that only have 'practice' lessons show empty on /study.
+ * Fix: Study page should use 'practice' lessonType to match Practice page.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import type { Payload } from 'payload'
+import { getPayload } from 'payload'
+import { startMongoContainer, stopMongoContainer } from '@/infra/utils/test/mongodb-container'
+import { prefetchStudyData } from '@/server/repos/queries/study-page'
+
+let payload: Payload
+let originalDatabaseUrl: string | undefined
+let chapterId: string
+let practiceLessonId: string
+let learningLessonId: string
+
+const GRADE_LEVEL = 'grade-8-study-test'
+const TENANT_SLUG = `study-test-tenant-${Date.now()}`
+
+beforeAll(async () => {
+  originalDatabaseUrl = process.env.DATABASE_URL
+
+  // @ts-expect-error: TypeScript doesn't allow delete on process.env
+  delete process.env.DATABASE_URL
+
+  const mongoUri = await startMongoContainer()
+  process.env.DATABASE_URL = mongoUri
+
+  const config = await import('@payload-config')
+  payload = await getPayload({ config: config.default })
+
+  // Ensure the default tenant exists
+  const existingTenants = await payload.find({
+    collection: 'tenants',
+    where: { slug: { equals: TENANT_SLUG } },
+    limit: 1,
+    overrideAccess: true,
+  })
+  if (existingTenants.docs.length === 0) {
+    await payload.create({
+      collection: 'tenants',
+      data: { name: TENANT_SLUG, slug: TENANT_SLUG, status: 'active' },
+      overrideAccess: true,
+    })
+  }
+
+  // Create a course with chapters and lessons of different types
+  const category = await payload.create({
+    collection: 'categories',
+    data: {
+      title: 'Study Test Category',
+      slug: `study-cat-${Date.now()}`,
+    } as any,
+    overrideAccess: true,
+  })
+
+  const course = await payload.create({
+    collection: 'courses',
+    data: {
+      courseLabel: GRADE_LEVEL,
+      title: 'Study Test Course',
+      slug: `study-test-course-${Date.now()}`,
+      status: 'published',
+      categories: [category.id],
+    } as any,
+    overrideAccess: true,
+  })
+
+  const chapter = await payload.create({
+    collection: 'chapters',
+    data: {
+      course: course.id,
+      title: 'Study Test Chapter',
+      slug: `study-chapter-${Date.now()}`,
+      status: 'published',
+      isActive: true,
+    } as any,
+    overrideAccess: true,
+  })
+  chapterId = chapter.id
+
+  // Create a practice lesson
+  const practiceLesson = await payload.create({
+    collection: 'lessons',
+    data: {
+      chapter: chapterId,
+      title: 'Practice Lesson',
+      slug: `practice-lesson-${Date.now()}`,
+      status: 'published',
+      isActive: true,
+      type: 'practice',
+      locale: 'he',
+    } as any,
+    overrideAccess: true,
+  })
+  practiceLessonId = practiceLesson.id
+
+  // Create a learning lesson
+  const learningLesson = await payload.create({
+    collection: 'lessons',
+    data: {
+      chapter: chapterId,
+      title: 'Learning Lesson',
+      slug: `learning-lesson-${Date.now()}`,
+      status: 'published',
+      isActive: true,
+      type: 'learning',
+      locale: 'he',
+    } as any,
+    overrideAccess: true,
+  })
+  learningLessonId = learningLesson.id
+}, 120_000)
+
+afterAll(async () => {
+  if (payload?.db?.destroy) await payload.db.destroy()
+  await stopMongoContainer()
+
+  if (originalDatabaseUrl !== undefined) {
+    process.env.DATABASE_URL = originalDatabaseUrl
+  } else {
+    // @ts-expect-error: TypeScript doesn't allow delete on process.env
+    delete process.env.DATABASE_URL
+  }
+}, 120_000)
+
+describe('prefetchStudyData — lessonType consistency', () => {
+  it('default lessonType returns practice lessons (matches Practice page)', async () => {
+    // The default lessonType is 'practice' — same as what Practice page uses.
+    // Study page SHOULD also use this default after the fix.
+    const result = await prefetchStudyData(GRADE_LEVEL, undefined)
+
+    expect(result).not.toBeNull()
+    expect(result!.chapters.length).toBeGreaterThan(0)
+
+    const allLessonIds = result!.chapters.flatMap((ch) => (ch.lessons ?? []).map((l) => l.id))
+    expect(allLessonIds).toContain(practiceLessonId)
+    expect(allLessonIds).not.toContain(learningLessonId)
+
+    // All returned lessons should be practice type (the default)
+    for (const chapter of result!.chapters) {
+      for (const lesson of chapter.lessons ?? []) {
+        expect(lesson.type).toBe('practice')
+      }
+    }
+  })
+
+  it('lessonType=learning returns only learning lessons (Study page OLD buggy behavior)', async () => {
+    // This is how Study page USED to call prefetchStudyData (third arg = 'learning').
+    // This is the BUG — it returns only learning lessons, showing empty on courses
+    // that only have practice lessons.
+    const result = await prefetchStudyData(GRADE_LEVEL, undefined, 'learning')
+
+    expect(result).not.toBeNull()
+    expect(result!.chapters.length).toBeGreaterThan(0)
+
+    const allLessonIds = result!.chapters.flatMap((ch) => (ch.lessons ?? []).map((l) => l.id))
+    expect(allLessonIds).toContain(learningLessonId)
+    expect(allLessonIds).not.toContain(practiceLessonId)
+
+    // All returned lessons should be learning type
+    for (const chapter of result!.chapters) {
+      for (const lesson of chapter.lessons ?? []) {
+        expect(lesson.type).toBe('learning')
+      }
+    }
+  })
+
+  it('BUG #1863: Study page should return practice lessons (same as Practice page)', async () => {
+    // BUG: Study page calls prefetchStudyData(grade, locale, 'learning')
+    //      Practice page calls prefetchStudyData(grade, locale) [default='practice']
+    // This means courses with only practice lessons show empty on /study.
+    //
+    // FIX: Study page now calls prefetchStudyData(grade, locale) [same as Practice].
+    //
+    // This test verifies that prefetchStudyData returns practice lessons
+    // when called with the default lessonType (as both pages do after fix).
+    const result = await prefetchStudyData(GRADE_LEVEL, undefined)
+
+    expect(result).not.toBeNull()
+    expect(result!.chapters.length).toBeGreaterThan(0)
+
+    const allLessonIds = result!.chapters.flatMap((ch) => (ch.lessons ?? []).map((l) => l.id))
+    expect(allLessonIds).toContain(practiceLessonId)
+    expect(allLessonIds).not.toContain(learningLessonId)
+  })
+})


### PR DESCRIPTION
## Summary

- **Repro test:** `tests/int/study-page-prefetch.int.spec.ts` — verifies `prefetchStudyData` returns practice lessons with the default lessonType (matching Practice page); documents that 'learning' and 'practice' lessonTypes return different content (the root bug condition).
- **Root cause:** `src/app/(frontend)/study/page.tsx` passed `'learning'` explicitly to `prefetchStudyData`, while `src/app/(frontend)/practice/page.tsx` used the default `'practice'`. For courses with only practice lessons (no learning lessons), Study returned chapters with empty lessons → "No topics available".
- **Fix:** Changed Study page to call `prefetchStudyData(grade, contentLocale)` (default `'practice'`) and `<StudyContent lessonType="practice">` — matching Practice page behavior exactly.
- **Files changed:** `src/app/(frontend)/study/page.tsx` (2 lines), `tests/int/study-page-prefetch.int.spec.ts` (new).
- **Quality gates:** All pass (`ok: true` on first attempt).

## Changes

- `.kody/tasks/1863/context.json`
- `.kody/tasks/1863/followups.json`
- `.kody/tasks/1863/handoff-notes.md`
- `.kody/tasks/1863/memory-recs.json`
- `src/app/(frontend)/study/page.tsx`
- `tests/int/study-page-prefetch.int.spec.ts`

Closes #1863

---
_Opened by kody (single-session autonomous run)._ 