### PR TITLE
fix(health-badge): Read 'version' field from /api/health response

### DIFF
--- a/src/ui/web/components/HealthBadge.tsx
+++ b/src/ui/web/components/HealthBadge.tsx
@@ -5,8 +5,7 @@ import { useEffect, useState } from 'react'
 interface HealthResponse {
   ok: boolean
   gitSha: string
-  payloadVersion: string
-  projectVersion: string
+  version: string
   timestamp: string
 }
 
@@ -87,7 +86,7 @@ export function HealthBadge({ showVersion = false }: HealthBadgeProps) {
       <span>API OK</span>
       {showVersion && data && (
         <span className="text-body-xs opacity-75 ms-2">
-          {data.projectVersion} ({data.gitSha.slice(0, 7)})
+          {data.version} ({data.gitSha.slice(0, 7)})
         </span>
       )}
     </div>

--- a/tests/int/health-badge.int.spec.ts
+++ b/tests/int/health-badge.int.spec.ts
@@ -7,24 +7,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 interface HealthResponse {
   ok: boolean
   gitSha: string
-  payloadVersion: string
-  projectVersion: string
+  version: string
   timestamp: string
 }
 
 const healthyResponse: HealthResponse = {
   ok: true,
   gitSha: 'abc123def456',
-  payloadVersion: '3.73.0',
-  projectVersion: '0.6.0',
+  version: '0.6.0',
   timestamp: '2026-07-02T12:00:00.000Z',
 }
 
 const unhealthyResponse: HealthResponse = {
   ok: false,
   gitSha: 'abc123def456',
-  payloadVersion: '3.73.0',
-  projectVersion: '0.6.0',
+  version: '0.6.0',
   timestamp: '2026-07-02T12:00:00.000Z',
 }
 
@@ -94,6 +91,29 @@ describe('HealthBadge component', () => {
 
       expect(await screen.findByText('API OK')).toBeTruthy()
       expect(screen.getByText(/0\.6\.0/)).toBeTruthy()
+      expect(screen.getByText(/abc123d/)).toBeTruthy()
+    })
+
+    // Regression test: health API returns `version` not `projectVersion`
+    it('displays version from actual API response when showVersion is true', async () => {
+      // This is the actual API response structure - note `version` not `projectVersion`
+      const actualApiResponse = {
+        ok: true,
+        checks: { database: true },
+        version: '1.2.3',
+        gitSha: 'abc123def456',
+        timestamp: '2026-07-02T12:00:00.000Z',
+      }
+
+      vi.spyOn(global, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify(actualApiResponse), { status: 200 }),
+      )
+
+      renderHealthBadge(true)
+
+      expect(await screen.findByText('API OK')).toBeTruthy()
+      // The version from the actual API should be displayed
+      expect(screen.getByText(/1\.2\.3/)).toBeTruthy()
       expect(screen.getByText(/abc123d/)).toBeTruthy()
     })
   })


### PR DESCRIPTION
## Summary

- The `HealthBadge` component reads `data.projectVersion` from the health API response, but `/api/health` actually returns `version` ([route.ts:14,44,49](src/app/api/health/route.ts#L14)). Result: the admin API status widget renders the version as `(unknown)`.
- This is a 2/-3 line fix to align the component's TypeScript interface and JSX with the real API shape.
- Cherry-picked from #1872, which had the correct fix but bundled it with 4 unrelated drive-by changes (ask-loading repro #1838, search-no-results repro #1840, csp-admin-gravatar, RequireCourseSelection). Those are dropped here.

## Test plan

- [ ] `pnpm test:int -- tests/int/health-badge.int.spec.ts` passes (includes a new regression test using the real `/api/health` response shape)
- [ ] On `/admin`, the API status widget shows version + git SHA instead of `(unknown)`

Closes #1842