### PR TITLE
fix(chat): Pin mobile FAB to left and shrink open panel to bottom 60dvh

### DIFF
--- a/src/ui/web/chat/MobileChatToggle/index.tsx
+++ b/src/ui/web/chat/MobileChatToggle/index.tsx
@@ -141,12 +141,12 @@ export function MobileChatToggle({
     onInputFocusChange(false)
   }
 
-  // Collapsed FAB state
+  // Collapsed FAB state — always bottom-left regardless of locale direction.
   if (!isInternalOpen) {
     return (
       <button
         onClick={handleFabClick}
-        className="fixed bottom-6 start-6 z-50 w-14 h-14 rounded-full bg-primary text-primary-foreground shadow-elevation-3 hover:scale-110 hover:bg-primary/90 transition-all duration-normal flex items-center justify-center"
+        className="fixed bottom-6 left-6 z-50 w-14 h-14 rounded-full bg-primary text-primary-foreground shadow-elevation-3 hover:scale-110 hover:bg-primary/90 transition-all duration-normal flex items-center justify-center"
         aria-label={t('openChat')}
       >
         <MessageCircle className="w-6 h-6" />
@@ -154,105 +154,101 @@ export function MobileChatToggle({
     )
   }
 
-  // Expanded input bar state
+  // Expanded input bar state — bottom-anchored partial panel.
+  // No full-viewport backdrop so the exercise above stays visible and interactive.
+  // Close via the collapse chevron or Escape.
   return (
     <div
-      className="fixed inset-0 z-40 bg-black/5 animate-in fade-in duration-normal"
-      onClick={handleCollapse}
+      className="fixed bottom-0 left-0 right-0 z-40 bg-card rounded-t-2xl shadow-elevation-4 p-card-padding pb-8 max-h-[60dvh] overflow-y-auto animate-in slide-in-from-bottom duration-normal"
+      onKeyDown={handleKeyDown}
     >
-      <div
-        className="absolute bottom-0 start-0 end-0 bg-card rounded-t-2xl shadow-elevation-4 p-card-padding pb-8 animate-in slide-in-from-bottom-0 duration-normal"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={handleKeyDown}
-      >
-        {/* Header with collapse button */}
-        <div className="flex items-center justify-between mb-3">
-          <button
-            type="button"
-            onClick={handleCollapse}
-            className="p-2 rounded-lg hover:bg-muted transition-colors"
-            aria-label={t('closeChat')}
-          >
-            <ChevronDown className="w-5 h-5 text-muted-foreground" />
-          </button>
-          <span className="text-body-sm font-medium text-foreground">{t('chatTitle')}</span>
-          <div className="w-9" /> {/* Spacer to balance layout */}
-        </div>
+      {/* Header with collapse button */}
+      <div className="flex items-center justify-between mb-3">
+        <button
+          type="button"
+          onClick={handleCollapse}
+          className="p-2 rounded-lg hover:bg-muted transition-colors"
+          aria-label={t('closeChat')}
+        >
+          <ChevronDown className="w-5 h-5 text-muted-foreground" />
+        </button>
+        <span className="text-body-sm font-medium text-foreground">{t('chatTitle')}</span>
+        <div className="w-9" /> {/* Spacer to balance layout */}
+      </div>
 
-        {/* Input form */}
-        <form ref={formRef} onSubmit={handleFormSubmit}>
-          <div
-            className={cn(
-              'bg-muted rounded-full flex items-center px-4 py-1.5 border border-input gap-3',
-              isInputFocused && 'ring-2 ring-primary/30',
-            )}
-          >
-            {/* Formula button */}
-            {showMathTools && (
-              <button
-                type="button"
-                onClick={onFormulaToggle}
-                className={cn(
-                  'p-1.5 rounded-lg border transition-colors',
-                  isFormulaOpen
-                    ? 'bg-primary/20 text-primary border-primary/40'
-                    : 'bg-primary/10 text-primary border-primary/20 hover:bg-primary/20',
-                )}
-                title={t('insertFormula')}
-              >
-                <FunctionSquare className="w-5 h-5" />
-              </button>
-            )}
-
-            {/* Text input */}
-            <input
-              ref={inputRef}
-              type="text"
-              className="flex-1 bg-transparent border-none outline-none py-2.5 text-chat-input text-foreground placeholder:text-muted-foreground"
-              placeholder={t('chatInputPlaceholder')}
-              value={localInputValue}
-              onChange={handleInputChange}
-              onFocus={handleInputFocus}
-              onBlur={handleInputBlur}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && !e.shiftKey) {
-                  e.preventDefault()
-                  handleFormSubmit(e as unknown as React.FormEvent)
-                }
-              }}
-              disabled={isSubmitting}
-            />
-
-            {/* Media upload button */}
+      {/* Input form */}
+      <form ref={formRef} onSubmit={handleFormSubmit}>
+        <div
+          className={cn(
+            'bg-muted rounded-full flex items-center px-4 py-1.5 border border-input gap-3',
+            isInputFocused && 'ring-2 ring-primary/30',
+          )}
+        >
+          {/* Formula button */}
+          {showMathTools && (
             <button
               type="button"
-              onClick={onOpenFilePicker}
+              onClick={onFormulaToggle}
               className={cn(
-                'p-1.5 text-muted-foreground hover:text-primary transition-colors',
-                isUploading && 'opacity-disabled cursor-not-allowed',
+                'p-1.5 rounded-lg border transition-colors',
+                isFormulaOpen
+                  ? 'bg-primary/20 text-primary border-primary/40'
+                  : 'bg-primary/10 text-primary border-primary/20 hover:bg-primary/20',
               )}
-              disabled={isUploading}
-              aria-label={t('attachFile')}
+              title={t('insertFormula')}
             >
-              {isUploading ? (
-                <Loader2 className="w-5 h-5 animate-spin" />
-              ) : (
-                <Plus className="w-5 h-5" />
-              )}
+              <FunctionSquare className="w-5 h-5" />
             </button>
+          )}
 
-            {/* Send button */}
-            <button
-              type="submit"
-              className="w-10 h-10 rounded-full bg-primary text-primary-foreground flex items-center justify-center shadow-input hover:bg-primary/90 transition-all hover:scale-105 disabled:opacity-disabled disabled:cursor-not-allowed disabled:hover:scale-100"
-              disabled={isSubmitting || !localInputValue.trim()}
-              aria-label={t('sendMessage')}
-            >
-              <Send className="w-5 h-5" />
-            </button>
-          </div>
-        </form>
-      </div>
+          {/* Text input */}
+          <input
+            ref={inputRef}
+            type="text"
+            className="flex-1 bg-transparent border-none outline-none py-2.5 text-chat-input text-foreground placeholder:text-muted-foreground"
+            placeholder={t('chatInputPlaceholder')}
+            value={localInputValue}
+            onChange={handleInputChange}
+            onFocus={handleInputFocus}
+            onBlur={handleInputBlur}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault()
+                handleFormSubmit(e as unknown as React.FormEvent)
+              }
+            }}
+            disabled={isSubmitting}
+          />
+
+          {/* Media upload button */}
+          <button
+            type="button"
+            onClick={onOpenFilePicker}
+            className={cn(
+              'p-1.5 text-muted-foreground hover:text-primary transition-colors',
+              isUploading && 'opacity-disabled cursor-not-allowed',
+            )}
+            disabled={isUploading}
+            aria-label={t('attachFile')}
+          >
+            {isUploading ? (
+              <Loader2 className="w-5 h-5 animate-spin" />
+            ) : (
+              <Plus className="w-5 h-5" />
+            )}
+          </button>
+
+          {/* Send button */}
+          <button
+            type="submit"
+            className="w-10 h-10 rounded-full bg-primary text-primary-foreground flex items-center justify-center shadow-input hover:bg-primary/90 transition-all hover:scale-105 disabled:opacity-disabled disabled:cursor-not-allowed disabled:hover:scale-100"
+            disabled={isSubmitting || !localInputValue.trim()}
+            aria-label={t('sendMessage')}
+          >
+            <Send className="w-5 h-5" />
+          </button>
+        </div>
+      </form>
     </div>
   )
 }

