### PR TITLE
fix(security): Clear CodeQL log-injection alerts in pdf-to-exercises jobs

### DIFF
--- a/src/server/payload/jobs/pdf-to-exercises-task.ts
+++ b/src/server/payload/jobs/pdf-to-exercises-task.ts
@@ -344,7 +344,7 @@ export const pdfToExercisesTask = {
         cause?: { message?: string }
         name?: string
       }
-      console.error(`[PDF→Exercises] Job ${job.id} failed:`, error)
+      console.error('[PDF→Exercises] Job failed:', job.id, error)
       await updateJobStatus(payload as unknown as { db: unknown }, job.id, 'failed', {
         ...output,
         error: err.message,

--- a/src/server/payload/jobs/pdf-to-exercises-v2-task.ts
+++ b/src/server/payload/jobs/pdf-to-exercises-v2-task.ts
@@ -274,7 +274,7 @@ export const pdfToExercisesV2Task = {
       return output
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error'
-      console.error(`[V2] Job ${job.id} failed:`, error)
+      console.error('[V2] Job failed:', job.id, error)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await updateJobStatus(payload as any, job.id, 'failed', {
         ...output,


### PR DESCRIPTION
## Summary
Re-applies the source-only fix from the previously **closed** PR #2265 to get **dev CI green**.

The failing `CodeQL` check on dev reports **2 high-severity `js/tainted-format-string` alerts** (#41, #42). `job.id` — sourced from Payload's job queue, which can carry user-controlled data — was interpolated directly into the `console.error` format string in two job handlers. This passes it as a separate argument so the format string stays constant.

## Changes
- `src/server/payload/jobs/pdf-to-exercises-task.ts` (line 347)
- `src/server/payload/jobs/pdf-to-exercises-v2-task.ts` (line 277)

No behavior change to logging output; only the format-string shape changes.

## Why the bot didn't land it
- PR #2265 (the original fix) was **closed without merging**.
- The latest auto-fix run crashed at the **preview Docker build (out of memory)** before reaching the fix.

## Test plan
- [x] Typecheck (pre-commit, passed)
- [x] ESLint + Prettier on both files (clean)
- [ ] CI green on this PR
- [ ] `CodeQL` check clears alerts #41 and #42

Closes #2269