### PR TITLE
fix(courses): Restore lesson titles and study/test page types

### DIFF
--- a/src/app/(frontend)/study/page.tsx
+++ b/src/app/(frontend)/study/page.tsx
@@ -13,12 +13,11 @@ export default async function StudyPage() {
   const contentLocale = isValidContentLocale(locale) ? locale : undefined
 
   // Server-side prefetch when grade is known (direct DB, no HTTP round-trip)
-  // Note: no lessonType argument → defaults to 'practice' to match Practice page behavior
-  const prefetchedData = grade ? await prefetchStudyData(grade, contentLocale) : null
+  const prefetchedData = grade ? await prefetchStudyData(grade, contentLocale, 'learning') : null
 
   return (
     <div>
-      <StudyContent lessonType="practice" prefetchedData={prefetchedData} />
+      <StudyContent lessonType="learning" prefetchedData={prefetchedData} />
     </div>
   )
 }

--- a/src/app/(frontend)/test/page.tsx
+++ b/src/app/(frontend)/test/page.tsx
@@ -12,12 +12,11 @@ export default async function TestPage() {
   const locale = await getSystemLocale()
   const contentLocale = isValidContentLocale(locale) ? locale : undefined
 
-  // Note: no lessonType argument → defaults to 'practice' to match Practice page behavior
-  const prefetchedData = grade ? await prefetchStudyData(grade, contentLocale) : null
+  const prefetchedData = grade ? await prefetchStudyData(grade, contentLocale, 'exam') : null
 
   return (
     <div>
-      <StudyContent lessonType="practice" prefetchedData={prefetchedData} />
+      <StudyContent lessonType="exam" prefetchedData={prefetchedData} />
     </div>
   )
 }

--- a/src/ui/web/components/UnifiedCard/CourseLessonCard.tsx
+++ b/src/ui/web/components/UnifiedCard/CourseLessonCard.tsx
@@ -33,10 +33,6 @@ export function CourseLessonCard({
 
   const isExam = lessonType === 'exam'
   const label = `${isExam ? tc('exam') : tc('lesson')} ${index}`
-  // Use index-based title to ensure it matches the sequential lesson number on the badge.
-  // This prevents stale/wrong lesson titles (e.g. from reordered lessons) from causing
-  // the heading to appear off-by-one compared to the badge.
-  const title = `${isExam ? tc('exam') : tc('lesson')} ${index}`
   const labelBadgeClassName = isExam ? 'text-[11.5px]' : undefined
 
   const href = `/courses/${courseSlug}/chapters/${chapterSlug}/lessons/${lesson.slug}`
@@ -64,7 +60,7 @@ export function CourseLessonCard({
   return (
     <UnifiedCard
       variant="lesson"
-      title={title}
+      title={lesson.title}
       label={label}
       labelBadgeClassName={labelBadgeClassName}
       accentColor={accentColor}

--- a/tests/unit/components/CourseLessonCard.test.tsx
+++ b/tests/unit/components/CourseLessonCard.test.tsx
@@ -60,12 +60,12 @@ afterEach(() => {
 
 describe('CourseLessonCard component', () => {
   describe('baseline rendering', () => {
-    it('renders title and badge both showing Lesson 1 (title matches badge after fix)', () => {
+    it('renders the lesson title as the heading and a separate "Lesson N" badge', () => {
       renderWithI18n(mockLesson)
 
-      // After the fix, title is derived from index so badge and title both show "Lesson 1"
-      const lesson1Elements = screen.getAllByText('Lesson 1')
-      expect(lesson1Elements.length).toBeGreaterThanOrEqual(2) // badge + title
+      // Title comes from lesson.title; badge is "Lesson <index>". They must not collide.
+      expect(screen.getByText('Test Lesson')).toBeTruthy()
+      expect(screen.getByText('Lesson 1')).toBeTruthy()
     })
   })
 
@@ -120,7 +120,7 @@ describe('CourseLessonCard component', () => {
   })
 
   describe('exam label', () => {
-    it('shows "Exam 1" when lessonType is "exam"', () => {
+    it('shows "Exam 1" badge when lessonType is "exam"', () => {
       render(
         <I18nProvider locale="en" messages={enMessages}>
           <CourseLessonCard
@@ -132,10 +132,11 @@ describe('CourseLessonCard component', () => {
           />
         </I18nProvider>,
       )
-      expect(screen.getAllByText('Exam 1').length).toBeGreaterThanOrEqual(2) // badge + title
+      expect(screen.getByText('Exam 1')).toBeTruthy()
+      expect(screen.getByText('Test Lesson')).toBeTruthy()
     })
 
-    it('shows "Lesson 1" when lessonType is "learning"', () => {
+    it('shows "Lesson 1" badge when lessonType is "learning"', () => {
       render(
         <I18nProvider locale="en" messages={enMessages}>
           <CourseLessonCard
@@ -147,10 +148,11 @@ describe('CourseLessonCard component', () => {
           />
         </I18nProvider>,
       )
-      expect(screen.getAllByText('Lesson 1').length).toBeGreaterThanOrEqual(2) // badge + title
+      expect(screen.getByText('Lesson 1')).toBeTruthy()
+      expect(screen.getByText('Test Lesson')).toBeTruthy()
     })
 
-    it('shows "Lesson 1" when lessonType is omitted (backward compat)', () => {
+    it('shows "Lesson 1" badge when lessonType is omitted (backward compat)', () => {
       render(
         <I18nProvider locale="en" messages={enMessages}>
           <CourseLessonCard
@@ -161,7 +163,8 @@ describe('CourseLessonCard component', () => {
           />
         </I18nProvider>,
       )
-      expect(screen.getAllByText('Lesson 1').length).toBeGreaterThanOrEqual(2) // badge + title
+      expect(screen.getByText('Lesson 1')).toBeTruthy()
+      expect(screen.getByText('Test Lesson')).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
## Summary

Reverts three regressions accidentally bundled into PR #1860 (whose declared scope was only the `/stats` chart fix from #1823). All three were unrelated to the stats ticket and broke the public learn/practice/test flow.

- **CourseLessonCard** — was hardcoding `title = "Lesson N"` (same string as the small badge label), making every lesson card show "Lesson 1", "Lesson 2"… instead of its real title. Restored to `title={lesson.title}`.
- **/study page** — was changed to query `practice` lessons (default arg) and pass `lessonType="practice"`. Restored to `'learning'`, so /study again shows learning lessons.
- **/test page** — same regression: was set to `practice`. Restored to `'exam'`.

Net effect on dev today: `/study` and `/test` were both rendering the same set of practice lessons, and every lesson card displayed the badge text in place of the title. After this revert, learning/practice/exam lessons each appear on their correct route and titles render from `lesson.title`.

## Test plan

- [ ] Visit `/study` while logged in with a grade that has learning lessons → cards render with real titles.
- [ ] Visit `/practice` → only practice lessons (unchanged behavior).
- [ ] Visit `/test` → only exam lessons.
- [ ] Visit `/courses/[slug]` Learn tab → cards render with real titles, not "Lesson N".
- [ ] Create a fresh lesson in admin with `type=learning` → appears on `/study`, not `/practice` or `/test`.