--- a/src/ui/web/chat/MobileChatToggle/index.tsx
+++ b/src/ui/web/chat/MobileChatToggle/index.tsx
@@ -46,7 +46,7 @@ interface MobileChatToggleProps {
  * On mobile (<1024px), replaces the draggable chat panel with a FAB that
  * expands into a full-width pill-shaped input bar.
  *
- * - FAB is always visible at bottom-left (LTR) or bottom-right (RTL)
+ * - FAB is always visible at bottom-left regardless of locale direction
  * - Tapping FAB expands it into the chat input bar
  * - Collapse button or Escape closes back to FAB
  * - Listens for focus-chat-input event to auto-open (from onChatInteraction callbacks)

--- a/src/ui/web/components/split-pane-layout.tsx
+++ b/src/ui/web/components/split-pane-layout.tsx
@@ -220,12 +220,19 @@ export function SplitPaneLayout({
         </div>
       )}
 
-      {!(!isDesktop && viewMode === 'PDF' && !chatExpandedInPdf) && (
+      {/*
+        Always render the chat container so MobileChatToggle (which lives
+        inside ChatInterface and is fixed-positioned) stays mounted. On mobile
+        in PDF mode with the chat collapsed, the container is given h-0 so it
+        takes no layout space — the FAB still appears at the viewport edge.
+      */}
+      {
         <div
           className={cn(
             'bg-background flex flex-col overflow-hidden relative',
             viewMode === 'CHAT' && 'flex-1',
-            viewMode === 'PDF' && !chatExpandedInPdf && 'flex-shrink-0 h-auto',
+            viewMode === 'PDF' && !chatExpandedInPdf && isDesktop && 'flex-shrink-0 h-auto',
+            viewMode === 'PDF' && !chatExpandedInPdf && !isDesktop && 'h-0',
             viewMode === 'PDF' && chatExpandedInPdf && 'flex-1',
           )}
         >
@@ -251,7 +258,7 @@ export function SplitPaneLayout({
           )}
           {isDragging && <div className="absolute inset-0 z-10" />}
         </div>
-      )}
+      }
     </div>
   )
 }

