### PR TITLE
Vibe: Remove AdminBarWrapper from frontend layout

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -9,7 +9,6 @@ import React from 'react'
 import { loadConfigValues } from '@/infra/config/runtime'
 import { isPasswordLoginEnabled } from '@/infra/config/system-params'
 import { mergeOpenGraph } from '@/infra/utils/mergeOpenGraph'
-import { AdminBarWrapper } from '@/ui/web/AdminBar/AdminBarWrapper'
 import { Toaster } from '@/ui/web/components/toaster'
 import { Footer } from '@/ui/web/footer/Component'
 import { Header } from '@/ui/web/header/Component'
@@ -103,11 +102,6 @@ export default async function RootLayout({ children }: { children: React.ReactNo
                 </a>
                 <RouteLoadingIndicator />
                 <LayoutClient />
-                <AdminBarWrapper
-                  adminBarProps={{
-                    preview: isEnabled,
-                  }}
-                />
                 <Header />
                 <NavigationBar />
                 <div id="main-content" className="flex-1">


### PR DESCRIPTION
Vibe session for #2181.

The runner will push commits to `2181-remove-adminbarwrapper-from-frontend-lay` as it implements the plan. Vercel begins cold-building this PR now so the preview is ready by the time the runner finishes.

Closes #2181