### PR TITLE
fix(csp): Allow *.gravatar.com subdomains in admin img-src

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -182,7 +182,7 @@ const nextConfig = {
           {
             key: 'Content-Security-Policy',
             value:
-              "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://vercel.live https://www.googletagmanager.com https://cdn.mxpnl.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' *.blob.vercel-storage.com img.youtube.com avatars.githubusercontent.com github.com *.githubusercontent.com gravatar.com data: blob:; font-src 'self' data:; connect-src 'self' *.sentry.io https://vercel.live https://blob.vercel-storage.com https://*.blob.vercel-storage.com https://api-js.mixpanel.com https://*.mxpnl.com; frame-src 'self' www.youtube.com vercel.live; frame-ancestors 'self' https://kody-dashboard-aguy.vercel.app; object-src 'none'; base-uri 'self'; form-action 'self'",
+              "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://vercel.live https://www.googletagmanager.com https://cdn.mxpnl.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' *.blob.vercel-storage.com img.youtube.com avatars.githubusercontent.com github.com *.githubusercontent.com *.gravatar.com data: blob:; font-src 'self' data:; connect-src 'self' *.sentry.io https://vercel.live https://blob.vercel-storage.com https://*.blob.vercel-storage.com https://api-js.mixpanel.com https://*.mxpnl.com; frame-src 'self' www.youtube.com vercel.live; frame-ancestors 'self' https://kody-dashboard-aguy.vercel.app; object-src 'none'; base-uri 'self'; form-action 'self'",
           },
           { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' },
           { key: 'X-Content-Type-Options', value: 'nosniff' },

--- a/tests/int/csp-vercel-feedback-admin.int.spec.ts
+++ b/tests/int/csp-vercel-feedback-admin.int.spec.ts
@@ -18,12 +18,6 @@ describe('CSP Configuration - Vercel Feedback Script on /admin', () => {
   const projectRoot = path.resolve(__dirname, '../..')
   const nextConfigPath = path.join(projectRoot, 'next.config.js')
 
-  // Helper to extract CSP value from headers array
-  function extractCSPValue(headers: Array<{ key: string; value: string }>): string | null {
-    const cspHeader = headers.find((h) => h.key === 'Content-Security-Policy')
-    return cspHeader?.value ?? null
-  }
-
   // Helper to extract script-src directive from CSP string
   function extractScriptSrc(csp: string): string | null {
     const match = csp.match(/script-src\s+([^;]+)/)
@@ -97,6 +91,28 @@ describe('CSP Configuration - Vercel Feedback Script on /admin', () => {
     expect(imgSrcMatch).not.toBeNull()
     const imgSrc = imgSrcMatch![1]
     // Admin routes MUST have gravatar.com in img-src for user avatars to load
-    expect(imgSrc).toContain('gravatar.com')
+    // Use *.gravatar.com to match www.gravatar.com where avatars are actually served
+    expect(imgSrc).toContain('*.gravatar.com')
+  })
+
+  it('should allow www.gravatar.com in img-src for /admin routes (not just gravatar.com)', async () => {
+    const configContent = fs.readFileSync(nextConfigPath, 'utf8')
+
+    // Extract the /admin route CSP
+    const adminRouteMatch = configContent.match(
+      /source:\s*'\/admin\/:path\*'[\s\S]*?Content-Security-Policy[\s\S]*?value:\s*"([^"]+)"/,
+    )
+    expect(adminRouteMatch).not.toBeNull()
+
+    const csp = adminRouteMatch![1]
+    const imgSrcMatch = csp.match(/img-src\s+([^;]+)/)
+
+    expect(imgSrcMatch).not.toBeNull()
+    const imgSrc = imgSrcMatch![1]
+    // Gravatar avatars are served from www.gravatar.com, not gravatar.com directly.
+    // In CSP, 'gravatar.com' does NOT match 'www.gravatar.com' (different host).
+    // We need '*.gravatar.com' to match subdomains like www.gravatar.com.
+    // See: https://www.w3.org/TR/CSP/#source-list-syntax
+    expect(imgSrc).toMatch(/\*\.gravatar\.com/)
   })
 })


### PR DESCRIPTION
## Summary

- Admin route CSP listed `gravatar.com` literally in `img-src`. CSP host matching requires either an exact host match or an explicit wildcard — `gravatar.com` does NOT match `www.gravatar.com` (where Gravatar actually serves avatars). Result: Payload admin avatars were blocked.
- 1-line fix in [next.config.js](next.config.js#L185): `gravatar.com` → `*.gravatar.com`.
- Plus an int-test assertion that explicitly checks for the wildcard form so this can't regress.

## Why a fresh PR

Cherry-picked from #2316, which had the correct 1-line fix but bundled it with 248 lines of unrelated `lesson-duplication-review-counters` tests and `exerciseState.ts` changes. Same root-cause fix also exists in duplicate PRs #2328 and #2334.

After this merges, close #2316 / #2328 / #2334 as superseded.

Also removed a pre-existing unused `extractCSPValue` helper in the test file that tripped stricter staged-file lint when this file was re-staged. Not introduced by this PR; just easier to delete than to add an underscore prefix.

## Test plan

- [ ] `pnpm test:int -- tests/int/csp-vercel-feedback-admin.int.spec.ts` passes (now asserts `*.gravatar.com` specifically)
- [ ] In `/admin`, user avatars load (no console CSP violations for `www.gravatar.com`)

Closes #2285
Closes #2286
Closes #2290