--- a/tests/e2e/mobile-chat-fab.e2e.spec.ts
+++ b/tests/e2e/mobile-chat-fab.e2e.spec.ts
@@ -6,7 +6,7 @@
  * Tests:
  * - On mobile (<1024px), chat is hidden behind a FAB by default
  * - Tapping the FAB expands it into a full-width pill input
- * - FAB is positioned at bottom-left (LTR) or bottom-right (RTL)
+ * - FAB is positioned at bottom-left regardless of locale direction
  * - Collapse button and Escape close the input back to FAB
  * - Backdrop dim shows when input is open
  * - onChatInteraction callbacks auto-open the FAB input


### PR DESCRIPTION
## Summary

Follow-up to #2155. Two issues with the merged mobile chat FAB:

1. **FAB position flipped by locale.** Used `start-6` (logical-start) which renders on the right in Hebrew (RTL). Boss wants it on the left in all locales.
2. **Open chat took over the whole screen.** Used `fixed inset-0` with a backdrop, hiding the exercise the user is working on. Now anchored to the bottom of the viewport, capped at `max-h-[60dvh]`, with no backdrop so the exercise above stays visible and interactive.

## Changes

- `src/ui/web/chat/MobileChatToggle/index.tsx`
  - Collapsed FAB: `bottom-6 start-6` → `bottom-6 left-6`
  - Expanded state: dropped the full-screen `fixed inset-0` backdrop wrapper, made the panel a single bottom-anchored element with `max-h-[60dvh]` and internal `overflow-y-auto`
  - Updated docstring
- `tests/e2e/mobile-chat-fab.e2e.spec.ts` — updated stale header comment

## Trade-off

The previous version closed when the user tapped the backdrop. With the backdrop removed (so the exercise above stays interactive), backdrop-click-to-close is gone. Closing remains available via the collapse chevron and the Escape key, which the existing tests cover.

## Test plan

- [ ] Hebrew lesson page on mobile: FAB sits at bottom-left (not bottom-right)
- [ ] English lesson page on mobile: FAB sits at bottom-left
- [ ] Tap FAB → bottom panel slides up, occupies ~60% of viewport height max
- [ ] Exercise above the open panel is still visible and scrollable
- [ ] Collapse chevron and Escape close the panel
- [ ] Send, formula button, media upload still work