### PR TITLE
fix(paypal): Drop Stripe-only placeholder from PayPal return_url

### DIFF
--- a/src/app/api/payments/checkout/route.ts
+++ b/src/app/api/payments/checkout/route.ts
@@ -360,9 +360,15 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  // 9. Build URLs for payment provider redirect
+  // 9. Build URLs for payment provider redirect.
+  // Stripe expands {CHECKOUT_SESSION_ID} at redirect time. PayPal rejects curly
+  // braces as INVALID_PARAMETER_SYNTAX per RFC 3986 and appends its own
+  // ?token=ORDER_ID&PayerID=... params automatically, so we hand it a clean URL.
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
-  const successUrl = `${baseUrl}/checkout/success?session_id={CHECKOUT_SESSION_ID}`
+  const successUrl =
+    provider === 'stripe'
+      ? `${baseUrl}/checkout/success?session_id={CHECKOUT_SESSION_ID}`
+      : `${baseUrl}/checkout/success?provider=paypal`
   const cancelParams = new URLSearchParams({ product_id: productId })
   const cancelUrl = `${baseUrl}/checkout/cancel?${cancelParams.toString()}`
 


### PR DESCRIPTION
## Summary

Follow-up to #2432. The logging fix in that PR confirmed every PayPal checkout was being rejected with:

\`\`\`
field: /application_context/return_url
value: https://dev.aguy.co.il/checkout/success?session_id={CHECKOUT_SESSION_ID}
issue: INVALID_PARAMETER_SYNTAX
\`\`\`

\`{CHECKOUT_SESSION_ID}\` is a Stripe-only placeholder. PayPal strict-validates URLs per RFC 3986 and rejects the curly braces, returning a 400 INVALID_REQUEST on every order creation attempt.

## Change

Branch the \`successUrl\` by provider in \`src/app/api/payments/checkout/route.ts\`:
- **Stripe**: keep \`?session_id={CHECKOUT_SESSION_ID}\` so Stripe can expand it
- **PayPal**: use \`?provider=paypal\` — PayPal appends its own \`?token=ORDER_ID&PayerID=...\` params on redirect

## Follow-up

The \`/checkout/success\` page was built expecting Stripe's \`?session_id=cs_...\`. After this fix lands, PayPal will land on the success page with a different query shape. The success page may not render correctly for the PayPal flow yet — a separate task can handle both query shapes if needed.

## Test plan

- [ ] Click PayPal button on a product → redirected to PayPal sandbox checkout (no 400)
- [ ] Complete sandbox payment → redirected back to /checkout/success
- [ ] Transaction created in admin
- [ ] Stripe flow unaffected (4242 card still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)