### PR TITLE
Vibe: Replace MessageCircle with MessageSquare on /start hero icon

### DIFF
--- a/src/ui/web/homepage/LandingPage/index.tsx
+++ b/src/ui/web/homepage/LandingPage/index.tsx
@@ -6,7 +6,7 @@ import { useTranslations } from '@/ui/web/providers/I18n'
 import { ThemeSelector } from '@/ui/web/providers/Theme/ThemeSelector'
 import { LanguageSwitcher } from '@/ui/web/LanguageSwitcher'
 import { motion } from 'framer-motion'
-import { BookOpen, GraduationCap, MessageCircle, Target, Trophy } from 'lucide-react'
+import { BookOpen, GraduationCap, MessageSquare, Target, Trophy } from 'lucide-react'
 
 interface LandingPageProps {
   onGetStarted: () => void
@@ -44,7 +44,7 @@ const FEATURES = [
   },
   {
     key: 'ask',
-    icon: MessageCircle,
+    icon: MessageSquare,
     color: 'hsl(142 71% 45%)',
     bgClass: 'from-green-500/20 to-green-600/5',
   },


### PR DESCRIPTION
Vibe session for #2170.

The runner will push commits to `2170-message-square-icon` as it implements the plan. Vercel begins cold-building this PR now so the preview is ready by the time the runner finishes.

Closes #2170