### PR TITLE
fix(lesson-duplication): batch lesson.blocks update after deep-clone

### DIFF
--- a/kody.config.json
+++ b/kody.config.json
@@ -12,9 +12,7 @@
   "github": {
     "owner": "A-Guy-educ",
     "repo": "A-Guy",
-    "operators": [
-      "aguyaharonyair"
-    ]
+    "operators": ["aguyaharonyair"]
   },
   "agent": {
     "model": "minimax/MiniMax-M2.7-highspeed"
@@ -24,9 +22,7 @@
   },
   "release": {
     "releaseBranch": "main",
-    "versionFiles": [
-      "package.json"
-    ],
+    "versionFiles": ["package.json"],
     "e2eCommand": "npx tsx scripts/release-e2e-gate.ts",
     "timeoutMs": 1800000
   },

--- a/src/server/payload/endpoints/lessons/duplicate.ts
+++ b/src/server/payload/endpoints/lessons/duplicate.ts
@@ -117,16 +117,27 @@ async function deepCloneLesson(req: PayloadRequest, sourceLessonId: string): Pro
   // block schema), don't kill the whole copy. Log it, count it, move on.
   // Without this guard, a 44-exercise lesson with one bad exercise produces
   // zero cloned exercises and a top-level 'Content > Content' error.
+  //
+  // We disable the per-exercise addBlockToLesson hook (via `_skipBlockSync`)
+  // and rebuild the lesson's blocks[] in one atomic write at the end. The
+  // per-exercise hook is fire-and-forget at the framework level — when this
+  // function returns and the serverless function exits, in-flight hook
+  // promises get killed, leaving only the first one's lesson update committed
+  // (lost-update bug observed on 44-exercise geometry clone: 43 FK exercises
+  // created, but only 1 entry in lesson.blocks[]).
   const cloneFailures: Array<{ id: string; reason: string }> = []
+  const newExerciseIds: string[] = []
   for (const exercise of exerciseDocs) {
     try {
       const exData = stripManagedFields(exercise as unknown as Record<string, unknown>)
-      await req.payload.create({
+      const created = await req.payload.create({
         collection: 'exercises',
         data: { ...exData, lesson: newLesson.id } as never,
         overrideAccess: true,
         req,
+        context: { _skipBlockSync: true },
       })
+      newExerciseIds.push(created.id)
     } catch (err) {
       const reason = err instanceof Error ? err.message : 'unknown'
       cloneFailures.push({ id: exercise.id, reason })
@@ -139,6 +150,25 @@ async function deepCloneLesson(req: PayloadRequest, sourceLessonId: string): Pro
     req.payload.logger.warn(
       `[deepCloneLesson] ${cloneFailures.length} of ${exerciseDocs.length} exercises failed to clone for lesson ${sourceLessonId}`,
     )
+  }
+
+  // Final batched write: build the full blocks[] array from the cloned ids
+  // and persist in a single lesson update. `_skipBlockSync` prevents the
+  // resulting lesson afterChange from triggering further block-sync churn.
+  if (newExerciseIds.length > 0) {
+    const blocks = newExerciseIds.map((exId) => ({
+      id: Math.random().toString(36).slice(2, 14),
+      blockType: 'exerciseRef' as const,
+      exercise: exId,
+    }))
+    await req.payload.update({
+      collection: 'lessons',
+      id: newLesson.id,
+      data: { blocks: JSON.stringify(blocks) },
+      overrideAccess: true,
+      req,
+      context: { _skipBlockSync: true },
+    })
   }
 
   return newLesson.id


### PR DESCRIPTION
## Summary

When cloning 40+ exercises into a new lesson via `level=none` duplication, the
per-exercise `addBlockToLesson` hook fires after the serverless function
returns and gets killed mid-write. Only the first exercise's hook commits its
lesson update; the other ~42 lose their writes.

Verified live on geometry source `6a018c56cb420b875820834f` (44 exercises):
- 43 exercises successfully created with FK pointing at the new lesson
- Only 1 entry in `lesson.blocks[]` — and it's the first cloned exercise

The migration fallback `populateLessonBlocks` skips lessons with
`blocks.length > 0`, so it doesn't help here either.

## Fix

`deepCloneLesson` now passes `_skipBlockSync: true` to each exercise create
(suppressing the per-exercise hook) and writes the full `blocks[]` array in a
single atomic lesson update at the end. No more race, no more lost writes.

## Test plan

- [x] Typecheck clean
- [ ] After merge: re-run a `level=none` duplication on a 40+ exercise lesson
      and verify `output.blocks[]` length matches the cloned exercise count.